### PR TITLE
[Backend] Open calls endpoint

### DIFF
--- a/backend/app/controllers/api/v1/open_calls_controller.rb
+++ b/backend/app/controllers/api/v1/open_calls_controller.rb
@@ -3,6 +3,8 @@ module API
     class OpenCallsController < BaseController
       include API::Pagination
 
+      before_action :fetch_open_call, only: [:show]
+
       def index
         open_calls = OpenCall.all.includes(:investor)
         pagy_object, open_calls = pagy(open_calls, page: current_page, items: per_page)
@@ -14,15 +16,13 @@ module API
       end
 
       def show
-        open_call = fetch_open_call
-
-        render json: OpenCallSerializer.new(open_call).serializable_hash
+        render json: OpenCallSerializer.new(@open_call).serializable_hash
       end
 
       private
 
       def fetch_open_call
-        OpenCall.friendly.find(params[:id])
+        @open_call = OpenCall.friendly.find(params[:id])
       end
     end
   end

--- a/backend/app/controllers/api/v1/open_calls_controller.rb
+++ b/backend/app/controllers/api/v1/open_calls_controller.rb
@@ -1,0 +1,29 @@
+module API
+  module V1
+    class OpenCallsController < BaseController
+      include API::Pagination
+
+      def index
+        open_calls = OpenCall.all.includes(:investor)
+        pagy_object, open_calls = pagy(open_calls, page: current_page, items: per_page)
+        render json: OpenCallSerializer.new(
+          open_calls,
+          links: pagination_links(:api_v1_open_calls_path, pagy_object),
+          meta: pagination_meta(pagy_object)
+        ).serializable_hash
+      end
+
+      def show
+        open_call = fetch_open_call
+
+        render json: OpenCallSerializer.new(open_call).serializable_hash
+      end
+
+      private
+
+      def fetch_open_call
+        OpenCall.friendly.find(params[:id])
+      end
+    end
+  end
+end

--- a/backend/app/controllers/concerns/api/errors.rb
+++ b/backend/app/controllers/concerns/api/errors.rb
@@ -12,15 +12,15 @@ module API
     end
 
     def render_error(exception)
-      render json: {errors: [{title: exception.message.downcase}]}, status: :bad_request
+      render json: {errors: [{title: exception.message}]}, status: :bad_request
     end
 
     def render_not_found_error(exception)
-      render json: {errors: [{title: exception.message.downcase}]}, status: :not_found
+      render json: {errors: [{title: exception.message}]}, status: :not_found
     end
 
     def render_unauthorized_error(exception)
-      render json: {errors: [{title: exception.message.downcase}]}, status: :unauthorized
+      render json: {errors: [{title: exception.message}]}, status: :unauthorized
     end
 
     def render_validation_errors(ex_or_record)

--- a/backend/app/models/account.rb
+++ b/backend/app/models/account.rb
@@ -10,6 +10,7 @@ class Account < ApplicationRecord
   validates :twitter, url: true
   validates :facebook, url: true
   validates :instagram, url: true
+  validates :language, inclusion: {in: I18n.available_locales.map(&:to_s)}
 
   def slug_preview
     set_slug unless slug.present?

--- a/backend/app/models/application_record.rb
+++ b/backend/app/models/application_record.rb
@@ -1,3 +1,5 @@
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
+
+  self.implicit_order_column = "created_at"
 end

--- a/backend/app/models/investor.rb
+++ b/backend/app/models/investor.rb
@@ -2,12 +2,15 @@ class Investor < ApplicationRecord
   include BelongsToAccount
   include Reviewable
 
+  has_many :open_calls, dependent: :destroy
+
   validates :categories, array_inclusion: {in: Category::TYPES}, presence: true
-  validates :impacts, array_inclusion: {in: Impact::TYPES}
   validates :instrument_types, array_inclusion: {in: InstrumentType::TYPES}, presence: true
-  validates :investor_type, inclusion: {in: InvestorType::TYPES, allow_blank: true}, presence: true
-  validates :sdgs, array_inclusion: {in: Sdg::TYPES}
   validates :ticket_sizes, array_inclusion: {in: TicketSize::TYPES}, presence: true
+  validates :impacts, array_inclusion: {in: Impact::TYPES}
+  validates :sdgs, array_inclusion: {in: Sdg::TYPES}
+  validates :investor_type, inclusion: {in: InvestorType::TYPES}
+  validates :language, inclusion: {in: I18n.available_locales.map(&:to_s)}
 
   translates :how_do_you_work, :what_makes_the_difference, :other_information, :previously_invested_description
 end

--- a/backend/app/models/open_call.rb
+++ b/backend/app/models/open_call.rb
@@ -4,11 +4,12 @@ class OpenCall < ApplicationRecord
 
   belongs_to :investor
 
-  validates :instrument_type, inclusion: {in: InstrumentType::TYPES, allow_blank: true}, presence: true
-  validates :ticket_size, inclusion: {in: TicketSize::TYPES, allow_blank: true}, presence: true
+  validates :instrument_type, inclusion: {in: InstrumentType::TYPES}
+  validates :ticket_size, inclusion: {in: TicketSize::TYPES}
   validates :sdgs, array_inclusion: {in: Sdg::TYPES}
+  validates :language, inclusion: {in: I18n.available_locales.map(&:to_s)}
 
-  validates_presence_of :closing_at, :language
+  validates_presence_of :closing_at
 
   translates :name, :description, :money_distribution, :impact_description
 
@@ -18,5 +19,8 @@ class OpenCall < ApplicationRecord
 
   def original_name
     I18n.with_locale(language) { name }
+    # to prevent crashing validations because of setting slug, fallback just to current locale name
+  rescue I18n::InvalidLocale
+    name
   end
 end

--- a/backend/app/models/open_call.rb
+++ b/backend/app/models/open_call.rb
@@ -1,0 +1,22 @@
+class OpenCall < ApplicationRecord
+  extend FriendlyId
+  friendly_id :investor_prefixed_name, use: :slugged
+
+  belongs_to :investor
+
+  validates :instrument_type, inclusion: {in: InstrumentType::TYPES, allow_blank: true}, presence: true
+  validates :ticket_size, inclusion: {in: TicketSize::TYPES, allow_blank: true}, presence: true
+  validates :sdgs, array_inclusion: {in: Sdg::TYPES}
+
+  validates_presence_of :closing_at, :language
+
+  translates :name, :description, :money_distribution, :impact_description
+
+  def investor_prefixed_name
+    "#{investor&.name} #{original_name}"
+  end
+
+  def original_name
+    I18n.with_locale(language) { name }
+  end
+end

--- a/backend/app/serializers/api/v1/open_call_serializer.rb
+++ b/backend/app/serializers/api/v1/open_call_serializer.rb
@@ -1,0 +1,14 @@
+module API
+  module V1
+    class OpenCallSerializer
+      include JSONAPI::Serializer
+
+      attributes :name, :slug, :description,
+        :ticket_size, :instrument_type, :sdgs,
+        :money_distribution, :impact_description,
+        :closing_at
+
+      belongs_to :investor
+    end
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   namespace :api, format: "json" do
     namespace :v1 do
       resources :investors, only: [:index, :show]
+      resources :open_calls, only: [:index, :show]
     end
   end
 end

--- a/backend/db/migrate/20220303132723_create_open_calls.rb
+++ b/backend/db/migrate/20220303132723_create_open_calls.rb
@@ -1,0 +1,38 @@
+class CreateOpenCalls < ActiveRecord::Migration[7.0]
+  def change
+    create_table :open_calls, id: :uuid do |t|
+      t.belongs_to :investor, foreign_key: {on_delete: :cascade}, type: :uuid, null: false, index: true
+
+      t.text :name_en
+      t.text :name_es
+      t.text :name_pt
+      t.text :slug
+      t.text :description_en
+      t.text :description_es
+      t.text :description_pt
+      t.text :money_distribution_en
+      t.text :money_distribution_es
+      t.text :money_distribution_pt
+      t.text :impact_description_en
+      t.text :impact_description_es
+      t.text :impact_description_pt
+
+      t.boolean :trusted, null: false, default: false
+
+      t.string :ticket_size, null: false
+      t.string :instrument_type, null: false
+      t.integer :sdgs, array: true
+
+      t.string :language, null: false
+
+      t.datetime :closing_at, null: false
+
+      t.index [:investor_id, :name_en], unique: true
+      t.index [:investor_id, :name_es], unique: true
+      t.index [:investor_id, :name_pt], unique: true
+      t.index :slug, unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_02_25_155135) do
+ActiveRecord::Schema[7.0].define(version: 2022_03_03_132723) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -101,7 +101,38 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_25_155135) do
     t.index ["account_id"], name: "index_investors_on_account_id"
   end
 
+  create_table "open_calls", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "investor_id", null: false
+    t.text "name_en"
+    t.text "name_es"
+    t.text "name_pt"
+    t.text "slug"
+    t.text "description_en"
+    t.text "description_es"
+    t.text "description_pt"
+    t.text "money_distribution_en"
+    t.text "money_distribution_es"
+    t.text "money_distribution_pt"
+    t.text "impact_description_en"
+    t.text "impact_description_es"
+    t.text "impact_description_pt"
+    t.boolean "trusted", default: false, null: false
+    t.string "ticket_size", null: false
+    t.string "instrument_type", null: false
+    t.integer "sdgs", array: true
+    t.string "language", null: false
+    t.datetime "closing_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["investor_id", "name_en"], name: "index_open_calls_on_investor_id_and_name_en", unique: true
+    t.index ["investor_id", "name_es"], name: "index_open_calls_on_investor_id_and_name_es", unique: true
+    t.index ["investor_id", "name_pt"], name: "index_open_calls_on_investor_id_and_name_pt", unique: true
+    t.index ["investor_id"], name: "index_open_calls_on_investor_id"
+    t.index ["slug"], name: "index_open_calls_on_slug", unique: true
+  end
+
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "investors", "accounts", on_delete: :cascade
+  add_foreign_key "open_calls", "investors", on_delete: :cascade
 end

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -4,9 +4,9 @@ if Rails.env.development?
   Account.delete_all
   Investor.delete_all
 
-  50.times do
+  5.times do
     investor_account = FactoryBot.create(:account)
-    Investor.create!(
+    investor = Investor.create!(
       account: investor_account,
       categories: Category::TYPES.shuffle.take((1..2).to_a.sample),
       sdgs: Sdg::TYPES.shuffle.take((1..10).to_a.sample),
@@ -21,5 +21,8 @@ if Rails.env.development?
       other_information: Faker::Lorem.paragraph(sentence_count: 4),
       language: investor_account.language
     )
+    (0..3).to_a.sample.times do
+      FactoryBot.create(:open_call, investor: investor)
+    end
   end
 end

--- a/backend/spec/factories/open_call.rb
+++ b/backend/spec/factories/open_call.rb
@@ -1,0 +1,23 @@
+FactoryBot.define do
+  factory :open_call do
+    investor
+
+    sequence(:name) do |n|
+      "Open call #{n}"
+    end
+
+    sdgs { [1, 4, 5] }
+    instrument_type { "loan" }
+    ticket_size { "scaling" }
+
+    trusted { false }
+
+    description { Faker::Lorem.paragraph(sentence_count: 4) }
+    money_distribution { Faker::Lorem.paragraph(sentence_count: 4) }
+    impact_description { Faker::Lorem.paragraph(sentence_count: 4) }
+
+    language { "en" }
+
+    closing_at { 10.months.from_now }
+  end
+end

--- a/backend/spec/fixtures/snapshots/api/v1/get-open_call-not-found.json
+++ b/backend/spec/fixtures/snapshots/api/v1/get-open_call-not-found.json
@@ -1,0 +1,7 @@
+{
+  "errors": [
+    {
+      "title": "can't find record with friendly id: \"not-found\""
+    }
+  ]
+}

--- a/backend/spec/fixtures/snapshots/api/v1/get-open_call.json
+++ b/backend/spec/fixtures/snapshots/api/v1/get-open_call.json
@@ -1,0 +1,29 @@
+{
+  "data": {
+    "id": "0436adc8-9ec9-422c-9486-a44ce021eedf",
+    "type": "open_call",
+    "attributes": {
+      "name": "Open call 1",
+      "slug": "kutch-spencer-open-call-1",
+      "description": "Voluptatem blanditiis autem. Iste voluptates rerum. Animi tempore iure. Inventore facere ad.",
+      "ticket_size": "scaling",
+      "instrument_type": "loan",
+      "sdgs": [
+        1,
+        4,
+        5
+      ],
+      "money_distribution": "Et dolorem assumenda. Praesentium magni totam. Dolorem minima et. Incidunt omnis error.",
+      "impact_description": "Voluptas molestiae est. Omnis asperiores quia. Dolorem autem corrupti. Totam nemo laborum.",
+      "closing_at": "2023-01-03T15:10:20.792Z"
+    },
+    "relationships": {
+      "investor": {
+        "data": {
+          "id": "6618f883-0d83-4b35-a476-9ca3dcc669bb",
+          "type": "investor"
+        }
+      }
+    }
+  }
+}

--- a/backend/spec/fixtures/snapshots/api/v1/open_calls.json
+++ b/backend/spec/fixtures/snapshots/api/v1/open_calls.json
@@ -1,0 +1,206 @@
+{
+  "data": [
+    {
+      "id": "0436adc8-9ec9-422c-9486-a44ce021eedf",
+      "type": "open_call",
+      "attributes": {
+        "name": "Open call 1",
+        "slug": "kutch-spencer-open-call-1",
+        "description": "Voluptatem blanditiis autem. Iste voluptates rerum. Animi tempore iure. Inventore facere ad.",
+        "ticket_size": "scaling",
+        "instrument_type": "loan",
+        "sdgs": [
+          1,
+          4,
+          5
+        ],
+        "money_distribution": "Et dolorem assumenda. Praesentium magni totam. Dolorem minima et. Incidunt omnis error.",
+        "impact_description": "Voluptas molestiae est. Omnis asperiores quia. Dolorem autem corrupti. Totam nemo laborum.",
+        "closing_at": "2023-01-03T15:10:20.792Z"
+      },
+      "relationships": {
+        "investor": {
+          "data": {
+            "id": "6618f883-0d83-4b35-a476-9ca3dcc669bb",
+            "type": "investor"
+          }
+        }
+      }
+    },
+    {
+      "id": "4279690a-325c-4c53-8895-3fb27eda45f8",
+      "type": "open_call",
+      "attributes": {
+        "name": "Open call 2",
+        "slug": "bartoletti-and-sons-open-call-2",
+        "description": "Molestias blanditiis voluptatibus. Temporibus eaque molestiae. Amet quia sit. Consequatur quas dicta.",
+        "ticket_size": "scaling",
+        "instrument_type": "loan",
+        "sdgs": [
+          1,
+          4,
+          5
+        ],
+        "money_distribution": "Placeat ut harum. Nihil autem non. Et debitis et. Itaque eum sit.",
+        "impact_description": "Quisquam ut ipsa. Eligendi aut aut. Aperiam aut odit. Minima delectus tenetur.",
+        "closing_at": "2023-01-03T15:10:20.829Z"
+      },
+      "relationships": {
+        "investor": {
+          "data": {
+            "id": "48c4d431-2e1d-4cd8-bffe-bbd6a7333feb",
+            "type": "investor"
+          }
+        }
+      }
+    },
+    {
+      "id": "a7a2167d-74f0-4687-90b4-68fa0f567895",
+      "type": "open_call",
+      "attributes": {
+        "name": "Open call 3",
+        "slug": "hane-lehner-and-goyette-open-call-3",
+        "description": "Dolor dicta labore. Ab fugit excepturi. Iure maiores sint. Dolorem minus veniam.",
+        "ticket_size": "scaling",
+        "instrument_type": "loan",
+        "sdgs": [
+          1,
+          4,
+          5
+        ],
+        "money_distribution": "Ut impedit molestiae. Velit impedit fugiat. Itaque culpa tempora. Optio amet sunt.",
+        "impact_description": "Voluptate fugit ipsam. Sapiente asperiores ut. Eos voluptatem id. Illum qui adipisci.",
+        "closing_at": "2023-01-03T15:10:20.865Z"
+      },
+      "relationships": {
+        "investor": {
+          "data": {
+            "id": "5298f589-bb52-4d24-b594-d6da699510ab",
+            "type": "investor"
+          }
+        }
+      }
+    },
+    {
+      "id": "589c9e27-38ee-48f5-ae5e-6bf277fc4a70",
+      "type": "open_call",
+      "attributes": {
+        "name": "Open call 4",
+        "slug": "hilpert-waters-and-johnston-open-call-4",
+        "description": "Vel quis ut. Eaque et illo. Eos eaque magni. At labore dignissimos.",
+        "ticket_size": "scaling",
+        "instrument_type": "loan",
+        "sdgs": [
+          1,
+          4,
+          5
+        ],
+        "money_distribution": "Praesentium vitae unde. Officiis veritatis temporibus. Magni molestias error. Est voluptas est.",
+        "impact_description": "Rerum optio iure. Aspernatur suscipit asperiores. Consequuntur ab molestiae. Ut sit nihil.",
+        "closing_at": "2023-01-03T15:10:20.902Z"
+      },
+      "relationships": {
+        "investor": {
+          "data": {
+            "id": "93709e67-79d9-493c-9b5d-78bb0204612b",
+            "type": "investor"
+          }
+        }
+      }
+    },
+    {
+      "id": "86695233-d889-4707-89ee-9b7b6201f381",
+      "type": "open_call",
+      "attributes": {
+        "name": "Open call 5",
+        "slug": "jacobson-fritsch-and-stanton-open-call-5",
+        "description": "Laboriosam rem qui. Quia et est. Quos fugiat voluptatem. Iusto animi voluptatem.",
+        "ticket_size": "scaling",
+        "instrument_type": "loan",
+        "sdgs": [
+          1,
+          4,
+          5
+        ],
+        "money_distribution": "Labore est sit. Maxime amet dolores. Ut sint suscipit. Saepe minima dolores.",
+        "impact_description": "Non qui velit. Exercitationem adipisci delectus. Voluptate distinctio eos. A porro vero.",
+        "closing_at": "2023-01-03T15:10:20.940Z"
+      },
+      "relationships": {
+        "investor": {
+          "data": {
+            "id": "e32e1f8e-2fce-45c1-a12e-1d4b4300e5f4",
+            "type": "investor"
+          }
+        }
+      }
+    },
+    {
+      "id": "8492f44a-edc7-4ebd-b90b-848e9eb53de6",
+      "type": "open_call",
+      "attributes": {
+        "name": "Open call 6",
+        "slug": "keebler-kub-and-zemlak-open-call-6",
+        "description": "Nesciunt modi architecto. Laudantium saepe molestiae. Vero porro nam. In eum numquam.",
+        "ticket_size": "scaling",
+        "instrument_type": "loan",
+        "sdgs": [
+          1,
+          4,
+          5
+        ],
+        "money_distribution": "Exercitationem earum placeat. Voluptas sapiente ut. Deleniti aut pariatur. Sint non eum.",
+        "impact_description": "Eos quia rem. Vitae minus laudantium. Ipsa quod quia. Voluptas et reiciendis.",
+        "closing_at": "2023-01-03T15:10:20.983Z"
+      },
+      "relationships": {
+        "investor": {
+          "data": {
+            "id": "7ef58183-8430-47ea-b697-bb8fd4b08d2e",
+            "type": "investor"
+          }
+        }
+      }
+    },
+    {
+      "id": "422af6d1-bf18-4ae6-ab0b-89eb5a89fad4",
+      "type": "open_call",
+      "attributes": {
+        "name": "Open call 7",
+        "slug": "becker-llc-open-call-7",
+        "description": "Earum sequi iusto. Quas assumenda vitae. Quia quia repudiandae. Commodi nobis est.",
+        "ticket_size": "scaling",
+        "instrument_type": "loan",
+        "sdgs": [
+          1,
+          4,
+          5
+        ],
+        "money_distribution": "Temporibus incidunt non. Qui cum officiis. Voluptatem ducimus nam. Non dolores accusantium.",
+        "impact_description": "Assumenda quae excepturi. Possimus et facilis. Vitae rem quo. Aut omnis in.",
+        "closing_at": "2023-01-03T15:10:21.030Z"
+      },
+      "relationships": {
+        "investor": {
+          "data": {
+            "id": "3deb7095-fffb-4c26-a1a2-77890ca7d5c4",
+            "type": "investor"
+          }
+        }
+      }
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "per_page": 10,
+    "from": 1,
+    "to": 7,
+    "total": 7,
+    "pages": 1
+  },
+  "links": {
+    "first": "/api/v1/open_calls?page%5Bsize%5D=10",
+    "self": "/api/v1/open_calls?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+    "last": "/api/v1/open_calls?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+  }
+}

--- a/backend/spec/models/account_spec.rb
+++ b/backend/spec/models/account_spec.rb
@@ -10,6 +10,16 @@ RSpec.describe Account, type: :model do
     expect(subject).to have(1).errors_on(:name)
   end
 
+  it "should not be valid with wrong language" do
+    subject.language = "fr"
+    expect(subject).to have(1).errors_on(:language)
+  end
+
+  it "should not be valid without language" do
+    subject.language = nil
+    expect(subject).to have(1).errors_on(:language)
+  end
+
   it "should not be valid if name is taken" do
     create(:account, name: "taken")
     subject.name = "Taken"

--- a/backend/spec/models/investor_spec.rb
+++ b/backend/spec/models/investor_spec.rb
@@ -10,6 +10,16 @@ RSpec.describe Investor, type: :model do
     expect(subject).to have(1).errors_on(:account)
   end
 
+  it "should not be valid with wrong language" do
+    subject.language = "fr"
+    expect(subject).to have(1).errors_on(:language)
+  end
+
+  it "should not be valid without language" do
+    subject.language = nil
+    expect(subject).to have(1).errors_on(:language)
+  end
+
   include_examples :static_relation_validations, attribute: :investor_type
   include_examples :static_relation_validations, attribute: :impacts, presence: false
   include_examples :static_relation_validations, attribute: :instrument_types

--- a/backend/spec/models/open_call_spec.rb
+++ b/backend/spec/models/open_call_spec.rb
@@ -15,6 +15,11 @@ RSpec.describe OpenCall, type: :model do
     expect(subject).to have(1).errors_on(:closing_at)
   end
 
+  it "should not be valid with wrong language" do
+    subject.language = "fr"
+    expect(subject).to have(1).errors_on(:language)
+  end
+
   it "should not be valid without language" do
     subject.language = nil
     expect(subject).to have(1).errors_on(:language)

--- a/backend/spec/models/open_call_spec.rb
+++ b/backend/spec/models/open_call_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe OpenCall, type: :model do
+  subject { build(:open_call) }
+
+  it { is_expected.to be_valid }
+
+  it "should not be valid without investor" do
+    subject.investor = nil
+    expect(subject).to have(1).errors_on(:investor)
+  end
+
+  it "should not be valid without closing at date" do
+    subject.closing_at = nil
+    expect(subject).to have(1).errors_on(:closing_at)
+  end
+
+  it "should not be valid without language" do
+    subject.language = nil
+    expect(subject).to have(1).errors_on(:language)
+  end
+
+  include_examples :static_relation_validations, attribute: :instrument_type
+  include_examples :static_relation_validations, attribute: :ticket_size
+  include_examples :static_relation_validations, attribute: :sdgs, presence: false
+end

--- a/backend/spec/requests/api/v1/open_calls_spec.rb
+++ b/backend/spec/requests/api/v1/open_calls_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe "API V1 Open Calls", type: :request do
+  before_all do
+    @open_call = create(:open_call)
+    create_list(:open_call, 6)
+  end
+
+  include_examples :api_pagination, model: OpenCall, expected_total: 7
+
+  describe "GET #index" do
+    it "should return open_calls" do
+      get "/api/v1/open_calls"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to match_snapshot("api/v1/open_calls", dynamic_attributes: %w[closing_at])
+    end
+  end
+
+  describe "GET #show" do
+    it "should return single open_call" do
+      get "/api/v1/open_calls/#{@open_call.id}"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to match_snapshot("api/v1/get-open_call", dynamic_attributes: %w[closing_at])
+    end
+
+    it "should return open_call by slug" do
+      get "/api/v1/open_calls/#{@open_call.slug}"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to match_snapshot("api/v1/get-open_call", dynamic_attributes: %w[closing_at])
+    end
+
+    describe "errors" do
+      it "displays not found error" do
+        get "/api/v1/open_calls/not-found"
+
+        expect(response).to have_http_status(:not_found)
+        expect(response.body).to match_snapshot("api/v1/get-open_call-not-found")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Open calls endpoints

- api/v1/open_calls/:slug
- api/v1/open_calls/:uuid
- api/v1/open_calls

To create open call slug, I'm using account name and open call name. The slug is done from open call original name (base language).

```
{
  "data": {
    "id": "0436adc8-9ec9-422c-9486-a44ce021eedf",
    "type": "open_call",
    "attributes": {
      "name": "Open call 1",
      "slug": "kutch-spencer-open-call-1",
      "description": "Voluptatem blanditiis autem. Iste voluptates rerum. Animi tempore iure. Inventore facere ad.",
      "ticket_size": "scaling",
      "instrument_type": "loan",
      "sdgs": [
        1,
        4,
        5
      ],
      "money_distribution": "Et dolorem assumenda. Praesentium magni totam. Dolorem minima et. Incidunt omnis error.",
      "impact_description": "Voluptas molestiae est. Omnis asperiores quia. Dolorem autem corrupti. Totam nemo laborum.",
      "closing_at": "2023-01-03T15:10:20.792Z"
    },
    "relationships": {
      "investor": {
        "data": {
          "id": "6618f883-0d83-4b35-a476-9ca3dcc669bb",
          "type": "investor"
        }
      }
    }
  }
}
```

## Testing instructions

Test endpoints. Also, the full spec suite has been done, please review it.

## Tracking

https://vizzuality.atlassian.net/browse/LET-110
https://vizzuality.atlassian.net/browse/LET-117
