### PR TITLE
[Backend] Setup API base controller

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -14,6 +14,9 @@ gem "sprockets-rails"
 gem "stimulus-rails"
 gem "turbo-rails"
 
+# API
+gem "jsonapi-serializer"
+
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 
 gem "bootsnap", require: false

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -105,6 +105,8 @@ GEM
       reline (>= 0.3.0)
     jsbundling-rails (1.0.1)
       railties (>= 6.0.0)
+    jsonapi-serializer (2.2.0)
+      activesupport (>= 4.2)
     loofah (2.14.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -273,6 +275,7 @@ DEPENDENCIES
   debug
   factory_bot_rails
   jsbundling-rails
+  jsonapi-serializer
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.1)

--- a/backend/app/controllers/api/v1/base_controller.rb
+++ b/backend/app/controllers/api/v1/base_controller.rb
@@ -1,0 +1,24 @@
+module API
+  module V1
+    class BaseController < ActionController::API
+      include ActionController::Cookies
+      include ActionController::RequestForgeryProtection
+      include API::Errors
+      include API::Authentication
+
+      protect_from_forgery with: :exception
+
+      wrap_parameters format: [:json]
+
+      before_action :require_json!
+
+      private
+
+      def require_json!
+        return if request.get? || request.content_type.to_s.starts_with?("application/json")
+
+        raise API::Error, "application/json content type is required by the requested endpoint"
+      end
+    end
+  end
+end

--- a/backend/app/controllers/concerns/api/authentication.rb
+++ b/backend/app/controllers/concerns/api/authentication.rb
@@ -1,0 +1,17 @@
+module API
+  module Authentication
+    # include Devise::Controllers::Helpers
+
+    def self.included(base)
+      base.after_action :set_csrf_cookie
+    end
+
+    # def authenticate_user!
+    #   raise API::UnauthorizedError, "You need to sign in before making this request" if current_user.nil?
+    # end
+
+    def set_csrf_cookie
+      cookies["csrf_token"] = form_authenticity_token
+    end
+  end
+end

--- a/backend/app/controllers/concerns/api/errors.rb
+++ b/backend/app/controllers/concerns/api/errors.rb
@@ -1,0 +1,36 @@
+module API
+  Error = Class.new(StandardError)
+  UnauthorizedError = Class.new(Error)
+
+  module Errors
+    def self.included(base)
+      base.rescue_from StandardError, with: :render_standard_error unless Rails.env.test? || Rails.env.development?
+      base.rescue_from API::Error, with: :render_error
+      base.rescue_from API::UnauthorizedError, with: :render_unauthorized_error
+      base.rescue_from ActiveRecord::RecordNotFound, with: :render_not_found_error
+      base.rescue_from ActiveRecord::RecordInvalid, with: :render_validation_errors
+    end
+
+    def render_error(exception)
+      render json: {errors: [{title: exception.message.downcase}]}, status: :bad_request
+    end
+
+    def render_not_found_error(exception)
+      render json: {errors: [{title: exception.message.downcase}]}, status: :not_found
+    end
+
+    def render_unauthorized_error(exception)
+      render json: {errors: [{title: exception.message.downcase}]}, status: :unauthorized
+    end
+
+    def render_validation_errors(ex_or_record)
+      record = ex_or_record.is_a?(ActiveRecord::Base) ? ex_or_record : ex_or_record.record
+      render json: {errors: record.errors.map { |e| {title: e.full_message} }}, status: :unprocessable_entity
+    end
+
+    def render_standard_error(_exception)
+      # add error logging
+      render json: {errors: [{title: "Unexpected error"}]}, status: :internal_server_error
+    end
+  end
+end

--- a/backend/config/initializers/inflections.rb
+++ b/backend/config/initializers/inflections.rb
@@ -1,16 +1,3 @@
-# Be sure to restart your server when you modify this file.
-
-# Add new inflection rules using the following format. Inflections
-# are locale specific, and you may define rules for as many different
-# locales as you wish. All of these examples are active by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.plural /^(ox)$/i, "\\1en"
-#   inflect.singular /^(ox)en/i, "\\1"
-#   inflect.irregular "person", "people"
-#   inflect.uncountable %w( fish sheep )
-# end
-
-# These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym "RESTful"
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym "API"
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Defines the root path route ("/")
-  # root "articles#index"
+  namespace :api, format: "json" do
+    namespace :v1 do
+    end
+  end
 end


### PR DESCRIPTION
Backend base API controller.

The controller is set up to use cookie authentication. I added the need of CSRF token that will be send to frontend as a cookie and should be sent back as `X-CSRF-TOKEN` (inspired by this https://blog.eq8.eu/article/rails-api-authentication-with-spa-csrf-tokens.html or this https://pragmaticstudio.com/tutorials/rails-session-cookies-for-api-authentication). Also, all requests will be required to be `application/json` requests, from what I know that should prevent any CSRF, but just in case we will also need CSRF token.

## Testing instructions

No need.

## Tracking

https://vizzuality.atlassian.net/browse/LET-119