### PR TITLE
Wrap the application in React Aria's SSRProvider

### DIFF
--- a/frontend/.storybook/preview.js
+++ b/frontend/.storybook/preview.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { themes } from '@storybook/theming';
 import { OverlayProvider } from '@react-aria/overlays';
 import '../styles/globals.css';
+import { SSRProvider } from '@react-aria/ssr';
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
@@ -24,9 +25,11 @@ export const parameters = {
 export const decorators = [
   (Story) => {
     return (
-      <OverlayProvider>
-        <div className="bg-background-light">{Story()}</div>
-      </OverlayProvider>
+      <SSRProvider>
+        <OverlayProvider>
+          <div className="bg-background-light">{Story()}</div>
+        </OverlayProvider>
+      </SSRProvider>
     );
   },
 ];

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
     "@react-aria/searchfield": "^3.1.3",
     "@react-aria/separator": "^3.1.3",
     "@react-aria/slider": "^3.0.2",
+    "@react-aria/ssr": "^3.1.0",
     "@react-aria/utils": "^3.8.0",
     "@react-aria/visually-hidden": "^3.2.2",
     "@react-stately/collections": "^3.3.4",

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -4,6 +4,7 @@ import { Provider as ReduxProvider } from 'react-redux';
 import type { AppProps } from 'next/app';
 
 import { OverlayProvider } from '@react-aria/overlays';
+import { SSRProvider } from '@react-aria/ssr';
 import { Provider as AuthenticationProvider } from 'next-auth/client';
 import { Hydrate } from 'react-query/hydration';
 
@@ -48,11 +49,13 @@ const HeCoApp: React.FC<AppProps> = ({ Component, pageProps }: Props) => {
               keepAlive: 10 * 60, // Send keepAlive message every 10 minutes
             }}
           >
-            <OverlayProvider>
-              <Layout {...layoutProps}>
-                <Component {...pageProps} />
-              </Layout>
-            </OverlayProvider>
+            <SSRProvider>
+              <OverlayProvider>
+                <Layout {...layoutProps}>
+                  <Component {...pageProps} />
+                </Layout>
+              </OverlayProvider>
+            </SSRProvider>
           </AuthenticationProvider>
         </Hydrate>
       </QueryClientProvider>


### PR DESCRIPTION
This PR aims to fix an error thrown when rendering the app on the server (SSR).

In order to make some parts of the application accessible, [React Aria](https://react-spectrum.adobe.com/react-aria/index.html) uses some randomly generated ids. In order to avoid generating different ids when rendering the app in the server and the browser, the application must be wrapped in React Aria's `SSRProvider` component. This is what this PR does.

Unfortunately, the application still throws some errors that seem to originate from the call to `useMenuTrigger` in `components/menu/component.tsx`. As such, it seems to be a bug in the library rather than a misconfiguration.

## Testing instructions

Unfortunately, the errors are still thrown, so there is no test to make sure this PR is correct.

1. Start the development server
2. Navigate to any page

Make sure there are no errors in the console related to the `SSRProvider` component.

## Tracking

[LET-77](https://vizzuality.atlassian.net/browse/LET-77).
