### PR TITLE
Replace `lodash` by `lodash-es` to reduce the bundle size

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -50,7 +50,7 @@
             "position": "after"
           },
           {
-            "pattern": "lodash/**",
+            "pattern": "lodash-es/**",
             "group": "builtin",
             "position": "after"
           },

--- a/frontend/components/button/component.tsx
+++ b/frontend/components/button/component.tsx
@@ -2,9 +2,9 @@ import React, { forwardRef } from 'react';
 
 import cx from 'classnames';
 
-import omit from 'lodash/omit';
-
 import Link from 'next/link';
+
+import { omit } from 'lodash-es';
 
 import Icon from 'components/icon';
 

--- a/frontend/components/map/component.tsx
+++ b/frontend/components/map/component.tsx
@@ -4,10 +4,9 @@ import ReactMapGL, { FlyToInterpolator, TRANSITION_EVENTS } from 'react-map-gl';
 
 import cx from 'classnames';
 
-import isEmpty from 'lodash/isEmpty';
-
 import { fitBounds } from '@math.gl/web-mercator';
 import { easeCubic } from 'd3-ease';
+import { isEmpty } from 'lodash-es';
 import { useDebouncedCallback } from 'use-debounce';
 
 import { DEFAULT_VIEWPORT } from './constants';

--- a/frontend/layouts/static-page/component.tsx
+++ b/frontend/layouts/static-page/component.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import cx from 'classnames';
 
-import omit from 'lodash/omit';
+import { omit } from 'lodash-es';
 
 import Footer from './footer';
 import Header from './header';

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -68,7 +68,7 @@
     "framer-motion": "^4.1.17",
     "jsona": "^1.9.2",
     "jsonwebtoken": "^8.5.1",
-    "lodash": "^4.17.21",
+    "lodash-es": "^4.17.21",
     "next": "^12.1.0",
     "next-auth": "^3.21.1",
     "popmotion": "^9.3.6",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -12168,7 +12168,7 @@ __metadata:
     jest: ^27.5.1
     jsona: ^1.9.2
     jsonwebtoken: ^8.5.1
-    lodash: ^4.17.21
+    lodash-es: ^4.17.21
     next: ^12.1.0
     next-auth: ^3.21.1
     popmotion: ^9.3.6
@@ -14349,6 +14349,13 @@ __metadata:
   dependencies:
     p-locate: ^5.0.0
   checksum: 72eb661788a0368c099a184c59d2fee760b3831c9c1c33955e8a19ae4a21b4116e53fa736dc086cdeb9fce9f7cc508f2f92d2d3aae516f133e16a2bb59a39f5a
+  languageName: node
+  linkType: hard
+
+"lodash-es@npm:^4.17.21":
+  version: 4.17.21
+  resolution: "lodash-es@npm:4.17.21"
+  checksum: 05cbffad6e2adbb331a4e16fbd826e7faee403a1a04873b82b42c0f22090f280839f85b95393f487c1303c8a3d2a010048bf06151a6cbe03eee4d388fb0a12d2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR replaces `lodash` by `lodash-es` (which is tree-shakeable) to reduce the bundle size of the application.

## Testing instructions

−

## Tracking

Not tracked.
