### PR TITLE
Implement the textarea component

### DIFF
--- a/frontend/components/forms/input/component.tsx
+++ b/frontend/components/forms/input/component.tsx
@@ -32,7 +32,7 @@ export const Input = <FormValues extends FieldValues>({
       aria-label={ariaLabel}
       type={type}
       className={cx({
-        'block w-full px-4 py-2 text-base text-gray-900 placeholder-gray-400 placeholder-opacity-100 border border-solid border-beige hover:shadow-sm focus:shadow-sm focus:border-green-dark outline-none bg-white rounded-lg disabled:opacity-60 transition-all':
+        'block w-full px-4 py-2 text-base text-gray-900 placeholder-gray-400 placeholder-opacity-100 border border-solid border-beige hover:shadow-sm focus:shadow-sm focus:border-green-dark outline-none bg-white rounded-lg disabled:opacity-60 transition':
           true,
         [className]: !!className,
         'invalid:border-red': invalid,

--- a/frontend/components/forms/textarea/component.stories.tsx
+++ b/frontend/components/forms/textarea/component.stories.tsx
@@ -1,43 +1,120 @@
-import { Story } from '@storybook/react/types-6-0';
+import React from 'react';
 
-import Textarea from './component';
-import { TextareaProps } from './types';
+import { SubmitHandler, useForm } from 'react-hook-form';
+
+import { action } from '@storybook/addon-actions';
+import { Story, Meta } from '@storybook/react/types-6-0';
+
+import Button from 'components/button';
+
+import Textarea, { TextareaProps, TextareaResize } from '.';
 
 export default {
-  title: 'Components/Forms/Textarea',
   component: Textarea,
+  title: 'Components/Forms/Textarea',
   argTypes: {
-    theme: {
-      control: {
-        type: 'select',
-        options: ['dark', 'light'],
-      },
-    },
-    status: {
-      control: {
-        type: 'select',
-        options: ['none', 'valid', 'error', 'disabled'],
-      },
-    },
-    TextareaHTMLAttributes: {
-      name: 'TextareaHTMLAttributes',
-      description: 'https://www.w3schools.com/tags/tag_textarea.asp',
-      table: {
-        type: {
-          summary: 'TextareaHTMLAttributes',
-          detail: null,
-        },
-      },
-      control: {
-        disabled: true,
-      },
-    },
+    register: { control: { disable: true } },
+  },
+} as Meta;
+
+interface FormValues {
+  details: string;
+}
+
+const Template: Story<TextareaProps<FormValues>> = (args: TextareaProps<FormValues>) => {
+  const { register } = useForm<FormValues>();
+
+  return (
+    <>
+      <Textarea register={register} {...args} />
+      <p className="mt-2 text-xs text-gray-50">
+        This textarea is not accessible. Either define <code>aria-label</code> or associate a label
+        (see the “With Label” story).
+      </p>
+    </>
+  );
+};
+
+export const Default: Story<TextareaProps<FormValues>> = Template.bind({});
+Default.args = {
+  id: 'form-details',
+  name: 'details',
+  placeholder: 'Details about your initiative',
+  resize: TextareaResize.Vertically,
+  registerOptions: {
+    disabled: false,
   },
 };
 
-const Template: Story<TextareaProps> = (args) => <Textarea {...args} />;
+const TemplateWithLabel: Story<TextareaProps<FormValues>> = (args: TextareaProps<FormValues>) => {
+  const { register } = useForm<FormValues>();
 
-export const Default = Template.bind({});
-Default.args = {
-  theme: 'dark',
+  return (
+    <>
+      <label htmlFor={args.id} className="mb-2">
+        Details
+      </label>
+      <Textarea register={register} {...args} />
+    </>
+  );
+};
+
+export const WithLabel: Story<TextareaProps<FormValues>> = TemplateWithLabel.bind({});
+WithLabel.args = {
+  id: 'form-details',
+  name: 'details',
+  placeholder: 'Details about your initiative',
+  registerOptions: {
+    disabled: false,
+  },
+};
+
+const TemplateWithForm: Story<TextareaProps<FormValues>> = (args: TextareaProps<FormValues>) => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>({
+    // Using the native validation, we're able to style the inputs using the `valid` and `invalid`
+    // pseudo class
+    shouldUseNativeValidation: true,
+  });
+  const onSubmit: SubmitHandler<FormValues> = (data) => action('onSubmit')(data);
+
+  return (
+    <form
+      // `noValidate` here prevents the browser from not submitting the form if there's a validation
+      // error. We absolutely want the form to be submitted so that React Hook Form is made aware of
+      // the validation errors and we can display errors below inputs.
+      noValidate
+      onSubmit={handleSubmit(onSubmit)}
+    >
+      <label htmlFor={args.id} className="mb-2">
+        Details
+      </label>
+      <Textarea register={register} aria-describedby="form-error" {...args} />
+      {errors.details?.message && (
+        <p id="form-error" className="pl-2 mt-1 text-xs text-red">
+          {errors.details?.message}
+        </p>
+      )}
+      <Button type="submit" className="mt-2">
+        Submit
+      </Button>
+      <p className="mt-2 text-xs text-gray-50">
+        Submit the form to see the {"textareas's"} error state (the textarea is required).
+      </p>
+    </form>
+  );
+};
+
+export const ErrorState: Story<TextareaProps<FormValues>> = TemplateWithForm.bind({});
+ErrorState.args = {
+  id: 'form-details',
+  name: 'details',
+  placeholder: 'Details about your initiative',
+  registerOptions: {
+    disabled: false,
+    required: 'Details are required.',
+  },
 };

--- a/frontend/components/forms/textarea/component.tsx
+++ b/frontend/components/forms/textarea/component.tsx
@@ -1,53 +1,47 @@
-import { FC } from 'react';
+import React, { useState } from 'react';
+
+import { FieldValues } from 'react-hook-form';
 
 import cx from 'classnames';
 
-import useStatus from '../utils';
+import { TextareaProps, TextareaResize } from './types';
 
-import type { TextareaProps } from './types';
-
-const THEME = {
-  dark: {
-    base: 'leading-tight text-white bg-transparent border rounded',
-    status: {
-      none: 'border-gray-500',
-      valid: 'border-green-500',
-      error: 'border-red-500',
-      disabled: 'border-gray-700 opacity-50',
-    },
-  },
-  light: {
-    base: 'leading-tight text-gray-800 bg-white border rounded',
-    status: {
-      none: 'border-gray-500',
-      valid: 'border-green-500',
-      error: 'border-red-500',
-      disabled: 'border-gray-700 opacity-50',
-    },
-  },
-};
-
-export const Textarea: FC<TextareaProps> = ({
-  theme = 'dark',
-  disabled = false,
-  meta = {},
-  input,
+export const Textarea = <FormValues extends FieldValues>({
+  id,
+  'aria-label': ariaLabel,
+  rows = 3,
+  resize = TextareaResize.None,
+  name,
+  register,
+  registerOptions,
   className,
-  ...props
-}: TextareaProps) => {
-  const st = useStatus({ meta, disabled });
+  ...rest
+}: TextareaProps<FormValues>) => {
+  // We want the input to have some specific styles when it is invalid (most likely required and
+  // empty). Unfortunately the `:invalid` pseudo-class is always matched, even if the form has not
+  // been submitted yet. In order to only display the error styles when relevant, we listen to the
+  // `invalid` event which is triggered when the input is validated and invalid. If not manually
+  // triggered, the validation only happens when the form is submitted, hence we can dynamically
+  // add the `:invalid` styles at that point.
+  // Note that we don't care about setting this variable back to `false` because what only matters
+  // is to not display the `:invalid` styles too soon.
+  const [invalid, setInvalid] = useState(false);
 
   return (
     <textarea
-      {...input}
-      {...props}
-      disabled={disabled}
+      id={id}
+      aria-label={ariaLabel}
       className={cx({
-        'form-textarea w-full': true,
-        [THEME[theme].base]: true,
-        [THEME[theme].status[st]]: true,
+        'block w-full px-4 py-2 text-base text-gray-900 placeholder-gray-400 placeholder-opacity-100 border border-solid border-beige hover:shadow-sm focus:shadow-sm focus:border-green-dark outline-none bg-white rounded-lg disabled:opacity-60 transition':
+          true,
+        [resize]: true,
         [className]: !!className,
+        'invalid:border-red': invalid,
       })}
+      rows={rows}
+      {...register(name, registerOptions)}
+      onInvalid={() => setInvalid(true)}
+      {...rest}
     />
   );
 };

--- a/frontend/components/forms/textarea/index.ts
+++ b/frontend/components/forms/textarea/index.ts
@@ -1,1 +1,3 @@
+export type { TextareaProps } from './types';
+export { TextareaResize } from './types';
 export { default } from './component';

--- a/frontend/components/forms/textarea/types.d.ts
+++ b/frontend/components/forms/textarea/types.d.ts
@@ -1,7 +1,0 @@
-import { TextareaHTMLAttributes } from 'react';
-
-export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
-  theme?: 'dark' | 'light';
-  input?: Record<string, unknown>;
-  meta?: Record<string, unknown>;
-}

--- a/frontend/components/forms/textarea/types.ts
+++ b/frontend/components/forms/textarea/types.ts
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import { Path, UseFormRegister, RegisterOptions, FieldPath } from 'react-hook-form';
+
+export enum TextareaResize {
+  Vertically = 'resize-y',
+  Horizontally = 'resize-x',
+  Resize = 'resize',
+  None = 'resize-none',
+}
+
+export type TextareaProps<FormValues> = {
+  /** ID of the element. Required if `aria-label` is not provided. */
+  id?: string;
+  /** Label of the element. Required `id` is not provided. */
+  'aria-label'?: string;
+  /** Number of rows to display. Defaults to `3` */
+  rows?: number;
+  /** Whether (and how) to allow the textarea to be resized. Defaults to `None` */
+  resize?: TextareaResize;
+  /** Name of the textarea */
+  name: Path<FormValues>;
+  /** React Hook Form's `register` function */
+  register: UseFormRegister<FormValues>;
+  /** Options for React Hook Form's `register` function */
+  registerOptions?: RegisterOptions<FormValues, FieldPath<FormValues>>;
+} & Omit<
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+  keyof RegisterOptions<FormValues, FieldPath<FormValues>>
+>;


### PR DESCRIPTION
This PR adds a simple textarea component.

## Testing instructions

- Respects the [visual design](https://www.figma.com/file/3epSYh4KQZBCyh4Y5OzmHw/HeCo---Design-System?node-id=2313%3A39251)
- Has visual error state when input validation fails ([see error state example](https://www.figma.com/file/3epSYh4KQZBCyh4Y5OzmHw/HeCo---Design-System?node-id=2377%3A3138))
- Compatible with React Hook Form (see [example of integration](https://react-hook-form.com/get-started/#Integratinganexistingform))
- Accessible by [WCAG 2.1 standards](https://www.w3.org/TR/WCAG21/)
- Focused state for keyboard users
- Requires an 'id' prop to link to a label externally
- Available in Storybook

## Tracking

[LET-169](https://vizzuality.atlassian.net/browse/LET-169).
