### PR TITLE
Use Rswag

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -7,6 +7,7 @@ gem "rails", "~> 7.0.1"
 gem "pg", "~> 1.1"
 gem "puma", "~> 5.0"
 gem "redis", "~> 4.0"
+gem "rswag"
 
 gem "cssbundling-rails"
 gem "jsbundling-rails"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -66,6 +66,8 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
     annotate (3.2.0)
       activerecord (>= 3.2, < 8.0)
       rake (>= 10.4, < 14.0)
@@ -109,6 +111,8 @@ GEM
       reline (>= 0.3.0)
     jsbundling-rails (1.0.2)
       railties (>= 6.0.0)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
     jsonapi-serializer (2.2.0)
       activesupport (>= 4.2)
     loofah (2.14.0)
@@ -150,6 +154,7 @@ GEM
     patience_diff (1.2.0)
       optimist (~> 3.0)
     pg (1.3.4)
+    public_suffix (4.0.6)
     puma (5.6.2)
       nio4r (~> 2.0)
     racc (1.6.0)
@@ -214,6 +219,19 @@ GEM
     rspec-request_snapshot (0.7.3)
       rspec (~> 3.0)
     rspec-support (3.11.0)
+    rswag (2.5.1)
+      rswag-api (= 2.5.1)
+      rswag-specs (= 2.5.1)
+      rswag-ui (= 2.5.1)
+    rswag-api (2.5.1)
+      railties (>= 3.1, < 7.1)
+    rswag-specs (2.5.1)
+      activesupport (>= 3.1, < 7.1)
+      json-schema (~> 2.2)
+      railties (>= 3.1, < 7.1)
+    rswag-ui (2.5.1)
+      actionpack (>= 3.1, < 7.1)
+      railties (>= 3.1, < 7.1)
     rubocop (1.25.1)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)
@@ -275,6 +293,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-18
+  x86_64-darwin-19
   x86_64-linux
 
 DEPENDENCIES
@@ -297,6 +316,7 @@ DEPENDENCIES
   rspec-collection_matchers
   rspec-rails (~> 5.0.0)
   rspec-request_snapshot
+  rswag
   rubocop
   rubocop-performance
   simplecov

--- a/backend/README.md
+++ b/backend/README.md
@@ -35,6 +35,12 @@ using foreman `bin/watch` and the server in the standard way in a separate termi
 
 `bundle exec rspec`
 
+### Run rswag to generate API documentation
+
+`rake rswag:specs:swaggerize`
+
+Documentation can be found at `/api-docs`.
+
 ### Run linters
 
 `bin/rails standard`

--- a/backend/config/initializers/rswag_api.rb
+++ b/backend/config/initializers/rswag_api.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rswag::Api.configure do |c|
+  c.swagger_root = Rails.root.join("swagger").to_s
+end

--- a/backend/config/initializers/rswag_ui.rb
+++ b/backend/config/initializers/rswag_ui.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rswag::Ui.configure do |c|
+  c.swagger_endpoint "/api-docs/v1/swagger.yaml", "API V1 Docs"
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  mount Rswag::Ui::Engine => "/api-docs"
+  mount Rswag::Api::Engine => "/api-docs"
+
   namespace :api, format: "json" do
     namespace :v1 do
       resources :investors, only: [:index, :show]

--- a/backend/spec/requests/api/v1/investors_spec.rb
+++ b/backend/spec/requests/api/v1/investors_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require "swagger_helper"
 
 RSpec.describe "API V1 Investors", type: :request do
   before_all do
@@ -8,54 +8,75 @@ RSpec.describe "API V1 Investors", type: :request do
 
   include_examples :api_pagination, model: Investor, expected_total: 7
 
-  describe "GET #index" do
-    it "should return investors" do
-      get "/api/v1/investors"
+  path "/api/v1/investors" do
+    get "Returns list of the investors" do
+      tags "Investors"
+      produces "application/json"
+      parameter name: "page[number]", in: :query, type: :integer, description: "Page number. Default: 1", required: false
+      parameter name: "page[size]", in: :query, type: :integer, description: "Per page items. Default: 10", required: false
+      parameter name: "fields[investor]", in: :query, type: :string, description: "Get only required fields. Use comma to separate multiple fields", required: false
 
-      expect(response).to have_http_status(:ok)
-      expect(response.body).to match_snapshot("api/v1/investors")
-    end
+      response "200", :success do
+        schema type: :object, properties: {
+          data: {type: :array, items: {"$ref" => "#/components/schemas/investor"}},
+          meta: {"$ref" => "#/components/schemas/pagination_meta"},
+          links: {"$ref" => "#/components/schemas/pagination_links"}
+        }
 
-    describe "sparse fieldset" do
-      it "should work" do
-        get "/api/v1/investors?fields[investor]=instagram,facebook,nonexisting"
+        run_test!
 
-        expect(response).to have_http_status(:ok)
-        expect(response.body).to match_snapshot("api/v1/investors-sparse-fieldset")
+        it "matches snapshot" do
+          expect(response.body).to match_snapshot("api/v1/investors")
+        end
+
+        context "with sparse fieldset" do
+          let("fields[investor]") { "instagram,facebook,nonexisting" }
+
+          it "matches snapshot" do
+            expect(response.body).to match_snapshot("api/v1/investors-sparse-fieldset")
+          end
+        end
       end
     end
   end
 
-  describe "GET #show" do
-    it "should return single investor" do
-      get "/api/v1/investors/#{@investor.id}"
+  path "/api/v1/investors/{id}" do
+    get "Find investor by id or slug" do
+      tags "Investors"
+      produces "application/json"
+      parameter name: :id, in: :path, type: :string, description: "Use investor ID or account slug"
+      parameter name: "fields[investor]", in: :query, type: :string, description: "Get only required fields. Use comma to separate multiple fields", required: false
 
-      expect(response).to have_http_status(:ok)
-      expect(response.body).to match_snapshot("api/v1/get-investor")
-    end
+      let(:id) { @investor.id }
 
-    it "should return investor by account slug" do
-      get "/api/v1/investors/#{@investor.account.slug}"
+      it_behaves_like "with not found error"
 
-      expect(response).to have_http_status(:ok)
-      expect(response.body).to match_snapshot("api/v1/get-investor")
-    end
+      response "200", :success do
+        schema type: :object, properties: {
+          data: {"$ref" => "#/components/schemas/investor"}
+        }
 
-    describe "errors" do
-      it "displays not found error" do
-        get "/api/v1/investors/not-found"
+        run_test!
 
-        expect(response).to have_http_status(:not_found)
-        expect(response.body).to match_snapshot("api/v1/get-investor-not-found")
-      end
-    end
+        it "matches snapshot" do
+          expect(response.body).to match_snapshot("api/v1/get-investor")
+        end
 
-    describe "sparse fieldset" do
-      it "should work" do
-        get "/api/v1/investors/#{@investor.id}?fields[investor]=instagram,facebook,nonexisting"
+        context "when slug is used" do
+          let(:id) { @investor.account.slug }
 
-        expect(response).to have_http_status(:ok)
-        expect(response.body).to match_snapshot("api/v1/get-investor-sparse-fieldset")
+          it "matches snapshot" do
+            expect(response.body).to match_snapshot("api/v1/get-investor")
+          end
+        end
+
+        context "with sparse fieldset" do
+          let("fields[investor]") { "instagram,facebook,nonexisting" }
+
+          it "matches snapshot" do
+            expect(response.body).to match_snapshot("api/v1/get-investor-sparse-fieldset")
+          end
+        end
       end
     end
   end

--- a/backend/spec/support/shared_examples/api/with_not_found_error.rb
+++ b/backend/spec/support/shared_examples/api/with_not_found_error.rb
@@ -1,0 +1,11 @@
+require "swagger_helper"
+
+RSpec.shared_examples "with not found error" do
+  response "404", "Not Found" do
+    let(:id) { "not-found" }
+
+    schema "$ref" => "#/components/schemas/errors"
+
+    run_test!
+  end
+end

--- a/backend/spec/swagger_helper.rb
+++ b/backend/spec/swagger_helper.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.configure do |config|
+  config.swagger_root = Rails.root.join("swagger").to_s
+
+  config.swagger_docs = {
+    "v1/swagger.yaml" => {
+      openapi: "3.0.1",
+      info: {
+        title: "API V1",
+        version: "v1"
+      },
+      paths: {},
+      components: {
+        securitySchemes: {},
+        schemas: {
+          investor: {
+            type: :object,
+            properties: {
+              id: {type: :string},
+              type: {type: :string},
+              attributes: {
+                type: :object,
+                properties: {
+                  name: {type: :string},
+                  slug: {type: :string},
+                  about: {type: :string, nullable: true},
+                  website: {type: :string, nullable: true},
+                  instagram: {type: :string, nullable: true},
+                  facebook: {type: :string, nullable: true},
+                  linkedin: {type: :string, nullable: true},
+                  twitter: {type: :string, nullable: true},
+                  how_do_you_work: {type: :string},
+                  what_makes_the_difference: {type: :string, nullable: true},
+                  other_information: {type: :string},
+                  investor_type: {type: :string},
+                  categories: {type: :array, items: {type: :string}},
+                  ticket_sizes: {type: :array, items: {type: :string}},
+                  instrument_types: {type: :array, items: {type: :string}},
+                  impacts: {type: :array, items: {type: :string}},
+                  sdgs: {type: :array, items: {type: :integer}},
+                  previously_invested: {type: :boolean},
+                  previously_invested_description: {type: :string, nullable: true},
+                  language: {type: :string}
+                }
+              }
+            },
+            required: %w[id type attributes]
+          },
+          pagination_meta: {
+            type: :object,
+            properties: {
+              page: {type: :integer},
+              per_page: {type: :integer},
+              from: {type: :integer},
+              to: {type: :integer},
+              total: {type: :integer},
+              pages: {type: :integer}
+            },
+            required: %w[page per_page from to total pages]
+          },
+          pagination_links: {
+            type: :object,
+            properties: {
+              first: {type: :string},
+              self: {type: :string},
+              last: {type: :string}
+            },
+            required: %w[first self last]
+          },
+          errors: {
+            type: :object,
+            properties: {
+              errors: {
+                type: :array,
+                items: {
+                  type: :object,
+                  properties: {
+                    title: {type: :string}
+                  },
+                  required: %w[title]
+                }
+              }
+            },
+            required: %w[errors]
+          }
+        }
+      },
+      servers: [
+        {
+          url: "{scheme}://{host}",
+          variables: {
+            scheme: {
+              default: "http"
+            },
+            host: {
+              default: "localhost:4000"
+            }
+          }
+        }
+      ]
+    }
+  }
+
+  config.swagger_format = :yaml
+end

--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -1,0 +1,181 @@
+---
+openapi: 3.0.1
+info:
+  title: API V1
+  version: v1
+paths:
+  "/api/v1/investors":
+    get:
+      summary: Returns list of the investors
+      tags:
+      - Investors
+      parameters:
+      - name: page[number]
+        in: query
+        description: 'Page number. Default: 1'
+        required: false
+        schema:
+          type: integer
+      - name: page[size]
+        in: query
+        description: 'Per page items. Default: 10'
+        required: false
+        schema:
+          type: integer
+      - name: fields[investor]
+        in: query
+        description: Get only required fields. Use comma to separate multiple fields
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/investor"
+                  meta:
+                    "$ref": "#/components/schemas/pagination_meta"
+                  links:
+                    "$ref": "#/components/schemas/pagination_links"
+  "/api/v1/investors/{id}":
+    get:
+      summary: Find investor by id or slug
+      tags:
+      - Investors
+      parameters:
+      - name: id
+        in: path
+        description: Use investor ID or account slug
+        required: true
+        schema:
+          type: string
+      - name: fields[investor]
+        in: query
+        description: Get only required fields. Use comma to separate multiple fields
+        required: false
+        schema:
+          type: string
+      responses:
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/errors"
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/investor"
+components:
+  securitySchemes: {}
+  schemas:
+    investor:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        attributes:
+          type: object
+          properties:
+            name:
+              type: string
+            slug:
+              type: string
+            about:
+              type: string
+            website:
+              type: string
+            instagram:
+              type: string
+            facebook:
+              type: string
+            linkedin:
+              type: string
+            twitter:
+              type: string
+            how_do_you_work:
+              type: string
+            what_makes_the_difference:
+              type: string
+            other_information:
+              type: string
+            investor_type:
+              type: string
+            categories:
+              type: array
+              items:
+                type: string
+            ticket_sizes:
+              type: array
+              items:
+                type: string
+            instrument_types:
+              type: array
+              items:
+                type: string
+            impacts:
+              type: array
+              items:
+                type: string
+            sdgs:
+              type: array
+              items:
+                type: integer
+            previously_invested:
+              type: boolean
+            previously_invested_description:
+              type: string
+            language:
+              type: string
+    pagination_meta:
+      type: object
+      properties:
+        page:
+          type: integer
+        per_page:
+          type: integer
+        from:
+          type: integer
+        to:
+          type: integer
+        total:
+          type: integer
+        pages:
+          type: integer
+    pagination_links:
+      type: object
+      properties:
+        first:
+          type: string
+        self:
+          type: string
+        last:
+          type: string
+    errors:
+      type: object
+      properties:
+        errors:
+          type: array
+          items:
+            type: object
+            properties:
+              title:
+                type: string
+servers:
+- url: "{scheme}://{host}"
+  variables:
+    scheme:
+      default: http
+    host:
+      default: localhost:4000


### PR DESCRIPTION
I have added Rswag gem and rewritten Investors API tests to actually use it. I have tried to be compatible with `match_snapshot` approach as much as possible and used rswag dsl as wrapper for all existing tests. Please @tsubik or @agnessa check it and if you are fine with this approach, I will refactor rest of the API tests ;)

**Note**:  This PR also adds `backend/swagger/v1/swagger.yaml` which is dynamically generated file that contains API documentation. Better approach is to generate this file during pipeline run so you are sure that documentation is always up to date. Please take into account that to actually generate this documentation from testing files, rails app needs to have access to testing database.

![Screenshot 2022-03-15 at 12 13 47](https://user-images.githubusercontent.com/20660167/158368450-7795593e-17a9-4d76-96c9-70dd6b3244b6.png)

## Testing instructions

To generate swagger documentation, please use `rake rswag:specs:swaggerize`. Afterwards, you can found it at `/api-docs`.

## Tracking

https://vizzuality.atlassian.net/browse/LET-153
