### PR TITLE
Fix linting regression and add stricter accessibility rules

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,9 +1,16 @@
 {
-  "extends": ["next/core-web-vitals", "next", "prettier", "plugin:prettier/recommended"],
+  "extends": ["next/core-web-vitals", "next", "prettier", "plugin:prettier/recommended", "plugin:jsx-a11y/recommended"],
   "plugins": [
     "prettier"
   ],
   "rules": {
+    // This rule is necessary to fix some issues between jsx-a11y and Next.js:
+    // https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/ea877c4cf4c8df7e735cafceefd591c203cca7d7/docs/rules/anchor-is-valid.md#case-i-use-nextjs-and-im-getting-this-error-inside-of-links
+    "jsx-a11y/anchor-is-valid": [ "error", {
+      "components": [ "Link" ],
+      "specialLink": [ "hrefLeft", "hrefRight" ],
+      "aspects": [ "invalidHref", "preferButton" ]
+    }],
     "prettier/prettier": [
       "error",
       {},

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,6 +1,16 @@
 {
-  "extends": ["next/core-web-vitals", "next", "prettier"],
+  "extends": ["next/core-web-vitals", "next", "prettier", "plugin:prettier/recommended"],
+  "plugins": [
+    "prettier"
+  ],
   "rules": {
+    "prettier/prettier": [
+      "error",
+      {},
+      {
+        "usePrettierrc": true
+      }
+    ],
     "import/no-anonymous-default-export": 0,
     "import/no-named-as-default": 0,
     "import/order": [

--- a/frontend/components/menu/component.tsx
+++ b/frontend/components/menu/component.tsx
@@ -39,6 +39,7 @@ export const Menu: React.FC<MenuProps> = ({
           align={rest.align ?? 'start'}
           direction={rest.direction ?? 'bottom'}
           domProps={menuProps}
+          // eslint-disable-next-line jsx-a11y/no-autofocus
           autoFocus={state.focusStrategy}
           disabledKeys={disabledKeys}
           expandedKeys={expandedKeys}

--- a/frontend/components/modal/component.tsx
+++ b/frontend/components/modal/component.tsx
@@ -119,7 +119,12 @@ export const Modal: FC<ModalProps> = ({
             exit="exit"
             className={cx({ [OVERLAY_CLASSES]: true })}
           >
-            <FocusScope contain restoreFocus autoFocus>
+            <FocusScope
+              contain
+              restoreFocus
+              // eslint-disable-next-line jsx-a11y/no-autofocus
+              autoFocus
+            >
               <div {...overlayProps} {...dialogProps} {...modalProps} ref={containerRef}>
                 <motion.div
                   variants={contentFramerVariants}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,6 +65,7 @@
     "classnames": "^2.3.1",
     "d3-ease": "^2.0.0",
     "downshift": "^6.1.3",
+    "eslint-plugin-prettier": "^4.0.0",
     "final-form": "^4.20.2",
     "framer-motion": "^4.1.17",
     "jsona": "^1.9.2",

--- a/frontend/pages/about.tsx
+++ b/frontend/pages/about.tsx
@@ -149,7 +149,13 @@ const AboutPage: PageComponent<{}, StaticPageLayoutProps> = () => {
             </div>
           </div>
           <div className="mt-8 md:mt-0">
-            <Image src="/images/about-intro.png" height={1209} width={1204} layout="responsive" alt="" />
+            <Image
+              src="/images/about-intro.png"
+              height={1209}
+              width={1204}
+              layout="responsive"
+              alt=""
+            />
           </div>
         </div>
       </LayoutContainer>
@@ -300,7 +306,13 @@ const AboutPage: PageComponent<{}, StaticPageLayoutProps> = () => {
             </p>
           </div>
           <div className="overflow-hidden lg:-mt-36 lg:pl-10 rounded-2xl md:rounded-none">
-            <Image src="/images/about-impact.png" height={1092} width={1092} layout="responsive" alt="" />
+            <Image
+              src="/images/about-impact.png"
+              height={1092}
+              width={1092}
+              layout="responsive"
+              alt=""
+            />
           </div>
         </div>
       </LayoutContainer>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -10473,6 +10473,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-prettier@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "eslint-plugin-prettier@npm:4.0.0"
+  dependencies:
+    prettier-linter-helpers: ^1.0.0
+  peerDependencies:
+    eslint: ">=7.28.0"
+    prettier: ">=2.0.0"
+  peerDependenciesMeta:
+    eslint-config-prettier:
+      optional: true
+  checksum: 03d69177a3c21fa2229c7e427ce604429f0b20ab7f411e2e824912f572a207c7f5a41fd1f0a95b9b8afe121e291c1b1f1dc1d44c7aad4b0837487f9c19f5210d
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-react-hooks@npm:^4.3.0":
   version: 4.3.0
   resolution: "eslint-plugin-react-hooks@npm:4.3.0"
@@ -10888,6 +10903,13 @@ __metadata:
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
   checksum: e21a9d8d84f53493b6aa15efc9cfd53dd5b714a1f23f67fb5dc8f574af80df889b3bce25dc081887c6d25457cce704e636395333abad896ccdec03abaf1f3f9d
+  languageName: node
+  linkType: hard
+
+"fast-diff@npm:^1.1.2":
+  version: 1.2.0
+  resolution: "fast-diff@npm:1.2.0"
+  checksum: 1b5306eaa9e826564d9e5ffcd6ebd881eb5f770b3f977fcbf38f05c824e42172b53c79920e8429c54eb742ce15a0caf268b0fdd5b38f6de52234c4a8368131ae
   languageName: node
   linkType: hard
 
@@ -12107,6 +12129,7 @@ __metadata:
     eslint: ^8.9.0
     eslint-config-next: 12.1.0
     eslint-config-prettier: ^8.4.0
+    eslint-plugin-prettier: ^4.0.0
     final-form: ^4.20.2
     framer-motion: ^4.1.17
     husky: ^7.0.0
@@ -16591,6 +16614,15 @@ __metadata:
   version: 1.1.2
   resolution: "prelude-ls@npm:1.1.2"
   checksum: c4867c87488e4a0c233e158e4d0d5565b609b105d75e4c05dc760840475f06b731332eb93cc8c9cecb840aa8ec323ca3c9a56ad7820ad2e63f0261dadcb154e4
+  languageName: node
+  linkType: hard
+
+"prettier-linter-helpers@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "prettier-linter-helpers@npm:1.0.0"
+  dependencies:
+    fast-diff: ^1.1.2
+  checksum: 00ce8011cf6430158d27f9c92cfea0a7699405633f7f1d4a45f07e21bf78e99895911cbcdc3853db3a824201a7c745bd49bfea8abd5fb9883e765a90f74f8392
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR fixes a regression from #9 where Prettier was not giving any errors anymore due to a removed plugin in the eslint configuration file. This PR also adds stricter accessibility rules. 

## Testing instructions

1. Add unnecessary spaces between `<` and the rest of any tag (e.g. `<      body`)

Make sure the editor picks up the unnecessary spaces and that `yarn lint` as well.

2. Add `tabIndex={5}` to any component

Make sure both the editor and `yarn lint` complain

## Tracking

Not tracked.
