### PR TITLE
Feature/enums jumbo endpoint

### DIFF
--- a/backend/app/controllers/api/v1/enums_controller.rb
+++ b/backend/app/controllers/api/v1/enums_controller.rb
@@ -1,0 +1,28 @@
+module API
+  module V1
+    class EnumsController < ApplicationController
+      def index
+        data = [
+          InstrumentType.all,
+          Category.all,
+          TicketSize.all,
+          Impact.all,
+          ProjectDeveloperType.all,
+          InvestorType.all
+        ].flatten
+
+        serialized_enums = data.map do |d|
+          resolve_serializer(d).new(d).serializable_hash[:data]
+        end.compact
+
+        render json: {data: serialized_enums}
+      end
+
+      private
+
+      def resolve_serializer(object)
+        API::V1.const_get("Enums::#{object.class.name}Serializer")
+      end
+    end
+  end
+end

--- a/backend/app/controllers/api/v1/enums_controller.rb
+++ b/backend/app/controllers/api/v1/enums_controller.rb
@@ -7,7 +7,7 @@ module API
           Category.all,
           TicketSize.all,
           Impact.all,
-          ProjectDeveloperType.all,
+          # ProjectDeveloperType.all, wait for better definition
           InvestorType.all
         ].flatten
 

--- a/backend/app/controllers/api/v1/instrument_types_controller.rb
+++ b/backend/app/controllers/api/v1/instrument_types_controller.rb
@@ -1,0 +1,9 @@
+module API
+  module V1
+    class InstrumentTypesController < ApplicationController
+      def index
+        render json: InstrumentTypeSerializer.new(InstrumentType.all).serializable_hash
+      end
+    end
+  end
+end

--- a/backend/app/controllers/api/v1/instrument_types_controller.rb
+++ b/backend/app/controllers/api/v1/instrument_types_controller.rb
@@ -1,9 +1,0 @@
-module API
-  module V1
-    class InstrumentTypesController < ApplicationController
-      def index
-        render json: InstrumentTypeSerializer.new(InstrumentType.all).serializable_hash
-      end
-    end
-  end
-end

--- a/backend/app/controllers/api/v1/investors_controller.rb
+++ b/backend/app/controllers/api/v1/investors_controller.rb
@@ -8,6 +8,7 @@ module API
         pagy_object, investors = pagy(investors, page: current_page, items: per_page)
         render json: InvestorSerializer.new(
           investors,
+          include: included_relationships,
           fields: sparse_fieldset,
           links: pagination_links(:api_v1_investors_path, pagy_object),
           meta: pagination_meta(pagy_object)

--- a/backend/app/models/category.rb
+++ b/backend/app/models/category.rb
@@ -1,5 +1,5 @@
 class Category
-  include StaticModel
+  include EnumModel
 
   TYPES = %w[
     sustainable_agrosystems
@@ -7,4 +7,15 @@ class Category
     forestry_and_agroforestry
     non_timber_forest_production
   ].freeze
+
+  COLORS = {
+    sustainable_agrosystems: "#E7C343",
+    tourism_and_recreation: "#4492E5",
+    forestry_and_agroforestry: "#E57D57",
+    non_timber_forest_production: "#404B9A"
+  }.freeze
+
+  def color
+    COLORS[slug.to_sym]
+  end
 end

--- a/backend/app/models/category.rb
+++ b/backend/app/models/category.rb
@@ -2,17 +2,17 @@ class Category
   include EnumModel
 
   TYPES = %w[
-    sustainable_agrosystems
-    tourism_and_recreation
-    forestry_and_agroforestry
-    non_timber_forest_production
+    sustainable-agrosystems
+    tourism-and-recreation
+    forestry-and-agroforestry
+    non-timber-forest-production
   ].freeze
 
   COLORS = {
-    sustainable_agrosystems: "#E7C343",
-    tourism_and_recreation: "#4492E5",
-    forestry_and_agroforestry: "#E57D57",
-    non_timber_forest_production: "#404B9A"
+    "sustainable-agrosystems": "#E7C343",
+    "tourism-and-recreation": "#4492E5",
+    "forestry-and-agroforestry": "#E57D57",
+    "non-timber-forest-production": "#404B9A"
   }.freeze
 
   def color

--- a/backend/app/models/category.rb
+++ b/backend/app/models/category.rb
@@ -18,4 +18,8 @@ class Category
   def color
     COLORS[slug.to_sym]
   end
+
+  def description
+    read_attribute("description")
+  end
 end

--- a/backend/app/models/concerns/enum_model.rb
+++ b/backend/app/models/concerns/enum_model.rb
@@ -1,7 +1,7 @@
-module StaticModel
+module EnumModel
   extend ActiveSupport::Concern
 
-  attr_accessor :slug
+  attr_reader :slug
 
   def initialize(slug:)
     @slug = slug
@@ -11,6 +11,7 @@ module StaticModel
     I18n.t("name", scope: ["enums", translation_key, slug])
   end
   alias_method :to_s, :name
+  alias_method :id, :slug
 
   def translation_key
     self.class.name.underscore
@@ -19,6 +20,14 @@ module StaticModel
   class_methods do
     def all
       const_get(:TYPES).map { |slug| new(slug: slug) }
+    end
+
+    def find_many(slugs)
+      Array.wrap(slugs).map { |s| find(s) }
+    end
+
+    def find(slug)
+      all.find { |o| o.slug == slug }
     end
   end
 end

--- a/backend/app/models/concerns/enum_model.rb
+++ b/backend/app/models/concerns/enum_model.rb
@@ -8,10 +8,14 @@ module EnumModel
   end
 
   def name
-    I18n.t("name", scope: ["enums", translation_key, slug])
+    read_attribute("name")
   end
   alias_method :to_s, :name
   alias_method :id, :slug
+
+  def read_attribute(name)
+    I18n.t(name, scope: ["enums", translation_key, slug])
+  end
 
   def translation_key
     self.class.name.underscore

--- a/backend/app/models/impact.rb
+++ b/backend/app/models/impact.rb
@@ -1,5 +1,5 @@
 class Impact
-  include StaticModel
+  include EnumModel
 
   TYPES = %w[
     biodiversity

--- a/backend/app/models/impact.rb
+++ b/backend/app/models/impact.rb
@@ -7,4 +7,8 @@ class Impact
     water
     community
   ].freeze
+
+  def description
+    read_attribute("description")
+  end
 end

--- a/backend/app/models/instrument_type.rb
+++ b/backend/app/models/instrument_type.rb
@@ -6,4 +6,8 @@ class InstrumentType
     loan
     equity
   ].freeze
+
+  def description
+    read_attribute("description")
+  end
 end

--- a/backend/app/models/instrument_type.rb
+++ b/backend/app/models/instrument_type.rb
@@ -1,5 +1,5 @@
 class InstrumentType
-  include StaticModel
+  include EnumModel
 
   TYPES = %w[
     grant

--- a/backend/app/models/investor_type.rb
+++ b/backend/app/models/investor_type.rb
@@ -1,5 +1,5 @@
 class InvestorType
-  include StaticModel
+  include EnumModel
 
   TYPES = %w[
     investor

--- a/backend/app/models/investor_type.rb
+++ b/backend/app/models/investor_type.rb
@@ -3,20 +3,20 @@ class InvestorType
 
   TYPES = %w[
     investor
-    angel_investor
-    commercial_bank
-    family_office
-    institutional_investor
-    investment_bank
-    international_financial_institution
-    micro_finance
-    non_VC_investment_vehicle
-    venture_capital_private_equity
-    carbon_fund
+    angel-investor
+    commercial-bank
+    family-office
+    institutional-investor
+    investment-bank
+    international-financial-institution
+    micro-finance
+    non-VC-investment-vehicle
+    venture-capital-private-equity
+    carbon-fund
     ngo
     foundation
-    corporate_foundation
+    corporate-foundation
     philanthropy
-    hnwi_or_celebrity
+    hnwi-or-celebrity
   ].freeze
 end

--- a/backend/app/models/project_developer_type.rb
+++ b/backend/app/models/project_developer_type.rb
@@ -1,5 +1,5 @@
 class ProjectDeveloperType
-  include StaticModel
+  include EnumModel
 
   TYPES = %w[
     TBD

--- a/backend/app/models/sdg.rb
+++ b/backend/app/models/sdg.rb
@@ -1,3 +1,5 @@
 class Sdg
+  include EnumModel
+
   TYPES = (1..17).to_a.freeze
 end

--- a/backend/app/models/ticket_size.rb
+++ b/backend/app/models/ticket_size.rb
@@ -1,5 +1,5 @@
 class TicketSize
-  include StaticModel
+  include EnumModel
 
   TYPES = %w[
     small_grants

--- a/backend/app/models/ticket_size.rb
+++ b/backend/app/models/ticket_size.rb
@@ -7,4 +7,8 @@ class TicketSize
     validation
     scaling
   ].freeze
+
+  def amount
+    read_attribute("amount")
+  end
 end

--- a/backend/app/serializers/api/v1/enums/category_serializer.rb
+++ b/backend/app/serializers/api/v1/enums/category_serializer.rb
@@ -4,7 +4,7 @@ module API
       class CategorySerializer
         include EnumSerializer
 
-        attribute :color
+        attribute :color, :description
       end
     end
   end

--- a/backend/app/serializers/api/v1/enums/category_serializer.rb
+++ b/backend/app/serializers/api/v1/enums/category_serializer.rb
@@ -1,0 +1,11 @@
+module API
+  module V1
+    module Enums
+      class CategorySerializer
+        include EnumSerializer
+
+        attribute :color
+      end
+    end
+  end
+end

--- a/backend/app/serializers/api/v1/enums/enum_serializer.rb
+++ b/backend/app/serializers/api/v1/enums/enum_serializer.rb
@@ -1,0 +1,15 @@
+module API
+  module V1
+    module Enums
+      module EnumSerializer
+        extend ActiveSupport::Concern
+        include JSONAPI::Serializer
+
+        included do
+          set_id :slug
+          attributes :name
+        end
+      end
+    end
+  end
+end

--- a/backend/app/serializers/api/v1/enums/impact_serializer.rb
+++ b/backend/app/serializers/api/v1/enums/impact_serializer.rb
@@ -1,0 +1,9 @@
+module API
+  module V1
+    module Enums
+      class ImpactSerializer
+        include EnumSerializer
+      end
+    end
+  end
+end

--- a/backend/app/serializers/api/v1/enums/impact_serializer.rb
+++ b/backend/app/serializers/api/v1/enums/impact_serializer.rb
@@ -3,6 +3,8 @@ module API
     module Enums
       class ImpactSerializer
         include EnumSerializer
+
+        attribute :description
       end
     end
   end

--- a/backend/app/serializers/api/v1/enums/instrument_type_serializer.rb
+++ b/backend/app/serializers/api/v1/enums/instrument_type_serializer.rb
@@ -1,0 +1,9 @@
+module API
+  module V1
+    module Enums
+      class InstrumentTypeSerializer
+        include EnumSerializer
+      end
+    end
+  end
+end

--- a/backend/app/serializers/api/v1/enums/instrument_type_serializer.rb
+++ b/backend/app/serializers/api/v1/enums/instrument_type_serializer.rb
@@ -3,6 +3,8 @@ module API
     module Enums
       class InstrumentTypeSerializer
         include EnumSerializer
+
+        attribute :description
       end
     end
   end

--- a/backend/app/serializers/api/v1/enums/investor_type_serializer.rb
+++ b/backend/app/serializers/api/v1/enums/investor_type_serializer.rb
@@ -1,0 +1,9 @@
+module API
+  module V1
+    module Enums
+      class InvestorTypeSerializer
+        include EnumSerializer
+      end
+    end
+  end
+end

--- a/backend/app/serializers/api/v1/enums/project_developer_type_serializer.rb
+++ b/backend/app/serializers/api/v1/enums/project_developer_type_serializer.rb
@@ -1,0 +1,9 @@
+module API
+  module V1
+    module Enums
+      class ProjectDeveloperTypeSerializer
+        include EnumSerializer
+      end
+    end
+  end
+end

--- a/backend/app/serializers/api/v1/enums/sdg_serializer.rb
+++ b/backend/app/serializers/api/v1/enums/sdg_serializer.rb
@@ -1,0 +1,9 @@
+module API
+  module V1
+    module Enums
+      class SdgSerializer
+        include EnumSerializer
+      end
+    end
+  end
+end

--- a/backend/app/serializers/api/v1/enums/ticket_size_serializer.rb
+++ b/backend/app/serializers/api/v1/enums/ticket_size_serializer.rb
@@ -1,0 +1,9 @@
+module API
+  module V1
+    module Enums
+      class TicketSizeSerializer
+        include EnumSerializer
+      end
+    end
+  end
+end

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -3,7 +3,7 @@ zu:
     category:
       sustainable-agrosystems:
         name: Sustainable Agrosystems
-        description: Sustainable and regenerative agriculture, fishing, and aquaculture  as well as manufacturing of derived subproducts.
+        description: Sustainable and regenerative agriculture, fishing, and aquaculture as well as manufacturing of derived subproducts.
       tourism-and-recreation:
         name: Tourism and Recreation
         description: Accommodation, travel, transportation, hospitality, visitor experiences and eco-tourism projects.
@@ -12,7 +12,7 @@ zu:
         description: Sustainable timber extraction and forest management practices, including reforestation and restoration.
       non-timber-forest-production:
         name: Non Timber Forest Production
-        description: Production of health, wellness, and cosmetic products; art, clothing, and  handcrafted products; production of food and drinks.
+        description: Production of health, wellness, and cosmetic products; art, clothing, and handcrafted products; production of food and drinks.
     investor_type:
       investor:
         name: Investor
@@ -78,7 +78,7 @@ zu:
         description: Impact of projects that reduce carbon emissions from the land sector (deforestation/degradation), as wood and soil biomass as well as application of sustainable forest measures.
       water:
         name: Water
-        description: Impact of projects  managing water cycling, quality and availability as well as the management of associated risks.
+        description: Impact of projects managing water cycling, quality and availability as well as the management of associated risks.
       community:
         name: Community
         description: Impact of projects on ensuring and improving equal and inclusive physical, mental, economic, and spiritual health.

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -3,12 +3,16 @@ zu:
     category:
       sustainable_agrosystems:
         name: Sustainable Agrosystems
+        description: Sustainable and regenerative agriculture, fishing, and aquaculture  as well as manufacturing of derived subproducts.
       tourism_and_recreation:
         name: Tourism and Recreation
+        description: Accommodation, travel, transportation, hospitality, visitor experiences and eco-tourism projects.
       forestry_and_agroforestry:
         name: Forestry and Agroforestry
+        description: Sustainable timber extraction and forest management practices, including reforestation and restoration.
       non_timber_forest_production:
         name: Non Timber Forest Production
+        description: Production of health, wellness, and cosmetic products; art, clothing, and  handcrafted products; production of food and drinks.
     investor_type:
       investor:
         name: Investor
@@ -45,25 +49,36 @@ zu:
     ticket_size:
       small_grants:
         name: Small Grants
+        amount: "<US$25,000"
       prototyping:
         name: Prototyping
+        amount: US$25,000 - 150,000
       validation:
         name: Validation
+        amount: US$150,000 - 750,000
       scaling:
         name: Scaling
+        amount: ">US$750,000"
     instrument_type:
       grant:
         name: Grant
+        description: Technical cooperation grants are resources provided by an entity to fulfill a well-defined purpose or objective. In general, they are non-reimbursable resources that are destined in particular to projects or enterprises in early stages of development.
       loan:
         name: Loan
+        description: A loan is a transaction in which a financial institution grants a predefined amount of money to develop a particular project. The institution or business that receives the loan is obliged to repay it within a certain period of time and to pay the agreed commissions, expenses and interest.
       equity:
         name: Equity
+        description: An equity investment consists of the acquisition, by an entity specialized in private equity, of a package of shares of a company or enterprise. The private equity firm thus becomes one of the owners of the company.
     impact:
       biodiversity:
         name: Biodiversity
+        description: Impact of projects on biodiversity conservation, calculated from indicators of endemism, land conservation/restoration, connectivity, and development of sustainable social projects.
       climate:
         name: Climate
+        description: Impact of projects that reduce carbon emissions from the land sector (deforestation/degradation), as wood and soil biomass as well as application of sustainable forest measures.
       water:
         name: Water
+        description: Impact of projects  managing water cycling, quality and availability as well as the management of associated risks.
       community:
         name: Community
+        description: Impact of projects on ensuring and improving equal and inclusive physical, mental, economic, and spiritual health.

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -1,53 +1,53 @@
 zu:
   enums:
     category:
-      sustainable_agrosystems:
+      sustainable-agrosystems:
         name: Sustainable Agrosystems
         description: Sustainable and regenerative agriculture, fishing, and aquaculture  as well as manufacturing of derived subproducts.
-      tourism_and_recreation:
+      tourism-and-recreation:
         name: Tourism and Recreation
         description: Accommodation, travel, transportation, hospitality, visitor experiences and eco-tourism projects.
-      forestry_and_agroforestry:
+      forestry-and-agroforestry:
         name: Forestry and Agroforestry
         description: Sustainable timber extraction and forest management practices, including reforestation and restoration.
-      non_timber_forest_production:
+      non-timber-forest-production:
         name: Non Timber Forest Production
         description: Production of health, wellness, and cosmetic products; art, clothing, and  handcrafted products; production of food and drinks.
     investor_type:
       investor:
         name: Investor
-      angel_investor:
+      angel-investor:
         name: Angel Investor
-      commercial_bank:
+      commercial-bank:
         name: Commercial Bank
-      family_office:
+      family-office:
         name: Family Office
-      institutional_investor:
+      institutional-investor:
         name: Institutional Investor
-      investment_bank:
+      investment-bank:
         name: Investment Bank
-      international_financial_institution:
+      international-financial-institution:
         name: International Financial Institution
-      micro_finance:
+      micro-finance:
         name: Micro Finance
-      non_VC_investment_vehicle:
+      non-VC-investment-vehicle:
         name: Non VC Investment Vehicle
-      venture_capital_private_equity:
+      venture-capital-private-equity:
         name: Venture Capital Private Equity
-      carbon_fund:
+      carbon-fund:
         name: Carbon Fund
       ngo:
         name: NGO
       foundation:
         name: Foundation
-      corporate_foundation:
+      corporate-foundation:
         name: Corporate Foundation
       philanthropy:
         name: Philanthropy
-      hnwi_or_celebrity:
+      hnwi-or-celebrity:
         name: HNWI or Celebrity
     ticket_size:
-      small_grants:
+      small-grants:
         name: Small Grants
         amount: "<US$25,000"
       prototyping:

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
       resources :open_calls, only: [:index, :show]
       resources :project_developers, only: [:index, :show]
       resources :projects, only: [:index, :show]
+
+      resources :enums, only: [:index]
     end
   end
 end

--- a/backend/spec/factories/investor.rb
+++ b/backend/spec/factories/investor.rb
@@ -2,10 +2,10 @@ FactoryBot.define do
   factory :investor do
     account
 
-    categories { %w[forestry_and_agroforestry non_timber_forest_production] }
+    categories { %w[forestry-and-agroforestry non-timber-forest-production] }
     sdgs { [1, 4, 5] }
     impacts { %w[climate water] }
-    investor_type { "angel_investor" }
+    investor_type { "angel-investor" }
     instrument_types { %w[grant loan] }
     ticket_sizes { %w[validation scaling] }
     review_status { "approved" }

--- a/backend/spec/factories/project.rb
+++ b/backend/spec/factories/project.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
       "Project #{n}"
     end
 
-    categories { %w[forestry_and_agroforestry non_timber_forest_production] }
+    categories { %w[forestry-and-agroforestry non-timber-forest-production] }
     sdgs { [1, 4, 5] }
     instrument_types { %w[grant loan] }
     ticket_size { "scaling" }

--- a/backend/spec/factories/project_developer.rb
+++ b/backend/spec/factories/project_developer.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :project_developer do
     account
 
-    categories { %w[forestry_and_agroforestry non_timber_forest_production] }
+    categories { %w[forestry-and-agroforestry non-timber-forest-production] }
     impacts { %w[climate water] }
     project_developer_type { "TBD" }
     review_status { "approved" }

--- a/backend/spec/fixtures/snapshots/api/v1/enums.json
+++ b/backend/spec/fixtures/snapshots/api/v1/enums.json
@@ -1,0 +1,236 @@
+{
+  "data": [
+    {
+      "id": "grant",
+      "type": "instrument_type",
+      "attributes": {
+        "name": "Grant",
+        "description": "Technical cooperation grants are resources provided by an entity to fulfill a well-defined purpose or objective. In general, they are non-reimbursable resources that are destined in particular to projects or enterprises in early stages of development."
+      }
+    },
+    {
+      "id": "loan",
+      "type": "instrument_type",
+      "attributes": {
+        "name": "Loan",
+        "description": "A loan is a transaction in which a financial institution grants a predefined amount of money to develop a particular project. The institution or business that receives the loan is obliged to repay it within a certain period of time and to pay the agreed commissions, expenses and interest."
+      }
+    },
+    {
+      "id": "equity",
+      "type": "instrument_type",
+      "attributes": {
+        "name": "Equity",
+        "description": "An equity investment consists of the acquisition, by an entity specialized in private equity, of a package of shares of a company or enterprise. The private equity firm thus becomes one of the owners of the company."
+      }
+    },
+    {
+      "id": "sustainable-agrosystems",
+      "type": "category",
+      "attributes": {
+        "name": "Sustainable Agrosystems",
+        "color": "#E7C343",
+        "description": "Sustainable and regenerative agriculture, fishing, and aquaculture as well as manufacturing of derived subproducts."
+      }
+    },
+    {
+      "id": "tourism-and-recreation",
+      "type": "category",
+      "attributes": {
+        "name": "Tourism and Recreation",
+        "color": "#4492E5",
+        "description": "Accommodation, travel, transportation, hospitality, visitor experiences and eco-tourism projects."
+      }
+    },
+    {
+      "id": "forestry-and-agroforestry",
+      "type": "category",
+      "attributes": {
+        "name": "Forestry and Agroforestry",
+        "color": "#E57D57",
+        "description": "Sustainable timber extraction and forest management practices, including reforestation and restoration."
+      }
+    },
+    {
+      "id": "non-timber-forest-production",
+      "type": "category",
+      "attributes": {
+        "name": "Non Timber Forest Production",
+        "color": "#404B9A",
+        "description": "Production of health, wellness, and cosmetic products; art, clothing, and handcrafted products; production of food and drinks."
+      }
+    },
+    {
+      "id": "small_grants",
+      "type": "ticket_size",
+      "attributes": {
+        "name": "translation missing: en.enums.ticket_size.small_grants.name"
+      }
+    },
+    {
+      "id": "prototyping",
+      "type": "ticket_size",
+      "attributes": {
+        "name": "Prototyping"
+      }
+    },
+    {
+      "id": "validation",
+      "type": "ticket_size",
+      "attributes": {
+        "name": "Validation"
+      }
+    },
+    {
+      "id": "scaling",
+      "type": "ticket_size",
+      "attributes": {
+        "name": "Scaling"
+      }
+    },
+    {
+      "id": "biodiversity",
+      "type": "impact",
+      "attributes": {
+        "name": "Biodiversity",
+        "description": "Impact of projects on biodiversity conservation, calculated from indicators of endemism, land conservation/restoration, connectivity, and development of sustainable social projects."
+      }
+    },
+    {
+      "id": "climate",
+      "type": "impact",
+      "attributes": {
+        "name": "Climate",
+        "description": "Impact of projects that reduce carbon emissions from the land sector (deforestation/degradation), as wood and soil biomass as well as application of sustainable forest measures."
+      }
+    },
+    {
+      "id": "water",
+      "type": "impact",
+      "attributes": {
+        "name": "Water",
+        "description": "Impact of projects managing water cycling, quality and availability as well as the management of associated risks."
+      }
+    },
+    {
+      "id": "community",
+      "type": "impact",
+      "attributes": {
+        "name": "Community",
+        "description": "Impact of projects on ensuring and improving equal and inclusive physical, mental, economic, and spiritual health."
+      }
+    },
+    {
+      "id": "investor",
+      "type": "investor_type",
+      "attributes": {
+        "name": "Investor"
+      }
+    },
+    {
+      "id": "angel-investor",
+      "type": "investor_type",
+      "attributes": {
+        "name": "Angel Investor"
+      }
+    },
+    {
+      "id": "commercial-bank",
+      "type": "investor_type",
+      "attributes": {
+        "name": "Commercial Bank"
+      }
+    },
+    {
+      "id": "family-office",
+      "type": "investor_type",
+      "attributes": {
+        "name": "Family Office"
+      }
+    },
+    {
+      "id": "institutional-investor",
+      "type": "investor_type",
+      "attributes": {
+        "name": "Institutional Investor"
+      }
+    },
+    {
+      "id": "investment-bank",
+      "type": "investor_type",
+      "attributes": {
+        "name": "Investment Bank"
+      }
+    },
+    {
+      "id": "international-financial-institution",
+      "type": "investor_type",
+      "attributes": {
+        "name": "International Financial Institution"
+      }
+    },
+    {
+      "id": "micro-finance",
+      "type": "investor_type",
+      "attributes": {
+        "name": "Micro Finance"
+      }
+    },
+    {
+      "id": "non-VC-investment-vehicle",
+      "type": "investor_type",
+      "attributes": {
+        "name": "Non VC Investment Vehicle"
+      }
+    },
+    {
+      "id": "venture-capital-private-equity",
+      "type": "investor_type",
+      "attributes": {
+        "name": "Venture Capital Private Equity"
+      }
+    },
+    {
+      "id": "carbon-fund",
+      "type": "investor_type",
+      "attributes": {
+        "name": "Carbon Fund"
+      }
+    },
+    {
+      "id": "ngo",
+      "type": "investor_type",
+      "attributes": {
+        "name": "NGO"
+      }
+    },
+    {
+      "id": "foundation",
+      "type": "investor_type",
+      "attributes": {
+        "name": "Foundation"
+      }
+    },
+    {
+      "id": "corporate-foundation",
+      "type": "investor_type",
+      "attributes": {
+        "name": "Corporate Foundation"
+      }
+    },
+    {
+      "id": "philanthropy",
+      "type": "investor_type",
+      "attributes": {
+        "name": "Philanthropy"
+      }
+    },
+    {
+      "id": "hnwi-or-celebrity",
+      "type": "investor_type",
+      "attributes": {
+        "name": "HNWI or Celebrity"
+      }
+    }
+  ]
+}

--- a/backend/spec/fixtures/snapshots/api/v1/get-investor-sparse-fieldset.json
+++ b/backend/spec/fixtures/snapshots/api/v1/get-investor-sparse-fieldset.json
@@ -1,6 +1,6 @@
 {
   "data": {
-    "id": "c9a30461-a0ab-4513-aba4-8700e838d972",
+    "id": "5b9d430d-73d4-4401-93ca-d560c915ba5f",
     "type": "investor",
     "attributes": {
       "instagram": "https://instagram.com/kutch-spencer",

--- a/backend/spec/fixtures/snapshots/api/v1/get-investor.json
+++ b/backend/spec/fixtures/snapshots/api/v1/get-investor.json
@@ -1,6 +1,6 @@
 {
   "data": {
-    "id": "ae5bfbda-1d40-4ca6-9af5-c5bd41025e59",
+    "id": "5b9d430d-73d4-4401-93ca-d560c915ba5f",
     "type": "investor",
     "attributes": {
       "name": "Kutch-Spencer",
@@ -14,9 +14,10 @@
       "how_do_you_work": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
       "what_makes_the_difference": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
       "other_information": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
+      "investor_type": "angel-investor",
       "categories": [
-        "forestry_and_agroforestry",
-        "non_timber_forest_production"
+        "forestry-and-agroforestry",
+        "non-timber-forest-production"
       ],
       "ticket_sizes": [
         "validation",
@@ -37,7 +38,6 @@
       ],
       "previously_invested": true,
       "previously_invested_description": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
-      "investor_type": "angel_investor",
       "language": "en"
     }
   }

--- a/backend/spec/fixtures/snapshots/api/v1/get-open-call-sparse-fieldset.json
+++ b/backend/spec/fixtures/snapshots/api/v1/get-open-call-sparse-fieldset.json
@@ -1,6 +1,6 @@
 {
   "data": {
-    "id": "9b9cda53-083a-4a83-9f68-59dc938ca0ed",
+    "id": "ff46a8df-f1e2-4003-927c-db5bedb99bea",
     "type": "open_call",
     "attributes": {
       "name": "Open call 1",

--- a/backend/spec/fixtures/snapshots/api/v1/get-open_call.json
+++ b/backend/spec/fixtures/snapshots/api/v1/get-open_call.json
@@ -1,6 +1,6 @@
 {
   "data": {
-    "id": "0436adc8-9ec9-422c-9486-a44ce021eedf",
+    "id": "ff46a8df-f1e2-4003-927c-db5bedb99bea",
     "type": "open_call",
     "attributes": {
       "name": "Open call 1",
@@ -15,13 +15,13 @@
       ],
       "money_distribution": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
       "impact_description": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
-      "closing_at": "2023-01-03T15:10:20.792Z",
+      "closing_at": "2023-01-15T11:45:07.390Z",
       "language": "en"
     },
     "relationships": {
       "investor": {
         "data": {
-          "id": "6618f883-0d83-4b35-a476-9ca3dcc669bb",
+          "id": "8f018244-0512-4cfd-9afe-bc488bba2f1b",
           "type": "investor"
         }
       }

--- a/backend/spec/fixtures/snapshots/api/v1/get-project-developer-sparse-fieldset.json
+++ b/backend/spec/fixtures/snapshots/api/v1/get-project-developer-sparse-fieldset.json
@@ -1,6 +1,6 @@
 {
   "data": {
-    "id": "6e04d4ae-358a-46e2-a093-a80a43539f1b",
+    "id": "7ab9a6ef-3b56-47ec-8b17-a6c176ea6299",
     "type": "project_developer",
     "attributes": {
       "instagram": "https://instagram.com/kutch-spencer",

--- a/backend/spec/fixtures/snapshots/api/v1/get-project-developer.json
+++ b/backend/spec/fixtures/snapshots/api/v1/get-project-developer.json
@@ -1,6 +1,6 @@
 {
   "data": {
-    "id": "976bd89d-0bb8-42d6-82b2-8a586b1556fd",
+    "id": "7ab9a6ef-3b56-47ec-8b17-a6c176ea6299",
     "type": "project_developer",
     "attributes": {
       "name": "Kutch-Spencer",
@@ -14,8 +14,8 @@
       "mission": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
       "project_developer_type": "TBD",
       "categories": [
-        "forestry_and_agroforestry",
-        "non_timber_forest_production"
+        "forestry-and-agroforestry",
+        "non-timber-forest-production"
       ],
       "impacts": [
         "climate",

--- a/backend/spec/fixtures/snapshots/api/v1/get-project-include-relationships.json
+++ b/backend/spec/fixtures/snapshots/api/v1/get-project-include-relationships.json
@@ -1,6 +1,6 @@
 {
   "data": {
-    "id": "619438da-c6d0-41a9-bfc0-8447ace8bdd9",
+    "id": "8fee8b68-ebb3-487b-b2d0-4acabee2e0de",
     "type": "project",
     "attributes": {
       "name": "Project 1"
@@ -8,7 +8,7 @@
     "relationships": {
       "project_developer": {
         "data": {
-          "id": "2771ec7a-ab77-4281-9066-5f5bd7ee7ff8",
+          "id": "8f4cea39-cf98-4554-a606-fd37c037626f",
           "type": "project_developer"
         }
       }
@@ -16,7 +16,7 @@
   },
   "included": [
     {
-      "id": "052a1e2e-672f-4405-87cc-0400b0559529",
+      "id": "8f4cea39-cf98-4554-a606-fd37c037626f",
       "type": "project_developer",
       "attributes": {
         "name": "Kutch-Spencer",
@@ -30,8 +30,8 @@
         "mission": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
         "project_developer_type": "TBD",
         "categories": [
-          "forestry_and_agroforestry",
-          "non_timber_forest_production"
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
         ],
         "impacts": [
           "climate",

--- a/backend/spec/fixtures/snapshots/api/v1/get-project-sparse-fieldset.json
+++ b/backend/spec/fixtures/snapshots/api/v1/get-project-sparse-fieldset.json
@@ -1,6 +1,6 @@
 {
   "data": {
-    "id": "c27e9ed7-dac7-4ce2-a193-9110952efef8",
+    "id": "8fee8b68-ebb3-487b-b2d0-4acabee2e0de",
     "type": "project",
     "attributes": {
       "name": "Project 1",

--- a/backend/spec/fixtures/snapshots/api/v1/get-project.json
+++ b/backend/spec/fixtures/snapshots/api/v1/get-project.json
@@ -1,6 +1,6 @@
 {
   "data": {
-    "id": "c27e9ed7-dac7-4ce2-a193-9110952efef8",
+    "id": "8fee8b68-ebb3-487b-b2d0-4acabee2e0de",
     "type": "project",
     "attributes": {
       "name": "Project 1",
@@ -8,8 +8,8 @@
       "description": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
       "ticket_size": "scaling",
       "categories": [
-        "forestry_and_agroforestry",
-        "non_timber_forest_production"
+        "forestry-and-agroforestry",
+        "non-timber-forest-production"
       ],
       "instrument_types": [
         "grant",
@@ -27,18 +27,18 @@
       "impact_description": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
       "sustainability": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
       "roi": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
-      "language": "en",
       "income_in_last_3_years": "100K - 500K",
       "number_of_employees": 10,
       "number_of_employees_women": 6,
       "number_of_employees_young": 2,
       "number_of_employees_indigenous": 3,
-      "number_of_employees_migrants": 2
+      "number_of_employees_migrants": 2,
+      "language": "en"
     },
     "relationships": {
       "project_developer": {
         "data": {
-          "id": "0e7f3b67-b037-4b8e-85e9-2fe16c66652d",
+          "id": "8f4cea39-cf98-4554-a606-fd37c037626f",
           "type": "project_developer"
         }
       }

--- a/backend/spec/fixtures/snapshots/api/v1/investors-sparse-fieldset.json
+++ b/backend/spec/fixtures/snapshots/api/v1/investors-sparse-fieldset.json
@@ -1,7 +1,7 @@
 {
   "data": [
     {
-      "id": "c9a30461-a0ab-4513-aba4-8700e838d972",
+      "id": "5b9d430d-73d4-4401-93ca-d560c915ba5f",
       "type": "investor",
       "attributes": {
         "instagram": "https://instagram.com/kutch-spencer",
@@ -9,7 +9,7 @@
       }
     },
     {
-      "id": "c707a731-b1ca-49a6-ab53-d7a59fef752e",
+      "id": "92669f73-0f15-4335-829f-813d482e3f5a",
       "type": "investor",
       "attributes": {
         "instagram": "https://instagram.com/bartoletti-and-sons",
@@ -17,7 +17,7 @@
       }
     },
     {
-      "id": "69cce555-3b54-40e7-ba8e-58518d0bc238",
+      "id": "857ae2a9-401e-4fb5-9fc2-fc617fb1e3e8",
       "type": "investor",
       "attributes": {
         "instagram": "https://instagram.com/hane-lehner-and-goyette",
@@ -25,7 +25,7 @@
       }
     },
     {
-      "id": "01008dd7-9b44-4621-b734-791f2ef5a2c7",
+      "id": "8f8bf934-6ceb-41ae-adcd-ccccd709dbb3",
       "type": "investor",
       "attributes": {
         "instagram": "https://instagram.com/hilpert-waters-and-johnston",
@@ -33,7 +33,7 @@
       }
     },
     {
-      "id": "2ce42988-6e27-4b43-8b76-dcc89e65e1d0",
+      "id": "0ae34130-1a98-404a-b1a6-21afb90f0ce2",
       "type": "investor",
       "attributes": {
         "instagram": "https://instagram.com/jacobson-fritsch-and-stanton",
@@ -41,7 +41,7 @@
       }
     },
     {
-      "id": "f01ccdcd-5e2b-4e4a-ac4c-33b32397e3f4",
+      "id": "4d272d04-6151-43fb-81a4-8b0bb8a2e0fa",
       "type": "investor",
       "attributes": {
         "instagram": "https://instagram.com/keebler-kub-and-zemlak",
@@ -49,7 +49,7 @@
       }
     },
     {
-      "id": "dcfd920b-b090-47fb-8a78-b89ba667851a",
+      "id": "c51fb028-582f-426e-8dd0-9fb4d525cdb1",
       "type": "investor",
       "attributes": {
         "instagram": "https://instagram.com/becker-llc",

--- a/backend/spec/fixtures/snapshots/api/v1/investors.json
+++ b/backend/spec/fixtures/snapshots/api/v1/investors.json
@@ -1,7 +1,7 @@
 {
   "data": [
     {
-      "id": "ae5bfbda-1d40-4ca6-9af5-c5bd41025e59",
+      "id": "5b9d430d-73d4-4401-93ca-d560c915ba5f",
       "type": "investor",
       "attributes": {
         "name": "Kutch-Spencer",
@@ -15,9 +15,10 @@
         "how_do_you_work": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
         "what_makes_the_difference": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
         "other_information": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
+        "investor_type": "angel-investor",
         "categories": [
-          "forestry_and_agroforestry",
-          "non_timber_forest_production"
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
         ],
         "ticket_sizes": [
           "validation",
@@ -38,12 +39,11 @@
         ],
         "previously_invested": true,
         "previously_invested_description": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
-        "investor_type": "angel_investor",
         "language": "en"
       }
     },
     {
-      "id": "ac63ddbc-b8af-40bc-9f7c-7aea8c7297df",
+      "id": "92669f73-0f15-4335-829f-813d482e3f5a",
       "type": "investor",
       "attributes": {
         "name": "Bartoletti and Sons",
@@ -57,9 +57,10 @@
         "how_do_you_work": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
         "what_makes_the_difference": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
         "other_information": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
+        "investor_type": "angel-investor",
         "categories": [
-          "forestry_and_agroforestry",
-          "non_timber_forest_production"
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
         ],
         "ticket_sizes": [
           "validation",
@@ -80,12 +81,11 @@
         ],
         "previously_invested": true,
         "previously_invested_description": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
-        "investor_type": "angel_investor",
         "language": "en"
       }
     },
     {
-      "id": "4bf2af50-c860-403e-9a71-d4c325205982",
+      "id": "857ae2a9-401e-4fb5-9fc2-fc617fb1e3e8",
       "type": "investor",
       "attributes": {
         "name": "Hane, Lehner and Goyette",
@@ -99,9 +99,10 @@
         "how_do_you_work": "Et quaerat omnis. Harum voluptas atque. Quo nesciunt voluptas. Suscipit ex cum.",
         "what_makes_the_difference": "Et quaerat omnis. Harum voluptas atque. Quo nesciunt voluptas. Suscipit ex cum.",
         "other_information": "Et quaerat omnis. Harum voluptas atque. Quo nesciunt voluptas. Suscipit ex cum.",
+        "investor_type": "angel-investor",
         "categories": [
-          "forestry_and_agroforestry",
-          "non_timber_forest_production"
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
         ],
         "ticket_sizes": [
           "validation",
@@ -122,12 +123,11 @@
         ],
         "previously_invested": true,
         "previously_invested_description": "Et quaerat omnis. Harum voluptas atque. Quo nesciunt voluptas. Suscipit ex cum.",
-        "investor_type": "angel_investor",
         "language": "en"
       }
     },
     {
-      "id": "c3d594ba-6495-4145-a6b1-d5445412ff72",
+      "id": "8f8bf934-6ceb-41ae-adcd-ccccd709dbb3",
       "type": "investor",
       "attributes": {
         "name": "Hilpert, Waters and Johnston",
@@ -141,9 +141,10 @@
         "how_do_you_work": "Dolores fugiat nesciunt. Ut laborum dolores. Sit neque eos. Expedita molestiae quia.",
         "what_makes_the_difference": "Dolores fugiat nesciunt. Ut laborum dolores. Sit neque eos. Expedita molestiae quia.",
         "other_information": "Dolores fugiat nesciunt. Ut laborum dolores. Sit neque eos. Expedita molestiae quia.",
+        "investor_type": "angel-investor",
         "categories": [
-          "forestry_and_agroforestry",
-          "non_timber_forest_production"
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
         ],
         "ticket_sizes": [
           "validation",
@@ -164,12 +165,11 @@
         ],
         "previously_invested": true,
         "previously_invested_description": "Dolores fugiat nesciunt. Ut laborum dolores. Sit neque eos. Expedita molestiae quia.",
-        "investor_type": "angel_investor",
         "language": "en"
       }
     },
     {
-      "id": "6dad7a5e-3361-46a6-b02f-30a4b7eccf1e",
+      "id": "0ae34130-1a98-404a-b1a6-21afb90f0ce2",
       "type": "investor",
       "attributes": {
         "name": "Jacobson, Fritsch and Stanton",
@@ -183,10 +183,10 @@
         "how_do_you_work": "Autem et et. Voluptatem neque quibusdam. Repellat recusandae eum. Eius ex est.",
         "what_makes_the_difference": "Autem et et. Voluptatem neque quibusdam. Repellat recusandae eum. Eius ex est.",
         "other_information": "Autem et et. Voluptatem neque quibusdam. Repellat recusandae eum. Eius ex est.",
-        "investor_type": "angel_investor",
+        "investor_type": "angel-investor",
         "categories": [
-          "forestry_and_agroforestry",
-          "non_timber_forest_production"
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
         ],
         "ticket_sizes": [
           "validation",
@@ -211,7 +211,7 @@
       }
     },
     {
-      "id": "ac9dc940-6872-488e-9da5-93a7b89ded13",
+      "id": "4d272d04-6151-43fb-81a4-8b0bb8a2e0fa",
       "type": "investor",
       "attributes": {
         "name": "Keebler, Kub and Zemlak",
@@ -225,10 +225,10 @@
         "how_do_you_work": "Porro soluta beatae. Quia ratione facilis. Eligendi sapiente voluptatem. Quas rerum officia.",
         "what_makes_the_difference": "Porro soluta beatae. Quia ratione facilis. Eligendi sapiente voluptatem. Quas rerum officia.",
         "other_information": "Porro soluta beatae. Quia ratione facilis. Eligendi sapiente voluptatem. Quas rerum officia.",
-        "investor_type": "angel_investor",
+        "investor_type": "angel-investor",
         "categories": [
-          "forestry_and_agroforestry",
-          "non_timber_forest_production"
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
         ],
         "ticket_sizes": [
           "validation",
@@ -253,7 +253,7 @@
       }
     },
     {
-      "id": "4979ff7f-10af-4824-80f1-8ac2e686ed56",
+      "id": "c51fb028-582f-426e-8dd0-9fb4d525cdb1",
       "type": "investor",
       "attributes": {
         "name": "Becker LLC",
@@ -267,10 +267,10 @@
         "how_do_you_work": "Mollitia aut vel. Qui illum accusantium. Et laudantium et. Sed recusandae aut.",
         "what_makes_the_difference": "Mollitia aut vel. Qui illum accusantium. Et laudantium et. Sed recusandae aut.",
         "other_information": "Mollitia aut vel. Qui illum accusantium. Et laudantium et. Sed recusandae aut.",
-        "investor_type": "angel_investor",
+        "investor_type": "angel-investor",
         "categories": [
-          "forestry_and_agroforestry",
-          "non_timber_forest_production"
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
         ],
         "ticket_sizes": [
           "validation",

--- a/backend/spec/fixtures/snapshots/api/v1/open-calls-sparse-fieldset.json
+++ b/backend/spec/fixtures/snapshots/api/v1/open-calls-sparse-fieldset.json
@@ -1,7 +1,7 @@
 {
   "data": [
     {
-      "id": "9b9cda53-083a-4a83-9f68-59dc938ca0ed",
+      "id": "ff46a8df-f1e2-4003-927c-db5bedb99bea",
       "type": "open_call",
       "attributes": {
         "name": "Open call 1",
@@ -11,7 +11,7 @@
       }
     },
     {
-      "id": "44db5d4b-3e6b-42fe-8552-7beb9f6ccde0",
+      "id": "dfae94ec-ef53-4124-a9c9-0f19556c1cb6",
       "type": "open_call",
       "attributes": {
         "name": "Open call 2",
@@ -21,7 +21,7 @@
       }
     },
     {
-      "id": "adfa5e3d-6d26-4602-aacb-b2bba5f74c37",
+      "id": "a3c19ad9-c8d8-465c-8ce1-eecb4e8ed868",
       "type": "open_call",
       "attributes": {
         "name": "Open call 3",
@@ -31,7 +31,7 @@
       }
     },
     {
-      "id": "e76d42c7-0efd-4d36-a283-503b197b28f2",
+      "id": "243bea84-58c2-4fa8-b8b1-60a454241376",
       "type": "open_call",
       "attributes": {
         "name": "Open call 4",
@@ -41,7 +41,7 @@
       }
     },
     {
-      "id": "ac7afeee-8f57-4b81-bba6-243a514f07e3",
+      "id": "2f6f9028-275a-493a-b09a-c9661358c78b",
       "type": "open_call",
       "attributes": {
         "name": "Open call 5",
@@ -51,7 +51,7 @@
       }
     },
     {
-      "id": "60d3c4f2-7fb9-49bb-b62b-228e0f670e3c",
+      "id": "4101d523-ec2f-486e-bf91-23cb63f31bce",
       "type": "open_call",
       "attributes": {
         "name": "Open call 6",
@@ -61,7 +61,7 @@
       }
     },
     {
-      "id": "7d404367-a350-49ce-a1af-54ff6d98de7d",
+      "id": "fdad2143-d57e-44d5-a318-af9beb52e0d2",
       "type": "open_call",
       "attributes": {
         "name": "Open call 7",

--- a/backend/spec/fixtures/snapshots/api/v1/open_calls.json
+++ b/backend/spec/fixtures/snapshots/api/v1/open_calls.json
@@ -1,7 +1,7 @@
 {
   "data": [
     {
-      "id": "0436adc8-9ec9-422c-9486-a44ce021eedf",
+      "id": "ff46a8df-f1e2-4003-927c-db5bedb99bea",
       "type": "open_call",
       "attributes": {
         "name": "Open call 1",
@@ -16,20 +16,20 @@
         ],
         "money_distribution": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
         "impact_description": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
-        "closing_at": "2023-01-03T15:10:20.792Z",
+        "closing_at": "2023-01-15T11:45:07.390Z",
         "language": "en"
       },
       "relationships": {
         "investor": {
           "data": {
-            "id": "6618f883-0d83-4b35-a476-9ca3dcc669bb",
+            "id": "8f018244-0512-4cfd-9afe-bc488bba2f1b",
             "type": "investor"
           }
         }
       }
     },
     {
-      "id": "4279690a-325c-4c53-8895-3fb27eda45f8",
+      "id": "dfae94ec-ef53-4124-a9c9-0f19556c1cb6",
       "type": "open_call",
       "attributes": {
         "name": "Open call 2",
@@ -44,20 +44,20 @@
         ],
         "money_distribution": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
         "impact_description": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
-        "closing_at": "2023-01-03T15:10:20.829Z",
+        "closing_at": "2023-01-15T11:45:07.428Z",
         "language": "en"
       },
       "relationships": {
         "investor": {
           "data": {
-            "id": "48c4d431-2e1d-4cd8-bffe-bbd6a7333feb",
+            "id": "8d802ea8-73b5-4ad8-b2e2-52890be63fc4",
             "type": "investor"
           }
         }
       }
     },
     {
-      "id": "a7a2167d-74f0-4687-90b4-68fa0f567895",
+      "id": "a3c19ad9-c8d8-465c-8ce1-eecb4e8ed868",
       "type": "open_call",
       "attributes": {
         "name": "Open call 3",
@@ -72,20 +72,20 @@
         ],
         "money_distribution": "Et quaerat omnis. Harum voluptas atque. Quo nesciunt voluptas. Suscipit ex cum.",
         "impact_description": "Et quaerat omnis. Harum voluptas atque. Quo nesciunt voluptas. Suscipit ex cum.",
-        "closing_at": "2023-01-03T15:10:20.865Z",
+        "closing_at": "2023-01-15T11:45:07.450Z",
         "language": "en"
       },
       "relationships": {
         "investor": {
           "data": {
-            "id": "5298f589-bb52-4d24-b594-d6da699510ab",
+            "id": "36012557-58f6-481d-b498-6b3bcf5e589b",
             "type": "investor"
           }
         }
       }
     },
     {
-      "id": "589c9e27-38ee-48f5-ae5e-6bf277fc4a70",
+      "id": "243bea84-58c2-4fa8-b8b1-60a454241376",
       "type": "open_call",
       "attributes": {
         "name": "Open call 4",
@@ -100,20 +100,20 @@
         ],
         "money_distribution": "Dolores fugiat nesciunt. Ut laborum dolores. Sit neque eos. Expedita molestiae quia.",
         "impact_description": "Dolores fugiat nesciunt. Ut laborum dolores. Sit neque eos. Expedita molestiae quia.",
-        "closing_at": "2023-01-03T15:10:20.902Z",
+        "closing_at": "2023-01-15T11:45:07.474Z",
         "language": "en"
       },
       "relationships": {
         "investor": {
           "data": {
-            "id": "93709e67-79d9-493c-9b5d-78bb0204612b",
+            "id": "b7dc4572-b55d-4106-850e-d942b8b823ce",
             "type": "investor"
           }
         }
       }
     },
     {
-      "id": "86695233-d889-4707-89ee-9b7b6201f381",
+      "id": "2f6f9028-275a-493a-b09a-c9661358c78b",
       "type": "open_call",
       "attributes": {
         "name": "Open call 5",
@@ -128,20 +128,20 @@
         ],
         "money_distribution": "Autem et et. Voluptatem neque quibusdam. Repellat recusandae eum. Eius ex est.",
         "impact_description": "Autem et et. Voluptatem neque quibusdam. Repellat recusandae eum. Eius ex est.",
-        "closing_at": "2023-01-03T15:10:20.940Z",
+        "closing_at": "2023-01-15T11:45:07.500Z",
         "language": "en"
       },
       "relationships": {
         "investor": {
           "data": {
-            "id": "e32e1f8e-2fce-45c1-a12e-1d4b4300e5f4",
+            "id": "5b308543-8637-4d2c-bf78-6c82b0b78467",
             "type": "investor"
           }
         }
       }
     },
     {
-      "id": "8492f44a-edc7-4ebd-b90b-848e9eb53de6",
+      "id": "4101d523-ec2f-486e-bf91-23cb63f31bce",
       "type": "open_call",
       "attributes": {
         "name": "Open call 6",
@@ -156,20 +156,20 @@
         ],
         "money_distribution": "Porro soluta beatae. Quia ratione facilis. Eligendi sapiente voluptatem. Quas rerum officia.",
         "impact_description": "Porro soluta beatae. Quia ratione facilis. Eligendi sapiente voluptatem. Quas rerum officia.",
-        "closing_at": "2023-01-03T15:10:20.983Z",
+        "closing_at": "2023-01-15T11:45:07.522Z",
         "language": "en"
       },
       "relationships": {
         "investor": {
           "data": {
-            "id": "7ef58183-8430-47ea-b697-bb8fd4b08d2e",
+            "id": "e3cb2e62-3a52-4a52-9a99-f145a0bb1712",
             "type": "investor"
           }
         }
       }
     },
     {
-      "id": "422af6d1-bf18-4ae6-ab0b-89eb5a89fad4",
+      "id": "fdad2143-d57e-44d5-a318-af9beb52e0d2",
       "type": "open_call",
       "attributes": {
         "name": "Open call 7",
@@ -184,13 +184,13 @@
         ],
         "money_distribution": "Mollitia aut vel. Qui illum accusantium. Et laudantium et. Sed recusandae aut.",
         "impact_description": "Mollitia aut vel. Qui illum accusantium. Et laudantium et. Sed recusandae aut.",
-        "closing_at": "2023-01-03T15:10:21.030Z",
+        "closing_at": "2023-01-15T11:45:07.546Z",
         "language": "en"
       },
       "relationships": {
         "investor": {
           "data": {
-            "id": "3deb7095-fffb-4c26-a1a2-77890ca7d5c4",
+            "id": "1606612e-2ea9-44e6-a746-e06d60dc2934",
             "type": "investor"
           }
         }

--- a/backend/spec/fixtures/snapshots/api/v1/project-developers-sparse-fieldset.json
+++ b/backend/spec/fixtures/snapshots/api/v1/project-developers-sparse-fieldset.json
@@ -1,7 +1,7 @@
 {
   "data": [
     {
-      "id": "6e04d4ae-358a-46e2-a093-a80a43539f1b",
+      "id": "7ab9a6ef-3b56-47ec-8b17-a6c176ea6299",
       "type": "project_developer",
       "attributes": {
         "instagram": "https://instagram.com/kutch-spencer",
@@ -9,7 +9,7 @@
       }
     },
     {
-      "id": "7d6fd256-2a8f-4753-ab93-c75b82cb07f6",
+      "id": "f4958a01-c431-43ab-b72b-9869d36c9f83",
       "type": "project_developer",
       "attributes": {
         "instagram": "https://instagram.com/bartoletti-and-sons",
@@ -17,7 +17,7 @@
       }
     },
     {
-      "id": "f19bcdf2-072f-45c7-b789-5dfca6b98c8f",
+      "id": "5e647a35-38b0-42c0-9699-376bc3cdb9b6",
       "type": "project_developer",
       "attributes": {
         "instagram": "https://instagram.com/hane-lehner-and-goyette",
@@ -25,7 +25,7 @@
       }
     },
     {
-      "id": "79ee58fe-a6d0-45c6-aaa0-2fb6bc9bba2f",
+      "id": "e8e5252c-1bbc-48f7-b47b-8ac3bc4c72d7",
       "type": "project_developer",
       "attributes": {
         "instagram": "https://instagram.com/hilpert-waters-and-johnston",
@@ -33,7 +33,7 @@
       }
     },
     {
-      "id": "50b6de25-7e27-454b-a0c6-5948019fb14f",
+      "id": "8331caaf-4160-4994-8bbc-873b5faa60d5",
       "type": "project_developer",
       "attributes": {
         "instagram": "https://instagram.com/jacobson-fritsch-and-stanton",
@@ -41,7 +41,7 @@
       }
     },
     {
-      "id": "cd0c335e-9827-443f-972f-c202aa736ecc",
+      "id": "105232ff-5279-4e44-b6b3-91501bf5788b",
       "type": "project_developer",
       "attributes": {
         "instagram": "https://instagram.com/keebler-kub-and-zemlak",
@@ -49,7 +49,7 @@
       }
     },
     {
-      "id": "32e7a50d-0aac-4004-b570-d7f005586b76",
+      "id": "838648ba-1407-43d0-9416-bfd0c24c4348",
       "type": "project_developer",
       "attributes": {
         "instagram": "https://instagram.com/becker-llc",

--- a/backend/spec/fixtures/snapshots/api/v1/project_developers.json
+++ b/backend/spec/fixtures/snapshots/api/v1/project_developers.json
@@ -1,7 +1,7 @@
 {
   "data": [
     {
-      "id": "976bd89d-0bb8-42d6-82b2-8a586b1556fd",
+      "id": "7ab9a6ef-3b56-47ec-8b17-a6c176ea6299",
       "type": "project_developer",
       "attributes": {
         "name": "Kutch-Spencer",
@@ -15,8 +15,8 @@
         "mission": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
         "project_developer_type": "TBD",
         "categories": [
-          "forestry_and_agroforestry",
-          "non_timber_forest_production"
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
         ],
         "impacts": [
           "climate",
@@ -26,7 +26,7 @@
       }
     },
     {
-      "id": "e1d343eb-4269-4b5f-8dde-6cfc35dee6b2",
+      "id": "f4958a01-c431-43ab-b72b-9869d36c9f83",
       "type": "project_developer",
       "attributes": {
         "name": "Bartoletti and Sons",
@@ -40,8 +40,8 @@
         "mission": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
         "project_developer_type": "TBD",
         "categories": [
-          "forestry_and_agroforestry",
-          "non_timber_forest_production"
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
         ],
         "impacts": [
           "climate",
@@ -51,7 +51,7 @@
       }
     },
     {
-      "id": "b9deafa5-1ef3-490a-af95-057ba06a193b",
+      "id": "5e647a35-38b0-42c0-9699-376bc3cdb9b6",
       "type": "project_developer",
       "attributes": {
         "name": "Hane, Lehner and Goyette",
@@ -65,8 +65,8 @@
         "mission": "Et quaerat omnis. Harum voluptas atque. Quo nesciunt voluptas. Suscipit ex cum.",
         "project_developer_type": "TBD",
         "categories": [
-          "forestry_and_agroforestry",
-          "non_timber_forest_production"
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
         ],
         "impacts": [
           "climate",
@@ -76,7 +76,7 @@
       }
     },
     {
-      "id": "47ab9afd-afee-40cc-b963-fddcc418972d",
+      "id": "e8e5252c-1bbc-48f7-b47b-8ac3bc4c72d7",
       "type": "project_developer",
       "attributes": {
         "name": "Hilpert, Waters and Johnston",
@@ -90,8 +90,8 @@
         "mission": "Dolores fugiat nesciunt. Ut laborum dolores. Sit neque eos. Expedita molestiae quia.",
         "project_developer_type": "TBD",
         "categories": [
-          "forestry_and_agroforestry",
-          "non_timber_forest_production"
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
         ],
         "impacts": [
           "climate",
@@ -101,7 +101,7 @@
       }
     },
     {
-      "id": "f1f92730-ec46-4bf9-88d8-2b3344feddcf",
+      "id": "8331caaf-4160-4994-8bbc-873b5faa60d5",
       "type": "project_developer",
       "attributes": {
         "name": "Jacobson, Fritsch and Stanton",
@@ -115,8 +115,8 @@
         "mission": "Autem et et. Voluptatem neque quibusdam. Repellat recusandae eum. Eius ex est.",
         "project_developer_type": "TBD",
         "categories": [
-          "forestry_and_agroforestry",
-          "non_timber_forest_production"
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
         ],
         "impacts": [
           "climate",
@@ -126,7 +126,7 @@
       }
     },
     {
-      "id": "ce24224b-7c8d-48d4-9160-75ce375ab716",
+      "id": "105232ff-5279-4e44-b6b3-91501bf5788b",
       "type": "project_developer",
       "attributes": {
         "name": "Keebler, Kub and Zemlak",
@@ -140,8 +140,8 @@
         "mission": "Porro soluta beatae. Quia ratione facilis. Eligendi sapiente voluptatem. Quas rerum officia.",
         "project_developer_type": "TBD",
         "categories": [
-          "forestry_and_agroforestry",
-          "non_timber_forest_production"
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
         ],
         "impacts": [
           "climate",
@@ -151,7 +151,7 @@
       }
     },
     {
-      "id": "fa1301e5-eca7-4a87-bb73-6a4cb7954fb7",
+      "id": "838648ba-1407-43d0-9416-bfd0c24c4348",
       "type": "project_developer",
       "attributes": {
         "name": "Becker LLC",
@@ -165,8 +165,8 @@
         "mission": "Mollitia aut vel. Qui illum accusantium. Et laudantium et. Sed recusandae aut.",
         "project_developer_type": "TBD",
         "categories": [
-          "forestry_and_agroforestry",
-          "non_timber_forest_production"
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
         ],
         "impacts": [
           "climate",

--- a/backend/spec/fixtures/snapshots/api/v1/projects-include-relationships.json
+++ b/backend/spec/fixtures/snapshots/api/v1/projects-include-relationships.json
@@ -1,7 +1,7 @@
 {
   "data": [
     {
-      "id": "570e6d75-c900-446f-8ef4-06d03d4706a9",
+      "id": "8fee8b68-ebb3-487b-b2d0-4acabee2e0de",
       "type": "project",
       "attributes": {
         "name": "Project 1"
@@ -9,14 +9,14 @@
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "ae066257-243c-4e9f-a556-3151125ff0b9",
+            "id": "8f4cea39-cf98-4554-a606-fd37c037626f",
             "type": "project_developer"
           }
         }
       }
     },
     {
-      "id": "e041e77b-4c5f-4b63-ac3e-2e2a57504ca7",
+      "id": "f5b7358b-2be1-484b-a724-32d1bf2973dd",
       "type": "project",
       "attributes": {
         "name": "Project 2"
@@ -24,14 +24,14 @@
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "b27d0dff-5983-4c67-b8b1-d47c4e2c803e",
+            "id": "205eb4a9-bb7f-4071-8a92-5d8165803199",
             "type": "project_developer"
           }
         }
       }
     },
     {
-      "id": "3f694548-f995-4bbf-b8c0-4c4a17b84036",
+      "id": "418adea0-e704-49e6-8308-e563c343ee7e",
       "type": "project",
       "attributes": {
         "name": "Project 3"
@@ -39,14 +39,14 @@
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "ee268213-d8b8-49fa-a539-f5a0eb7c032f",
+            "id": "1ce36e88-28ab-4639-aac3-adc44d409782",
             "type": "project_developer"
           }
         }
       }
     },
     {
-      "id": "24a70298-d5d9-4c3e-90e3-a47ac909dd01",
+      "id": "233caed9-dc7c-46a2-9f52-cce6a414ad2f",
       "type": "project",
       "attributes": {
         "name": "Project 4"
@@ -54,14 +54,14 @@
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "324e0871-84bb-4429-8f94-b3fa33c46850",
+            "id": "7931a314-56cd-408f-bca7-f0c1ee0a1dc2",
             "type": "project_developer"
           }
         }
       }
     },
     {
-      "id": "a34208f6-4bd4-48ed-8963-dc06b5eac193",
+      "id": "e50cca72-4e0b-4693-991b-704d0ef9a95e",
       "type": "project",
       "attributes": {
         "name": "Project 5"
@@ -69,14 +69,14 @@
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "e06a7b5c-fe50-42f7-a25a-b13bec787741",
+            "id": "01b8dc61-7e5d-4385-89f9-668c0f6ac087",
             "type": "project_developer"
           }
         }
       }
     },
     {
-      "id": "daa71346-9123-4d2a-a6c6-a965929733eb",
+      "id": "ac67dc12-a11b-458f-ae84-de2e30d789a4",
       "type": "project",
       "attributes": {
         "name": "Project 6"
@@ -84,14 +84,14 @@
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "f877d565-37fe-4efa-bdd9-ab9bdf994cfd",
+            "id": "44dbfd7b-e7df-4270-a857-22b39c5117fc",
             "type": "project_developer"
           }
         }
       }
     },
     {
-      "id": "1f1b51da-adef-4bce-bf5b-7f4c7bc5be7c",
+      "id": "29842cba-21ca-493b-a6db-644194b9f357",
       "type": "project",
       "attributes": {
         "name": "Project 7"
@@ -99,10 +99,187 @@
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "f33c4ad5-dc74-4e9c-ba31-2b9a630eeb2b",
+            "id": "f97297b2-83d5-4387-8e50-5ac49f9a4ea9",
             "type": "project_developer"
           }
         }
+      }
+    }
+  ],
+  "included": [
+    {
+      "id": "8f4cea39-cf98-4554-a606-fd37c037626f",
+      "type": "project_developer",
+      "attributes": {
+        "name": "Kutch-Spencer",
+        "slug": "kutch-spencer",
+        "about": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
+        "website": "https://kutch-spencer.com",
+        "instagram": "https://instagram.com/kutch-spencer",
+        "facebook": "https://facebook.com/kutch-spencer",
+        "linkedin": "https://linkedin.com/kutch-spencer",
+        "twitter": "https://twitter.com/kutch-spencer",
+        "mission": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
+        "project_developer_type": "TBD",
+        "categories": [
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
+        ],
+        "impacts": [
+          "climate",
+          "water"
+        ],
+        "language": "en"
+      }
+    },
+    {
+      "id": "205eb4a9-bb7f-4071-8a92-5d8165803199",
+      "type": "project_developer",
+      "attributes": {
+        "name": "Bartoletti and Sons",
+        "slug": "bartoletti-and-sons",
+        "about": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
+        "website": "https://bartoletti-and-sons.com",
+        "instagram": "https://instagram.com/bartoletti-and-sons",
+        "facebook": "https://facebook.com/bartoletti-and-sons",
+        "linkedin": "https://linkedin.com/bartoletti-and-sons",
+        "twitter": "https://twitter.com/bartoletti-and-sons",
+        "mission": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
+        "project_developer_type": "TBD",
+        "categories": [
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
+        ],
+        "impacts": [
+          "climate",
+          "water"
+        ],
+        "language": "en"
+      }
+    },
+    {
+      "id": "1ce36e88-28ab-4639-aac3-adc44d409782",
+      "type": "project_developer",
+      "attributes": {
+        "name": "Hane, Lehner and Goyette",
+        "slug": "hane-lehner-and-goyette",
+        "about": "Et quaerat omnis. Harum voluptas atque. Quo nesciunt voluptas. Suscipit ex cum.",
+        "website": "https://hane-lehner-and-goyette.com",
+        "instagram": "https://instagram.com/hane-lehner-and-goyette",
+        "facebook": "https://facebook.com/hane-lehner-and-goyette",
+        "linkedin": "https://linkedin.com/hane-lehner-and-goyette",
+        "twitter": "https://twitter.com/hane-lehner-and-goyette",
+        "mission": "Et quaerat omnis. Harum voluptas atque. Quo nesciunt voluptas. Suscipit ex cum.",
+        "project_developer_type": "TBD",
+        "categories": [
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
+        ],
+        "impacts": [
+          "climate",
+          "water"
+        ],
+        "language": "en"
+      }
+    },
+    {
+      "id": "7931a314-56cd-408f-bca7-f0c1ee0a1dc2",
+      "type": "project_developer",
+      "attributes": {
+        "name": "Hilpert, Waters and Johnston",
+        "slug": "hilpert-waters-and-johnston",
+        "about": "Dolores fugiat nesciunt. Ut laborum dolores. Sit neque eos. Expedita molestiae quia.",
+        "website": "https://hilpert-waters-and-johnston.com",
+        "instagram": "https://instagram.com/hilpert-waters-and-johnston",
+        "facebook": "https://facebook.com/hilpert-waters-and-johnston",
+        "linkedin": "https://linkedin.com/hilpert-waters-and-johnston",
+        "twitter": "https://twitter.com/hilpert-waters-and-johnston",
+        "mission": "Dolores fugiat nesciunt. Ut laborum dolores. Sit neque eos. Expedita molestiae quia.",
+        "project_developer_type": "TBD",
+        "categories": [
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
+        ],
+        "impacts": [
+          "climate",
+          "water"
+        ],
+        "language": "en"
+      }
+    },
+    {
+      "id": "01b8dc61-7e5d-4385-89f9-668c0f6ac087",
+      "type": "project_developer",
+      "attributes": {
+        "name": "Jacobson, Fritsch and Stanton",
+        "slug": "jacobson-fritsch-and-stanton",
+        "about": "Autem et et. Voluptatem neque quibusdam. Repellat recusandae eum. Eius ex est.",
+        "website": "https://jacobson-fritsch-and-stanton.com",
+        "instagram": "https://instagram.com/jacobson-fritsch-and-stanton",
+        "facebook": "https://facebook.com/jacobson-fritsch-and-stanton",
+        "linkedin": "https://linkedin.com/jacobson-fritsch-and-stanton",
+        "twitter": "https://twitter.com/jacobson-fritsch-and-stanton",
+        "mission": "Autem et et. Voluptatem neque quibusdam. Repellat recusandae eum. Eius ex est.",
+        "project_developer_type": "TBD",
+        "categories": [
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
+        ],
+        "impacts": [
+          "climate",
+          "water"
+        ],
+        "language": "en"
+      }
+    },
+    {
+      "id": "44dbfd7b-e7df-4270-a857-22b39c5117fc",
+      "type": "project_developer",
+      "attributes": {
+        "name": "Keebler, Kub and Zemlak",
+        "slug": "keebler-kub-and-zemlak",
+        "about": "Porro soluta beatae. Quia ratione facilis. Eligendi sapiente voluptatem. Quas rerum officia.",
+        "website": "https://keebler-kub-and-zemlak.com",
+        "instagram": "https://instagram.com/keebler-kub-and-zemlak",
+        "facebook": "https://facebook.com/keebler-kub-and-zemlak",
+        "linkedin": "https://linkedin.com/keebler-kub-and-zemlak",
+        "twitter": "https://twitter.com/keebler-kub-and-zemlak",
+        "mission": "Porro soluta beatae. Quia ratione facilis. Eligendi sapiente voluptatem. Quas rerum officia.",
+        "project_developer_type": "TBD",
+        "categories": [
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
+        ],
+        "impacts": [
+          "climate",
+          "water"
+        ],
+        "language": "en"
+      }
+    },
+    {
+      "id": "f97297b2-83d5-4387-8e50-5ac49f9a4ea9",
+      "type": "project_developer",
+      "attributes": {
+        "name": "Becker LLC",
+        "slug": "becker-llc",
+        "about": "Mollitia aut vel. Qui illum accusantium. Et laudantium et. Sed recusandae aut.",
+        "website": "https://becker-llc.com",
+        "instagram": "https://instagram.com/becker-llc",
+        "facebook": "https://facebook.com/becker-llc",
+        "linkedin": "https://linkedin.com/becker-llc",
+        "twitter": "https://twitter.com/becker-llc",
+        "mission": "Mollitia aut vel. Qui illum accusantium. Et laudantium et. Sed recusandae aut.",
+        "project_developer_type": "TBD",
+        "categories": [
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
+        ],
+        "impacts": [
+          "climate",
+          "water"
+        ],
+        "language": "en"
       }
     }
   ],
@@ -118,182 +295,5 @@
     "first": "/api/v1/projects?page%5Bsize%5D=10",
     "self": "/api/v1/projects?page%5Bnumber%5D=1&page%5Bsize%5D=10",
     "last": "/api/v1/projects?page%5Bnumber%5D=1&page%5Bsize%5D=10"
-  },
-  "included": [
-    {
-      "id": "ae066257-243c-4e9f-a556-3151125ff0b9",
-      "type": "project_developer",
-      "attributes": {
-        "name": "Kutch-Spencer",
-        "slug": "kutch-spencer",
-        "about": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
-        "website": "https://kutch-spencer.com",
-        "instagram": "https://instagram.com/kutch-spencer",
-        "facebook": "https://facebook.com/kutch-spencer",
-        "linkedin": "https://linkedin.com/kutch-spencer",
-        "twitter": "https://twitter.com/kutch-spencer",
-        "mission": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
-        "project_developer_type": "TBD",
-        "categories": [
-          "forestry_and_agroforestry",
-          "non_timber_forest_production"
-        ],
-        "impacts": [
-          "climate",
-          "water"
-        ],
-        "language": "en"
-      }
-    },
-    {
-      "id": "b27d0dff-5983-4c67-b8b1-d47c4e2c803e",
-      "type": "project_developer",
-      "attributes": {
-        "name": "Bartoletti and Sons",
-        "slug": "bartoletti-and-sons",
-        "about": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
-        "website": "https://bartoletti-and-sons.com",
-        "instagram": "https://instagram.com/bartoletti-and-sons",
-        "facebook": "https://facebook.com/bartoletti-and-sons",
-        "linkedin": "https://linkedin.com/bartoletti-and-sons",
-        "twitter": "https://twitter.com/bartoletti-and-sons",
-        "mission": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
-        "project_developer_type": "TBD",
-        "categories": [
-          "forestry_and_agroforestry",
-          "non_timber_forest_production"
-        ],
-        "impacts": [
-          "climate",
-          "water"
-        ],
-        "language": "en"
-      }
-    },
-    {
-      "id": "ee268213-d8b8-49fa-a539-f5a0eb7c032f",
-      "type": "project_developer",
-      "attributes": {
-        "name": "Hane, Lehner and Goyette",
-        "slug": "hane-lehner-and-goyette",
-        "about": "Et quaerat omnis. Harum voluptas atque. Quo nesciunt voluptas. Suscipit ex cum.",
-        "website": "https://hane-lehner-and-goyette.com",
-        "instagram": "https://instagram.com/hane-lehner-and-goyette",
-        "facebook": "https://facebook.com/hane-lehner-and-goyette",
-        "linkedin": "https://linkedin.com/hane-lehner-and-goyette",
-        "twitter": "https://twitter.com/hane-lehner-and-goyette",
-        "mission": "Et quaerat omnis. Harum voluptas atque. Quo nesciunt voluptas. Suscipit ex cum.",
-        "project_developer_type": "TBD",
-        "categories": [
-          "forestry_and_agroforestry",
-          "non_timber_forest_production"
-        ],
-        "impacts": [
-          "climate",
-          "water"
-        ],
-        "language": "en"
-      }
-    },
-    {
-      "id": "324e0871-84bb-4429-8f94-b3fa33c46850",
-      "type": "project_developer",
-      "attributes": {
-        "name": "Hilpert, Waters and Johnston",
-        "slug": "hilpert-waters-and-johnston",
-        "about": "Dolores fugiat nesciunt. Ut laborum dolores. Sit neque eos. Expedita molestiae quia.",
-        "website": "https://hilpert-waters-and-johnston.com",
-        "instagram": "https://instagram.com/hilpert-waters-and-johnston",
-        "facebook": "https://facebook.com/hilpert-waters-and-johnston",
-        "linkedin": "https://linkedin.com/hilpert-waters-and-johnston",
-        "twitter": "https://twitter.com/hilpert-waters-and-johnston",
-        "mission": "Dolores fugiat nesciunt. Ut laborum dolores. Sit neque eos. Expedita molestiae quia.",
-        "project_developer_type": "TBD",
-        "categories": [
-          "forestry_and_agroforestry",
-          "non_timber_forest_production"
-        ],
-        "impacts": [
-          "climate",
-          "water"
-        ],
-        "language": "en"
-      }
-    },
-    {
-      "id": "e06a7b5c-fe50-42f7-a25a-b13bec787741",
-      "type": "project_developer",
-      "attributes": {
-        "name": "Jacobson, Fritsch and Stanton",
-        "slug": "jacobson-fritsch-and-stanton",
-        "about": "Autem et et. Voluptatem neque quibusdam. Repellat recusandae eum. Eius ex est.",
-        "website": "https://jacobson-fritsch-and-stanton.com",
-        "instagram": "https://instagram.com/jacobson-fritsch-and-stanton",
-        "facebook": "https://facebook.com/jacobson-fritsch-and-stanton",
-        "linkedin": "https://linkedin.com/jacobson-fritsch-and-stanton",
-        "twitter": "https://twitter.com/jacobson-fritsch-and-stanton",
-        "mission": "Autem et et. Voluptatem neque quibusdam. Repellat recusandae eum. Eius ex est.",
-        "project_developer_type": "TBD",
-        "categories": [
-          "forestry_and_agroforestry",
-          "non_timber_forest_production"
-        ],
-        "impacts": [
-          "climate",
-          "water"
-        ],
-        "language": "en"
-      }
-    },
-    {
-      "id": "f877d565-37fe-4efa-bdd9-ab9bdf994cfd",
-      "type": "project_developer",
-      "attributes": {
-        "name": "Keebler, Kub and Zemlak",
-        "slug": "keebler-kub-and-zemlak",
-        "about": "Porro soluta beatae. Quia ratione facilis. Eligendi sapiente voluptatem. Quas rerum officia.",
-        "website": "https://keebler-kub-and-zemlak.com",
-        "instagram": "https://instagram.com/keebler-kub-and-zemlak",
-        "facebook": "https://facebook.com/keebler-kub-and-zemlak",
-        "linkedin": "https://linkedin.com/keebler-kub-and-zemlak",
-        "twitter": "https://twitter.com/keebler-kub-and-zemlak",
-        "mission": "Porro soluta beatae. Quia ratione facilis. Eligendi sapiente voluptatem. Quas rerum officia.",
-        "project_developer_type": "TBD",
-        "categories": [
-          "forestry_and_agroforestry",
-          "non_timber_forest_production"
-        ],
-        "impacts": [
-          "climate",
-          "water"
-        ],
-        "language": "en"
-      }
-    },
-    {
-      "id": "f33c4ad5-dc74-4e9c-ba31-2b9a630eeb2b",
-      "type": "project_developer",
-      "attributes": {
-        "name": "Becker LLC",
-        "slug": "becker-llc",
-        "about": "Mollitia aut vel. Qui illum accusantium. Et laudantium et. Sed recusandae aut.",
-        "website": "https://becker-llc.com",
-        "instagram": "https://instagram.com/becker-llc",
-        "facebook": "https://facebook.com/becker-llc",
-        "linkedin": "https://linkedin.com/becker-llc",
-        "twitter": "https://twitter.com/becker-llc",
-        "mission": "Mollitia aut vel. Qui illum accusantium. Et laudantium et. Sed recusandae aut.",
-        "project_developer_type": "TBD",
-        "categories": [
-          "forestry_and_agroforestry",
-          "non_timber_forest_production"
-        ],
-        "impacts": [
-          "climate",
-          "water"
-        ],
-        "language": "en"
-      }
-    }
-  ]
+  }
 }

--- a/backend/spec/fixtures/snapshots/api/v1/projects-sparse-fieldset.json
+++ b/backend/spec/fixtures/snapshots/api/v1/projects-sparse-fieldset.json
@@ -1,7 +1,7 @@
 {
   "data": [
     {
-      "id": "c27e9ed7-dac7-4ce2-a193-9110952efef8",
+      "id": "8fee8b68-ebb3-487b-b2d0-4acabee2e0de",
       "type": "project",
       "attributes": {
         "name": "Project 1",
@@ -11,7 +11,7 @@
       }
     },
     {
-      "id": "7c60b022-40df-4f6e-bd9f-fff45c560bc1",
+      "id": "f5b7358b-2be1-484b-a724-32d1bf2973dd",
       "type": "project",
       "attributes": {
         "name": "Project 2",
@@ -21,7 +21,7 @@
       }
     },
     {
-      "id": "2ed01c95-6801-4816-846d-07fe102b53c0",
+      "id": "418adea0-e704-49e6-8308-e563c343ee7e",
       "type": "project",
       "attributes": {
         "name": "Project 3",
@@ -31,7 +31,7 @@
       }
     },
     {
-      "id": "5fdfc348-60ac-485e-832a-33d4e4edf0d1",
+      "id": "233caed9-dc7c-46a2-9f52-cce6a414ad2f",
       "type": "project",
       "attributes": {
         "name": "Project 4",
@@ -41,7 +41,7 @@
       }
     },
     {
-      "id": "c5fd7ccd-5c91-413e-af30-8812d0ca834c",
+      "id": "e50cca72-4e0b-4693-991b-704d0ef9a95e",
       "type": "project",
       "attributes": {
         "name": "Project 5",
@@ -51,7 +51,7 @@
       }
     },
     {
-      "id": "7654da0e-9795-435a-82ce-6cf3b64c2ee4",
+      "id": "ac67dc12-a11b-458f-ae84-de2e30d789a4",
       "type": "project",
       "attributes": {
         "name": "Project 6",
@@ -61,7 +61,7 @@
       }
     },
     {
-      "id": "4b25c8b9-7a7d-4a9a-a45b-066992bf1f00",
+      "id": "29842cba-21ca-493b-a6db-644194b9f357",
       "type": "project",
       "attributes": {
         "name": "Project 7",

--- a/backend/spec/fixtures/snapshots/api/v1/projects.json
+++ b/backend/spec/fixtures/snapshots/api/v1/projects.json
@@ -1,7 +1,7 @@
 {
   "data": [
     {
-      "id": "c27e9ed7-dac7-4ce2-a193-9110952efef8",
+      "id": "8fee8b68-ebb3-487b-b2d0-4acabee2e0de",
       "type": "project",
       "attributes": {
         "name": "Project 1",
@@ -9,8 +9,8 @@
         "description": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
         "ticket_size": "scaling",
         "categories": [
-          "forestry_and_agroforestry",
-          "non_timber_forest_production"
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
         ],
         "instrument_types": [
           "grant",
@@ -28,25 +28,25 @@
         "impact_description": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
         "sustainability": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
         "roi": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
-        "language": "en",
         "income_in_last_3_years": "100K - 500K",
         "number_of_employees": 10,
         "number_of_employees_women": 6,
         "number_of_employees_young": 2,
         "number_of_employees_indigenous": 3,
-        "number_of_employees_migrants": 2
+        "number_of_employees_migrants": 2,
+        "language": "en"
       },
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "0e7f3b67-b037-4b8e-85e9-2fe16c66652d",
+            "id": "8f4cea39-cf98-4554-a606-fd37c037626f",
             "type": "project_developer"
           }
         }
       }
     },
     {
-      "id": "7c60b022-40df-4f6e-bd9f-fff45c560bc1",
+      "id": "f5b7358b-2be1-484b-a724-32d1bf2973dd",
       "type": "project",
       "attributes": {
         "name": "Project 2",
@@ -54,8 +54,8 @@
         "description": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
         "ticket_size": "scaling",
         "categories": [
-          "forestry_and_agroforestry",
-          "non_timber_forest_production"
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
         ],
         "instrument_types": [
           "grant",
@@ -73,25 +73,25 @@
         "impact_description": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
         "sustainability": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
         "roi": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
-        "language": "en",
         "income_in_last_3_years": "100K - 500K",
         "number_of_employees": 10,
         "number_of_employees_women": 6,
         "number_of_employees_young": 2,
         "number_of_employees_indigenous": 3,
-        "number_of_employees_migrants": 2
+        "number_of_employees_migrants": 2,
+        "language": "en"
       },
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "f970df1c-c023-4e22-87ae-4f052ef1d017",
+            "id": "205eb4a9-bb7f-4071-8a92-5d8165803199",
             "type": "project_developer"
           }
         }
       }
     },
     {
-      "id": "2ed01c95-6801-4816-846d-07fe102b53c0",
+      "id": "418adea0-e704-49e6-8308-e563c343ee7e",
       "type": "project",
       "attributes": {
         "name": "Project 3",
@@ -99,8 +99,8 @@
         "description": "Et quaerat omnis. Harum voluptas atque. Quo nesciunt voluptas. Suscipit ex cum.",
         "ticket_size": "scaling",
         "categories": [
-          "forestry_and_agroforestry",
-          "non_timber_forest_production"
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
         ],
         "instrument_types": [
           "grant",
@@ -118,25 +118,25 @@
         "impact_description": "Et quaerat omnis. Harum voluptas atque. Quo nesciunt voluptas. Suscipit ex cum.",
         "sustainability": "Et quaerat omnis. Harum voluptas atque. Quo nesciunt voluptas. Suscipit ex cum.",
         "roi": "Et quaerat omnis. Harum voluptas atque. Quo nesciunt voluptas. Suscipit ex cum.",
-        "language": "en",
         "income_in_last_3_years": "100K - 500K",
         "number_of_employees": 10,
         "number_of_employees_women": 6,
         "number_of_employees_young": 2,
         "number_of_employees_indigenous": 3,
-        "number_of_employees_migrants": 2
+        "number_of_employees_migrants": 2,
+        "language": "en"
       },
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "5c66a40b-2975-4829-8111-711263b7901e",
+            "id": "1ce36e88-28ab-4639-aac3-adc44d409782",
             "type": "project_developer"
           }
         }
       }
     },
     {
-      "id": "5fdfc348-60ac-485e-832a-33d4e4edf0d1",
+      "id": "233caed9-dc7c-46a2-9f52-cce6a414ad2f",
       "type": "project",
       "attributes": {
         "name": "Project 4",
@@ -144,8 +144,8 @@
         "description": "Dolores fugiat nesciunt. Ut laborum dolores. Sit neque eos. Expedita molestiae quia.",
         "ticket_size": "scaling",
         "categories": [
-          "forestry_and_agroforestry",
-          "non_timber_forest_production"
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
         ],
         "instrument_types": [
           "grant",
@@ -163,25 +163,25 @@
         "impact_description": "Dolores fugiat nesciunt. Ut laborum dolores. Sit neque eos. Expedita molestiae quia.",
         "sustainability": "Dolores fugiat nesciunt. Ut laborum dolores. Sit neque eos. Expedita molestiae quia.",
         "roi": "Dolores fugiat nesciunt. Ut laborum dolores. Sit neque eos. Expedita molestiae quia.",
-        "language": "en",
         "income_in_last_3_years": "100K - 500K",
         "number_of_employees": 10,
         "number_of_employees_women": 6,
         "number_of_employees_young": 2,
         "number_of_employees_indigenous": 3,
-        "number_of_employees_migrants": 2
+        "number_of_employees_migrants": 2,
+        "language": "en"
       },
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "ffa35d29-40a6-4a5c-82fe-837ac16acc00",
+            "id": "7931a314-56cd-408f-bca7-f0c1ee0a1dc2",
             "type": "project_developer"
           }
         }
       }
     },
     {
-      "id": "c5fd7ccd-5c91-413e-af30-8812d0ca834c",
+      "id": "e50cca72-4e0b-4693-991b-704d0ef9a95e",
       "type": "project",
       "attributes": {
         "name": "Project 5",
@@ -189,8 +189,8 @@
         "description": "Autem et et. Voluptatem neque quibusdam. Repellat recusandae eum. Eius ex est.",
         "ticket_size": "scaling",
         "categories": [
-          "forestry_and_agroforestry",
-          "non_timber_forest_production"
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
         ],
         "instrument_types": [
           "grant",
@@ -208,25 +208,25 @@
         "impact_description": "Autem et et. Voluptatem neque quibusdam. Repellat recusandae eum. Eius ex est.",
         "sustainability": "Autem et et. Voluptatem neque quibusdam. Repellat recusandae eum. Eius ex est.",
         "roi": "Autem et et. Voluptatem neque quibusdam. Repellat recusandae eum. Eius ex est.",
-        "language": "en",
         "income_in_last_3_years": "100K - 500K",
         "number_of_employees": 10,
         "number_of_employees_women": 6,
         "number_of_employees_young": 2,
         "number_of_employees_indigenous": 3,
-        "number_of_employees_migrants": 2
+        "number_of_employees_migrants": 2,
+        "language": "en"
       },
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "932f9390-9fa7-4e3c-9d56-391534bfb74f",
+            "id": "01b8dc61-7e5d-4385-89f9-668c0f6ac087",
             "type": "project_developer"
           }
         }
       }
     },
     {
-      "id": "7654da0e-9795-435a-82ce-6cf3b64c2ee4",
+      "id": "ac67dc12-a11b-458f-ae84-de2e30d789a4",
       "type": "project",
       "attributes": {
         "name": "Project 6",
@@ -234,8 +234,8 @@
         "description": "Porro soluta beatae. Quia ratione facilis. Eligendi sapiente voluptatem. Quas rerum officia.",
         "ticket_size": "scaling",
         "categories": [
-          "forestry_and_agroforestry",
-          "non_timber_forest_production"
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
         ],
         "instrument_types": [
           "grant",
@@ -253,25 +253,25 @@
         "impact_description": "Porro soluta beatae. Quia ratione facilis. Eligendi sapiente voluptatem. Quas rerum officia.",
         "sustainability": "Porro soluta beatae. Quia ratione facilis. Eligendi sapiente voluptatem. Quas rerum officia.",
         "roi": "Porro soluta beatae. Quia ratione facilis. Eligendi sapiente voluptatem. Quas rerum officia.",
-        "language": "en",
         "income_in_last_3_years": "100K - 500K",
         "number_of_employees": 10,
         "number_of_employees_women": 6,
         "number_of_employees_young": 2,
         "number_of_employees_indigenous": 3,
-        "number_of_employees_migrants": 2
+        "number_of_employees_migrants": 2,
+        "language": "en"
       },
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "464ad823-8159-40fc-86b9-b20a94762b7e",
+            "id": "44dbfd7b-e7df-4270-a857-22b39c5117fc",
             "type": "project_developer"
           }
         }
       }
     },
     {
-      "id": "4b25c8b9-7a7d-4a9a-a45b-066992bf1f00",
+      "id": "29842cba-21ca-493b-a6db-644194b9f357",
       "type": "project",
       "attributes": {
         "name": "Project 7",
@@ -279,8 +279,8 @@
         "description": "Mollitia aut vel. Qui illum accusantium. Et laudantium et. Sed recusandae aut.",
         "ticket_size": "scaling",
         "categories": [
-          "forestry_and_agroforestry",
-          "non_timber_forest_production"
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
         ],
         "instrument_types": [
           "grant",
@@ -298,18 +298,18 @@
         "impact_description": "Mollitia aut vel. Qui illum accusantium. Et laudantium et. Sed recusandae aut.",
         "sustainability": "Mollitia aut vel. Qui illum accusantium. Et laudantium et. Sed recusandae aut.",
         "roi": "Mollitia aut vel. Qui illum accusantium. Et laudantium et. Sed recusandae aut.",
-        "language": "en",
         "income_in_last_3_years": "100K - 500K",
         "number_of_employees": 10,
         "number_of_employees_women": 6,
         "number_of_employees_young": 2,
         "number_of_employees_indigenous": 3,
-        "number_of_employees_migrants": 2
+        "number_of_employees_migrants": 2,
+        "language": "en"
       },
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "3075a1f9-fa39-489b-be40-45b645371ec1",
+            "id": "f97297b2-83d5-4387-8e50-5ac49f9a4ea9",
             "type": "project_developer"
           }
         }

--- a/backend/spec/requests/api/v1/enums_spec.rb
+++ b/backend/spec/requests/api/v1/enums_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe "API V1 Enums", type: :request do
+  describe "GET #index" do
+    it "should return enums" do
+      get "/api/v1/enums"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to match_snapshot("api/v1/enums")
+    end
+  end
+end


### PR DESCRIPTION
Adding jumbo endpoint that fetches all enums and will be cached on the frontend `api/v1/enums`

Also adding missing descriptions and other attributes for some of them.

Slugs were changed to use hyphen instead of underscore for consistency.

Source strings for translations pushed to Transifex. I have done this manually to check what happens when changing slugs, and looks like old were removed and new were added. We could add GitHub action to `tx push -s` whenever PR is merged to develop.

## Testing instructions

Check `api/v1/enums`

## Tracking

https://vizzuality.atlassian.net/browse/LET-151
