### PR TITLE
Display which link is active in the static layout's header

### DIFF
--- a/frontend/components/active-link/component.tsx
+++ b/frontend/components/active-link/component.tsx
@@ -1,0 +1,68 @@
+/**
+ * This component comes from Next.js' repository:
+ * https://github.com/vercel/next.js/blob/canary/examples/active-class-name/components/ActiveLink.js
+ */
+import React, { useState, useEffect, Children } from 'react';
+
+import cx from 'classnames';
+
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+import { ActiveLinkProps } from './types';
+
+export const ActiveLink: React.FC<ActiveLinkProps> = ({
+  activeClassName,
+  children,
+  ...props
+}: ActiveLinkProps) => {
+  const { asPath, isReady } = useRouter();
+
+  const child = Children.only(children);
+  const childClassName = child.props.className ?? '';
+  const [className, setClassName] = useState(childClassName);
+  const [additionalProps, setAdditionalProps] = useState({});
+
+  useEffect(() => {
+    // Check if the router fields are updated client-side
+    if (isReady) {
+      // Dynamic route will be matched via props.as
+      // Static route will be matched via props.href
+      const linkPathname = new URL((props.as ?? props.href).toString(), window.location.href)
+        .pathname;
+
+      // Using URL().pathname to get rid of query and hash
+      const activePathname = new URL(asPath, window.location.href).pathname;
+      const isActive = linkPathname === activePathname;
+
+      setClassName(
+        cx({
+          [childClassName]: true,
+          [activeClassName]: isActive,
+        })
+      );
+
+      setAdditionalProps({ 'aria-current': isActive ? 'page' : undefined });
+    }
+  }, [
+    asPath,
+    isReady,
+    props.as,
+    props.href,
+    childClassName,
+    activeClassName,
+    setClassName,
+    className,
+  ]);
+
+  return (
+    <Link {...props}>
+      {React.cloneElement(child, {
+        className: className ?? undefined,
+        ...additionalProps,
+      })}
+    </Link>
+  );
+};
+
+export default ActiveLink;

--- a/frontend/components/active-link/index.ts
+++ b/frontend/components/active-link/index.ts
@@ -1,0 +1,2 @@
+export type { ActiveLinkProps } from './types';
+export { default } from './component';

--- a/frontend/components/active-link/types.ts
+++ b/frontend/components/active-link/types.ts
@@ -1,0 +1,8 @@
+import { LinkProps } from 'next/link';
+
+export type ActiveLinkProps = LinkProps & {
+  /** String to apply to the link when it is active */
+  activeClassName: string;
+  /** Anchor element */
+  children: React.ReactElement;
+};

--- a/frontend/layouts/static-page/header/component.tsx
+++ b/frontend/layouts/static-page/header/component.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/router';
 
 import { useWindowScrollPosition } from 'rooks';
 
+import ActiveLink from 'components/active-link';
 import Button from 'components/button';
 import Icon from 'components/icon';
 import LanguageSelector from 'components/language-selector-no-ssr';
@@ -90,20 +91,20 @@ export const Header: React.FC<HeaderProps> = ({
           </div>
           <div className="hidden lg:flex-1 lg:flex lg:items-center lg:justify-end">
             <nav className="flex space-x-8">
-              <Link href="/discover">
+              <ActiveLink href="/discover" activeClassName="font-semibold">
                 <a title="Search">
                   <Icon icon={SearchIcon} />
                 </a>
-              </Link>
-              <Link href="/investors">
+              </ActiveLink>
+              <ActiveLink href="/investors" activeClassName="font-semibold">
                 <a>For investors</a>
-              </Link>
-              <Link href="/project-developers">
+              </ActiveLink>
+              <ActiveLink href="/project-developers" activeClassName="font-semibold">
                 <a>For project developers</a>
-              </Link>
-              <Link href="/about">
+              </ActiveLink>
+              <ActiveLink href="/about" activeClassName="font-semibold">
                 <a>About</a>
-              </Link>
+              </ActiveLink>
             </nav>
             <div className="flex items-center space-x-6 md:ml-4">
               <div className="shrink-0">


### PR DESCRIPTION
This PR modifies the static layout's header to indicate which link is active in the navigation bar.

To do so, a new component, `ActiveLink`, has been added. It is based on [Next.js' example](https://github.com/vercel/next.js/blob/canary/examples/active-class-name/components/ActiveLink.js).

## Testing instructions

1. Go on the homepage

No link should be highlighted.

2. Go to the about page

The about page link should be highlighted and it should have a `aria-current` attribute set to `'true'`.

## Tracking

[LET-76](https://vizzuality.atlassian.net/browse/LET-76?atlOrigin=eyJpIjoiYmI5M2IyODNhMmE4NDRmOTgyODI1MjZlZDZiZjZiZGMiLCJwIjoiaiJ9).
