### PR TITLE
[Backend] API sparse fieldset

### DIFF
--- a/backend/app/controllers/api/v1/base_controller.rb
+++ b/backend/app/controllers/api/v1/base_controller.rb
@@ -6,6 +6,7 @@ module API
       include API::Errors
       include API::Authentication
       include API::Localization
+      include API::SparseFieldset
 
       protect_from_forgery with: :exception
 

--- a/backend/app/controllers/api/v1/investors_controller.rb
+++ b/backend/app/controllers/api/v1/investors_controller.rb
@@ -8,6 +8,7 @@ module API
         pagy_object, investors = pagy(investors, page: current_page, items: per_page)
         render json: InvestorSerializer.new(
           investors,
+          fields: sparse_fieldset,
           links: pagination_links(:api_v1_investors_path, pagy_object),
           meta: pagination_meta(pagy_object)
         ).serializable_hash
@@ -16,7 +17,10 @@ module API
       def show
         investor = fetch_investor
 
-        render json: InvestorSerializer.new(investor).serializable_hash
+        render json: InvestorSerializer.new(
+          investor,
+          fields: sparse_fieldset
+        ).serializable_hash
       end
 
       private

--- a/backend/app/controllers/api/v1/open_calls_controller.rb
+++ b/backend/app/controllers/api/v1/open_calls_controller.rb
@@ -10,13 +10,17 @@ module API
         pagy_object, open_calls = pagy(open_calls, page: current_page, items: per_page)
         render json: OpenCallSerializer.new(
           open_calls,
+          fields: sparse_fieldset,
           links: pagination_links(:api_v1_open_calls_path, pagy_object),
           meta: pagination_meta(pagy_object)
         ).serializable_hash
       end
 
       def show
-        render json: OpenCallSerializer.new(@open_call).serializable_hash
+        render json: OpenCallSerializer.new(
+          @open_call,
+          fields: sparse_fieldset
+        ).serializable_hash
       end
 
       private

--- a/backend/app/controllers/api/v1/project_developers_controller.rb
+++ b/backend/app/controllers/api/v1/project_developers_controller.rb
@@ -8,6 +8,7 @@ module API
         pagy_object, project_developers = pagy(project_developers, page: current_page, items: per_page)
         render json: ProjectDeveloperSerializer.new(
           project_developers,
+          fields: sparse_fieldset,
           links: pagination_links(:api_v1_project_developers_path, pagy_object),
           meta: pagination_meta(pagy_object)
         ).serializable_hash
@@ -16,7 +17,10 @@ module API
       def show
         project_developer = fetch_project_developer
 
-        render json: ProjectDeveloperSerializer.new(project_developer).serializable_hash
+        render json: ProjectDeveloperSerializer.new(
+          project_developer,
+          fields: sparse_fieldset
+        ).serializable_hash
       end
 
       private

--- a/backend/app/controllers/concerns/api/sparse_fieldset.rb
+++ b/backend/app/controllers/concerns/api/sparse_fieldset.rb
@@ -1,0 +1,7 @@
+module API
+  module SparseFieldset
+    def sparse_fieldset
+      (params[:fields]&.to_unsafe_h || {}).transform_values { |v| v.split(",") }
+    end
+  end
+end

--- a/backend/spec/fixtures/snapshots/api/v1/get-investor-sparse-fieldset.json
+++ b/backend/spec/fixtures/snapshots/api/v1/get-investor-sparse-fieldset.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "id": "c9a30461-a0ab-4513-aba4-8700e838d972",
+    "type": "investor",
+    "attributes": {
+      "instagram": "https://instagram.com/kutch-spencer",
+      "facebook": "https://facebook.com/kutch-spencer"
+    }
+  }
+}

--- a/backend/spec/fixtures/snapshots/api/v1/get-open-call-sparse-fieldset.json
+++ b/backend/spec/fixtures/snapshots/api/v1/get-open-call-sparse-fieldset.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "id": "9b9cda53-083a-4a83-9f68-59dc938ca0ed",
+    "type": "open_call",
+    "attributes": {
+      "name": "Open call 1",
+      "description": "Voluptatem blanditiis autem. Iste voluptates rerum. Animi tempore iure. Inventore facere ad."
+    },
+    "relationships": {
+    }
+  }
+}

--- a/backend/spec/fixtures/snapshots/api/v1/get-project-developer-sparse-fieldset.json
+++ b/backend/spec/fixtures/snapshots/api/v1/get-project-developer-sparse-fieldset.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "id": "6e04d4ae-358a-46e2-a093-a80a43539f1b",
+    "type": "project_developer",
+    "attributes": {
+      "instagram": "https://instagram.com/kutch-spencer",
+      "facebook": "https://facebook.com/kutch-spencer"
+    }
+  }
+}

--- a/backend/spec/fixtures/snapshots/api/v1/investors-sparse-fieldset.json
+++ b/backend/spec/fixtures/snapshots/api/v1/investors-sparse-fieldset.json
@@ -1,0 +1,73 @@
+{
+  "data": [
+    {
+      "id": "c9a30461-a0ab-4513-aba4-8700e838d972",
+      "type": "investor",
+      "attributes": {
+        "instagram": "https://instagram.com/kutch-spencer",
+        "facebook": "https://facebook.com/kutch-spencer"
+      }
+    },
+    {
+      "id": "c707a731-b1ca-49a6-ab53-d7a59fef752e",
+      "type": "investor",
+      "attributes": {
+        "instagram": "https://instagram.com/bartoletti-and-sons",
+        "facebook": "https://facebook.com/bartoletti-and-sons"
+      }
+    },
+    {
+      "id": "69cce555-3b54-40e7-ba8e-58518d0bc238",
+      "type": "investor",
+      "attributes": {
+        "instagram": "https://instagram.com/hane-lehner-and-goyette",
+        "facebook": "https://facebook.com/hane-lehner-and-goyette"
+      }
+    },
+    {
+      "id": "01008dd7-9b44-4621-b734-791f2ef5a2c7",
+      "type": "investor",
+      "attributes": {
+        "instagram": "https://instagram.com/hilpert-waters-and-johnston",
+        "facebook": "https://facebook.com/hilpert-waters-and-johnston"
+      }
+    },
+    {
+      "id": "2ce42988-6e27-4b43-8b76-dcc89e65e1d0",
+      "type": "investor",
+      "attributes": {
+        "instagram": "https://instagram.com/jacobson-fritsch-and-stanton",
+        "facebook": "https://facebook.com/jacobson-fritsch-and-stanton"
+      }
+    },
+    {
+      "id": "f01ccdcd-5e2b-4e4a-ac4c-33b32397e3f4",
+      "type": "investor",
+      "attributes": {
+        "instagram": "https://instagram.com/keebler-kub-and-zemlak",
+        "facebook": "https://facebook.com/keebler-kub-and-zemlak"
+      }
+    },
+    {
+      "id": "dcfd920b-b090-47fb-8a78-b89ba667851a",
+      "type": "investor",
+      "attributes": {
+        "instagram": "https://instagram.com/becker-llc",
+        "facebook": "https://facebook.com/becker-llc"
+      }
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "per_page": 10,
+    "from": 1,
+    "to": 7,
+    "total": 7,
+    "pages": 1
+  },
+  "links": {
+    "first": "/api/v1/investors?page%5Bsize%5D=10",
+    "self": "/api/v1/investors?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+    "last": "/api/v1/investors?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+  }
+}

--- a/backend/spec/fixtures/snapshots/api/v1/open-calls-sparse-fieldset.json
+++ b/backend/spec/fixtures/snapshots/api/v1/open-calls-sparse-fieldset.json
@@ -1,0 +1,87 @@
+{
+  "data": [
+    {
+      "id": "9b9cda53-083a-4a83-9f68-59dc938ca0ed",
+      "type": "open_call",
+      "attributes": {
+        "name": "Open call 1",
+        "description": "Voluptatem blanditiis autem. Iste voluptates rerum. Animi tempore iure. Inventore facere ad."
+      },
+      "relationships": {
+      }
+    },
+    {
+      "id": "44db5d4b-3e6b-42fe-8552-7beb9f6ccde0",
+      "type": "open_call",
+      "attributes": {
+        "name": "Open call 2",
+        "description": "Molestias blanditiis voluptatibus. Temporibus eaque molestiae. Amet quia sit. Consequatur quas dicta."
+      },
+      "relationships": {
+      }
+    },
+    {
+      "id": "adfa5e3d-6d26-4602-aacb-b2bba5f74c37",
+      "type": "open_call",
+      "attributes": {
+        "name": "Open call 3",
+        "description": "Dolor dicta labore. Ab fugit excepturi. Iure maiores sint. Dolorem minus veniam."
+      },
+      "relationships": {
+      }
+    },
+    {
+      "id": "e76d42c7-0efd-4d36-a283-503b197b28f2",
+      "type": "open_call",
+      "attributes": {
+        "name": "Open call 4",
+        "description": "Vel quis ut. Eaque et illo. Eos eaque magni. At labore dignissimos."
+      },
+      "relationships": {
+      }
+    },
+    {
+      "id": "ac7afeee-8f57-4b81-bba6-243a514f07e3",
+      "type": "open_call",
+      "attributes": {
+        "name": "Open call 5",
+        "description": "Laboriosam rem qui. Quia et est. Quos fugiat voluptatem. Iusto animi voluptatem."
+      },
+      "relationships": {
+      }
+    },
+    {
+      "id": "60d3c4f2-7fb9-49bb-b62b-228e0f670e3c",
+      "type": "open_call",
+      "attributes": {
+        "name": "Open call 6",
+        "description": "Nesciunt modi architecto. Laudantium saepe molestiae. Vero porro nam. In eum numquam."
+      },
+      "relationships": {
+      }
+    },
+    {
+      "id": "7d404367-a350-49ce-a1af-54ff6d98de7d",
+      "type": "open_call",
+      "attributes": {
+        "name": "Open call 7",
+        "description": "Earum sequi iusto. Quas assumenda vitae. Quia quia repudiandae. Commodi nobis est."
+      },
+      "relationships": {
+      }
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "per_page": 10,
+    "from": 1,
+    "to": 7,
+    "total": 7,
+    "pages": 1
+  },
+  "links": {
+    "first": "/api/v1/open_calls?page%5Bsize%5D=10",
+    "self": "/api/v1/open_calls?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+    "last": "/api/v1/open_calls?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+  }
+}

--- a/backend/spec/fixtures/snapshots/api/v1/project-developers-sparse-fieldset.json
+++ b/backend/spec/fixtures/snapshots/api/v1/project-developers-sparse-fieldset.json
@@ -1,0 +1,73 @@
+{
+  "data": [
+    {
+      "id": "6e04d4ae-358a-46e2-a093-a80a43539f1b",
+      "type": "project_developer",
+      "attributes": {
+        "instagram": "https://instagram.com/kutch-spencer",
+        "facebook": "https://facebook.com/kutch-spencer"
+      }
+    },
+    {
+      "id": "7d6fd256-2a8f-4753-ab93-c75b82cb07f6",
+      "type": "project_developer",
+      "attributes": {
+        "instagram": "https://instagram.com/bartoletti-and-sons",
+        "facebook": "https://facebook.com/bartoletti-and-sons"
+      }
+    },
+    {
+      "id": "f19bcdf2-072f-45c7-b789-5dfca6b98c8f",
+      "type": "project_developer",
+      "attributes": {
+        "instagram": "https://instagram.com/hane-lehner-and-goyette",
+        "facebook": "https://facebook.com/hane-lehner-and-goyette"
+      }
+    },
+    {
+      "id": "79ee58fe-a6d0-45c6-aaa0-2fb6bc9bba2f",
+      "type": "project_developer",
+      "attributes": {
+        "instagram": "https://instagram.com/hilpert-waters-and-johnston",
+        "facebook": "https://facebook.com/hilpert-waters-and-johnston"
+      }
+    },
+    {
+      "id": "50b6de25-7e27-454b-a0c6-5948019fb14f",
+      "type": "project_developer",
+      "attributes": {
+        "instagram": "https://instagram.com/jacobson-fritsch-and-stanton",
+        "facebook": "https://facebook.com/jacobson-fritsch-and-stanton"
+      }
+    },
+    {
+      "id": "cd0c335e-9827-443f-972f-c202aa736ecc",
+      "type": "project_developer",
+      "attributes": {
+        "instagram": "https://instagram.com/keebler-kub-and-zemlak",
+        "facebook": "https://facebook.com/keebler-kub-and-zemlak"
+      }
+    },
+    {
+      "id": "32e7a50d-0aac-4004-b570-d7f005586b76",
+      "type": "project_developer",
+      "attributes": {
+        "instagram": "https://instagram.com/becker-llc",
+        "facebook": "https://facebook.com/becker-llc"
+      }
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "per_page": 10,
+    "from": 1,
+    "to": 7,
+    "total": 7,
+    "pages": 1
+  },
+  "links": {
+    "first": "/api/v1/project_developers?page%5Bsize%5D=10",
+    "self": "/api/v1/project_developers?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+    "last": "/api/v1/project_developers?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+  }
+}

--- a/backend/spec/requests/api/v1/investors_spec.rb
+++ b/backend/spec/requests/api/v1/investors_spec.rb
@@ -15,6 +15,15 @@ RSpec.describe "API V1 Investors", type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.body).to match_snapshot("api/v1/investors")
     end
+
+    describe "sparse fieldset" do
+      it "should work" do
+        get "/api/v1/investors?fields[investor]=instagram,facebook,nonexisting"
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to match_snapshot("api/v1/investors-sparse-fieldset")
+      end
+    end
   end
 
   describe "GET #show" do
@@ -38,6 +47,15 @@ RSpec.describe "API V1 Investors", type: :request do
 
         expect(response).to have_http_status(:not_found)
         expect(response.body).to match_snapshot("api/v1/get-investor-not-found")
+      end
+    end
+
+    describe "sparse fieldset" do
+      it "should work" do
+        get "/api/v1/investors/#{@investor.id}?fields[investor]=instagram,facebook,nonexisting"
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to match_snapshot("api/v1/get-investor-sparse-fieldset")
       end
     end
   end

--- a/backend/spec/requests/api/v1/open_calls_spec.rb
+++ b/backend/spec/requests/api/v1/open_calls_spec.rb
@@ -15,6 +15,15 @@ RSpec.describe "API V1 Open Calls", type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.body).to match_snapshot("api/v1/open_calls", dynamic_attributes: %w[closing_at])
     end
+
+    describe "sparse fieldset" do
+      it "should work" do
+        get "/api/v1/open_calls?fields[open_call]=name,description,nonexisting"
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to match_snapshot("api/v1/open-calls-sparse-fieldset")
+      end
+    end
   end
 
   describe "GET #show" do
@@ -38,6 +47,15 @@ RSpec.describe "API V1 Open Calls", type: :request do
 
         expect(response).to have_http_status(:not_found)
         expect(response.body).to match_snapshot("api/v1/get-open_call-not-found")
+      end
+    end
+
+    describe "sparse fieldset" do
+      it "should work" do
+        get "/api/v1/open_calls/#{@open_call.id}?fields[open_call]=name,description,nonexisting"
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to match_snapshot("api/v1/get-open-call-sparse-fieldset")
       end
     end
   end

--- a/backend/spec/requests/api/v1/project_developers_spec.rb
+++ b/backend/spec/requests/api/v1/project_developers_spec.rb
@@ -15,6 +15,15 @@ RSpec.describe "API V1 ProjectDevelopers", type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.body).to match_snapshot("api/v1/project_developers")
     end
+
+    describe "sparse fieldset" do
+      it "should work" do
+        get "/api/v1/project_developers?fields[project_developer]=instagram,facebook,nonexisting"
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to match_snapshot("api/v1/project-developers-sparse-fieldset")
+      end
+    end
   end
 
   describe "GET #show" do
@@ -38,6 +47,15 @@ RSpec.describe "API V1 ProjectDevelopers", type: :request do
 
         expect(response).to have_http_status(:not_found)
         expect(response.body).to match_snapshot("api/v1/get-project-developer-not-found")
+      end
+    end
+
+    describe "sparse fieldset" do
+      it "should work" do
+        get "/api/v1/project_developers/#{@project_developer.id}?fields[project_developer]=instagram,facebook,nonexisting"
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to match_snapshot("api/v1/get-project-developer-sparse-fieldset")
       end
     end
   end


### PR DESCRIPTION
Allow for sparse fieldset (very basic for now)

For example `api/v1/investors?fields[investor]=instagram,facebook`

We can use this for lists, map endpoints for which we don't need all the attributes.

## Testing instructions

Try API investors endpoint with different fields

## Tracking

No tracking
