### PR TITLE
Adding regions to Colombia locations

### DIFF
--- a/backend/app/controllers/api/v1/enums_controller.rb
+++ b/backend/app/controllers/api/v1/enums_controller.rb
@@ -8,7 +8,8 @@ module API
           TicketSize.all,
           Impact.all,
           # ProjectDeveloperType.all, wait for better definition
-          InvestorType.all
+          InvestorType.all,
+          LocationType.all
         ].flatten
 
         serialized_enums = data.map do |d|

--- a/backend/app/controllers/api/v1/locations_controller.rb
+++ b/backend/app/controllers/api/v1/locations_controller.rb
@@ -1,0 +1,36 @@
+module API
+  module V1
+    class LocationsController < BaseController
+      before_action :fetch_location, only: :show
+
+      def index
+        locations = apply_filter_for Location.all.includes(:regions, parent: :parent)
+        render json: LocationSerializer.new(
+          locations,
+          include: included_relationships,
+          fields: sparse_fieldset
+        ).serializable_hash
+      end
+
+      def show
+        render json: LocationSerializer.new(
+          @location,
+          include: included_relationships,
+          fields: sparse_fieldset
+        ).serializable_hash
+      end
+
+      private
+
+      def apply_filter_for(query)
+        query = query.where location_type: params[:location_type] if params[:location_type].present?
+        query = query.where parent_id: params[:parent_id] if params[:parent_id].present?
+        query
+      end
+
+      def fetch_location
+        @location = Location.find(params[:id])
+      end
+    end
+  end
+end

--- a/backend/app/models/location.rb
+++ b/backend/app/models/location.rb
@@ -2,6 +2,8 @@ class Location < ApplicationRecord
   belongs_to :parent, class_name: "Location", optional: true
 
   has_many :locations, class_name: "Location", foreign_key: "parent_id", dependent: :destroy
+  has_many :location_members, dependent: :destroy
+  has_many :regions, through: :location_members, source: :member
 
   validates :location_type, inclusion: {in: LocationType::TYPES}
   validates_presence_of :name

--- a/backend/app/models/location_member.rb
+++ b/backend/app/models/location_member.rb
@@ -1,0 +1,4 @@
+class LocationMember < ApplicationRecord
+  belongs_to :location
+  belongs_to :member, class_name: "Location"
+end

--- a/backend/app/models/location_type.rb
+++ b/backend/app/models/location_type.rb
@@ -2,7 +2,7 @@ class LocationType
   include EnumModel
 
   TYPES = %w[
-    state
+    country
     department
     municipality
     region

--- a/backend/app/models/location_type.rb
+++ b/backend/app/models/location_type.rb
@@ -5,5 +5,6 @@ class LocationType
     state
     department
     municipality
+    region
   ].freeze
 end

--- a/backend/app/serializers/api/v1/enums/location_type_serializer.rb
+++ b/backend/app/serializers/api/v1/enums/location_type_serializer.rb
@@ -1,0 +1,9 @@
+module API
+  module V1
+    module Enums
+      class LocationTypeSerializer
+        include EnumSerializer
+      end
+    end
+  end
+end

--- a/backend/app/serializers/api/v1/location_serializer.rb
+++ b/backend/app/serializers/api/v1/location_serializer.rb
@@ -1,0 +1,13 @@
+module API
+  module V1
+    class LocationSerializer
+      include JSONAPI::Serializer
+
+      attributes :name, :location_type
+
+      belongs_to :parent, serializer: :location
+
+      has_many :regions, serializer: :location
+    end
+  end
+end

--- a/backend/app/services/importers/locations.rb
+++ b/backend/app/services/importers/locations.rb
@@ -2,12 +2,13 @@ require "csv"
 
 module Importers
   class Locations
-    attr_accessor :state_name, :state, :departments_file_path, :municipalities_file_path
+    attr_accessor :state_name, :state, :departments_file_path, :municipalities_file_path, :regions_file_path
 
-    def initialize(state_name, departments_file_path:, municipalities_file_path:)
+    def initialize(state_name, departments_file_path:, municipalities_file_path:, regions_file_path:)
       @state_name = state_name
       @departments_file_path = departments_file_path
       @municipalities_file_path = municipalities_file_path
+      @regions_file_path = regions_file_path
     end
 
     def call
@@ -15,6 +16,8 @@ module Importers
         import_state!
         import_departments!
         import_municipalities!
+        import_regions!
+        add_regions_to_municipalities!
       end
     end
 
@@ -38,8 +41,40 @@ module Importers
       Location.insert_all data
     end
 
+    def import_regions!
+      data = CSV.foreach(regions_file_path, col_sep: ";").first[1..].map do |header|
+        {name_en: header, parent_id: state.id, location_type: "region"}
+      end
+      Location.insert_all data
+    end
+
+    def add_regions_to_municipalities!
+      data = CSV.parse(File.read(regions_file_path), headers: true, col_sep: ";").each_with_object([]) do |row, res|
+        row.to_hash.except("municipality").each do |region_name, indicator|
+          next unless indicator == "True"
+
+          res << {location_id: municipalities[row["municipality"]].first.id,
+                   member_id: regions[region_name].first.id}
+        end
+      end
+      LocationMember.insert_all data
+    end
+
     def departments
-      @departments ||= Location.where(parent: state).select(:id, :name_en).group_by(&:name_en)
+      @departments ||= minify Location.where(parent: state, location_type: "department")
+    end
+
+    def regions
+      @regions ||= minify Location.where(parent: state, location_type: "region")
+    end
+
+    def municipalities
+      @municipalities ||= minify Location.where(parent_id: departments.values.flatten.map(&:id),
+        location_type: "municipality")
+    end
+
+    def minify(query)
+      query.select(:id, :name_en).group_by(&:name_en)
     end
   end
 end

--- a/backend/app/services/importers/locations.rb
+++ b/backend/app/services/importers/locations.rb
@@ -57,7 +57,7 @@ module Importers
                    member_id: regions[region_name].first.id}
         end
       end
-      LocationMember.insert_all data
+      LocationMember.insert_all data if data.present?
     end
 
     def departments

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -82,3 +82,12 @@ zu:
       community:
         name: Community
         description: Impact of projects on ensuring and improving equal and inclusive physical, mental, economic, and spiritual health.
+    location_type:
+      country:
+        name: Country
+      department:
+        name: Department
+      municipality:
+        name: Municipality
+      region:
+        name: Region

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   namespace :api, format: "json" do
     namespace :v1 do
       resources :investors, only: [:index, :show]
+      resources :locations, only: [:index, :show]
       resources :open_calls, only: [:index, :show]
       resources :project_developers, only: [:index, :show]
       resources :projects, only: [:index, :show]

--- a/backend/db/migrate/20220318141809_create_location_members.rb
+++ b/backend/db/migrate/20220318141809_create_location_members.rb
@@ -1,0 +1,12 @@
+class CreateLocationMembers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :location_members, id: :uuid do |t|
+      t.belongs_to :location, foreign_key: {on_delete: :cascade}, type: :uuid, null: false
+      t.belongs_to :member, foreign_key: {on_delete: :cascade, to_table: :locations}, type: :uuid, null: false
+
+      t.index [:location_id, :member_id], unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_17_074221) do
+ActiveRecord::Schema[7.0].define(version: 2022_03_18_141809) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -99,6 +99,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_17_074221) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["account_id"], name: "index_investors_on_account_id"
+  end
+
+  create_table "location_members", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "location_id", null: false
+    t.uuid "member_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["location_id", "member_id"], name: "index_location_members_on_location_id_and_member_id", unique: true
+    t.index ["location_id"], name: "index_location_members_on_location_id"
+    t.index ["member_id"], name: "index_location_members_on_member_id"
   end
 
   create_table "locations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -233,6 +243,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_17_074221) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "investors", "accounts", on_delete: :cascade
+  add_foreign_key "location_members", "locations", column: "member_id", on_delete: :cascade
+  add_foreign_key "location_members", "locations", on_delete: :cascade
   add_foreign_key "locations", "locations", column: "parent_id", on_delete: :cascade
   add_foreign_key "open_calls", "investors", on_delete: :cascade
   add_foreign_key "project_developers", "accounts", on_delete: :cascade

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -43,5 +43,6 @@ if Rails.env.development?
 
   Importers::Locations.new("Colombia",
     departments_file_path: Rails.root.join("db/seeds/files/colombia_departments.csv"),
-    municipalities_file_path: Rails.root.join("db/seeds/files/colombia_municipalities.csv")).call
+    municipalities_file_path: Rails.root.join("db/seeds/files/colombia_municipalities.csv"),
+    regions_file_path: Rails.root.join("db/seeds/files/colombia_regions.csv")).call
 end

--- a/backend/db/seeds/files/colombia_departments.csv
+++ b/backend/db/seeds/files/colombia_departments.csv
@@ -1,34 +1,33 @@
-name;wiki_link
-Amazonas Department;/wiki/Amazonas_Department
-Antioquia Department;/wiki/Antioquia_Department
-Arauca Department;/wiki/Arauca_Department
-Atlántico Department;/wiki/Atl%C3%A1ntico_Department
-Bogotá, Capital District;/wiki/Bogot%C3%A1;_Capital_District
-Bolívar Department;/wiki/Bol%C3%ADvar_Department
-Boyacá Department;/wiki/Boyac%C3%A1_Department
-Caldas Department;/wiki/Caldas_Department
-Caquetá Department;/wiki/Caquet%C3%A1_Department
-Casanare Department;/wiki/Casanare_Department
-Cauca Department;/wiki/Cauca_Department
-Cesar Department;/wiki/Cesar_Department
-Chocó Department;/wiki/Choc%C3%B3_Department
-Córdoba Department;/wiki/C%C3%B3rdoba_Department
-Cundinamarca Department;/wiki/Cundinamarca_Department
-La Guajira Department;/wiki/La_Guajira_Department
-Guainía Department;/wiki/Guain%C3%ADa_Department
-Guaviare Department;/wiki/Guaviare_Department
-Huila Department;/wiki/Huila_Department
-Magdalena Department;/wiki/Magdalena_Department
-Meta Department;/wiki/Meta_Department
-Nariño Department;/wiki/Nari%C3%B1o_Department
-Norte de Santander Department;/wiki/Norte_de_Santander_Department
-Putumayo Department;/wiki/Putumayo_Department
-Quindío Department;/wiki/Quind%C3%ADo_Department
-Risaralda Department;/wiki/Risaralda_Department
-San Andrés and Providencia Department;/wiki/Archipelago_of_San_Andr%C3%A9s;_Providencia_and_Santa_Catalina
-Santander Department;/wiki/Santander_Department
-Sucre Department;/wiki/Sucre_Department
-Tolima Department;/wiki/Tolima_Department
-Valle del Cauca Department;/wiki/Valle_del_Cauca_Department
-Vaupés Department;/wiki/Vaup%C3%A9s_Department
-Vichada Department;/wiki/Vichada_Department
+name
+Amazonas
+Antioquia
+Arauca
+Atlántico
+Bolívar
+Boyacá
+Caldas
+Caquetá
+Casanare
+Cauca
+Cesar
+Chocó
+Córdoba
+Cundinamarca
+Guainía
+Guaviare
+Huila
+La Guajira
+Magdalena
+Meta
+Nariño
+Norte De Santander
+Putumayo
+Quindío
+Risaralda
+San Andrés Providencia Y Santa Catalina
+Santander
+Sucre
+Tolima
+Valle Del Cauca
+Vaupés
+Vichada

--- a/backend/db/seeds/files/colombia_municipalities.csv
+++ b/backend/db/seeds/files/colombia_municipalities.csv
@@ -1,485 +1,485 @@
 name;department;wiki_link;latitude;longitude
-Leticia;Amazonas Department;/wiki/Leticia;_Colombia;-4.216666666666667;-69.93333333333334
+Leticia;Amazonas Department;/wiki/Leticia,_Colombia;-4.216666666666667;-69.93333333333334
 Puerto Nariño;Amazonas Department;/wiki/Puerto_Nari%C3%B1o;-3.7666666666666666;-70.36666666666666
 El Encanto;Amazonas Department;/wiki/El_Encanto;-1.7666666666666666;-73.2
-La Chorrera;Amazonas Department;/wiki/La_Chorrera;_Colombia;-1.4333333333333333;-72.78333333333333
-La Pedrera;Amazonas Department;/wiki/La_Pedrera;_Amazonas;-1.3166666666666667;-69.56666666666666
-La Victoria;Amazonas Department;/wiki/La_Victoria;_Amazonas;0.05;-71.21666666666667
+La Chorrera;Amazonas Department;/wiki/La_Chorrera,_Colombia;-1.4333333333333333;-72.78333333333333
+La Pedrera;Amazonas Department;/wiki/La_Pedrera,_Amazonas;-1.3166666666666667;-69.56666666666666
+La Victoria;Amazonas Department;/wiki/La_Victoria,_Amazonas;0.05;-71.21666666666667
 Mirití-Paraná;Amazonas Department;/wiki/Mirit%C3%AD-Paran%C3%A1;-0.8833333333333333;-70.98333333333333
 Puerto Alegría;Amazonas Department;/wiki/Puerto_Alegr%C3%ADa;-1.0333333333333334;-74.03333333333333
 Puerto Arica;Amazonas Department;/wiki/Puerto_Arica;-2.1333333333333333;-71.75
-Puerto Santander;Amazonas Department;/wiki/Puerto_Santander;_Amazonas;-0.6166666666666667;-72.38333333333334
-Tarapacá;Amazonas Department;/wiki/Tarapac%C3%A1;_Amazonas;-2.8666666666666667;-69.73333333333333
+Puerto Santander;Amazonas Department;/wiki/Puerto_Santander,_Amazonas;-0.6166666666666667;-72.38333333333334
+Tarapacá;Amazonas Department;/wiki/Tarapac%C3%A1,_Amazonas;-2.8666666666666667;-69.73333333333333
 Abejorral;Antioquia Department;/wiki/Abejorral;5.783333333333333;-75.41666666666667
 Abriaquí;Antioquia Department;/wiki/Abriaqu%C3%AD;6.633333333333333;-76.06666666666666
 Alejandría;Antioquia Department;/wiki/Alejandr%C3%ADa;6.366666666666666;-75.13333333333334
 Amagá;Antioquia Department;/wiki/Amag%C3%A1;6.05;-75.7
-Amalfi;Antioquia Department;/wiki/Amalfi;_Antioquia;6.916666666666667;-75.08333333333333
-Andes;Antioquia Department;/wiki/Andes;_Antioquia;5.583333333333333;-75.91666666666667
+Amalfi;Antioquia Department;/wiki/Amalfi,_Antioquia;6.916666666666667;-75.08333333333333
+Andes;Antioquia Department;/wiki/Andes,_Antioquia;5.583333333333333;-75.91666666666667
 Angelópolis;Antioquia Department;/wiki/Angel%C3%B3polis;6.133333333333334;-75.7
-Angostura;Antioquia Department;/wiki/Angostura;_Antioquia;6.866666666666667;-75.33333333333333
+Angostura;Antioquia Department;/wiki/Angostura,_Antioquia;6.866666666666667;-75.33333333333333
 Anorí;Antioquia Department;/wiki/Anor%C3%AD;7.066666666666666;-75.13333333333334
-Anzá;Antioquia Department;/wiki/Anz%C3%A1;_Antioquia;6.3;-75.85
+Anzá;Antioquia Department;/wiki/Anz%C3%A1,_Antioquia;6.3;-75.85
 Apartadó;Antioquia Department;/wiki/Apartad%C3%B3;7.883333333333333;-76.63333333333334
 Arboletes;Antioquia Department;/wiki/Arboletes;8.85;-76.41666666666667
-Argelia;Antioquia Department;/wiki/Argelia;_Antioquia;5.733333333333333;-75.13333333333334
-Armenia;Antioquia Department;/wiki/Armenia;_Antioquia;6.15;-75.78333333333333
-Barbosa;Antioquia Department;/wiki/Barbosa;_Antioquia;6.433333333333334;-75.31666666666666
-Bello;Antioquia Department;/wiki/Bello;_Antioquia;6.333333333333333;-75.56666666666666
+Argelia;Antioquia Department;/wiki/Argelia,_Antioquia;5.733333333333333;-75.13333333333334
+Armenia;Antioquia Department;/wiki/Armenia,_Antioquia;6.15;-75.78333333333333
+Barbosa;Antioquia Department;/wiki/Barbosa,_Antioquia;6.433333333333334;-75.31666666666666
+Bello;Antioquia Department;/wiki/Bello,_Antioquia;6.333333333333333;-75.56666666666666
 Belmira;Antioquia Department;/wiki/Belmira;6.6;-75.66666666666667
-Betania;Antioquia Department;/wiki/Betania;_Antioquia;5.75;-75.96666666666667
-Betulia;Antioquia Department;/wiki/Betulia;_Antioquia;6.1;-75.98333333333333
-Bolívar;Antioquia Department;/wiki/Ciudad_Bol%C3%ADvar;_Antioquia;5.85;-76.03333333333333
-Briceño;Antioquia Department;/wiki/Brice%C3%B1o;_Antioquia;7.1;-75.55
+Betania;Antioquia Department;/wiki/Betania,_Antioquia;5.75;-75.96666666666667
+Betulia;Antioquia Department;/wiki/Betulia,_Antioquia;6.1;-75.98333333333333
+Bolívar;Antioquia Department;/wiki/Ciudad_Bol%C3%ADvar,_Antioquia;5.85;-76.03333333333333
+Briceño;Antioquia Department;/wiki/Brice%C3%B1o,_Antioquia;7.1;-75.55
 Buriticá;Antioquia Department;/wiki/Buritic%C3%A1;6.75;-75.91666666666667
-Cáceres;Antioquia Department;/wiki/C%C3%A1ceres;_Antioquia;7.666666666666667;-75.33333333333333
+Cáceres;Antioquia Department;/wiki/C%C3%A1ceres,_Antioquia;7.666666666666667;-75.33333333333333
 Caicedo;Antioquia Department;/wiki/Caicedo;6.4;-75.96666666666667
-Caldas;Antioquia Department;/wiki/Caldas;_Antioquia;6.083333333333333;-75.63333333333334
-Campamento;Antioquia Department;/wiki/Campamento;_Antioquia;6.966666666666667;-75.28333333333333
+Caldas;Antioquia Department;/wiki/Caldas,_Antioquia;6.083333333333333;-75.63333333333334
+Campamento;Antioquia Department;/wiki/Campamento,_Antioquia;6.966666666666667;-75.28333333333333
 Cañasgordas;Antioquia Department;/wiki/Ca%C3%B1asgordas;6.733333333333333;-76.01666666666667
 Caracolí;Antioquia Department;/wiki/Caracol%C3%AD;6.4;-74.75
 Caramanta;Antioquia Department;/wiki/Caramanta;5.583333333333333;-75.58333333333333
 Carepa;Antioquia Department;/wiki/Carepa;7.75;-76.65
 El Carmen de Viboral;Antioquia Department;/wiki/El_Carmen_de_Viboral;6.083333333333333;-75.33333333333333
-Carolina del Príncipe;Antioquia Department;/wiki/Carolina_del_Pr%C3%ADncipe;_Antioquia;6.716666666666667;-75.26666666666667
-Caucasia;Antioquia Department;/wiki/Caucasia;_Antioquia;7.983333333333333;-75.2
+Carolina del Príncipe;Antioquia Department;/wiki/Carolina_del_Pr%C3%ADncipe,_Antioquia;6.716666666666667;-75.26666666666667
+Caucasia;Antioquia Department;/wiki/Caucasia,_Antioquia;7.983333333333333;-75.2
 Chigorodó;Antioquia Department;/wiki/Chigorod%C3%B3;7.666666666666667;-76.66666666666667
-Cisneros;Antioquia Department;/wiki/Cisneros;_Antioquia;6.533333333333333;-75.08333333333333
+Cisneros;Antioquia Department;/wiki/Cisneros,_Antioquia;6.533333333333333;-75.08333333333333
 Cocorná;Antioquia Department;/wiki/Cocorn%C3%A1;6.05;-75.18333333333334
-Concepción;Antioquia Department;/wiki/Concepci%C3%B3n;_Antioquia;6.383333333333334;-75.25
-Concordia;Antioquia Department;/wiki/Concordia;_Antioquia;6.033333333333333;-75.9
-Copacabana;Antioquia Department;/wiki/Copacabana;_Antioquia;6.333333333333333;-75.5
+Concepción;Antioquia Department;/wiki/Concepci%C3%B3n,_Antioquia;6.383333333333334;-75.25
+Concordia;Antioquia Department;/wiki/Concordia,_Antioquia;6.033333333333333;-75.9
+Copacabana;Antioquia Department;/wiki/Copacabana,_Antioquia;6.333333333333333;-75.5
 Dabeiba;Antioquia Department;/wiki/Dabeiba;7.0;-76.25
 Don Matías;Antioquia Department;/wiki/Don_Mat%C3%ADas;6.483333333333333;-75.43333333333334
 Ebéjico;Antioquia Department;/wiki/Eb%C3%A9jico;6.333333333333333;-75.76666666666667
 El Bagre;Antioquia Department;/wiki/El_Bagre;7.583333333333333;-74.8
 Entrerríos;Antioquia Department;/wiki/Entrerr%C3%ADos;6.566666666666666;-75.51666666666667
 Envigado;Antioquia Department;/wiki/Envigado;6.166666666666667;-75.56666666666666
-Fredonia;Antioquia Department;/wiki/Fredonia;_Antioquia;5.916666666666667;-75.66666666666667
-Frontino;Antioquia Department;/wiki/Frontino;_Antioquia;6.783333333333333;-76.13333333333334
-Giraldo;Antioquia Department;/wiki/Giraldo;_Antioquia;6.666666666666667;-75.95
+Fredonia;Antioquia Department;/wiki/Fredonia,_Antioquia;5.916666666666667;-75.66666666666667
+Frontino;Antioquia Department;/wiki/Frontino,_Antioquia;6.783333333333333;-76.13333333333334
+Giraldo;Antioquia Department;/wiki/Giraldo,_Antioquia;6.666666666666667;-75.95
 Girardota;Antioquia Department;/wiki/Girardota;6.366666666666666;-75.43333333333334
 Gómez Plata;Antioquia Department;/wiki/G%C3%B3mez_Plata;6.683333333333334;-75.21666666666667
-Granada;Antioquia Department;/wiki/Granada;_Antioquia;6.147;-75.188
-Guadalupe;Antioquia Department;/wiki/Guadalupe;_Antioquia;6.816666666666666;-75.23333333333333
+Granada;Antioquia Department;/wiki/Granada,_Antioquia;6.147;-75.188
+Guadalupe;Antioquia Department;/wiki/Guadalupe,_Antioquia;6.816666666666666;-75.23333333333333
 Guarne;Antioquia Department;/wiki/Guarne;6.266666666666667;-75.43333333333334
 Guatapé;Antioquia Department;/wiki/Guatap%C3%A9;6.233333333333333;-75.16666666666667
-Heliconia;Antioquia Department;/wiki/Heliconia;_Antioquia;6.216666666666667;-75.73333333333333
-Hispania;Antioquia Department;/wiki/Hispania;_Antioquia;5.8;-75.9
+Heliconia;Antioquia Department;/wiki/Heliconia,_Antioquia;6.216666666666667;-75.73333333333333
+Hispania;Antioquia Department;/wiki/Hispania,_Antioquia;5.8;-75.9
 Itagüí;Antioquia Department;/wiki/Itag%C3%BC%C3%AD;6.166666666666667;-75.61666666666666
 Ituango;Antioquia Department;/wiki/Ituango;7.166666666666667;-75.75
 Jardín;Antioquia Department;/wiki/Jard%C3%ADn;5.583333333333333;-75.81666666666666
-Jericó;Antioquia Department;/wiki/Jeric%C3%B3;_Antioquia;5.783333333333333;-75.78333333333333
-La Ceja;Antioquia Department;/wiki/La_Ceja;_Antioquia;6.016666666666667;-75.41666666666667
-La Estrella;Antioquia Department;/wiki/La_Estrella;_Antioquia;6.166666666666667;-75.66666666666667
-La Pintada;Antioquia Department;/wiki/La_Pintada;_Antioquia;5.75;-75.6
-La Unión;Antioquia Department;/wiki/La_Uni%C3%B3n;_Antioquia;5.966666666666667;-75.35
+Jericó;Antioquia Department;/wiki/Jeric%C3%B3,_Antioquia;5.783333333333333;-75.78333333333333
+La Ceja;Antioquia Department;/wiki/La_Ceja,_Antioquia;6.016666666666667;-75.41666666666667
+La Estrella;Antioquia Department;/wiki/La_Estrella,_Antioquia;6.166666666666667;-75.66666666666667
+La Pintada;Antioquia Department;/wiki/La_Pintada,_Antioquia;5.75;-75.6
+La Unión;Antioquia Department;/wiki/La_Uni%C3%B3n,_Antioquia;5.966666666666667;-75.35
 Liborina;Antioquia Department;/wiki/Liborina;6.683333333333334;-75.81666666666666
-Maceo;Antioquia Department;/wiki/Maceo;_Antioquia;6.55;-74.78333333333333
+Maceo;Antioquia Department;/wiki/Maceo,_Antioquia;6.55;-74.78333333333333
 Marinilla;Antioquia Department;/wiki/Marinilla;6.166666666666667;-75.33333333333333
 Medellín;Antioquia Department;/wiki/Medell%C3%ADn;6.216666666666667;-75.58333333333333
-Montebello;Antioquia Department;/wiki/Montebello;_Antioquia;5.916666666666667;-75.5
+Montebello;Antioquia Department;/wiki/Montebello,_Antioquia;5.916666666666667;-75.5
 Murindó;Antioquia Department;/wiki/Murind%C3%B3;6.8;-76.8
 Mutatá;Antioquia Department;/wiki/Mutat%C3%A1;7.233333333333333;-76.43333333333334
-Nariño;Antioquia Department;/wiki/Nari%C3%B1o;_Antioquia;5.6;-75.16666666666667
+Nariño;Antioquia Department;/wiki/Nari%C3%B1o,_Antioquia;5.6;-75.16666666666667
 Nechí;Antioquia Department;/wiki/Nech%C3%AD;8.1;-74.78333333333333
 Necoclí;Antioquia Department;/wiki/Necocl%C3%AD;8.416666666666666;-76.78333333333333
-Olaya;Antioquia Department;/wiki/Olaya;_Antioquia;6.616666666666667;-75.8
-Peñol;Antioquia Department;/wiki/El_Pe%C3%B1ol;_Antioquia;6.216666666666667;-75.23333333333333
-Peque;Antioquia Department;/wiki/Peque;_Antioquia;7.016666666666667;-75.91666666666667
+Olaya;Antioquia Department;/wiki/Olaya,_Antioquia;6.616666666666667;-75.8
+Peñol;Antioquia Department;/wiki/El_Pe%C3%B1ol,_Antioquia;6.216666666666667;-75.23333333333333
+Peque;Antioquia Department;/wiki/Peque,_Antioquia;7.016666666666667;-75.91666666666667
 Pueblorrico;Antioquia Department;/wiki/Pueblorrico;5.8;-75.85
 Puerto Berrío;Antioquia Department;/wiki/Puerto_Berr%C3%ADo;6.483333333333333;-74.4
 Puerto Nare;Antioquia Department;/wiki/Puerto_Nare;6.183333333333334;-74.58333333333333
 Puerto Triunfo;Antioquia Department;/wiki/Puerto_Triunfo;5.866666666666667;-74.65
-Remedios;Antioquia Department;/wiki/Remedios;_Antioquia;7.016666666666667;-74.68333333333334
-Retiro;Antioquia Department;/wiki/Retiro;_Antioquia;6.05;-75.5
+Remedios;Antioquia Department;/wiki/Remedios,_Antioquia;7.016666666666667;-74.68333333333334
+Retiro;Antioquia Department;/wiki/Retiro,_Antioquia;6.05;-75.5
 Rionegro;Antioquia Department;/wiki/Rionegro;6.15;-75.36666666666666
-Sabanalarga;Antioquia Department;/wiki/Sabanalarga;_Antioquia;6.85;-75.81666666666666
-Sabaneta;Antioquia Department;/wiki/Sabaneta;_Antioquia;6.15;-75.6
+Sabanalarga;Antioquia Department;/wiki/Sabanalarga,_Antioquia;6.85;-75.81666666666666
+Sabaneta;Antioquia Department;/wiki/Sabaneta,_Antioquia;6.15;-75.6
 Salgar;Antioquia Department;/wiki/Salgar;5.95;-75.96666666666667
 San Andrés;Antioquia Department;/wiki/San_Andr%C3%A9s_de_Cuerquia;6.9;-75.66666666666667
-San Carlos;Antioquia Department;/wiki/San_Carlos;_Antioquia;6.18972;-74.9969
-San Francisco;Antioquia Department;/wiki/San_Francisco;_Antioquia;5.95;-75.1
-San Jerónimo;Antioquia Department;/wiki/San_Jer%C3%B3nimo;_Antioquia;6.433333333333334;-75.71666666666667
+San Carlos;Antioquia Department;/wiki/San_Carlos,_Antioquia;6.18972;-74.9969
+San Francisco;Antioquia Department;/wiki/San_Francisco,_Antioquia;5.95;-75.1
+San Jerónimo;Antioquia Department;/wiki/San_Jer%C3%B3nimo,_Antioquia;6.433333333333334;-75.71666666666667
 San José de la Montaña;Antioquia Department;/wiki/San_Jos%C3%A9_de_la_Monta%C3%B1a;7.583333333333333;-72.71666666666667
 San Juan de Urabá;Antioquia Department;/wiki/San_Juan_de_Urab%C3%A1;8.766666666666667;-76.53333333333333
-San Luis;Antioquia Department;/wiki/San_Luis;_Antioquia;6.033333333333333;-74.98333333333333
+San Luis;Antioquia Department;/wiki/San_Luis,_Antioquia;6.033333333333333;-74.98333333333333
 San Pedro;Antioquia Department;/wiki/San_Pedro_de_los_Milagros;6.45;-75.55
 San Pedro de Urabá;Antioquia Department;/wiki/San_Pedro_de_Urab%C3%A1;8.283333333333333;-76.38333333333334
-San Rafael;Antioquia Department;/wiki/San_Rafael;_Antioquia;6.283333333333333;-75.01666666666667
-San Roque;Antioquia Department;/wiki/San_Roque;_Antioquia;6.483333333333333;-75.01666666666667
-Santa Bárbara;Antioquia Department;/wiki/Santa_B%C3%A1rbara;_Antioquia;5.866666666666667;-75.55
+San Rafael;Antioquia Department;/wiki/San_Rafael,_Antioquia;6.283333333333333;-75.01666666666667
+San Roque;Antioquia Department;/wiki/San_Roque,_Antioquia;6.483333333333333;-75.01666666666667
+Santa Bárbara;Antioquia Department;/wiki/Santa_B%C3%A1rbara,_Antioquia;5.866666666666667;-75.55
 Santa Fe de Antioquia;Antioquia Department;/wiki/Santa_Fe_de_Antioquia;6.55;-75.81666666666666
 Santa Rosa de Osos;Antioquia Department;/wiki/Santa_Rosa_de_Osos;6.65;-75.46666666666667
-Santo Domingo;Antioquia Department;/wiki/Santo_Domingo;_Antioquia;6.466666666666667;-75.15
+Santo Domingo;Antioquia Department;/wiki/Santo_Domingo,_Antioquia;6.466666666666667;-75.15
 El Santuario;Antioquia Department;/wiki/El_Santuario;6.133333333333334;-75.25
-San Vicente;Antioquia Department;/wiki/San_Vicente;_Antioquia;6.266666666666667;-75.31666666666666
-Segovia;Antioquia Department;/wiki/Segovia;_Antioquia;7.066666666666666;-74.7
+San Vicente;Antioquia Department;/wiki/San_Vicente,_Antioquia;6.266666666666667;-75.31666666666666
+Segovia;Antioquia Department;/wiki/Segovia,_Antioquia;7.066666666666666;-74.7
 Sonsón;Antioquia Department;/wiki/Sons%C3%B3n;5.7;-75.3
 Sopetrán;Antioquia Department;/wiki/Sopetr%C3%A1n;6.5;-75.73333333333333
-Támesis;Antioquia Department;/wiki/T%C3%A1mesis;_Antioquia;5.666666666666667;-75.71666666666667
+Támesis;Antioquia Department;/wiki/T%C3%A1mesis,_Antioquia;5.666666666666667;-75.71666666666667
 Tarazá;Antioquia Department;/wiki/Taraz%C3%A1;7.583333333333333;-75.4
 Tarso;Antioquia Department;/wiki/Tarso;5.866666666666667;-75.83333333333333
 Titiribí;Antioquia Department;/wiki/Titirib%C3%AD;6.066666666666666;-75.8
-Toledo;Antioquia Department;/wiki/Toledo;_Antioquia;7.0;-75.7
-Turbo;Antioquia Department;/wiki/Turbo;_Colombia;8.1;-76.73333333333333
+Toledo;Antioquia Department;/wiki/Toledo,_Antioquia;7.0;-75.7
+Turbo;Antioquia Department;/wiki/Turbo,_Colombia;8.1;-76.73333333333333
 Uramita;Antioquia Department;/wiki/Uramita;6.883333333333333;-76.16666666666667
 Urrao;Antioquia Department;/wiki/Urrao;6.3;-76.13333333333334
-Valdivia;Antioquia Department;/wiki/Valdivia;_Antioquia;7.283333333333333;-75.38333333333334
-Valparaíso;Antioquia Department;/wiki/Valpara%C3%ADso;_Antioquia;5.6;-75.61666666666666
+Valdivia;Antioquia Department;/wiki/Valdivia,_Antioquia;7.283333333333333;-75.38333333333334
+Valparaíso;Antioquia Department;/wiki/Valpara%C3%ADso,_Antioquia;5.6;-75.61666666666666
 Vegachi;Antioquia Department;/wiki/Vegachi;6.766666666666667;-74.78333333333333
-Venecia;Antioquia Department;/wiki/Venecia;_Antioquia;5.916666666666667;-75.75
+Venecia;Antioquia Department;/wiki/Venecia,_Antioquia;5.916666666666667;-75.75
 Vigía del Fuerte;Antioquia Department;/wiki/Vig%C3%ADa_del_Fuerte;6.583333333333333;-76.88333333333334
-Yali;Antioquia Department;/wiki/Yali;_Antioquia;6.666666666666667;-74.83333333333333
+Yali;Antioquia Department;/wiki/Yali,_Antioquia;6.666666666666667;-74.83333333333333
 Yarumal;Antioquia Department;/wiki/Yarumal;7.0;-75.5
 Yolombó;Antioquia Department;/wiki/Yolomb%C3%B3;6.583333333333333;-75.0
 Yondó;Antioquia Department;/wiki/Yond%C3%B3;7.0;-73.91666666666667
-Zaragoza;Antioquia Department;/wiki/Zaragoza;_Antioquia;7.483333333333333;-74.86666666666666
-Arauca;Arauca Department;/wiki/Arauca;_Arauca;7.083333333333333;-70.75
+Zaragoza;Antioquia Department;/wiki/Zaragoza,_Antioquia;7.483333333333333;-74.86666666666666
+Arauca;Arauca Department;/wiki/Arauca,_Arauca;7.083333333333333;-70.75
 Arauquita;Arauca Department;/wiki/Arauquita;7.03028;-71.4356
 Cravo Norte;Arauca Department;/wiki/Cravo_Norte;6.3;-70.2
 Fortul;Arauca Department;/wiki/Fortul;6.79222;-71.7756
 Puerto Rondón;Arauca Department;/wiki/Puerto_Rond%C3%B3n;6.283333333333333;-71.1
 Saravena;Arauca Department;/wiki/Saravena;6.95;-71.86666666666666
-Tame;Arauca Department;/wiki/Tame;_Arauca;6.466666666666667;-71.73333333333333
+Tame;Arauca Department;/wiki/Tame,_Arauca;6.466666666666667;-71.73333333333333
 Baranoa;Atlántico Department;/wiki/Baranoa;10.8;-74.91666666666667
 Barranquilla;Atlántico Department;/wiki/Barranquilla;10.95;-74.78333333333333
 Campo de la Cruz;Atlántico Department;/wiki/Campo_de_la_Cruz;10.366666666666667;-74.86666666666666
-Candelaria;Atlántico Department;/wiki/Candelaria;_Atl%C3%A1ntico;10.45;-74.86666666666666
-Galapa;Atlántico Department;/wiki/Galapa;_Atl%C3%A1ntico;10.916666666666666;-74.83333333333333
+Candelaria;Atlántico Department;/wiki/Candelaria,_Atl%C3%A1ntico;10.45;-74.86666666666666
+Galapa;Atlántico Department;/wiki/Galapa,_Atl%C3%A1ntico;10.916666666666666;-74.83333333333333
 Juan de Acosta;Atlántico Department;/wiki/Juan_de_Acosta;10.833333333333334;-75.03333333333333
 Luruaco;Atlántico Department;/wiki/Luruaco;10.6;-75.13333333333334
-Malambo;Atlántico Department;/wiki/Malambo;_Atl%C3%A1ntico;10.85;-74.75
-Manatí;Atlántico Department;/wiki/Manat%C3%AD;_Atl%C3%A1ntico;10.433333333333334;-74.95
+Malambo;Atlántico Department;/wiki/Malambo,_Atl%C3%A1ntico;10.85;-74.75
+Manatí;Atlántico Department;/wiki/Manat%C3%AD,_Atl%C3%A1ntico;10.433333333333334;-74.95
 Palmar de Varela;Atlántico Department;/wiki/Palmar_de_Varela;10.75;-74.75
 Piojó;Atlántico Department;/wiki/Pioj%C3%B3;10.75;-75.11666666666666
 Polonuevo;Atlántico Department;/wiki/Polonuevo;10.783333333333333;-74.86666666666666
 Ponedera;Atlántico Department;/wiki/Ponedera;10.65;-74.75
 Puerto Colombia;Atlántico Department;/wiki/Puerto_Colombia;11.016666666666667;-74.88333333333334
 Repelón;Atlántico Department;/wiki/Repel%C3%B3n;10.55;-75.13333333333334
-Sabanagrande;Atlántico Department;/wiki/Sabanagrande;_Atl%C3%A1ntico;10.8;-74.75
-Sabanalarga;Atlántico Department;/wiki/Sabanalarga;_Atl%C3%A1ntico;6.85;-75.81666666666666
-Santa Lucia;Atlántico Department;/wiki/Santa_Luc%C3%ADa;_Atl%C3%A1ntico;10.316666666666666;-74.95
-Santo Tomas;Atlántico Department;/wiki/Santo_Tom%C3%A1s;_Atlantico;10.766666666666667;-74.91666666666667
-Soledad;Atlántico Department;/wiki/Soledad;_Atl%C3%A1ntico;10.916666666666666;-74.75
-Suan;Atlántico Department;/wiki/Suan;_Atl%C3%A1ntico;10.333333333333334;-74.88333333333334
+Sabanagrande;Atlántico Department;/wiki/Sabanagrande,_Atl%C3%A1ntico;10.8;-74.75
+Sabanalarga;Atlántico Department;/wiki/Sabanalarga,_Atl%C3%A1ntico;6.85;-75.81666666666666
+Santa Lucia;Atlántico Department;/wiki/Santa_Luc%C3%ADa,_Atl%C3%A1ntico;10.316666666666666;-74.95
+Santo Tomas;Atlántico Department;/wiki/Santo_Tom%C3%A1s,_Atlantico;10.766666666666667;-74.91666666666667
+Soledad;Atlántico Department;/wiki/Soledad,_Atl%C3%A1ntico;10.916666666666666;-74.75
+Suan;Atlántico Department;/wiki/Suan,_Atl%C3%A1ntico;10.333333333333334;-74.88333333333334
 Tubará;Atlántico Department;/wiki/Tubar%C3%A1;10.866666666666667;-74.98333333333333
 Usiacurí;Atlántico Department;/wiki/Usiacur%C3%AD;10.75;-74.98333333333333
-Antonio Nariño;Bogotá, Capital District;/wiki/Antonio_Nari%C3%B1o;_Bogot%C3%A1;4.583333333333333;-74.1
+Antonio Nariño;Bogotá, Capital District;/wiki/Antonio_Nari%C3%B1o,_Bogot%C3%A1;4.583333333333333;-74.1
 Barrios Unidos;Bogotá, Capital District;/wiki/Barrios_Unidos;4.666666666666667;-74.06666666666666
-Bosa;Bogotá, Capital District;/wiki/Bosa;_Bogot%C3%A1;4.616666666666667;-74.18333333333334
+Bosa;Bogotá, Capital District;/wiki/Bosa,_Bogot%C3%A1;4.616666666666667;-74.18333333333334
 Chapinero;Bogotá, Capital District;/wiki/Chapinero;4.633333333333333;-74.05
-Ciudad Bolívar;Bogotá, Capital District;/wiki/Ciudad_Bol%C3%ADvar;_Bogot%C3%A1;4.533333333333333;-74.13333333333334
+Ciudad Bolívar;Bogotá, Capital District;/wiki/Ciudad_Bol%C3%ADvar,_Bogot%C3%A1;4.533333333333333;-74.13333333333334
 Engativá;Bogotá, Capital District;/wiki/Engativ%C3%A1;4.716666666666667;-74.1
 Fontibón;Bogotá, Capital District;/wiki/Fontib%C3%B3n;4.666666666666667;-74.13333333333334
-Kennedy;Bogotá, Capital District;/wiki/Kennedy;_Bogot%C3%A1;4.633333333333333;-74.15
+Kennedy;Bogotá, Capital District;/wiki/Kennedy,_Bogot%C3%A1;4.633333333333333;-74.15
 La Candelaria;Bogotá, Capital District;/wiki/La_Candelaria;4.583333333333333;-74.06666666666666
 Los Mártires;Bogotá, Capital District;/wiki/Los_M%C3%A1rtires;4.6;-74.08333333333333
 Puente Aranda;Bogotá, Capital District;/wiki/Puente_Aranda;4.6;-74.1
-Rafael Uribe Uribe;Bogotá, Capital District;/wiki/Rafael_Uribe_Uribe;_Bogot%C3%A1;4.566666666666666;-74.11666666666666
-San Cristóbal;Bogotá, Capital District;/wiki/San_Crist%C3%B3bal;_Bogot%C3%A1;4.55;-74.08333333333333
-Santa Fe;Bogotá, Capital District;/wiki/Santa_Fe;_Bogot%C3%A1;4.6;-74.06666666666666
-Suba;Bogotá, Capital District;/wiki/Suba;_Bogot%C3%A1;4.741;-74.084
+Rafael Uribe Uribe;Bogotá, Capital District;/wiki/Rafael_Uribe_Uribe,_Bogot%C3%A1;4.566666666666666;-74.11666666666666
+San Cristóbal;Bogotá, Capital District;/wiki/San_Crist%C3%B3bal,_Bogot%C3%A1;4.55;-74.08333333333333
+Santa Fe;Bogotá, Capital District;/wiki/Santa_Fe,_Bogot%C3%A1;4.6;-74.06666666666666
+Suba;Bogotá, Capital District;/wiki/Suba,_Bogot%C3%A1;4.741;-74.084
 Sumapaz;Bogotá, Capital District;/wiki/Sumapaz;4.25;-74.16666666666667
 Teusaquillo;Bogotá, Capital District;/wiki/Teusaquillo;4.666666666666667;-74.08333333333333
 Tunjuelito;Bogotá, Capital District;/wiki/Tunjuelito;4.566666666666666;-74.11666666666666
 Usaquén;Bogotá, Capital District;/wiki/Usaqu%C3%A9n;4.716666666666667;-74.03333333333333
 Usme;Bogotá, Capital District;/wiki/Usme;4.433333333333334;-74.15
-Achí;Bolívar Department;/wiki/Ach%C3%AD;_Bol%C3%ADvar;8.566666666666666;-74.55
+Achí;Bolívar Department;/wiki/Ach%C3%AD,_Bol%C3%ADvar;8.566666666666666;-74.55
 Altos del Rosario;Bolívar Department;/wiki/Altos_del_Rosario;8.8;-74.16666666666667
-Arjona;Bolívar Department;/wiki/Arjona;_Colombia;10.25;-75.33333333333333
-Arroyo Hondo;Bolívar Department;/wiki/Arroyo_Hondo;_Bol%C3%ADvar;10.133333333333333;-75.56666666666666
+Arjona;Bolívar Department;/wiki/Arjona,_Colombia;10.25;-75.33333333333333
+Arroyo Hondo;Bolívar Department;/wiki/Arroyo_Hondo,_Bol%C3%ADvar;10.133333333333333;-75.56666666666666
 Barranco de Loba;Bolívar Department;/wiki/Barranco_de_Loba;8.95;-74.11666666666666
 Brazuelo de Papayal;Bolívar Department;/wiki/Brazuelo_de_Papayal;8.95;-73.95
-Calamar;Bolívar Department;/wiki/Calamar;_Bol%C3%ADvar;10.25;-74.9
-Cantagallo;Bolívar Department;/wiki/Cantagallo;_Bol%C3%ADvar;7.366666666666666;-73.9
-Cartagena;Bolívar Department;/wiki/Cartagena;_Colombia;10.4;-75.5
+Calamar;Bolívar Department;/wiki/Calamar,_Bol%C3%ADvar;10.25;-74.9
+Cantagallo;Bolívar Department;/wiki/Cantagallo,_Bol%C3%ADvar;7.366666666666666;-73.9
+Cartagena;Bolívar Department;/wiki/Cartagena,_Colombia;10.4;-75.5
 Cicuco;Bolívar Department;/wiki/Cicuco;9.266666666666667;-74.65
-Clemencia;Bolívar Department;/wiki/Clemencia;_Colombia;10.583333333333334;-75.33333333333333
-Córdoba;Bolívar Department;/wiki/C%C3%B3rdoba;_Bol%C3%ADvar;9.583333333333334;-74.81666666666666
+Clemencia;Bolívar Department;/wiki/Clemencia,_Colombia;10.583333333333334;-75.33333333333333
+Córdoba;Bolívar Department;/wiki/C%C3%B3rdoba,_Bol%C3%ADvar;9.583333333333334;-74.81666666666666
 El Carmen de Bolívar;Bolívar Department;/wiki/El_Carmen_de_Bol%C3%ADvar;9.716666666666667;-75.13333333333334
 El Guamo;Bolívar Department;/wiki/El_Guamo;10.083333333333334;-74.91666666666667
-El Peñón;Bolívar Department;/wiki/El_Pe%C3%B1%C3%B3n;_Bol%C3%ADvar;8.983333333333333;-73.93333333333334
+El Peñón;Bolívar Department;/wiki/El_Pe%C3%B1%C3%B3n,_Bol%C3%ADvar;8.983333333333333;-73.93333333333334
 Hatillo de Loba;Bolívar Department;/wiki/Hatillo_de_Loba;8.95861;-74.0808
 Magangué;Bolívar Department;/wiki/Magangu%C3%A9;9.25;-74.76666666666667
 Mahates;Bolívar Department;/wiki/Mahates;10.233333333333333;-75.18333333333334
-Margarita;Bolívar Department;/wiki/Margarita;_Bol%C3%ADvar;9.083333333333334;-74.2
+Margarita;Bolívar Department;/wiki/Margarita,_Bol%C3%ADvar;9.083333333333334;-74.2
 María La Baja;Bolívar Department;/wiki/Mar%C3%ADa_La_Baja;10.0;-75.33333333333333
 Mompóx;Bolívar Department;/wiki/Santa_Cruz_de_Mompox;9.233333333333333;-74.41666666666667
-Montecristo;Bolívar Department;/wiki/Montecristo;_Bol%C3%ADvar;8.29944;-74.4756
-Morales;Bolívar Department;/wiki/Morales;_Bol%C3%ADvar;8.31333;-73.8719
+Montecristo;Bolívar Department;/wiki/Montecristo,_Bol%C3%ADvar;8.29944;-74.4756
+Morales;Bolívar Department;/wiki/Morales,_Bol%C3%ADvar;8.31333;-73.8719
 Norosí;Bolívar Department;/wiki/Noros%C3%AD;8.516666666666667;-74.03333333333333
 Pinillos;Bolívar Department;/wiki/Pinillos;8.916666666666666;-74.46666666666667
-Regidor;Bolívar Department;/wiki/Regidor;_Bolivar;8.666666666666666;-73.83333333333333
+Regidor;Bolívar Department;/wiki/Regidor,_Bolivar;8.666666666666666;-73.83333333333333
 Rio Viejo;Bolívar Department;/wiki/Rio_Viejo;8.59;-73.8436
-San Cristóbal;Bolívar Department;/wiki/San_Crist%C3%B3bal;_Bol%C3%ADvar;9.88333;-75.25
-San Estanislao;Bolívar Department;/wiki/San_Estanislao;_Bol%C3%ADvar;10.4;-75.15
-San Fernando;Bolívar Department;/wiki/San_Fernando;_Bol%C3%ADvar;9.266666666666667;-74.53333333333333
-San Jacinto;Bolívar Department;/wiki/San_Jacinto;_Bol%C3%ADvar;9.816666666666666;-75.11666666666666
-San Juan Nepomuceno;Bolívar Department;/wiki/San_Juan_Nepomuceno;_Bol%C3%ADvar;9.95;-75.08333333333333
+San Cristóbal;Bolívar Department;/wiki/San_Crist%C3%B3bal,_Bol%C3%ADvar;9.88333;-75.25
+San Estanislao;Bolívar Department;/wiki/San_Estanislao,_Bol%C3%ADvar;10.4;-75.15
+San Fernando;Bolívar Department;/wiki/San_Fernando,_Bol%C3%ADvar;9.266666666666667;-74.53333333333333
+San Jacinto;Bolívar Department;/wiki/San_Jacinto,_Bol%C3%ADvar;9.816666666666666;-75.11666666666666
+San Juan Nepomuceno;Bolívar Department;/wiki/San_Juan_Nepomuceno,_Bol%C3%ADvar;9.95;-75.08333333333333
 San Martín de Loba;Bolívar Department;/wiki/San_Mart%C3%ADn_de_Loba;8.833333333333334;-73.91666666666667
-San Pablo;Bolívar Department;/wiki/San_Pablo;_Bol%C3%ADvar;7.466666666666667;-73.91666666666667
-Santa Catalina;Bolívar Department;/wiki/Santa_Catalina;_Bol%C3%ADvar;10.6;-75.28333333333333
-Santa Rosa;Bolívar Department;/wiki/Santa_Rosa;_Bol%C3%ADvar;10.433333333333334;-75.36666666666666
+San Pablo;Bolívar Department;/wiki/San_Pablo,_Bol%C3%ADvar;7.466666666666667;-73.91666666666667
+Santa Catalina;Bolívar Department;/wiki/Santa_Catalina,_Bol%C3%ADvar;10.6;-75.28333333333333
+Santa Rosa;Bolívar Department;/wiki/Santa_Rosa,_Bol%C3%ADvar;10.433333333333334;-75.36666666666666
 Santa Rosa del Sur;Bolívar Department;/wiki/Santa_Rosa_del_Sur;7.966666666666667;-74.05
 Simití;Bolívar Department;/wiki/Simit%C3%AD;7.966666666666667;-73.95
 Soplaviento;Bolívar Department;/wiki/Soplaviento;10.333333333333334;-75.1
 Talaiga Nuevo;Bolívar Department;/wiki/Talaiga_Nuevo;9.30694;-74.5686
 Tiquisio;Bolívar Department;/wiki/Tiquisio;8.566666666666666;-74.26666666666667
 Turbaco;Bolívar Department;/wiki/Turbaco;10.35;-75.33333333333333
-Turbana;Bolívar Department;/wiki/Turbana;_Bol%C3%ADvar;10.283333333333333;-75.45
-Villanueva;Bolívar Department;/wiki/Villanueva;_Bol%C3%ADvar;10.4456;-75.2761
-Zambrano;Bolívar Department;/wiki/Zambrano;_Bol%C3%ADvar;9.75;-74.83333333333333
-Almeida;Boyacá Department;/wiki/Almeida;_Boyac%C3%A1;4.966666666666667;-73.38333333333334
-Aquitania;Boyacá Department;/wiki/Aquitania;_Boyac%C3%A1;5.583333333333333;-72.83333333333333
+Turbana;Bolívar Department;/wiki/Turbana,_Bol%C3%ADvar;10.283333333333333;-75.45
+Villanueva;Bolívar Department;/wiki/Villanueva,_Bol%C3%ADvar;10.4456;-75.2761
+Zambrano;Bolívar Department;/wiki/Zambrano,_Bol%C3%ADvar;9.75;-74.83333333333333
+Almeida;Boyacá Department;/wiki/Almeida,_Boyac%C3%A1;4.966666666666667;-73.38333333333334
+Aquitania;Boyacá Department;/wiki/Aquitania,_Boyac%C3%A1;5.583333333333333;-72.83333333333333
 Arcabuco;Boyacá Department;/wiki/Arcabuco;5.75;-73.43333333333334
-Belén;Boyacá Department;/wiki/Bel%C3%A9n;_Boyac%C3%A1;6.083333333333333;-72.91666666666667
+Belén;Boyacá Department;/wiki/Bel%C3%A9n,_Boyac%C3%A1;6.083333333333333;-72.91666666666667
 Berbeo;Boyacá Department;/wiki/Berbeo;5.216666666666667;-73.11666666666666
 Betéitiva;Boyacá Department;/wiki/Bet%C3%A9itiva;5.916666666666667;-72.81666666666666
 Boavita;Boyacá Department;/wiki/Boavita;6.333333333333333;-72.58333333333333
-Boyacá;Boyacá Department;/wiki/Boyac%C3%A1;_Boyac%C3%A1;5.45;-73.35
-Briceño;Boyacá Department;/wiki/Brice%C3%B1o;_Boyac%C3%A1;5.7;-73.9333
-Buenavista;Boyacá Department;/wiki/Buenavista;_Boyac%C3%A1;5.5;-73.93333333333334
+Boyacá;Boyacá Department;/wiki/Boyac%C3%A1,_Boyac%C3%A1;5.45;-73.35
+Briceño;Boyacá Department;/wiki/Brice%C3%B1o,_Boyac%C3%A1;5.7;-73.9333
+Buenavista;Boyacá Department;/wiki/Buenavista,_Boyac%C3%A1;5.5;-73.93333333333334
 Busbanzá;Boyacá Department;/wiki/Busbanz%C3%A1;5.816666666666666;-72.86666666666666
-Caldas;Boyacá Department;/wiki/Caldas;_Boyac%C3%A1;5.5575;-73.8686
+Caldas;Boyacá Department;/wiki/Caldas,_Boyac%C3%A1;5.5575;-73.8686
 Campohermoso;Boyacá Department;/wiki/Campohermoso;5.083333333333333;-73.0
 Cerinza;Boyacá Department;/wiki/Cerinza;6.0;-72.91666666666667
 Chinavita;Boyacá Department;/wiki/Chinavita;5.166666666666667;-73.36666666666666
 Chiquinquirá;Boyacá Department;/wiki/Chiquinquir%C3%A1;5.633333333333333;-73.75
 Chíquiza;Boyacá Department;/wiki/Ch%C3%ADquiza;5.6;-73.48333333333333
-Chiscas;Boyacá Department;/wiki/Chiscas;_Boyac%C3%A1;6.533333333333333;-72.5
-Chita;Boyacá Department;/wiki/Chita;_Boyac%C3%A1;6.166666666666667;-72.41666666666667
+Chiscas;Boyacá Department;/wiki/Chiscas,_Boyac%C3%A1;6.533333333333333;-72.5
+Chita;Boyacá Department;/wiki/Chita,_Boyac%C3%A1;6.166666666666667;-72.41666666666667
 Chitaraque;Boyacá Department;/wiki/Chitaraque;6.083333333333333;-73.36666666666666
 Chivatá;Boyacá Department;/wiki/Chivat%C3%A1;5.533333333333333;-73.26666666666667
 Chivor;Boyacá Department;/wiki/Chivor;4.883333333333333;-73.36666666666666
-Ciénega;Boyacá Department;/wiki/Ci%C3%A9nega;_Boyac%C3%A1;5.4;-73.28333333333333
-Coper;Boyacá Department;/wiki/Coper;_Boyac%C3%A1;5.483333333333333;-74.05
-Corrales;Boyacá Department;/wiki/Corrales;_Boyac%C3%A1;5.866666666666667;-72.83333333333333
+Ciénega;Boyacá Department;/wiki/Ci%C3%A9nega,_Boyac%C3%A1;5.4;-73.28333333333333
+Coper;Boyacá Department;/wiki/Coper,_Boyac%C3%A1;5.483333333333333;-74.05
+Corrales;Boyacá Department;/wiki/Corrales,_Boyac%C3%A1;5.866666666666667;-72.83333333333333
 Covarachía;Boyacá Department;/wiki/Covarach%C3%ADa;6.5;-72.75
 Cubará;Boyacá Department;/wiki/Cubar%C3%A1;7.033333333333333;-72.06666666666666
 Cucaita;Boyacá Department;/wiki/Cucaita;5.533333333333333;-73.45
-Cuítiva;Boyacá Department;/wiki/Cu%C3%ADtiva;_Boyac%C3%A1;5.583333333333333;-72.96666666666667
+Cuítiva;Boyacá Department;/wiki/Cu%C3%ADtiva,_Boyac%C3%A1;5.583333333333333;-72.96666666666667
 Cómbita;Boyacá Department;/wiki/C%C3%B3mbita;5.75;-73.25
 Duitama;Boyacá Department;/wiki/Duitama;5.833333333333333;-73.01666666666667
 El Cocuy;Boyacá Department;/wiki/El_Cocuy;6.416666666666667;-72.41666666666667
-El Espino;Boyacá Department;/wiki/El_Espino;_Boyac%C3%A1;6.583333333333333;-72.41666666666667
+El Espino;Boyacá Department;/wiki/El_Espino,_Boyac%C3%A1;6.583333333333333;-72.41666666666667
 Firavitoba;Boyacá Department;/wiki/Firavitoba;5.65;-73.0
-Floresta;Boyacá Department;/wiki/Floresta;_Boyac%C3%A1;5.916666666666667;-72.91666666666667
+Floresta;Boyacá Department;/wiki/Floresta,_Boyac%C3%A1;5.916666666666667;-72.91666666666667
 Gachantivá;Boyacá Department;/wiki/Gachantiv%C3%A1;5.75;-73.5
-Garagoa;Boyacá Department;/wiki/Garagoa;_Boyac%C3%A1;5.083333333333333;-73.36666666666666
-Guacamayas;Boyacá Department;/wiki/Guacamayas;_Boyac%C3%A1;6.5;-72.5
+Garagoa;Boyacá Department;/wiki/Garagoa,_Boyac%C3%A1;5.083333333333333;-73.36666666666666
+Guacamayas;Boyacá Department;/wiki/Guacamayas,_Boyac%C3%A1;6.5;-72.5
 Guateque;Boyacá Department;/wiki/Guateque;5.0;-73.46666666666667
 Guayatá;Boyacá Department;/wiki/Guayat%C3%A1;4.966666666666667;-73.48333333333333
 Gámeza;Boyacá Department;/wiki/G%C3%A1meza;5.8;-72.8
 Güicán;Boyacá Department;/wiki/G%C3%BCic%C3%A1n;6.466666666666667;-72.41666666666667
-Iza;Boyacá Department;/wiki/Iza;_Boyac%C3%A1;5.6;-72.98333333333333
+Iza;Boyacá Department;/wiki/Iza,_Boyac%C3%A1;5.6;-72.98333333333333
 Jenesano;Boyacá Department;/wiki/Jenesano;5.383333333333334;-73.36666666666666
-Jericó;Boyacá Department;/wiki/Jeric%C3%B3;_Boyac%C3%A1;6.14917;-72.555
+Jericó;Boyacá Department;/wiki/Jeric%C3%B3,_Boyac%C3%A1;6.14917;-72.555
 La Capilla;Boyacá Department;/wiki/La_Capilla;5.083333333333333;-73.43333333333334
 La Uvita;Boyacá Department;/wiki/La_Uvita;6.333333333333333;-72.5
-La Victoria;Boyacá Department;/wiki/La_Victoria;_Boyac%C3%A1;5.52278;-74.2328
+La Victoria;Boyacá Department;/wiki/La_Victoria,_Boyac%C3%A1;5.52278;-74.2328
 Labranzagrande;Boyacá Department;/wiki/Labranzagrande;5.566666666666666;-72.56666666666666
 Macanal;Boyacá Department;/wiki/Macanal;4.966666666666667;-73.31666666666666
 Maripí;Boyacá Department;/wiki/Marip%C3%AD;5.55;-74.01666666666667
-Miraflores;Boyacá Department;/wiki/Miraflores;_Boyac%C3%A1;5.183333333333334;-73.13333333333334
+Miraflores;Boyacá Department;/wiki/Miraflores,_Boyac%C3%A1;5.183333333333334;-73.13333333333334
 Mongua;Boyacá Department;/wiki/Mongua;5.75;-72.8
 Monguí;Boyacá Department;/wiki/Mongu%C3%AD;5.75;-72.83333333333333
 Moniquirá;Boyacá Department;/wiki/Moniquir%C3%A1;5.916666666666667;-73.5
 Motavita;Boyacá Department;/wiki/Motavita;5.566666666666666;-73.36666666666666
 Muzo;Boyacá Department;/wiki/Muzo;5.516666666666667;-74.1
 Nobsa;Boyacá Department;/wiki/Nobsa;5.766666666666667;-72.95
-Nuevo Colón;Boyacá Department;/wiki/Nuevo_Col%C3%B3n;_Boyac%C3%A1;5.35;-73.46666666666667
+Nuevo Colón;Boyacá Department;/wiki/Nuevo_Col%C3%B3n,_Boyac%C3%A1;5.35;-73.46666666666667
 Oicatá;Boyacá Department;/wiki/Oicat%C3%A1;5.583333333333333;-73.31666666666666
 Otanche;Boyacá Department;/wiki/Otanche;5.75;-74.25
 Pachavita;Boyacá Department;/wiki/Pachavita;5.133333333333334;-73.4
 Paipa;Boyacá Department;/wiki/Paipa;5.833333333333333;-73.15
-Pajarito;Boyacá Department;/wiki/Pajarito;_Boyac%C3%A1;5.416666666666667;-72.66666666666667
+Pajarito;Boyacá Department;/wiki/Pajarito,_Boyac%C3%A1;5.416666666666667;-72.66666666666667
 Panqueba;Boyacá Department;/wiki/Panqueba;6.433333333333334;-72.46666666666667
 Pauna;Boyacá Department;/wiki/Pauna;5.666666666666667;-73.98333333333333
-Paya;Boyacá Department;/wiki/Paya;_Boyac%C3%A1;5.633333333333333;-72.43333333333334
+Paya;Boyacá Department;/wiki/Paya,_Boyac%C3%A1;5.633333333333333;-72.43333333333334
 Paz de Río;Boyacá Department;/wiki/Paz_de_R%C3%ADo;5.983333333333333;-72.75
 Pesca;Boyacá Department;/wiki/Pesca;5.583333333333333;-73.05
-Pisba;Boyacá Department;/wiki/Pisba;_Boyac%C3%A1;5.716666666666667;-72.48333333333333
+Pisba;Boyacá Department;/wiki/Pisba,_Boyac%C3%A1;5.716666666666667;-72.48333333333333
 Puerto Boyacá;Boyacá Department;/wiki/Puerto_Boyac%C3%A1;6.0;-74.41666666666667
-Páez;Boyacá Department;/wiki/P%C3%A1ez;_Boyac%C3%A1;5.10444;-73.0556
+Páez;Boyacá Department;/wiki/P%C3%A1ez,_Boyac%C3%A1;5.10444;-73.0556
 Quípama;Boyacá Department;/wiki/Qu%C3%ADpama;5.516666666666667;-74.18333333333334
 Ramiriquí;Boyacá Department;/wiki/Ramiriqu%C3%AD;5.4;-73.33333333333333
-Rondón;Boyacá Department;/wiki/Rond%C3%B3n;_Boyac%C3%A1;5.35;-73.2
+Rondón;Boyacá Department;/wiki/Rond%C3%B3n,_Boyac%C3%A1;5.35;-73.2
 Ráquira;Boyacá Department;/wiki/R%C3%A1quira;5.533333333333333;-73.63333333333334
 Saboyá;Boyacá Department;/wiki/Saboy%C3%A1;5.7;-73.76666666666667
 Samacá;Boyacá Department;/wiki/Samac%C3%A1;5.5;-73.48333333333333
-San Eduardo;Boyacá Department;/wiki/San_Eduardo;_Boyac%C3%A1;5.216666666666667;-73.06666666666666
+San Eduardo;Boyacá Department;/wiki/San_Eduardo,_Boyac%C3%A1;5.216666666666667;-73.06666666666666
 San José de Pare;Boyacá Department;/wiki/San_Jos%C3%A9_de_Pare;6.016666666666667;-73.55
 San Luis de Gaceno;Boyacá Department;/wiki/San_Luis_de_Gaceno;4.816666666666666;-73.16666666666667
-San Mateo;Boyacá Department;/wiki/San_Mateo;_Boyac%C3%A1;6.4;-72.55
+San Mateo;Boyacá Department;/wiki/San_Mateo,_Boyac%C3%A1;6.4;-72.55
 San Miguel de Sema;Boyacá Department;/wiki/San_Miguel_de_Sema;5.55;-73.75
 San Pablo de Borbur;Boyacá Department;/wiki/San_Pablo_de_Borbur;5.75;-74.08333333333333
-Santa María;Boyacá Department;/wiki/Santa_Mar%C3%ADa;_Boyac%C3%A1;4.85;-73.25
-Santa Rosa de Viterbo;Boyacá Department;/wiki/Santa_Rosa_de_Viterbo;_Boyac%C3%A1;5.883333333333333;-72.98333333333333
-Santa Sofía;Boyacá Department;/wiki/Santa_Sof%C3%ADa;_Boyac%C3%A1;5.75;-73.58333333333333
-Santana;Boyacá Department;/wiki/Santana;_Boyac%C3%A1;6.05;-73.46666666666667
+Santa María;Boyacá Department;/wiki/Santa_Mar%C3%ADa,_Boyac%C3%A1;4.85;-73.25
+Santa Rosa de Viterbo;Boyacá Department;/wiki/Santa_Rosa_de_Viterbo,_Boyac%C3%A1;5.883333333333333;-72.98333333333333
+Santa Sofía;Boyacá Department;/wiki/Santa_Sof%C3%ADa,_Boyac%C3%A1;5.75;-73.58333333333333
+Santana;Boyacá Department;/wiki/Santana,_Boyac%C3%A1;6.05;-73.46666666666667
 Sativanorte;Boyacá Department;/wiki/Sativanorte;6.116666666666666;-72.7
 Sativasur;Boyacá Department;/wiki/Sativasur;6.083333333333333;-72.73333333333333
 Siachoque;Boyacá Department;/wiki/Siachoque;5.5;-73.23333333333333
-Soatá;Boyacá Department;/wiki/Soat%C3%A1;_Boyac%C3%A1;6.333333333333333;-72.66666666666667
+Soatá;Boyacá Department;/wiki/Soat%C3%A1,_Boyac%C3%A1;6.333333333333333;-72.66666666666667
 Socha;Boyacá Department;/wiki/Socha;6.0;-72.66666666666667
 Socotá;Boyacá Department;/wiki/Socot%C3%A1;6.05;-72.63333333333334
 Sogamoso;Boyacá Department;/wiki/Sogamoso;5.716666666666667;-72.91666666666667
 Somondoco;Boyacá Department;/wiki/Somondoco;4.98778;-73.4361
-Sora;Boyacá Department;/wiki/Sora;_Boyac%C3%A1;5.566666666666666;-73.43333333333334
+Sora;Boyacá Department;/wiki/Sora,_Boyac%C3%A1;5.566666666666666;-73.43333333333334
 Soracá;Boyacá Department;/wiki/Sorac%C3%A1;5.5;-73.31666666666666
 Sotaquirá;Boyacá Department;/wiki/Sotaquir%C3%A1;5.766666666666667;-73.25
 Susacón;Boyacá Department;/wiki/Susac%C3%B3n;6.233333333333333;-72.7
 Sutamarchán;Boyacá Department;/wiki/Sutamarch%C3%A1n;5.6;-73.63333333333334
 Sutatenza;Boyacá Department;/wiki/Sutatenza;5.016666666666667;-73.45
 Sáchica;Boyacá Department;/wiki/S%C3%A1chica;5.583333333333333;-73.55
-Tasco;Boyacá Department;/wiki/Tasco;_Boyac%C3%A1;5.916666666666667;-72.78333333333333
+Tasco;Boyacá Department;/wiki/Tasco,_Boyac%C3%A1;5.916666666666667;-72.78333333333333
 Tenza;Boyacá Department;/wiki/Tenza;5.083333333333333;-73.41666666666667
 Tibaná;Boyacá Department;/wiki/Tiban%C3%A1;5.316666666666666;-73.4
 Tibasosa;Boyacá Department;/wiki/Tibasosa;5.833333333333333;-72.96666666666667
 Tinjacá;Boyacá Department;/wiki/Tinjac%C3%A1;5.566666666666666;-73.65
 Tipacoque;Boyacá Department;/wiki/Tipacoque;6.416666666666667;-72.7
-Toca;Boyacá Department;/wiki/Toca;_Boyac%C3%A1;5.566666666666666;-73.2
-Togüí, Boyacá;Boyacá Department;/wiki/Tog%C3%BC%C3%AD;_Boyac%C3%A1;5.933333333333334;-73.5
-Tota;Boyacá Department;/wiki/Tota;_Boyac%C3%A1;5.566666666666666;-72.98333333333333
+Toca;Boyacá Department;/wiki/Toca,_Boyac%C3%A1;5.566666666666666;-73.2
+Togüí, Boyacá;Boyacá Department;/wiki/Tog%C3%BC%C3%AD,_Boyac%C3%A1;5.933333333333334;-73.5
+Tota;Boyacá Department;/wiki/Tota,_Boyac%C3%A1;5.566666666666666;-72.98333333333333
 Tunja;Boyacá Department;/wiki/Tunja;5.533333333333333;-73.36666666666666
 Tununguá;Boyacá Department;/wiki/Tunungu%C3%A1;5.733333333333333;-73.93333333333334
 Turmequé;Boyacá Department;/wiki/Turmequ%C3%A9;5.316666666666666;-73.5
-Tuta;Boyacá Department;/wiki/Tuta;_Boyac%C3%A1;5.7;-73.23333333333333
+Tuta;Boyacá Department;/wiki/Tuta,_Boyac%C3%A1;5.7;-73.23333333333333
 Tutazá;Boyacá Department;/wiki/Tutaz%C3%A1;6.05;-72.86666666666666
-Tópaga;Boyacá Department;/wiki/T%C3%B3paga;_Boyac%C3%A1;5.766666666666667;-72.83333333333333
+Tópaga;Boyacá Department;/wiki/T%C3%B3paga,_Boyac%C3%A1;5.766666666666667;-72.83333333333333
 Úmbita;Boyacá Department;/wiki/%C3%9Ambita;5.216666666666667;-73.46666666666667
 Ventaquemada;Boyacá Department;/wiki/Ventaquemada;5.416666666666667;-73.5
 Villa de Leyva;Boyacá Department;/wiki/Villa_de_Leyva;5.633333333333333;-73.53333333333333
 Viracachá;Boyacá Department;/wiki/Viracach%C3%A1;5.433333333333334;-73.3
 Zetaquirá;Boyacá Department;/wiki/Zetaquir%C3%A1;5.35;-73.16666666666667
-Aguadas;Caldas Department;/wiki/Aguadas;_Caldas;5.616666666666667;-75.46666666666667
-Anserma;Caldas Department;/wiki/Anserma;_Caldas;5.233333333333333;-75.78333333333333
-Aranzazu;Caldas Department;/wiki/Aranzazu;_Caldas;5.3;-75.45
-Belalcázar;Caldas Department;/wiki/Belalc%C3%A1zar;_Caldas;5.0;-75.81666666666666
-Chinchiná;Caldas Department;/wiki/Chinchin%C3%A1;_Caldas;5.0;-75.58333333333333
-Filadelfia;Caldas Department;/wiki/Filadelfia;_Caldas;5.3;-75.6
-La Dorada;Caldas Department;/wiki/La_Dorada;_Caldas;5.45;-74.65
-La Merced;Caldas Department;/wiki/La_Merced;_Caldas;5.383333333333334;-75.53333333333333
+Aguadas;Caldas Department;/wiki/Aguadas,_Caldas;5.616666666666667;-75.46666666666667
+Anserma;Caldas Department;/wiki/Anserma,_Caldas;5.233333333333333;-75.78333333333333
+Aranzazu;Caldas Department;/wiki/Aranzazu,_Caldas;5.3;-75.45
+Belalcázar;Caldas Department;/wiki/Belalc%C3%A1zar,_Caldas;5.0;-75.81666666666666
+Chinchiná;Caldas Department;/wiki/Chinchin%C3%A1,_Caldas;5.0;-75.58333333333333
+Filadelfia;Caldas Department;/wiki/Filadelfia,_Caldas;5.3;-75.6
+La Dorada;Caldas Department;/wiki/La_Dorada,_Caldas;5.45;-74.65
+La Merced;Caldas Department;/wiki/La_Merced,_Caldas;5.383333333333334;-75.53333333333333
 Manizales;Caldas Department;/wiki/Manizales;5.1;-75.55
-Manzanares;Caldas Department;/wiki/Manzanares;_Caldas;5.25;-75.15
-Marmato;Caldas Department;/wiki/Marmato;_Caldas;5.5;-75.58333333333333
-Marquetalia;Caldas Department;/wiki/Marquetalia;_Caldas;5.333333333333333;-75.0
-Marulanda;Caldas Department;/wiki/Marulanda;_Caldas;5.283333333333333;-75.26666666666667
-Neira;Caldas Department;/wiki/Neira;_Caldas;5.15;-75.51666666666667
-Norcasia;Caldas Department;/wiki/Norcasia;_Caldas;5.566666666666666;-74.88333333333334
-Pácora;Caldas Department;/wiki/P%C3%A1cora;_Caldas;5.516666666666667;-75.45
-Palestina;Caldas Department;/wiki/Palestina;_Caldas;5.083333333333333;-75.66666666666667
-Pensilvania;Caldas Department;/wiki/Pensilvania;_Caldas;5.5;-75.08333333333333
-Riosucio;Caldas Department;/wiki/Riosucio;_Caldas;5.416666666666667;-75.7
-Risaralda;Caldas Department;/wiki/Risaralda;_Caldas;5.166666666666667;-75.75
-Salamina;Caldas Department;/wiki/Salamina;_Caldas;5.4;-75.48333333333333
-Samaná;Caldas Department;/wiki/Saman%C3%A1;_Caldas;5.583333333333333;-74.91666666666667
-San José;Caldas Department;/wiki/San_Jos%C3%A9;_Caldas;5.083333333333333;-75.78333333333333
-Supía;Caldas Department;/wiki/Sup%C3%ADa;_Caldas;5.466666666666667;-75.65
-Victoria;Caldas Department;/wiki/Victoria;_Caldas;5.416666666666667;-74.83333333333333
-Villamaría;Caldas Department;/wiki/Villamar%C3%ADa;_Caldas;5.0;-75.5
-Viterbo;Caldas Department;/wiki/Viterbo;_Caldas;5.066666666666666;-75.88333333333334
-Albania;Caquetá Department;/wiki/Albania;_Caquet%C3%A1;1.33167;-75.8822
+Manzanares;Caldas Department;/wiki/Manzanares,_Caldas;5.25;-75.15
+Marmato;Caldas Department;/wiki/Marmato,_Caldas;5.5;-75.58333333333333
+Marquetalia;Caldas Department;/wiki/Marquetalia,_Caldas;5.333333333333333;-75.0
+Marulanda;Caldas Department;/wiki/Marulanda,_Caldas;5.283333333333333;-75.26666666666667
+Neira;Caldas Department;/wiki/Neira,_Caldas;5.15;-75.51666666666667
+Norcasia;Caldas Department;/wiki/Norcasia,_Caldas;5.566666666666666;-74.88333333333334
+Pácora;Caldas Department;/wiki/P%C3%A1cora,_Caldas;5.516666666666667;-75.45
+Palestina;Caldas Department;/wiki/Palestina,_Caldas;5.083333333333333;-75.66666666666667
+Pensilvania;Caldas Department;/wiki/Pensilvania,_Caldas;5.5;-75.08333333333333
+Riosucio;Caldas Department;/wiki/Riosucio,_Caldas;5.416666666666667;-75.7
+Risaralda;Caldas Department;/wiki/Risaralda,_Caldas;5.166666666666667;-75.75
+Salamina;Caldas Department;/wiki/Salamina,_Caldas;5.4;-75.48333333333333
+Samaná;Caldas Department;/wiki/Saman%C3%A1,_Caldas;5.583333333333333;-74.91666666666667
+San José;Caldas Department;/wiki/San_Jos%C3%A9,_Caldas;5.083333333333333;-75.78333333333333
+Supía;Caldas Department;/wiki/Sup%C3%ADa,_Caldas;5.466666666666667;-75.65
+Victoria;Caldas Department;/wiki/Victoria,_Caldas;5.416666666666667;-74.83333333333333
+Villamaría;Caldas Department;/wiki/Villamar%C3%ADa,_Caldas;5.0;-75.5
+Viterbo;Caldas Department;/wiki/Viterbo,_Caldas;5.066666666666666;-75.88333333333334
+Albania;Caquetá Department;/wiki/Albania,_Caquet%C3%A1;1.33167;-75.8822
 Belén de Andaquies;Caquetá Department;/wiki/Bel%C3%A9n_de_Andaquies;1.41611;-75.8725
 Cartagena del Chairá;Caquetá Department;/wiki/Cartagena_del_Chair%C3%A1;1.35;-74.83333333333333
 Curillo;Caquetá Department;/wiki/Curillo;1.0333333333333334;-75.91666666666667
 El Doncello;Caquetá Department;/wiki/El_Doncello;1.6833333333333333;-75.28333333333333
 El Paujil;Caquetá Department;/wiki/El_Paujil;1.56444;-75.3319
-Florencia;Caquetá Department;/wiki/Florencia;_Caquet%C3%A1;1.6;-75.6
+Florencia;Caquetá Department;/wiki/Florencia,_Caquet%C3%A1;1.6;-75.6
 La Montañita;Caquetá Department;/wiki/La_Monta%C3%B1ita;1.5833333333333335;-75.25
-Milán;Caquetá Department;/wiki/Mil%C3%A1n;_Caquet%C3%A1;1.2833333333333332;-75.5
-Morelia;Caquetá Department;/wiki/Morelia;_Caquet%C3%A1;1.4875;-75.725
-Puerto Rico;Caquetá Department;/wiki/Puerto_Rico;_Caquet%C3%A1;1.91417;-75.145
+Milán;Caquetá Department;/wiki/Mil%C3%A1n,_Caquet%C3%A1;1.2833333333333332;-75.5
+Morelia;Caquetá Department;/wiki/Morelia,_Caquet%C3%A1;1.4875;-75.725
+Puerto Rico;Caquetá Department;/wiki/Puerto_Rico,_Caquet%C3%A1;1.91417;-75.145
 San José de la Fragua;Caquetá Department;/wiki/San_Jos%C3%A9_de_la_Fragua;1.3166666666666667;-75.96666666666667
 San Vicente del Caguán;Caquetá Department;/wiki/San_Vicente_del_Cagu%C3%A1n;2.1166666666666667;-74.76666666666667
-Solano;Caquetá Department;/wiki/Solano;_Caquet%C3%A1;0.6833333333333333;-75.25
-Solita;Caquetá Department;/wiki/Solita;_Caquet%C3%A1;0.8666666666666667;-75.65
-Valparaíso;Caquetá Department;/wiki/Valpara%C3%ADso;_Caquet%C3%A1;1.19917;-75.7097
+Solano;Caquetá Department;/wiki/Solano,_Caquet%C3%A1;0.6833333333333333;-75.25
+Solita;Caquetá Department;/wiki/Solita,_Caquet%C3%A1;0.8666666666666667;-75.65
+Valparaíso;Caquetá Department;/wiki/Valpara%C3%ADso,_Caquet%C3%A1;1.19917;-75.7097
 Aguazul;Casanare Department;/wiki/Aguazul;5.17306;-72.5547
 Chámeza;Casanare Department;/wiki/Ch%C3%A1meza;5.216666666666667;-72.88333333333334
 Hato Corozal;Casanare Department;/wiki/Hato_Corozal;3.183333333333333;-73.75
 La Salina;Casanare Department;/wiki/La_Salina;6.13056;-72.3378
-Maní;Casanare Department;/wiki/Man%C3%AD;_Casanare;4.816666666666666;-72.28333333333333
-Monterrey;Casanare Department;/wiki/Monterrey;_Casanare;4.87833;-72.8972
+Maní;Casanare Department;/wiki/Man%C3%AD,_Casanare;4.816666666666666;-72.28333333333333
+Monterrey;Casanare Department;/wiki/Monterrey,_Casanare;4.87833;-72.8972
 Nunchía;Casanare Department;/wiki/Nunch%C3%ADa;5.633333333333333;-72.2
 Orocué;Casanare Department;/wiki/Orocu%C3%A9;1.8;-72.75
 Paz de Ariporo;Casanare Department;/wiki/Paz_de_Ariporo;5.883333333333333;-71.9
-Pore;Casanare Department;/wiki/Pore;_Casanare;5.72722;-71.9947
+Pore;Casanare Department;/wiki/Pore,_Casanare;5.72722;-71.9947
 Recetor;Casanare Department;/wiki/Recetor;5.233333333333333;-72.76666666666667
-Sabanalarga;Casanare Department;/wiki/Sabanalarga;_Casanare;4.85361;-73.0431
+Sabanalarga;Casanare Department;/wiki/Sabanalarga,_Casanare;4.85361;-73.0431
 Sácama;Casanare Department;/wiki/S%C3%A1cama;6.1;-72.25
 San Luis de Palenque;Casanare Department;/wiki/San_Luis_de_Palenque;5.416666666666667;-71.73333333333333
-Támara;Casanare Department;/wiki/T%C3%A1mara;_Casanare;5.82972;-72.1633
+Támara;Casanare Department;/wiki/T%C3%A1mara,_Casanare;5.82972;-72.1633
 Tauramena;Casanare Department;/wiki/Tauramena;5.016666666666667;-72.75
-Trinidad;Casanare Department;/wiki/Trinidad;_Casanare;5.40889;-71.6622
-Villanueva;Casanare Department;/wiki/Villanueva;_Casanare;4.6;-72.91666666666667
+Trinidad;Casanare Department;/wiki/Trinidad,_Casanare;5.40889;-71.6622
+Villanueva;Casanare Department;/wiki/Villanueva,_Casanare;4.6;-72.91666666666667
 Yopal;Casanare Department;/wiki/Yopal;5.35;-72.4
-Almaguer;Cauca Department;/wiki/Almaguer;_Cauca;1.9166666666666665;-76.86666666666666
-Argelia;Cauca Department;/wiki/Argelia;_Cauca;2.2333333333333334;-77.26666666666667
-Balboa;Cauca Department;/wiki/Balboa;_Cauca;2.033333333333333;-77.21666666666667
-Bolívar;Cauca Department;/wiki/Bol%C3%ADvar;_Cauca;1.97083;-76.9694
-Buenos Aires;Cauca Department;/wiki/Buenos_Aires;_Cauca;2.9166666666666665;-76.66666666666667
-Cajibio;Cauca Department;/wiki/Cajibio;_Cauca;2.6333333333333333;-76.63333333333334
-Caldono;Cauca Department;/wiki/Caldono;_Cauca;2.8;-76.53333333333333
-Caloto;Cauca Department;/wiki/Caloto;_Cauca;3.033333333333333;-76.41666666666667
-Corinto;Cauca Department;/wiki/Corinto;_Cauca;3.1666666666666665;-76.25
-El Tambo;Cauca Department;/wiki/El_Tambo;_Cauca;2.45417;-76.8178
-Florencia;Cauca Department;/wiki/Florencia;_Cauca;1.6666666666666665;-77.06666666666666
+Almaguer;Cauca Department;/wiki/Almaguer,_Cauca;1.9166666666666665;-76.86666666666666
+Argelia;Cauca Department;/wiki/Argelia,_Cauca;2.2333333333333334;-77.26666666666667
+Balboa;Cauca Department;/wiki/Balboa,_Cauca;2.033333333333333;-77.21666666666667
+Bolívar;Cauca Department;/wiki/Bol%C3%ADvar,_Cauca;1.97083;-76.9694
+Buenos Aires;Cauca Department;/wiki/Buenos_Aires,_Cauca;2.9166666666666665;-76.66666666666667
+Cajibio;Cauca Department;/wiki/Cajibio,_Cauca;2.6333333333333333;-76.63333333333334
+Caldono;Cauca Department;/wiki/Caldono,_Cauca;2.8;-76.53333333333333
+Caloto;Cauca Department;/wiki/Caloto,_Cauca;3.033333333333333;-76.41666666666667
+Corinto;Cauca Department;/wiki/Corinto,_Cauca;3.1666666666666665;-76.25
+El Tambo;Cauca Department;/wiki/El_Tambo,_Cauca;2.45417;-76.8178
+Florencia;Cauca Department;/wiki/Florencia,_Cauca;1.6666666666666665;-77.06666666666666
 Guachené;Cauca Department;/wiki/Guachen%C3%A9;3.1333333333333333;-76.38333333333334
-Guapi;Cauca Department;/wiki/Guapi;_Cauca;2.5666666666666664;-77.88333333333334
-Inza;Cauca Department;/wiki/Inza;_Cauca;2.55;-76.06666666666666
-Jambalo;Cauca Department;/wiki/Jambalo;_Cauca;2.85;-76.31666666666666
-La Sierra;Cauca Department;/wiki/La_Sierra;_Cauca;2.25;-76.83333333333333
-La Vega;Cauca Department;/wiki/La_Vega;_Cauca;2.0;-76.76666666666667
+Guapi;Cauca Department;/wiki/Guapi,_Cauca;2.5666666666666664;-77.88333333333334
+Inza;Cauca Department;/wiki/Inza,_Cauca;2.55;-76.06666666666666
+Jambalo;Cauca Department;/wiki/Jambalo,_Cauca;2.85;-76.31666666666666
+La Sierra;Cauca Department;/wiki/La_Sierra,_Cauca;2.25;-76.83333333333333
+La Vega;Cauca Department;/wiki/La_Vega,_Cauca;2.0;-76.76666666666667
 López de Micay;Cauca Department;/wiki/L%C3%B3pez_de_Micay;3.0;-77.25
-Mercaderes;Cauca Department;/wiki/Mercaderes;_Cauca;1.8;-77.16666666666667
-Miranda;Cauca Department;/wiki/Miranda;_Cauca;3.25;-76.25
-Morales;Cauca Department;/wiki/Morales;_Cauca;2.76028;-76.6339
-Padilla;Cauca Department;/wiki/Padilla;_Cauca;3.2333333333333334;-76.31666666666666
-Páez;Cauca Department;/wiki/P%C3%A1ez;_Cauca;2.65472;-75.9928
-Patía;Cauca Department;/wiki/Pat%C3%ADa;_Cauca;2.1666666666666665;-77.08333333333333
+Mercaderes;Cauca Department;/wiki/Mercaderes,_Cauca;1.8;-77.16666666666667
+Miranda;Cauca Department;/wiki/Miranda,_Cauca;3.25;-76.25
+Morales;Cauca Department;/wiki/Morales,_Cauca;2.76028;-76.6339
+Padilla;Cauca Department;/wiki/Padilla,_Cauca;3.2333333333333334;-76.31666666666666
+Páez;Cauca Department;/wiki/P%C3%A1ez,_Cauca;2.65472;-75.9928
+Patía;Cauca Department;/wiki/Pat%C3%ADa,_Cauca;2.1666666666666665;-77.08333333333333
 Piamonte;Cauca Department;/wiki/Piamonte;1.1158;-76.3261
-Piendamó;Cauca Department;/wiki/Piendam%C3%B3;_Cauca;2.6333333333333333;-76.51666666666667
+Piendamó;Cauca Department;/wiki/Piendam%C3%B3,_Cauca;2.6333333333333333;-76.51666666666667
 Popayán;Cauca Department;/wiki/Popay%C3%A1n;2.45;-76.6
-Puerto Tejada;Cauca Department;/wiki/Puerto_Tejada;_Cauca;3.25;-76.41666666666667
-Purace;Cauca Department;/wiki/Purace;_Cauca;2.25;-76.41666666666667
-Rosas;Cauca Department;/wiki/Rosas;_Cauca;2.2666666666666666;-76.75
-San Sebastián;Cauca Department;/wiki/San_Sebasti%C3%A1n;_Cauca;1.8333333333333335;-76.76666666666667
+Puerto Tejada;Cauca Department;/wiki/Puerto_Tejada,_Cauca;3.25;-76.41666666666667
+Purace;Cauca Department;/wiki/Purace,_Cauca;2.25;-76.41666666666667
+Rosas;Cauca Department;/wiki/Rosas,_Cauca;2.2666666666666666;-76.75
+San Sebastián;Cauca Department;/wiki/San_Sebasti%C3%A1n,_Cauca;1.8333333333333335;-76.76666666666667
 Santander de Quilichao;Cauca Department;/wiki/Santander_de_Quilichao;3.0166666666666666;-76.48333333333333
-Santa Rosa;Cauca Department;/wiki/Santa_Rosa;_Cauca;1.72944;-76.6044
-Silvia;Cauca Department;/wiki/Silvia;_Cauca;2.6166666666666667;-76.38333333333334
-Sotará;Cauca Department;/wiki/Sotar%C3%A1;_Cauca;2.25;-76.58333333333333
-Suarez;Cauca Department;/wiki/Suarez;_Cauca;2.95889;-76.6953
-Sucre;Cauca Department;/wiki/Sucre;_Cauca;2.033333333333333;-76.91666666666667
+Santa Rosa;Cauca Department;/wiki/Santa_Rosa,_Cauca;1.72944;-76.6044
+Silvia;Cauca Department;/wiki/Silvia,_Cauca;2.6166666666666667;-76.38333333333334
+Sotará;Cauca Department;/wiki/Sotar%C3%A1,_Cauca;2.25;-76.58333333333333
+Suarez;Cauca Department;/wiki/Suarez,_Cauca;2.95889;-76.6953
+Sucre;Cauca Department;/wiki/Sucre,_Cauca;2.033333333333333;-76.91666666666667
 Timbío;Cauca Department;/wiki/Timb%C3%ADo;2.3333333333333335;-76.68333333333334
-Timbiqui;Cauca Department;/wiki/Timbiqui;_Cauca;2.7666666666666666;-77.63333333333334
-Toribío;Cauca Department;/wiki/Torib%C3%ADo;_Cauca;2.95;-76.26666666666667
-Totoro;Cauca Department;/wiki/Totoro;_Cauca;2.5833333333333335;-76.33333333333333
-Villa Rica;Cauca Department;/wiki/Villa_Rica;_Cauca;2.5166666666666666;-76.85
+Timbiqui;Cauca Department;/wiki/Timbiqui,_Cauca;2.7666666666666666;-77.63333333333334
+Toribío;Cauca Department;/wiki/Torib%C3%ADo,_Cauca;2.95;-76.26666666666667
+Totoro;Cauca Department;/wiki/Totoro,_Cauca;2.5833333333333335;-76.33333333333333
+Villa Rica;Cauca Department;/wiki/Villa_Rica,_Cauca;2.5166666666666666;-76.85
 Aguachica;Cesar Department;/wiki/Aguachica;8.316666666666666;-73.63333333333334
-Astrea;Cesar Department;/wiki/Astrea;_Cesar;9.5;-73.98333333333333
+Astrea;Cesar Department;/wiki/Astrea,_Cesar;9.5;-73.98333333333333
 Becerril;Cesar Department;/wiki/Becerril;9.7;-73.28333333333333
 Bosconia;Cesar Department;/wiki/Bosconia;9.97611;-73.8903
 Chimichagua;Cesar Department;/wiki/Chimichagua;9.25;-73.81666666666666
 Chiriguaná;Cesar Department;/wiki/Chiriguan%C3%A1;9.366666666666667;-73.6
-Codazzi;Cesar Department;/wiki/Agust%C3%ADn_Codazzi;_Cesar;10.033333333333333;-73.23333333333333
+Codazzi;Cesar Department;/wiki/Agust%C3%ADn_Codazzi,_Cesar;10.033333333333333;-73.23333333333333
 Curumaní;Cesar Department;/wiki/Curuman%C3%AD;9.2;-73.55
 El Copey;Cesar Department;/wiki/El_Copey;10.15;-73.96666666666667
-El Paso;Cesar Department;/wiki/El_Paso;_Cesar;9.66222;-73.7519
-Gamarra;Cesar Department;/wiki/Gamarra;_Cesar;8.333333333333334;-73.66666666666667
-González;Cesar Department;/wiki/Gonz%C3%A1lez;_Cesar;8.4;-73.33333333333333
-La Gloria;Cesar Department;/wiki/La_Gloria;_Cesar;8.583333333333334;-73.58333333333333
-La Jagua de Ibirico;Cesar Department;/wiki/La_Jagua_de_Ibirico;_Cesar;9.566666666666666;-73.33333333333333
-Manaure;Cesar Department;/wiki/Manaure;_Cesar;11.783333333333333;-72.45
+El Paso;Cesar Department;/wiki/El_Paso,_Cesar;9.66222;-73.7519
+Gamarra;Cesar Department;/wiki/Gamarra,_Cesar;8.333333333333334;-73.66666666666667
+González;Cesar Department;/wiki/Gonz%C3%A1lez,_Cesar;8.4;-73.33333333333333
+La Gloria;Cesar Department;/wiki/La_Gloria,_Cesar;8.583333333333334;-73.58333333333333
+La Jagua de Ibirico;Cesar Department;/wiki/La_Jagua_de_Ibirico,_Cesar;9.566666666666666;-73.33333333333333
+Manaure;Cesar Department;/wiki/Manaure,_Cesar;11.783333333333333;-72.45
 Pailitas;Cesar Department;/wiki/Pailitas;8.966666666666667;-73.63333333333334
 Pelaya;Cesar Department;/wiki/Pelaya;8.683333333333334;-73.66666666666667
 Pueblo Bello;Cesar Department;/wiki/Pueblo_Bello;10.416666666666666;-73.58333333333333
-Rio de Oro;Cesar Department;/wiki/R%C3%ADo_de_Oro;_Cesar;8.0;-73.5
+Rio de Oro;Cesar Department;/wiki/R%C3%ADo_de_Oro,_Cesar;8.0;-73.5
 Los Robles La Paz;Cesar Department;/wiki/Los_Robles_La_Paz;10.383333333333333;-73.16666666666667
-San Alberto;Cesar Department;/wiki/San_Alberto;_Cesar;7.7525;-73.3892
-San Diego;Cesar Department;/wiki/San_Diego;_Cesar;10.3375;-73.1825
-San Martín;Cesar Department;/wiki/San_Mart%C3%ADn;_Cesar;8.033333333333333;-73.5
+San Alberto;Cesar Department;/wiki/San_Alberto,_Cesar;7.7525;-73.3892
+San Diego;Cesar Department;/wiki/San_Diego,_Cesar;10.3375;-73.1825
+San Martín;Cesar Department;/wiki/San_Mart%C3%ADn,_Cesar;8.033333333333333;-73.5
 Tamalameque;Cesar Department;/wiki/Tamalameque;8.833333333333334;-73.58333333333333
 Valledupar;Cesar Department;/wiki/Valledupar;10.483333333333333;-73.25
 Acandí;Chocó Department;/wiki/Acand%C3%AD;8.533333333333333;-77.23333333333333
@@ -506,14 +506,14 @@ Nuquí;Chocó Department;/wiki/Nuqu%C3%AD;5.716666666666667;-77.26666666666667
 Quibdó;Chocó Department;/wiki/Quibd%C3%B3;5.683333333333334;-76.65
 Río Iró;Chocó Department;/wiki/R%C3%ADo_Ir%C3%B3;5.18333;-76.4833
 Río Quito;Chocó Department;/wiki/R%C3%ADo_Quito;5.466666666666667;-76.73333333333333
-Riosucio;Chocó Department;/wiki/Riosucio;_Choc%C3%B3;7.4406;-77.1189
+Riosucio;Chocó Department;/wiki/Riosucio,_Choc%C3%B3;7.4406;-77.1189
 San José del Palmar;Chocó Department;/wiki/San_Jos%C3%A9_del_Palmar;4.966666666666667;-76.23333333333333
 Sipí;Chocó Department;/wiki/Sip%C3%AD;4.65;-76.48333333333333
 Tadó;Chocó Department;/wiki/Tad%C3%B3;5.266666666666667;-76.56666666666666
 Unguía;Chocó Department;/wiki/Ungu%C3%ADa;8.05;-77.1
 Unión Panamericana;Chocó Department;/wiki/Uni%C3%B3n_Panamericana;5.266666666666667;-76.61666666666666
 Ayapel;Córdoba Department;/wiki/Ayapel;8.316666666666666;-75.15
-Buenavista;Córdoba Department;/wiki/Buenavista;_C%C3%B3rdoba;8.68333;-75.25
+Buenavista;Córdoba Department;/wiki/Buenavista,_C%C3%B3rdoba;8.68333;-75.25
 Canalete;Córdoba Department;/wiki/Canalete;8.783333333333333;-76.23333333333333
 Cereté;Córdoba Department;/wiki/Ceret%C3%A9;8.883333333333333;-75.8
 Chimá;Córdoba Department;/wiki/Chim%C3%A1;9.15;-75.63333333333334
@@ -528,31 +528,31 @@ Moñitos;Córdoba Department;/wiki/Mo%C3%B1itos;9.25028;-76.1325
 Montelíbano;Córdoba Department;/wiki/Montel%C3%ADbano;7.966666666666667;-75.41666666666667
 Montería;Córdoba Department;/wiki/Monter%C3%ADa;8.75;-75.88333333333334
 Planeta Rica;Córdoba Department;/wiki/Planeta_Rica;8.4;-75.56666666666666
-Pueblo Nuevo;Córdoba Department;/wiki/Pueblo_Nuevo;_C%C3%B3rdoba;8.50083;-75.5072
-Puerto Escondido;Córdoba Department;/wiki/Puerto_Escondido;_C%C3%B3rdoba;8.95;-76.25
+Pueblo Nuevo;Córdoba Department;/wiki/Pueblo_Nuevo,_C%C3%B3rdoba;8.50083;-75.5072
+Puerto Escondido;Córdoba Department;/wiki/Puerto_Escondido,_C%C3%B3rdoba;8.95;-76.25
 Puerto Libertador;Córdoba Department;/wiki/Puerto_Libertador;7.90667;-75.6733
 Purísima;Córdoba Department;/wiki/Pur%C3%ADsima;9.233333333333333;-75.73333333333333
-Sahagún;Córdoba Department;/wiki/Sahag%C3%BAn;_C%C3%B3rdoba;8.95;-75.45
+Sahagún;Córdoba Department;/wiki/Sahag%C3%BAn,_C%C3%B3rdoba;8.95;-75.45
 San Andrés de Sotavento;Córdoba Department;/wiki/San_Andr%C3%A9s_de_Sotavento;9.15;-75.5
 San Antero;Córdoba Department;/wiki/San_Antero;9.383333333333333;-75.75
 San Bernardo del Viento;Córdoba Department;/wiki/San_Bernardo_del_Viento;9.35;-75.95
-San Carlos;Córdoba Department;/wiki/San_Carlos;_C%C3%B3rdoba;8.80056;-75.7022
+San Carlos;Córdoba Department;/wiki/San_Carlos,_C%C3%B3rdoba;8.80056;-75.7022
 San José de Uré;Córdoba Department;/wiki/San_Jos%C3%A9_de_Ur%C3%A9;7.783333333333333;-75.53333333333333
-San Pelayo;Córdoba Department;/wiki/San_Pelayo;_Colombia;8.966666666666667;-75.85
+San Pelayo;Córdoba Department;/wiki/San_Pelayo,_Colombia;8.966666666666667;-75.85
 Tierralta;Córdoba Department;/wiki/Tierralta;7.916666666666667;-76.16666666666667
 Tuchín;Córdoba Department;/wiki/Tuch%C3%ADn;9.183333333333334;-75.55
-Valencia;Córdoba Department;/wiki/Valencia;_C%C3%B3rdoba;8.3;-76.16666666666667
+Valencia;Córdoba Department;/wiki/Valencia,_C%C3%B3rdoba;8.3;-76.16666666666667
 Agua de Dios;Cundinamarca Department;/wiki/Agua_de_Dios;4.366666666666666;-74.66666666666667
-Albán;Cundinamarca Department;/wiki/Alb%C3%A1n;_Cundinamarca;4.866666666666667;-74.43333333333334
+Albán;Cundinamarca Department;/wiki/Alb%C3%A1n,_Cundinamarca;4.866666666666667;-74.43333333333334
 Anapoima;Cundinamarca Department;/wiki/Anapoima;4.55;-74.53333333333333
 Anolaima;Cundinamarca Department;/wiki/Anolaima;4.75;-74.45
 Apulo;Cundinamarca Department;/wiki/Apulo;4.516666666666667;-74.58333333333333
 Arbeláez;Cundinamarca Department;/wiki/Arbel%C3%A1ez;4.266666666666667;-74.4
-Beltrán;Cundinamarca Department;/wiki/Beltr%C3%A1n;_Cundinamarca;4.8;-74.73333333333333
+Beltrán;Cundinamarca Department;/wiki/Beltr%C3%A1n,_Cundinamarca;4.8;-74.73333333333333
 Bituima;Cundinamarca Department;/wiki/Bituima;4.866666666666667;-74.53333333333333
 Bojacá;Cundinamarca Department;/wiki/Bojac%C3%A1;4.733333333333333;-74.33333333333333
-Cabrera;Cundinamarca Department;/wiki/Cabrera;_Cundinamarca;3.966666666666667;-74.48333333333333
-Cachipay;Cundinamarca Department;/wiki/Cachipay;_Cundinamarca;4.716666666666667;-74.43333333333334
+Cabrera;Cundinamarca Department;/wiki/Cabrera,_Cundinamarca;3.966666666666667;-74.48333333333333
+Cachipay;Cundinamarca Department;/wiki/Cachipay,_Cundinamarca;4.716666666666667;-74.43333333333334
 Cajicá;Cundinamarca Department;/wiki/Cajic%C3%A1;4.916666666666667;-74.03333333333333
 Caparrapí;Cundinamarca Department;/wiki/Caparrap%C3%AD;5.333333333333333;-74.48333333333333
 Cáqueza;Cundinamarca Department;/wiki/C%C3%A1queza;4.4;-73.93333333333334
@@ -561,25 +561,25 @@ Chaguaní;Cundinamarca Department;/wiki/Chaguan%C3%AD;4.933333333333334;-74.5833
 Chipaque;Cundinamarca Department;/wiki/Chipaque;4.433333333333334;-74.03333333333333
 Choachí;Cundinamarca Department;/wiki/Choach%C3%AD;4.516666666666667;-73.91666666666667
 Chocontá;Cundinamarca Department;/wiki/Chocont%C3%A1;5.133333333333334;-73.66666666666667
-Chía;Cundinamarca Department;/wiki/Ch%C3%ADa;_Cundinamarca;4.85;-74.05
+Chía;Cundinamarca Department;/wiki/Ch%C3%ADa,_Cundinamarca;4.85;-74.05
 Cogua;Cundinamarca Department;/wiki/Cogua;5.066666666666666;-73.98333333333333
-Cota;Cundinamarca Department;/wiki/Cota;_Cundinamarca;4.816666666666666;-74.1
+Cota;Cundinamarca Department;/wiki/Cota,_Cundinamarca;4.816666666666666;-74.1
 Cucunubá;Cundinamarca Department;/wiki/Cucunub%C3%A1;5.25;-73.75
 El Colegio;Cundinamarca Department;/wiki/El_Colegio;4.566666666666666;-74.43333333333334
-El Peñón;Cundinamarca Department;/wiki/El_Pe%C3%B1%C3%B3n;_Cundinamarca;5.25;-74.28333333333333
-El Rosal;Cundinamarca Department;/wiki/El_Rosal;_Cundinamarca;4.85;-74.25
+El Peñón;Cundinamarca Department;/wiki/El_Pe%C3%B1%C3%B3n,_Cundinamarca;5.25;-74.28333333333333
+El Rosal;Cundinamarca Department;/wiki/El_Rosal,_Cundinamarca;4.85;-74.25
 Facatativá;Cundinamarca Department;/wiki/Facatativ%C3%A1;4.816666666666666;-74.36666666666666
 Fómeque;Cundinamarca Department;/wiki/F%C3%B3meque;4.483333333333333;-73.88333333333334
-Fosca;Cundinamarca Department;/wiki/Fosca;_Cundinamarca;4.333333333333333;-73.93333333333334
+Fosca;Cundinamarca Department;/wiki/Fosca,_Cundinamarca;4.333333333333333;-73.93333333333334
 Funza;Cundinamarca Department;/wiki/Funza;4.716666666666667;-74.21666666666667
 Fusagasugá;Cundinamarca Department;/wiki/Fusagasug%C3%A1;4.333333333333333;-74.35
 Fúquene;Cundinamarca Department;/wiki/F%C3%BAquene;5.4;-73.78333333333333
 Gachalá;Cundinamarca Department;/wiki/Gachal%C3%A1;4.683333333333334;-73.51666666666667
 Gachancipá;Cundinamarca Department;/wiki/Gachancip%C3%A1;4.983333333333333;-73.86666666666666
 Gachetá;Cundinamarca Department;/wiki/Gachet%C3%A1;4.816666666666666;-73.63333333333334
-Gama;Cundinamarca Department;/wiki/Gama;_Cundinamarca;4.75;-73.6
-Girardot;Cundinamarca Department;/wiki/Girardot;_Cundinamarca;4.3;-74.8
-Granada;Cundinamarca Department;/wiki/Granada;_Cundinamarca;4.516666666666667;-74.35
+Gama;Cundinamarca Department;/wiki/Gama,_Cundinamarca;4.75;-73.6
+Girardot;Cundinamarca Department;/wiki/Girardot,_Cundinamarca;4.3;-74.8
+Granada;Cundinamarca Department;/wiki/Granada,_Cundinamarca;4.516666666666667;-74.35
 Guachetá;Cundinamarca Department;/wiki/Guachet%C3%A1;5.383333333333334;-73.68333333333334
 Guaduas;Cundinamarca Department;/wiki/Guaduas;5.066666666666666;-74.58333333333333
 Guasca;Cundinamarca Department;/wiki/Guasca;4.85;-73.86666666666666
@@ -587,56 +587,56 @@ Guataquí;Cundinamarca Department;/wiki/Guataqu%C3%AD;4.516666666666667;-74.7833
 Guatavita;Cundinamarca Department;/wiki/Guatavita;4.933333333333334;-73.83333333333333
 Guayabal de Síquima;Cundinamarca Department;/wiki/Guayabal_de_S%C3%ADquima;4.866666666666667;-74.46666666666667
 Guayabetal;Cundinamarca Department;/wiki/Guayabetal;4.2;-73.8
-Gutiérrez;Cundinamarca Department;/wiki/Guti%C3%A9rrez;_Cundinamarca;4.25;-74.0
-Jerusalen;Cundinamarca Department;/wiki/Jerusal%C3%A9n;_Cundinamarca;4.55;-74.68333333333334
-Junín;Cundinamarca Department;/wiki/Jun%C3%ADn;_Cundinamarca;4.783333333333333;-73.8
-La Calera;Cundinamarca Department;/wiki/La_Calera;_Cundinamarca;4.75;-73.91666666666667
-La Mesa;Cundinamarca Department;/wiki/La_Mesa;_Cundinamarca;4.616666666666667;-74.45
-La Palma;Cundinamarca Department;/wiki/La_Palma;_Cundinamarca;5.35;-74.38333333333334
-La Peña;Cundinamarca Department;/wiki/La_Pe%C3%B1a;_Cundinamarca;5.183333333333334;-74.38333333333334
-La Vega;Cundinamarca Department;/wiki/La_Vega;_Cundinamarca;4.983333333333333;-74.33333333333333
+Gutiérrez;Cundinamarca Department;/wiki/Guti%C3%A9rrez,_Cundinamarca;4.25;-74.0
+Jerusalen;Cundinamarca Department;/wiki/Jerusal%C3%A9n,_Cundinamarca;4.55;-74.68333333333334
+Junín;Cundinamarca Department;/wiki/Jun%C3%ADn,_Cundinamarca;4.783333333333333;-73.8
+La Calera;Cundinamarca Department;/wiki/La_Calera,_Cundinamarca;4.75;-73.91666666666667
+La Mesa;Cundinamarca Department;/wiki/La_Mesa,_Cundinamarca;4.616666666666667;-74.45
+La Palma;Cundinamarca Department;/wiki/La_Palma,_Cundinamarca;5.35;-74.38333333333334
+La Peña;Cundinamarca Department;/wiki/La_Pe%C3%B1a,_Cundinamarca;5.183333333333334;-74.38333333333334
+La Vega;Cundinamarca Department;/wiki/La_Vega,_Cundinamarca;4.983333333333333;-74.33333333333333
 Lenguazaque;Cundinamarca Department;/wiki/Lenguazaque;5.3;-73.7
 Machetá;Cundinamarca Department;/wiki/Machet%C3%A1;5.066666666666666;-73.6
-Madrid;Cundinamarca Department;/wiki/Madrid;_Cundinamarca;4.733333333333333;-74.26666666666667
-Manta;Cundinamarca Department;/wiki/Manta;_Cundinamarca;5.083333333333333;-73.58333333333333
-Medina;Cundinamarca Department;/wiki/Medina;_Cundinamarca;4.5;-73.33333333333333
-Mosquera;Cundinamarca Department;/wiki/Mosquera;_Cundinamarca;4.7;-74.21666666666667
-Nariño;Cundinamarca Department;/wiki/Nari%C3%B1o;_Cundinamarca;4.383333333333334;-74.81666666666666
+Madrid;Cundinamarca Department;/wiki/Madrid,_Cundinamarca;4.733333333333333;-74.26666666666667
+Manta;Cundinamarca Department;/wiki/Manta,_Cundinamarca;5.083333333333333;-73.58333333333333
+Medina;Cundinamarca Department;/wiki/Medina,_Cundinamarca;4.5;-73.33333333333333
+Mosquera;Cundinamarca Department;/wiki/Mosquera,_Cundinamarca;4.7;-74.21666666666667
+Nariño;Cundinamarca Department;/wiki/Nari%C3%B1o,_Cundinamarca;4.383333333333334;-74.81666666666666
 Nemocón;Cundinamarca Department;/wiki/Nemoc%C3%B3n;5.05;-73.88333333333334
-Nilo;Cundinamarca Department;/wiki/Nilo;_Cundinamarca;4.3;-74.61666666666666
+Nilo;Cundinamarca Department;/wiki/Nilo,_Cundinamarca;4.3;-74.61666666666666
 Nimaima;Cundinamarca Department;/wiki/Nimaima;5.116666666666666;-74.38333333333334
 Nocaima;Cundinamarca Department;/wiki/Nocaima;5.066666666666666;-74.36666666666666
 Pacho;Cundinamarca Department;/wiki/Pacho;5.116666666666666;-74.15
 Paime;Cundinamarca Department;/wiki/Paime;5.366666666666666;-74.15
-Pandi;Cundinamarca Department;/wiki/Pandi;_Cundinamarca;4.183333333333334;-74.48333333333333
+Pandi;Cundinamarca Department;/wiki/Pandi,_Cundinamarca;4.183333333333334;-74.48333333333333
 Paratebueno;Cundinamarca Department;/wiki/Paratebueno;4.366666666666666;-73.2
 Pasca;Cundinamarca Department;/wiki/Pasca;4.3;-74.3
 Puerto Salgar;Cundinamarca Department;/wiki/Puerto_Salgar;5.5;-74.58333333333333
-Pulí;Cundinamarca Department;/wiki/Pul%C3%AD;_Cundinamarca;4.683333333333334;-74.71666666666667
+Pulí;Cundinamarca Department;/wiki/Pul%C3%AD,_Cundinamarca;4.683333333333334;-74.71666666666667
 Quebradanegra;Cundinamarca Department;/wiki/Quebradanegra;5.116666666666666;-74.46666666666667
 Quetame;Cundinamarca Department;/wiki/Quetame;4.316666666666666;-73.85
 Quipile;Cundinamarca Department;/wiki/Quipile;4.733333333333333;-74.56666666666666
-Ricaurte;Cundinamarca Department;/wiki/Ricaurte;_Cundinamarca;4.266666666666667;-74.76666666666667
+Ricaurte;Cundinamarca Department;/wiki/Ricaurte,_Cundinamarca;4.266666666666667;-74.76666666666667
 San Antonio del Tequendama;Cundinamarca Department;/wiki/San_Antonio_del_Tequendama;4.616666666666667;-74.35
-San Bernardo;Cundinamarca Department;/wiki/San_Bernardo;_Cundinamarca;4.166666666666667;-74.41666666666667
-San Cayetano;Cundinamarca Department;/wiki/San_Cayetano;_Cundinamarca;5.316666666666666;-74.01666666666667
-San Francisco;Cundinamarca Department;/wiki/San_Francisco;_Cundinamarca;4.966666666666667;-74.28333333333333
+San Bernardo;Cundinamarca Department;/wiki/San_Bernardo,_Cundinamarca;4.166666666666667;-74.41666666666667
+San Cayetano;Cundinamarca Department;/wiki/San_Cayetano,_Cundinamarca;5.316666666666666;-74.01666666666667
+San Francisco;Cundinamarca Department;/wiki/San_Francisco,_Cundinamarca;4.966666666666667;-74.28333333333333
 San Juan de Rioseco;Cundinamarca Department;/wiki/San_Juan_de_Rioseco;4.833333333333333;-74.61666666666666
 Sasaima;Cundinamarca Department;/wiki/Sasaima;4.95;-74.43333333333334
 Sesquilé;Cundinamarca Department;/wiki/Sesquil%C3%A9;5.033333333333333;-73.78333333333333
 Sibaté;Cundinamarca Department;/wiki/Sibat%C3%A9;4.483333333333333;-74.25
-Silvania;Cundinamarca Department;/wiki/Silvania;_Colombia;4.4;-74.38333333333334
+Silvania;Cundinamarca Department;/wiki/Silvania,_Colombia;4.4;-74.38333333333334
 Simijaca;Cundinamarca Department;/wiki/Simijaca;5.5;-73.85
 Soacha;Cundinamarca Department;/wiki/Soacha;4.583333333333333;-74.21666666666667
 Sopó;Cundinamarca Department;/wiki/Sop%C3%B3;4.916666666666667;-73.93333333333334
 Subachoque;Cundinamarca Department;/wiki/Subachoque;4.916666666666667;-74.16666666666667
 Suesca;Cundinamarca Department;/wiki/Suesca;5.1;-73.8
 Supatá;Cundinamarca Department;/wiki/Supat%C3%A1;5.05;-74.23333333333333
-Susa;Cundinamarca Department;/wiki/Susa;_Cundinamarca;5.45;-73.8
+Susa;Cundinamarca Department;/wiki/Susa,_Cundinamarca;5.45;-73.8
 Sutatausa;Cundinamarca Department;/wiki/Sutatausa;5.233333333333333;-73.85
 Tabio;Cundinamarca Department;/wiki/Tabio;4.9;-74.08333333333333
 Tausa;Cundinamarca Department;/wiki/Tausa;5.183333333333334;-73.88333333333334
-Tena;Cundinamarca Department;/wiki/Tena;_Cundinamarca;4.65;-74.38333333333334
+Tena;Cundinamarca Department;/wiki/Tena,_Cundinamarca;4.65;-74.38333333333334
 Tenjo;Cundinamarca Department;/wiki/Tenjo;4.916666666666667;-74.16666666666667
 Tibacuy;Cundinamarca Department;/wiki/Tibacuy;4.333333333333333;-74.45
 Tibiritá;Cundinamarca Department;/wiki/Tibirit%C3%A1;5.05;-73.5
@@ -648,123 +648,123 @@ Ubaque;Cundinamarca Department;/wiki/Ubaque;4.466666666666667;-73.93333333333334
 Ubaté;Cundinamarca Department;/wiki/Ubat%C3%A9;5.3;-73.8
 Une;Cundinamarca Department;/wiki/Une;4.4;-74.01666666666667
 Útica;Cundinamarca Department;/wiki/%C3%9Atica;5.183333333333334;-74.48333333333333
-Venecia;Cundinamarca Department;/wiki/Venecia;_Cundinamarca;4.083333333333333;-74.46666666666667
-Vergara;Cundinamarca Department;/wiki/Vergara;_Cundinamarca;5.166666666666667;-74.33333333333333
+Venecia;Cundinamarca Department;/wiki/Venecia,_Cundinamarca;4.083333333333333;-74.46666666666667
+Vergara;Cundinamarca Department;/wiki/Vergara,_Cundinamarca;5.166666666666667;-74.33333333333333
 Vianí;Cundinamarca Department;/wiki/Vian%C3%AD;4.866666666666667;-74.55
 Villagómez;Cundinamarca Department;/wiki/Villag%C3%B3mez;5.283333333333333;-74.2
 Villapinzón;Cundinamarca Department;/wiki/Villapinz%C3%B3n;5.216666666666667;-73.6
-Villeta;Cundinamarca Department;/wiki/Villeta;_Cundinamarca;5.0;-74.46666666666667
+Villeta;Cundinamarca Department;/wiki/Villeta,_Cundinamarca;5.0;-74.46666666666667
 Viotá;Cundinamarca Department;/wiki/Viot%C3%A1;4.433333333333334;-74.51666666666667
 Yacopí;Cundinamarca Department;/wiki/Yacop%C3%AD;5.466666666666667;-74.33333333333333
 Zipacón;Cundinamarca Department;/wiki/Zipac%C3%B3n;4.75;-74.36666666666666
 Zipaquirá;Cundinamarca Department;/wiki/Zipaquir%C3%A1;5.033333333333333;-74.0
-Albania;La Guajira Department;/wiki/Albania;_La_Guajira;11.1597;-72.5856
-Barrancas;La Guajira Department;/wiki/Barrancas;_La_Guajira;11.0;-72.75
-Dibulla;La Guajira Department;/wiki/Dibulla;_La_Guajira;11.266666666666667;-73.3
-Distracción;La Guajira Department;/wiki/Distracci%C3%B3n;_La_Guajira;10.9;-72.88333333333334
-El Molino;La Guajira Department;/wiki/El_Molino;_La_Guajira;10.6533;-72.9242
-Fonseca;La Guajira Department;/wiki/Fonseca;_La_Guajira;10.833333333333334;-72.83333333333333
+Albania;La Guajira Department;/wiki/Albania,_La_Guajira;11.1597;-72.5856
+Barrancas;La Guajira Department;/wiki/Barrancas,_La_Guajira;11.0;-72.75
+Dibulla;La Guajira Department;/wiki/Dibulla,_La_Guajira;11.266666666666667;-73.3
+Distracción;La Guajira Department;/wiki/Distracci%C3%B3n,_La_Guajira;10.9;-72.88333333333334
+El Molino;La Guajira Department;/wiki/El_Molino,_La_Guajira;10.6533;-72.9242
+Fonseca;La Guajira Department;/wiki/Fonseca,_La_Guajira;10.833333333333334;-72.83333333333333
 Hatonuevo;La Guajira Department;/wiki/Hatonuevo;11.0694;-72.7669
 La Jagua del Pilar;La Guajira Department;/wiki/La_Jagua_del_Pilar;10.516666666666667;-73.08333333333333
 Maicao;La Guajira Department;/wiki/Maicao;11.366666666666667;-72.23333333333333
-Manaure;La Guajira Department;/wiki/Manaure;_La_Guajira;11.766666666666667;-72.43333333333334
-Riohacha;La Guajira Department;/wiki/Riohacha_Municipality
+Manaure;La Guajira Department;/wiki/Manaure,_La_Guajira;11.766666666666667;-72.43333333333334
+Riohacha;La Guajira Department;/wiki/Riohacha_Municipality;11.551770;-72.909752
 San Juan del Cesar;La Guajira Department;/wiki/San_Juan_del_Cesar;10.766666666666667;-73.0
-Uribia;La Guajira Department;/wiki/Uribia;_La_Guajira;11.916666666666666;-72.0
+Uribia;La Guajira Department;/wiki/Uribia,_La_Guajira;11.916666666666666;-72.0
 Urumita;La Guajira Department;/wiki/Urumita;10.566666666666666;-73.01666666666667
-Villanueva;La Guajira Department;/wiki/Villanueva;_La_Guajira;10.6;-72.98333333333333
+Villanueva;La Guajira Department;/wiki/Villanueva,_La_Guajira;10.6;-72.98333333333333
 Barranco Minas;Guainía Department;/wiki/Barranco_Minas;3.4833333333333334;-69.8
 Cacahual;Guainía Department;/wiki/Cacahual;7.58322;-75.46466
-Inirida;Guainía Department;/wiki/In%C3%ADrida;_Guain%C3%ADa;3.85;-67.91666666666667
+Inirida;Guainía Department;/wiki/In%C3%ADrida,_Guain%C3%ADa;3.85;-67.91666666666667
 La Guadalupe;Guainía Department;/wiki/La_Guadalupe;1.2333333333333334;-66.85
 Morichal Nuevo;Guainía Department;/wiki/Morichal_Nuevo;2.21667;-70.0333
 Pana Pana;Guainía Department;/wiki/Pana_Pana;1.85;-69.0
-Puerto Colombia;Guainía Department;/wiki/Puerto_Colombia;_Guain%C3%ADa;2.72028;-67.5644
-San Felipe;Guainía Department;/wiki/San_Felipe;_Guain%C3%ADa;2.90556;-67.0856
-Calamar;Guaviare Department;/wiki/Calamar;_Guaviare;1.9166666666666665;-72.55
+Puerto Colombia;Guainía Department;/wiki/Puerto_Colombia,_Guain%C3%ADa;2.72028;-67.5644
+San Felipe;Guainía Department;/wiki/San_Felipe,_Guain%C3%ADa;2.90556;-67.0856
+Calamar;Guaviare Department;/wiki/Calamar,_Guaviare;1.9166666666666665;-72.55
 El Retorno;Guaviare Department;/wiki/El_Retorno;2.33056;-72.6278
-Miraflores;Guaviare Department;/wiki/Miraflores;_Guaviare;1.33667;-71.9511
+Miraflores;Guaviare Department;/wiki/Miraflores,_Guaviare;1.33667;-71.9511
 San José del Guaviare;Guaviare Department;/wiki/San_Jos%C3%A9_del_Guaviare;2.5666666666666664;-72.63333333333334
-Acevedo;Huila Department;/wiki/Acevedo;_Huila;1.81917;-75.8964
+Acevedo;Huila Department;/wiki/Acevedo,_Huila;1.81917;-75.8964
 Agrado;Huila Department;/wiki/Agrado;4.583333333333333;-74.06666666666666
 Aipe;Huila Department;/wiki/Aipe;3.216666666666667;-75.23333333333333
-Algeciras;Huila Department;/wiki/Algeciras;_Huila;2.533333333333333;-75.31666666666666
-Altamira;Huila Department;/wiki/Altamira;_Huila;2.06278;-75.7872
+Algeciras;Huila Department;/wiki/Algeciras,_Huila;2.533333333333333;-75.31666666666666
+Altamira;Huila Department;/wiki/Altamira,_Huila;2.06278;-75.7872
 Baraya;Huila Department;/wiki/Baraya;3.15;-75.05
 Campoalegre;Huila Department;/wiki/Campoalegre;2.6833333333333336;-75.31666666666666
-Colombia;Huila Department;/wiki/Colombia;_Huila;3.37778;-74.8078
-Elias;Huila Department;/wiki/Elias;_Huila;2.0166666666666666;-75.93333333333334
-Garzón;Huila Department;/wiki/Garz%C3%B3n;_Huila;2.1666666666666665;-75.65
-Gigante;Huila Department;/wiki/Gigante;_Huila;2.38667;-75.5461
-Guadalupe;Huila Department;/wiki/Guadalupe;_Huila;2.025;-75.7572
-Hobo;Huila Department;/wiki/Hobo;_Huila;2.5833333333333335;-75.45
+Colombia;Huila Department;/wiki/Colombia,_Huila;3.37778;-74.8078
+Elias;Huila Department;/wiki/Elias,_Huila;2.0166666666666666;-75.93333333333334
+Garzón;Huila Department;/wiki/Garz%C3%B3n,_Huila;2.1666666666666665;-75.65
+Gigante;Huila Department;/wiki/Gigante,_Huila;2.38667;-75.5461
+Guadalupe;Huila Department;/wiki/Guadalupe,_Huila;2.025;-75.7572
+Hobo;Huila Department;/wiki/Hobo,_Huila;2.5833333333333335;-75.45
 Iquira;Huila Department;/wiki/Iquira;2.65;-75.65
 Isnos;Huila Department;/wiki/Isnos;1.9333333333333333;-76.23333333333333
-La Argentina;Huila Department;/wiki/La_Argentina;_Huila;2.19611;-75.98
-La Plata;Huila Department;/wiki/La_Plata;_Huila;2.3833333333333333;-75.9
+La Argentina;Huila Department;/wiki/La_Argentina,_Huila;2.19611;-75.98
+La Plata;Huila Department;/wiki/La_Plata,_Huila;2.3833333333333333;-75.9
 Nataga;Huila Department;/wiki/Nataga;2.55;-75.83333333333333
-Neiva;Huila Department;/wiki/Neiva;_Huila;2.9333333333333336;-75.26666666666667
+Neiva;Huila Department;/wiki/Neiva,_Huila;2.9333333333333336;-75.26666666666667
 Oporapa;Huila Department;/wiki/Oporapa;2.05;-75.96666666666667
 Paicol;Huila Department;/wiki/Paicol;2.4333333333333336;-75.76666666666667
-Palermo;Huila Department;/wiki/Palermo;_Huila;2.8833333333333333;-75.43333333333334
-Palestina;Huila Department;/wiki/Palestina;_Huila;1.75;-76.0667
-Pital;Huila Department;/wiki/Pital;_Huila;2.987;-75.826
+Palermo;Huila Department;/wiki/Palermo,_Huila;2.8833333333333333;-75.43333333333334
+Palestina;Huila Department;/wiki/Palestina,_Huila;1.75;-76.0667
+Pital;Huila Department;/wiki/Pital,_Huila;2.987;-75.826
 Pitalito;Huila Department;/wiki/Pitalito;1.8833333333333333;-76.03333333333333
-Rivera;Huila Department;/wiki/Rivera;_Huila;2.78528;-75.2589
+Rivera;Huila Department;/wiki/Rivera,_Huila;2.78528;-75.2589
 Saladoblanco;Huila Department;/wiki/Saladoblanco;2.0166666666666666;-76.05
-San Agustín;Huila Department;/wiki/San_Agust%C3%ADn;_Huila;1.9;-76.28333333333333
-Santa María;Huila Department;/wiki/Santa_Mar%C3%ADa;_Huila;2.95;-75.65
+San Agustín;Huila Department;/wiki/San_Agust%C3%ADn,_Huila;1.9;-76.28333333333333
+Santa María;Huila Department;/wiki/Santa_Mar%C3%ADa,_Huila;2.95;-75.65
 Suaza;Huila Department;/wiki/Suaza;1.9833333333333334;-75.81666666666666
-Tarqui;Huila Department;/wiki/Tarqui;_Huila;2.1;-75.81666666666666
-Tello;Huila Department;/wiki/Tello;_Huila;3.066666666666667;-75.13333333333334
-Teruel;Huila Department;/wiki/Teruel;_Huila;2.75;-75.56666666666666
+Tarqui;Huila Department;/wiki/Tarqui,_Huila;2.1;-75.81666666666666
+Tello;Huila Department;/wiki/Tello,_Huila;3.066666666666667;-75.13333333333334
+Teruel;Huila Department;/wiki/Teruel,_Huila;2.75;-75.56666666666666
 Tesalia;Huila Department;/wiki/Tesalia;2.4833333333333334;-75.73333333333333
 Timaná;Huila Department;/wiki/Timan%C3%A1;1.9833333333333334;-75.95
-Villavieja;Huila Department;/wiki/Villavieja;_Huila;3.216666666666667;-75.21666666666667
+Villavieja;Huila Department;/wiki/Villavieja,_Huila;3.216666666666667;-75.21666666666667
 Yaguara;Huila Department;/wiki/Yaguara;2.66611;-75.5186
-Algarrobo;Magdalena Department;/wiki/Algarrobo;_Magdalena;10.1;-74.2667
+Algarrobo;Magdalena Department;/wiki/Algarrobo,_Magdalena;10.1;-74.2667
 Aracataca;Magdalena Department;/wiki/Aracataca;10.583333333333334;-74.18333333333334
 Ariguaní;Magdalena Department;/wiki/Ariguan%C3%AD;9.85;-74.2386
 Cerro San Antonio;Magdalena Department;/wiki/Cerro_San_Antonio;10.333333333333334;-74.86666666666666
 Chibolo;Magdalena Department;/wiki/Chibolo;10.016666666666667;-74.61666666666666
-Ciénaga;Magdalena Department;/wiki/Ci%C3%A9naga;_Magdalena;11.0;-74.25
-Concordia;Magdalena Department;/wiki/Concordia;_Magdalena;10.2667;-74.8333
+Ciénaga;Magdalena Department;/wiki/Ci%C3%A9naga,_Magdalena;11.0;-74.25
+Concordia;Magdalena Department;/wiki/Concordia,_Magdalena;10.2667;-74.8333
 El Banco;Magdalena Department;/wiki/El_Banco;8.983333333333333;-73.96666666666667
 El Piñón;Magdalena Department;/wiki/El_Pi%C3%B1%C3%B3n;10.333333333333334;-74.66666666666667
 El Retén;Magdalena Department;/wiki/El_Ret%C3%A9n;10.616666666666667;-74.26666666666667
 Fundación;Magdalena Department;/wiki/Fundaci%C3%B3n;10.516666666666667;-74.18333333333334
 Guamal;Magdalena Department;/wiki/Guamal;9.14722;-74.23
-Nueva Granada;Magdalena Department;/wiki/Nueva_Granada;_Magdalena;9.80306;-74.3903
-Pedraza;Magdalena Department;/wiki/Pedraza;_Magdalena;10.183333333333334;-74.91666666666667
-Pinto;Magdalena Department;/wiki/Pinto;_Magdalena;9.433333333333334;-74.7
+Nueva Granada;Magdalena Department;/wiki/Nueva_Granada,_Magdalena;9.80306;-74.3903
+Pedraza;Magdalena Department;/wiki/Pedraza,_Magdalena;10.183333333333334;-74.91666666666667
+Pinto;Magdalena Department;/wiki/Pinto,_Magdalena;9.433333333333334;-74.7
 Pijiño;Magdalena Department;/wiki/Piji%C3%B1o;9.333333333333334;-74.45
 Pivijay;Magdalena Department;/wiki/Pivijay;10.466666666666667;-74.61666666666666
-Plato;Magdalena Department;/wiki/Plato;_Magdalena;9.783333333333333;-74.78333333333333
-Pueblo Viejo;Magdalena Department;/wiki/Pueblo_Viejo;_Magdalena;10.9972;-74.2875
+Plato;Magdalena Department;/wiki/Plato,_Magdalena;9.783333333333333;-74.78333333333333
+Pueblo Viejo;Magdalena Department;/wiki/Pueblo_Viejo,_Magdalena;10.9972;-74.2875
 Remolino;Magdalena Department;/wiki/Remolino;10.666666666666666;-74.58333333333333
 Sabanas de San Ángel;Magdalena Department;/wiki/Sabanas_de_San_%C3%81ngel;10.0333;-74.2167
-Salamina;Magdalena Department;/wiki/Salamina;_Magdalena;10.4933;-74.7983
+Salamina;Magdalena Department;/wiki/Salamina,_Magdalena;10.4933;-74.7983
 San Sebastián de Buenavista;Magdalena Department;/wiki/San_Sebasti%C3%A1n_de_Buenavista;9.233333333333333;-74.35
-Santa Ana;Magdalena Department;/wiki/Santa_Ana;_Magdalena;9.319;-74.57
+Santa Ana;Magdalena Department;/wiki/Santa_Ana,_Magdalena;9.319;-74.57
 Santa Marta;Magdalena Department;/wiki/Santa_Marta;11.233333333333333;-74.2
 San Zenón;Magdalena Department;/wiki/San_Zen%C3%B3n;9.333333333333334;-74.3
 Sitionuevo;Magdalena Department;/wiki/Sitionuevo;10.783333333333333;-74.71666666666667
-Tenerife;Magdalena Department;/wiki/Tenerife;_Magdalena;10.0;-74.66666666666667
+Tenerife;Magdalena Department;/wiki/Tenerife,_Magdalena;10.0;-74.66666666666667
 Zapayán;Magdalena Department;/wiki/Zapay%C3%A1n;10.1708;-74.7194
-Zona Bananera;Magdalena Department;/wiki/Zona_Bananera;_Magdalena;10.7647;-74.1586
+Zona Bananera;Magdalena Department;/wiki/Zona_Bananera,_Magdalena;10.7647;-74.1586
 Acacías;Meta Department;/wiki/Acac%C3%ADas;3.9833333333333334;-73.75
 Barranca de Upía;Meta Department;/wiki/Barranca_de_Up%C3%ADa;4.583333333333333;-72.96666666666667
 Cabuyaro;Meta Department;/wiki/Cabuyaro;4.283333333333333;-72.78333333333333
-Castilla la Nueva;Meta Department;/wiki/Castilla_la_Nueva;_Meta;3.8333333333333335;-73.68333333333334
+Castilla la Nueva;Meta Department;/wiki/Castilla_la_Nueva,_Meta;3.8333333333333335;-73.68333333333334
 Cubarral;Meta Department;/wiki/Cubarral;3.783333333333333;-73.83333333333333
 Cumaral;Meta Department;/wiki/Cumaral;4.266666666666667;-73.48333333333333
 El Calvario;Meta Department;/wiki/El_Calvario;4.416666666666667;-73.66666666666667
-El Castillo;Meta Department;/wiki/El_Castillo;_Meta;3.56806;-73.7839
-El Dorado;Meta Department;/wiki/El_Dorado;_Meta;3.74167;-73.8389
+El Castillo;Meta Department;/wiki/El_Castillo,_Meta;3.56806;-73.7839
+El Dorado;Meta Department;/wiki/El_Dorado,_Meta;3.74167;-73.8389
 Fuente de Oro;Meta Department;/wiki/Fuente_de_Oro;3.466666666666667;-73.61666666666666
-Granada;Meta Department;/wiki/Granada;_Meta;3.533333333333333;-73.7
-Guamal;Meta Department;/wiki/Guamal;_Meta;3.88;-73.7656
-La Macarena;Meta Department;/wiki/La_Macarena;_Meta;2.1666666666666665;-73.78333333333333
+Granada;Meta Department;/wiki/Granada,_Meta;3.533333333333333;-73.7
+Guamal;Meta Department;/wiki/Guamal,_Meta;3.88;-73.7656
+La Macarena;Meta Department;/wiki/La_Macarena,_Meta;2.1666666666666665;-73.78333333333333
 La Uribe;Meta Department;/wiki/La_Uribe;3.2333333333333334;-74.35
 Lejanías;Meta Department;/wiki/Lejan%C3%ADas;3.5166666666666666;-74.01666666666667
 Mapiripán;Meta Department;/wiki/Mapirip%C3%A1n;2.8833333333333333;-72.13333333333334
@@ -772,76 +772,76 @@ Mesetas;Meta Department;/wiki/Mesetas;3.37806;-74.0447
 Puerto Concordia;Meta Department;/wiki/Puerto_Concordia;2.6833333333333336;-72.76666666666667
 Puerto Gaitán;Meta Department;/wiki/Puerto_Gait%C3%A1n;4.31417;-72.0825
 Puerto Lleras;Meta Department;/wiki/Puerto_Lleras;3.2666666666666666;-73.36666666666666
-Puerto López;Meta Department;/wiki/Puerto_L%C3%B3pez;_Meta;4.083333333333333;-72.96666666666667
-Puerto Rico;Meta Department;/wiki/Puerto_Rico;_Meta;2.9333333333333336;-73.2
-Restrepo;Meta Department;/wiki/Restrepo;_Meta;4.25;-73.5667
+Puerto López;Meta Department;/wiki/Puerto_L%C3%B3pez,_Meta;4.083333333333333;-72.96666666666667
+Puerto Rico;Meta Department;/wiki/Puerto_Rico,_Meta;2.9333333333333336;-73.2
+Restrepo;Meta Department;/wiki/Restrepo,_Meta;4.25;-73.5667
 San Carlos de Guaroa;Meta Department;/wiki/San_Carlos_de_Guaroa;3.7;-73.23333333333333
 San Juan de Arama;Meta Department;/wiki/San_Juan_de_Arama;3.3666666666666667;-73.86666666666666
-San Juanito;Meta Department;/wiki/San_Juanito;_Meta;4.45861;-73.6731
-San Martín;Meta Department;/wiki/San_Mart%C3%ADn;_Meta;3.69444;-73.6936
+San Juanito;Meta Department;/wiki/San_Juanito,_Meta;4.45861;-73.6731
+San Martín;Meta Department;/wiki/San_Mart%C3%ADn,_Meta;3.69444;-73.6936
 Villavicencio;Meta Department;/wiki/Villavicencio;4.15;-73.63333333333334
-Vista Hermosa;Meta Department;/wiki/Vista_Hermosa;_Meta;3.1166666666666667;-73.75
+Vista Hermosa;Meta Department;/wiki/Vista_Hermosa,_Meta;3.1166666666666667;-73.75
 Albán;Nariño Department;/wiki/Alb%C3%A1n;1.4666666666666668;-77.08333333333333
 Aldana;Nariño Department;/wiki/Aldana;0.8833333333333333;-77.7
 Ancuya;Nariño Department;/wiki/Ancuya;1.2666666666666666;-77.53333333333333
 Arboleda;Nariño Department;/wiki/Arboleda;1.50333;-77.0878
-Barbacoas;Nariño Department;/wiki/Barbacoas;_Nari%C3%B1o;1.6666666666666665;-78.13333333333334
-Belén;Nariño Department;/wiki/Bel%C3%A9n;_Nari%C3%B1o;1.66417;-77.0175
+Barbacoas;Nariño Department;/wiki/Barbacoas,_Nari%C3%B1o;1.6666666666666665;-78.13333333333334
+Belén;Nariño Department;/wiki/Bel%C3%A9n,_Nari%C3%B1o;1.66417;-77.0175
 Buesaco;Nariño Department;/wiki/Buesaco;1.3833333333333333;-77.16666666666667
 Chachagüí;Nariño Department;/wiki/Chachag%C3%BC%C3%AD;1.3605;-77.2835
-Colón;Nariño Department;/wiki/Col%C3%B3n;_Nari%C3%B1o;1.6333333333333333;-77.01666666666667
+Colón;Nariño Department;/wiki/Col%C3%B3n,_Nari%C3%B1o;1.6333333333333333;-77.01666666666667
 Consaca;Nariño Department;/wiki/Consaca;1.2;-77.46666666666667
 Contadero;Nariño Department;/wiki/Contadero;0.91;-77.5506
-Córdoba;Nariño Department;/wiki/C%C3%B3rdoba;_Nari%C3%B1o;0.855;-77.5211
+Córdoba;Nariño Department;/wiki/C%C3%B3rdoba,_Nari%C3%B1o;0.855;-77.5211
 Cuaspud;Nariño Department;/wiki/Cuaspud;0.865833;-77.7294
 Cumbal;Nariño Department;/wiki/Cumbal;0.9;-77.78333333333333
 Cumbitara;Nariño Department;/wiki/Cumbitara;1.67694;-77.3253
 El Charco;Nariño Department;/wiki/El_Charco;2.466666666666667;-78.1
-El Peñol;Nariño Department;/wiki/El_Pe%C3%B1ol;_Nari%C3%B1o;1.45;-77.43333333333334
-El Rosario;Nariño Department;/wiki/El_Rosario;_Nari%C3%B1o;1.7333333333333334;-77.33333333333333
+El Peñol;Nariño Department;/wiki/El_Pe%C3%B1ol,_Nari%C3%B1o;1.45;-77.43333333333334
+El Rosario;Nariño Department;/wiki/El_Rosario,_Nari%C3%B1o;1.7333333333333334;-77.33333333333333
 El Tablón;Nariño Department;/wiki/El_Tabl%C3%B3n;1.4166666666666667;-77.08333333333333
-El Tambo;Nariño Department;/wiki/El_Tambo;_Nari%C3%B1o;1.41306;-77.3981
-Francisco Pizarro;Nariño Department;/wiki/Francisco_Pizarro;_Nari%C3%B1o;2.1;-78.71666666666667
-Funes;Nariño Department;/wiki/Funes;_Nari%C3%B1o;1.0;-77.45
+El Tambo;Nariño Department;/wiki/El_Tambo,_Nari%C3%B1o;1.41306;-77.3981
+Francisco Pizarro;Nariño Department;/wiki/Francisco_Pizarro,_Nari%C3%B1o;2.1;-78.71666666666667
+Funes;Nariño Department;/wiki/Funes,_Nari%C3%B1o;1.0;-77.45
 Guachucal;Nariño Department;/wiki/Guachucal;0.9666666666666667;-77.73333333333333
 Guaitarilla;Nariño Department;/wiki/Guaitarilla;1.13333;-77.5564
 Gualmatán;Nariño Department;/wiki/Gualmat%C3%A1n;0.919167;-77.5661
-Iles;Nariño Department;/wiki/Iles;_Nari%C3%B1o;0.9666666666666667;-77.51666666666667
+Iles;Nariño Department;/wiki/Iles,_Nari%C3%B1o;0.9666666666666667;-77.51666666666667
 Imués;Nariño Department;/wiki/Imu%C3%A9s;1.0666666666666667;-77.5
 Ipiales;Nariño Department;/wiki/Ipiales;0.8166666666666667;-77.63333333333334
-La Cruz;Nariño Department;/wiki/La_Cruz;_Nari%C3%B1o;1.60472;-76.9742
-La Florida;Nariño Department;/wiki/La_Florida;_Nari%C3%B1o;1.30167;-77.4106
+La Cruz;Nariño Department;/wiki/La_Cruz,_Nari%C3%B1o;1.60472;-76.9742
+La Florida;Nariño Department;/wiki/La_Florida,_Nari%C3%B1o;1.30167;-77.4106
 La Llanada;Nariño Department;/wiki/La_Llanada;1.47778;-77.5839
 La Tola;Nariño Department;/wiki/La_Tola;2.4166666666666665;-78.25
-La Unión;Nariño Department;/wiki/La_Uni%C3%B3n;_Nari%C3%B1o;1.6019;-77.1317
-Leiva;Nariño Department;/wiki/Leiva;_Nari%C3%B1o;1.9375;-77.3081
-Linares;Nariño Department;/wiki/Linares;_Nari%C3%B1o;1.35;-77.53333333333333
-Los Andes;Nariño Department;/wiki/Los_Andes;_Nari%C3%B1o;1.4833333333333334;-77.51666666666667
+La Unión;Nariño Department;/wiki/La_Uni%C3%B3n,_Nari%C3%B1o;1.6019;-77.1317
+Leiva;Nariño Department;/wiki/Leiva,_Nari%C3%B1o;1.9375;-77.3081
+Linares;Nariño Department;/wiki/Linares,_Nari%C3%B1o;1.35;-77.53333333333333
+Los Andes;Nariño Department;/wiki/Los_Andes,_Nari%C3%B1o;1.4833333333333334;-77.51666666666667
 Magüí Payán;Nariño Department;/wiki/Mag%C3%BC%C3%AD_Pay%C3%A1n;1.9333333333333333;-78.2
 Mallama;Nariño Department;/wiki/Mallama;1.1333333333333333;-77.85
-Mosquera;Nariño Department;/wiki/Mosquera;_Nari%C3%B1o;2.49028;-78.4953
-Nariño;Nariño Department;/wiki/Nari%C3%B1o;_Nari%C3%B1o;1.26667;-77.3667
+Mosquera;Nariño Department;/wiki/Mosquera,_Nari%C3%B1o;2.49028;-78.4953
+Nariño;Nariño Department;/wiki/Nari%C3%B1o,_Nari%C3%B1o;1.26667;-77.3667
 Olaya Herrera;Nariño Department;/wiki/Olaya_Herrera;2.3333333333333335;-78.31666666666666
 Ospina;Nariño Department;/wiki/Ospina;1.05;-77.55
-Pasto;Nariño Department;/wiki/Pasto;_Colombia;1.2;-77.26666666666667
-Policarpa;Nariño Department;/wiki/Policarpa;_Nari%C3%B1o;1.6333333333333333;-77.46666666666667
-Potosí;Nariño Department;/wiki/Potos%C3%AD;_Nari%C3%B1o;0.8;-77.56666666666666
-Providencia;Nariño Department;/wiki/Providencia;_Nari%C3%B1o;1.2333333333333334;-77.58333333333333
+Pasto;Nariño Department;/wiki/Pasto,_Colombia;1.2;-77.26666666666667
+Policarpa;Nariño Department;/wiki/Policarpa,_Nari%C3%B1o;1.6333333333333333;-77.46666666666667
+Potosí;Nariño Department;/wiki/Potos%C3%AD,_Nari%C3%B1o;0.8;-77.56666666666666
+Providencia;Nariño Department;/wiki/Providencia,_Nari%C3%B1o;1.2333333333333334;-77.58333333333333
 Puerres;Nariño Department;/wiki/Puerres;0.8666666666666667;-77.5
 Pupiales;Nariño Department;/wiki/Pupiales;0.8666666666666667;-77.65
-Ricaurte;Nariño Department;/wiki/Ricaurte;_Nari%C3%B1o;1.2;-77.98333333333333
+Ricaurte;Nariño Department;/wiki/Ricaurte,_Nari%C3%B1o;1.2;-77.98333333333333
 Roberto Payán;Nariño Department;/wiki/Roberto_Pay%C3%A1n;1.6833333333333333;-78.23333333333333
-Samaniego;Nariño Department;/wiki/Samaniego;_Nari%C3%B1o;1.35;-77.6
-San Bernardo;Nariño Department;/wiki/San_Bernardo;_Nari%C3%B1o;1.5;-77.03333333333333
+Samaniego;Nariño Department;/wiki/Samaniego,_Nari%C3%B1o;1.35;-77.6
+San Bernardo;Nariño Department;/wiki/San_Bernardo,_Nari%C3%B1o;1.5;-77.03333333333333
 Sandona;Nariño Department;/wiki/Sandona;1.2833333333333332;-77.46666666666667
-San Lorenzo;Nariño Department;/wiki/San_Lorenzo;_Nari%C3%B1o;1.50389;-77.2178
-San Pablo;Nariño Department;/wiki/San_Pablo;_Nari%C3%B1o;1.6725;-77.0139
+San Lorenzo;Nariño Department;/wiki/San_Lorenzo,_Nari%C3%B1o;1.50389;-77.2178
+San Pablo;Nariño Department;/wiki/San_Pablo,_Nari%C3%B1o;1.6725;-77.0139
 San Pedro de Cartago;Nariño Department;/wiki/San_Pedro_de_Cartago;1.5666666666666667;-77.11666666666666
-Santa Barbara;Nariño Department;/wiki/Santa_Barbara;_Nari%C3%B1o;2.44444;-77.9717
-Santacruz;Nariño Department;/wiki/Santacruz;_Nari%C3%B1o;1.2166666666666668;-77.66666666666667
+Santa Barbara;Nariño Department;/wiki/Santa_Barbara,_Nari%C3%B1o;2.44444;-77.9717
+Santacruz;Nariño Department;/wiki/Santacruz,_Nari%C3%B1o;1.2166666666666668;-77.66666666666667
 Sapuyes;Nariño Department;/wiki/Sapuyes;1.0333333333333334;-77.61666666666666
 Taminango;Nariño Department;/wiki/Taminango;1.5666666666666667;-77.28333333333333
-Tangua;Nariño Department;/wiki/Tangua;_Nari%C3%B1o;1.1;-77.4
+Tangua;Nariño Department;/wiki/Tangua,_Nari%C3%B1o;1.1;-77.4
 Tumaco;Nariño Department;/wiki/Tumaco;1.8;-78.75
 Túquerres;Nariño Department;/wiki/T%C3%BAquerres;1.0833333333333333;-77.61666666666666
 Yacuanquer;Nariño Department;/wiki/Yacuanquer;1.1166666666666667;-77.4
@@ -857,61 +857,61 @@ Convención;Norte de Santander Department;/wiki/Convenci%C3%B3n;8.83333333333333
 Cúcuta;Norte de Santander Department;/wiki/C%C3%BAcuta;7.883333333333333;-72.5
 Cucutilla;Norte de Santander Department;/wiki/Cucutilla;7.55;-72.78333333333333
 Durania;Norte de Santander Department;/wiki/Durania;7.71722;-72.66
-El Carmen;Norte de Santander Department;/wiki/El_Carmen;_Norte_de_Santander;8.51278;-73.4508
+El Carmen;Norte de Santander Department;/wiki/El_Carmen,_Norte_de_Santander;8.51278;-73.4508
 El Tarra;Norte de Santander Department;/wiki/El_Tarra;8.0475;-73.0836
 El Zulia;Norte de Santander Department;/wiki/El_Zulia;7.933333333333334;-72.6
 Gramalote;Norte de Santander Department;/wiki/Gramalote;7.916666666666667;-72.75
 Hacari;Norte de Santander Department;/wiki/Hacari;8.316666666666666;-73.15
 Herrán;Norte de Santander Department;/wiki/Herr%C3%A1n;7.516666666666667;-72.48333333333333
-La Esperanza;Norte de Santander Department;/wiki/La_Esperanza;_Norte_de_Santander;7.63917;-73.3358
+La Esperanza;Norte de Santander Department;/wiki/La_Esperanza,_Norte_de_Santander;7.63917;-73.3358
 La Playa;Norte de Santander Department;/wiki/La_Playa_de_Bel%C3%A9n;8.25;-73.16666666666667
 Labateca;Norte de Santander Department;/wiki/Labateca;7.333333333333333;-72.5
 Los Patios;Norte de Santander Department;/wiki/Los_Patios;7.833333333333333;-72.51666666666667
-Lourdes;Norte de Santander Department;/wiki/Lourdes;_Norte_de_Santander;7.966666666666667;-72.83333333333333
+Lourdes;Norte de Santander Department;/wiki/Lourdes,_Norte_de_Santander;7.966666666666667;-72.83333333333333
 Mutiscua;Norte de Santander Department;/wiki/Mutiscua;7.333333333333333;-72.71666666666667
-Ocaña;Norte de Santander Department;/wiki/Oca%C3%B1a;_Norte_de_Santander;8.233333333333333;-73.35
-Pamplona;Norte de Santander Department;/wiki/Pamplona;_Norte_de_Santander;7.366666666666666;-72.65
+Ocaña;Norte de Santander Department;/wiki/Oca%C3%B1a,_Norte_de_Santander;8.233333333333333;-73.35
+Pamplona;Norte de Santander Department;/wiki/Pamplona,_Norte_de_Santander;7.366666666666666;-72.65
 Pamplonita;Norte de Santander Department;/wiki/Pamplonita;7.5;-72.58333333333333
-Puerto Santander;Norte de Santander Department;/wiki/Puerto_Santander;_Norte_de_Santander;8.36361;-72.4075
+Puerto Santander;Norte de Santander Department;/wiki/Puerto_Santander,_Norte_de_Santander;8.36361;-72.4075
 Ragonvalia;Norte de Santander Department;/wiki/Ragonvalia;7.583333333333333;-72.48333333333333
 Salazar de las Palmas;Norte de Santander Department;/wiki/Salazar_de_las_Palmas;7.766666666666667;-72.8
 San Calixto;Norte de Santander Department;/wiki/San_Calixto;8.4;-73.21666666666667
-San Cayetano;Norte de Santander Department;/wiki/San_Cayetano;_Norte_de_Santander;7.88028;-72.6278
-Santiago;Norte de Santander Department;/wiki/Santiago;_Norte_de_Santander;7.916666666666667;-72.66666666666667
+San Cayetano;Norte de Santander Department;/wiki/San_Cayetano,_Norte_de_Santander;7.88028;-72.6278
+Santiago;Norte de Santander Department;/wiki/Santiago,_Norte_de_Santander;7.916666666666667;-72.66666666666667
 Sardinata;Norte de Santander Department;/wiki/Sardinata;8.083333333333334;-72.8
-Silos;Norte de Santander Department;/wiki/Silos;_Norte_de_Santander;7.2;-72.76666666666667
+Silos;Norte de Santander Department;/wiki/Silos,_Norte_de_Santander;7.2;-72.76666666666667
 Teorama;Norte de Santander Department;/wiki/Teorama;8.433333333333334;-72.28333333333333
 Tibú;Norte de Santander Department;/wiki/Tib%C3%BA;8.65;-72.73333333333333
-Toledo;Norte de Santander Department;/wiki/Toledo;_Norte_de_Santander;7.31306;-72.4875
+Toledo;Norte de Santander Department;/wiki/Toledo,_Norte_de_Santander;7.31306;-72.4875
 Villa Caro;Norte de Santander Department;/wiki/Villa_Caro;7.91694;-72.9764
-Villa del Rosario;Norte de Santander Department;/wiki/Villa_del_Rosario;_Norte_de_Santander;7.833333333333333;-72.46666666666667
-Colón;Putumayo Department;/wiki/Col%C3%B3n;_Putumayo;1.1833333333333333;-76.96666666666667
+Villa del Rosario;Norte de Santander Department;/wiki/Villa_del_Rosario,_Norte_de_Santander;7.833333333333333;-72.46666666666667
+Colón;Putumayo Department;/wiki/Col%C3%B3n,_Putumayo;1.1833333333333333;-76.96666666666667
 Mocoa;Putumayo Department;/wiki/Mocoa;1.15;-76.63333333333334
 Orito;Putumayo Department;/wiki/Orito;0.65;-76.86666666666666
 Puerto Asís;Putumayo Department;/wiki/Puerto_As%C3%ADs;0.5166666666666667;-76.5
 Puerto Caicedo;Putumayo Department;/wiki/Puerto_Caicedo;0.6833333333333333;-76.6
 Puerto Guzmán;Putumayo Department;/wiki/Puerto_Guzm%C3%A1n;0.9666666666666667;-76.58333333333333
 Puerto Leguízamo;Putumayo Department;/wiki/Puerto_Legu%C3%ADzamo;-0.18333333333333332;-74.76666666666667
-San Francisco;Putumayo Department;/wiki/San_Francisco;_Putumayo;1.1666666666666667;-76.86666666666666
-San Miguel;Putumayo Department;/wiki/San_Miguel;_Putumayo;0.3333333333333333;-76.9
-Santiago;Putumayo Department;/wiki/Santiago;_Putumayo;1.1333333333333333;-77.0
+San Francisco;Putumayo Department;/wiki/San_Francisco,_Putumayo;1.1666666666666667;-76.86666666666666
+San Miguel;Putumayo Department;/wiki/San_Miguel,_Putumayo;0.3333333333333333;-76.9
+Santiago;Putumayo Department;/wiki/Santiago,_Putumayo;1.1333333333333333;-77.0
 Sibundoy;Putumayo Department;/wiki/Sibundoy;1.2;-76.91666666666667
 Valle del Guamez;Putumayo Department;/wiki/Valle_del_Guamez;0.4166666666666667;-76.9
 Villa Garzón;Putumayo Department;/wiki/Villa_Garz%C3%B3n;1.0166666666666666;-76.6
-Armenia;Quindío Department;/wiki/Armenia;_Colombia;4.53;-75.68
-Buenavista;Quindío Department;/wiki/Buenavista;_Quind%C3%ADo;4.533333333333333;-75.68333333333334
+Armenia;Quindío Department;/wiki/Armenia,_Colombia;4.53;-75.68
+Buenavista;Quindío Department;/wiki/Buenavista,_Quind%C3%ADo;4.533333333333333;-75.68333333333334
 Calarcá;Quindío Department;/wiki/Calarc%C3%A1;4.533333333333333;-75.65
-Circasia;Quindío Department;/wiki/Circasia;_Quind%C3%ADo;4.616666666666667;-75.63333333333334
-Córdoba;Quindío Department;/wiki/C%C3%B3rdoba;_Quind%C3%ADo;4.383333333333334;-75.68333333333334
-Filandia;Quindío Department;/wiki/Filandia;_Quind%C3%ADo;4.666666666666667;-75.63333333333334
-Génova;Quindío Department;/wiki/G%C3%A9nova;_Quind%C3%ADo;4.25;-75.66666666666667
-La Tebaida;Quindío Department;/wiki/La_Tebaida;_Quind%C3%ADo;4.45;-75.8
-Montenegro;Quindío Department;/wiki/Montenegro;_Quind%C3%ADo;4.56714;-75.75038
-Pijao;Quindío Department;/wiki/Pijao;_Quind%C3%ADo;4.333333333333333;-75.7
-Quimbaya;Quindío Department;/wiki/Quimbaya;_Quind%C3%ADo;4.633333333333333;-75.75
-Salento;Quindío Department;/wiki/Salento;_Quind%C3%ADo;4.633333333333333;-75.56666666666666
-Apía;Risaralda Department;/wiki/Ap%C3%ADa;_Risaralda;5.1;-75.95
-Balboa;Risaralda Department;/wiki/Balboa;_Risaralda;4.916666666666667;-75.95
+Circasia;Quindío Department;/wiki/Circasia,_Quind%C3%ADo;4.616666666666667;-75.63333333333334
+Córdoba;Quindío Department;/wiki/C%C3%B3rdoba,_Quind%C3%ADo;4.383333333333334;-75.68333333333334
+Filandia;Quindío Department;/wiki/Filandia,_Quind%C3%ADo;4.666666666666667;-75.63333333333334
+Génova;Quindío Department;/wiki/G%C3%A9nova,_Quind%C3%ADo;4.25;-75.66666666666667
+La Tebaida;Quindío Department;/wiki/La_Tebaida,_Quind%C3%ADo;4.45;-75.8
+Montenegro;Quindío Department;/wiki/Montenegro,_Quind%C3%ADo;4.56714;-75.75038
+Pijao;Quindío Department;/wiki/Pijao,_Quind%C3%ADo;4.333333333333333;-75.7
+Quimbaya;Quindío Department;/wiki/Quimbaya,_Quind%C3%ADo;4.633333333333333;-75.75
+Salento;Quindío Department;/wiki/Salento,_Quind%C3%ADo;4.633333333333333;-75.56666666666666
+Apía;Risaralda Department;/wiki/Ap%C3%ADa,_Risaralda;5.1;-75.95
+Balboa;Risaralda Department;/wiki/Balboa,_Risaralda;4.916666666666667;-75.95
 Belén de Umbría;Risaralda Department;/wiki/Bel%C3%A9n_de_Umbr%C3%ADa;5.2;-75.86666666666666
 Dosquebradas;Risaralda Department;/wiki/Dosquebradas;4.833333333333333;-75.68333333333334
 Guática;Risaralda Department;/wiki/Gu%C3%A1tica;5.316666666666666;-75.8
@@ -919,210 +919,210 @@ La Celia;Risaralda Department;/wiki/La_Celia;5.0;-76.0
 La Virginia;Risaralda Department;/wiki/La_Virginia;4.916666666666667;-75.83333333333333
 Marsella;Risaralda Department;/wiki/Marsella;4.916666666666667;-75.75
 Mistrató;Risaralda Department;/wiki/Mistrat%C3%B3;5.3;-75.88333333333334
-Pereira;Risaralda Department;/wiki/Pereira;_Colombia;4.8;-75.68333333333334
-Pueblo Rico;Risaralda Department;/wiki/Pueblo_Rico;_Risaralda;5.25;-76.16666666666667
+Pereira;Risaralda Department;/wiki/Pereira,_Colombia;4.8;-75.68333333333334
+Pueblo Rico;Risaralda Department;/wiki/Pueblo_Rico,_Risaralda;5.25;-76.16666666666667
 Quinchía;Risaralda Department;/wiki/Quinch%C3%ADa;5.333333333333333;-75.71666666666667
 Santa Rosa de Cabal;Risaralda Department;/wiki/Santa_Rosa_de_Cabal;4.866666666666667;-75.61666666666666
-Santuario;Risaralda Department;/wiki/Santuario;_Risaralda;5.066666666666666;-75.95
+Santuario;Risaralda Department;/wiki/Santuario,_Risaralda;5.066666666666666;-75.95
 Providencia and Santa Catalina Islands;San Andrés and Providencia Department;/wiki/Providencia_and_Santa_Catalina_Islands;13.533333333333333;-81.35
-San Andrés;San Andrés and Providencia Department;/wiki/San_Andr%C3%A9s;_San_Andr%C3%A9s_y_Providencia;12.583333333333334;-81.7
-Aguada;Santander Department;/wiki/Aguada;_Santander;6.25;-73.46666666666667
-Albania;Santander Department;/wiki/Albania;_Santander;5.76139;-73.9178
+San Andrés;San Andrés and Providencia Department;/wiki/San_Andr%C3%A9s,_San_Andr%C3%A9s_y_Providencia;12.583333333333334;-81.7
+Aguada;Santander Department;/wiki/Aguada,_Santander;6.25;-73.46666666666667
+Albania;Santander Department;/wiki/Albania,_Santander;5.76139;-73.9178
 Aratoca;Santander Department;/wiki/Aratoca;6.7;-73.01666666666667
-Barbosa;Santander Department;/wiki/Barbosa;_Santander;5.933;-73.621
+Barbosa;Santander Department;/wiki/Barbosa,_Santander;5.933;-73.621
 Barichara;Santander Department;/wiki/Barichara;6.633333333333333;-73.23333333333333
 Barrancabermeja;Santander Department;/wiki/Barrancabermeja;7.066666666666666;-73.85
-Betulia;Santander Department;/wiki/Betulia;_Santander;6.9;-73.28333333333333
-Bolívar;Santander Department;/wiki/Bol%C3%ADvar;_Santander;5.983333333333333;-73.76666666666667
+Betulia;Santander Department;/wiki/Betulia,_Santander;6.9;-73.28333333333333
+Bolívar;Santander Department;/wiki/Bol%C3%ADvar,_Santander;5.983333333333333;-73.76666666666667
 Bucaramanga;Santander Department;/wiki/Bucaramanga;7.133333333333334;-73.13333333333334
-Cabrera;Santander Department;/wiki/Cabrera;_Santander;6.583333333333333;-73.23333333333333
-California;Santander Department;/wiki/California;_Santander;7.35;-72.96666666666667
-Capitanejo;Santander Department;/wiki/Capitanejo;_Santander;6.533333333333333;-72.7
+Cabrera;Santander Department;/wiki/Cabrera,_Santander;6.583333333333333;-73.23333333333333
+California;Santander Department;/wiki/California,_Santander;7.35;-72.96666666666667
+Capitanejo;Santander Department;/wiki/Capitanejo,_Santander;6.533333333333333;-72.7
 Carcasí;Santander Department;/wiki/Carcas%C3%AD;6.633333333333333;-72.63333333333334
 Cepitá;Santander Department;/wiki/Cepit%C3%A1;6.75;-72.98333333333333
-Cerrito;Santander Department;/wiki/Cerrito;_Santander;6.845;-72.698
+Cerrito;Santander Department;/wiki/Cerrito,_Santander;6.845;-72.698
 Charalá;Santander Department;/wiki/Charal%C3%A1;6.25;-73.08333333333333
 Charta;Santander Department;/wiki/Charta;7.283333333333333;-72.96666666666667
 Chima;Santander Department;/wiki/Chima_(town);6.35078;-73.37116
-Chipatá;Santander Department;/wiki/Chipat%C3%A1;_Santander;6.05;-73.63333333333334
+Chipatá;Santander Department;/wiki/Chipat%C3%A1,_Santander;6.05;-73.63333333333334
 Cimitarra;Santander Department;/wiki/Cimitarra;6.316666666666666;-73.95
-Concepción;Santander Department;/wiki/Concepci%C3%B3n;_Santander;6.766666666666667;-72.68333333333334
+Concepción;Santander Department;/wiki/Concepci%C3%B3n,_Santander;6.766666666666667;-72.68333333333334
 Confines;Santander Department;/wiki/Confines;6.416666666666667;-73.16666666666667
 Contratación;Santander Department;/wiki/Contrataci%C3%B3n;6.283333333333333;-73.48333333333333
 Coromoro;Santander Department;/wiki/Coromoro;6.3;-73.03333333333333
 Curití;Santander Department;/wiki/Curit%C3%AD;6.666666666666667;-73.0
-El Carmen;Santander Department;/wiki/El_Carmen;_Santander;6.69806;-73.5111
+El Carmen;Santander Department;/wiki/El_Carmen,_Santander;6.69806;-73.5111
 El Guacamayo;Santander Department;/wiki/El_Guacamayo;6.333333333333333;-73.46666666666667
-El Peñón;Santander Department;/wiki/El_Pe%C3%B1%C3%B3n;_Santander;5.89222;-73.7403
-El Playón;Santander Department;/wiki/El_Play%C3%B3n;_Santander;7.47667;-73.2081
-Encino;Santander Department;/wiki/Encino;_Santander;6.133333333333334;-73.08333333333333
-Enciso;Santander Department;/wiki/Enciso;_Santander;6.75;-72.63333333333334
+El Peñón;Santander Department;/wiki/El_Pe%C3%B1%C3%B3n,_Santander;5.89222;-73.7403
+El Playón;Santander Department;/wiki/El_Play%C3%B3n,_Santander;7.47667;-73.2081
+Encino;Santander Department;/wiki/Encino,_Santander;6.133333333333334;-73.08333333333333
+Enciso;Santander Department;/wiki/Enciso,_Santander;6.75;-72.63333333333334
 Florián;Santander Department;/wiki/Flori%C3%A1n;5.80472;-73.9742
-Floridablanca;Santander Department;/wiki/Floridablanca;_Santander;7.216666666666667;-73.06666666666666
-Galán;Santander Department;/wiki/Gal%C3%A1n;_Santander;6.7;-73.3
+Floridablanca;Santander Department;/wiki/Floridablanca,_Santander;7.216666666666667;-73.06666666666666
+Galán;Santander Department;/wiki/Gal%C3%A1n,_Santander;6.7;-73.3
 Gámbita;Santander Department;/wiki/G%C3%A1mbita;6.0;-73.25
 Girón;Santander Department;/wiki/San_Juan_de_Gir%C3%B3n;7.066666666666666;-73.16666666666667
-Guaca;Santander Department;/wiki/Guaca;_Santander;6.883333333333333;-72.86666666666666
-Guadalupe;Santander Department;/wiki/Guadalupe;_Santander;6.247;-73.418
+Guaca;Santander Department;/wiki/Guaca,_Santander;6.883333333333333;-72.86666666666666
+Guadalupe;Santander Department;/wiki/Guadalupe,_Santander;6.247;-73.418
 Guapotá;Santander Department;/wiki/Guapot%C3%A1;6.383333333333334;-73.25
 Guavatá;Santander Department;/wiki/Guavat%C3%A1;5.95;-73.7
 Güepsa;Santander Department;/wiki/G%C3%BCepsa;6.016666666666667;-73.56666666666666
-Hato;Santander Department;/wiki/Hato;_Santander;6.583333333333333;-73.33333333333333
-Jesus María;Santander Department;/wiki/Jesus_Mar%C3%ADa;_Santander;5.883333333333333;-73.78333333333333
-Jordán;Santander Department;/wiki/Jord%C3%A1n;_Santander;6.75;-73.06666666666666
+Hato;Santander Department;/wiki/Hato,_Santander;6.583333333333333;-73.33333333333333
+Jesus María;Santander Department;/wiki/Jesus_Mar%C3%ADa,_Santander;5.883333333333333;-73.78333333333333
+Jordán;Santander Department;/wiki/Jord%C3%A1n,_Santander;6.75;-73.06666666666666
 La Belleza;Santander Department;/wiki/La_Belleza;5.86139;-73.9683
 Landázuri;Santander Department;/wiki/Land%C3%A1zuri;6.216666666666667;-73.8
-La Paz;Santander Department;/wiki/La_Paz;_Santander;6.166666666666667;-73.58333333333333
-Lebrija;Santander Department;/wiki/Lebrija;_Santander;7.416666666666667;-73.41666666666667
-Los Santos;Santander Department;/wiki/Los_Santos;_Santander;6.916666666666667;-73.08333333333333
+La Paz;Santander Department;/wiki/La_Paz,_Santander;6.166666666666667;-73.58333333333333
+Lebrija;Santander Department;/wiki/Lebrija,_Santander;7.416666666666667;-73.41666666666667
+Los Santos;Santander Department;/wiki/Los_Santos,_Santander;6.916666666666667;-73.08333333333333
 Macaravita;Santander Department;/wiki/Macaravita;6.5;-72.6
-Málaga;Santander Department;/wiki/M%C3%A1laga;_Santander;6.783333333333333;-72.66666666666667
-Matanza;Santander Department;/wiki/Matanza;_Santander;7.416666666666667;-73.08333333333333
+Málaga;Santander Department;/wiki/M%C3%A1laga,_Santander;6.783333333333333;-72.66666666666667
+Matanza;Santander Department;/wiki/Matanza,_Santander;7.416666666666667;-73.08333333333333
 Mogotes;Santander Department;/wiki/Mogotes;6.483333333333333;-72.96666666666667
 Molagavita;Santander Department;/wiki/Molagavita;6.683333333333334;-72.81666666666666
 Ocamonte;Santander Department;/wiki/Ocamonte;6.333333333333333;-73.11666666666666
 Oiba;Santander Department;/wiki/Oiba;6.266666666666667;-73.3
 Onzaga;Santander Department;/wiki/Onzaga;6.35;-72.81666666666666
-Palmar;Santander Department;/wiki/Palmar;_Santander;6.583333333333333;-73.25
+Palmar;Santander Department;/wiki/Palmar,_Santander;6.583333333333333;-73.25
 Palmas Socorro;Santander Department;/wiki/Palmas_Socorro;6.40722;-73.2883
-Páramo;Santander Department;/wiki/P%C3%A1ramo;_Santander;6.5;-73.13333333333334
+Páramo;Santander Department;/wiki/P%C3%A1ramo,_Santander;6.5;-73.13333333333334
 Piedecuesta;Santander Department;/wiki/Piedecuesta;7.083333333333333;-73.0
 Pinchote;Santander Department;/wiki/Pinchote;6.533333333333333;-73.18333333333334
-Puente Nacional;Santander Department;/wiki/Puente_Nacional;_Santander;5.883333333333333;-73.68333333333334
+Puente Nacional;Santander Department;/wiki/Puente_Nacional,_Santander;5.883333333333333;-73.68333333333334
 Puerto Parra;Santander Department;/wiki/Puerto_Parra;6.65;-74.06666666666666
 Puerto Wilches;Santander Department;/wiki/Puerto_Wilches;7.35;-73.9
-Rionegro;Santander Department;/wiki/Rionegro;_Santander;7.15361;-73.1536
+Rionegro;Santander Department;/wiki/Rionegro,_Santander;7.15361;-73.1536
 Sabana de Torres;Santander Department;/wiki/Sabana_de_Torres;7.4;-73.5
-San Andrés;Santander Department;/wiki/San_Andr%C3%A9s;_Santander;6.81278;-72.8536
-San Benito;Santander Department;/wiki/San_Benito;_Santander
+San Andrés;Santander Department;/wiki/San_Andr%C3%A9s,_Santander;6.81278;-72.8536
+San Benito;Santander Department;/wiki/San_Benito,_Santander;6.120270;-73.496689
 San Gil;Santander Department;/wiki/San_Gil;6.55;-73.13333333333334
-San Joaquín;Santander Department;/wiki/San_Joaqu%C3%ADn;_Santander
+San Joaquín;Santander Department;/wiki/San_Joaqu%C3%ADn,_Santander;6.4710188;-72.8451961
 San José de Miranda;Santander Department;/wiki/San_Jos%C3%A9_de_Miranda;6.65;-72.71666666666667
-San Miguel;Santander Department;/wiki/San_Miguel;_Santander;6.566666666666666;-72.63333333333334
-Santa Bárbara;Santander Department;/wiki/Santa_B%C3%A1rbara;_Santander;6.983333333333333;-72.9
+San Miguel;Santander Department;/wiki/San_Miguel,_Santander;6.566666666666666;-72.63333333333334
+Santa Bárbara;Santander Department;/wiki/Santa_B%C3%A1rbara,_Santander;6.983333333333333;-72.9
 Santa Helena del Opón;Santander Department;/wiki/Santa_Helena_del_Op%C3%B3n;6.333333333333333;-73.6
 San Vicente de Chucurí;Santander Department;/wiki/San_Vicente_de_Chucur%C3%AD;6.883333333333333;-73.41666666666667
 Simacota;Santander Department;/wiki/Simacota;6.45;-73.33333333333333
-Socorro;Santander Department;/wiki/Socorro;_Santander;6.533333333333333;-73.2
-Suaita;Santander Department;/wiki/Suaita
-Sucre;Santander Department;/wiki/Sucre;_Santander;5.923;-73.795
+Socorro;Santander Department;/wiki/Socorro,_Santander;6.533333333333333;-73.2
+Suaita;Santander Department;/wiki/Suaita;6.1257536;-73.3627147
+Sucre;Santander Department;/wiki/Sucre,_Santander;5.923;-73.795
 Surata;Santander Department;/wiki/Surata;7.366666666666666;-72.98333333333333
-Tona;Santander Department;/wiki/Tona;_Santander;7.25;-72.9
+Tona;Santander Department;/wiki/Tona,_Santander;7.25;-72.9
 Valle de San José;Santander Department;/wiki/Valle_de_San_Jos%C3%A9;6.4475;-73.1436
-Vélez;Santander Department;/wiki/V%C3%A9lez;_Santander;6.0103333333333335;-73.67633331666667
+Vélez;Santander Department;/wiki/V%C3%A9lez,_Santander;6.0103333333333335;-73.67633331666667
 Vetas;Santander Department;/wiki/Vetas;7.33333;-72.8667
-Villanueva;Santander Department;/wiki/Villanueva;_Santander;6.67417;-73.1778
+Villanueva;Santander Department;/wiki/Villanueva,_Santander;6.67417;-73.1778
 Zapatoca;Santander Department;/wiki/Zapatoca;6.816666666666666;-73.26666666666667
-Buenavista;Sucre Department;/wiki/Buenavista;_Sucre;9.32222;-74.9772
-Caimito;Sucre Department;/wiki/Caimito;_Sucre;8.833333333333334;-75.16666666666667
+Buenavista;Sucre Department;/wiki/Buenavista,_Sucre;9.32222;-74.9772
+Caimito;Sucre Department;/wiki/Caimito,_Sucre;8.833333333333334;-75.16666666666667
 Chalán;Sucre Department;/wiki/Chal%C3%A1n;9.55;-75.31666666666666
 Colosó;Sucre Department;/wiki/Colos%C3%B3;9.5;-75.35
-Corozal;Sucre Department;/wiki/Corozal;_Sucre;9.333333333333334;-75.25
+Corozal;Sucre Department;/wiki/Corozal,_Sucre;9.333333333333334;-75.25
 Coveñas;Sucre Department;/wiki/Cove%C3%B1as;9.416666666666666;-75.7
-El Roble;Sucre Department;/wiki/El_Roble;_Sucre;9.1;-75.2
-Galeras;Sucre Department;/wiki/Galeras;_Sucre;9.166666666666666;-75.05
-Guaranda;Sucre Department;/wiki/Guaranda;_Sucre;8.466666666666667;-75.53333333333333
-La Unión;Sucre Department;/wiki/La_Uni%C3%B3n;_Sucre;8.86056;-75.2806
+El Roble;Sucre Department;/wiki/El_Roble,_Sucre;9.1;-75.2
+Galeras;Sucre Department;/wiki/Galeras,_Sucre;9.166666666666666;-75.05
+Guaranda;Sucre Department;/wiki/Guaranda,_Sucre;8.466666666666667;-75.53333333333333
+La Unión;Sucre Department;/wiki/La_Uni%C3%B3n,_Sucre;8.86056;-75.2806
 Los Palmitos;Sucre Department;/wiki/Los_Palmitos;9.38111;-75.2714
-Majagual;Sucre Department;/wiki/Majagual;_Sucre;8.5;-74.66666666666667
+Majagual;Sucre Department;/wiki/Majagual,_Sucre;8.5;-74.66666666666667
 Morroa;Sucre Department;/wiki/Morroa;9.333333333333334;-75.31666666666666
 Ovejas;Sucre Department;/wiki/Ovejas;9.5;-75.16666666666667
-Palmito;Sucre Department;/wiki/Palmito;_Sucre;9.333333333333334;-75.55
+Palmito;Sucre Department;/wiki/Palmito,_Sucre;9.333333333333334;-75.55
 Sampués;Sucre Department;/wiki/Sampu%C3%A9s;9.183333333333334;-75.38333333333334
 San Benito Abad;Sucre Department;/wiki/San_Benito_Abad;8.933333333333334;-75.03333333333333
 San Juan Betulia;Sucre Department;/wiki/San_Juan_Betulia;9.27556;-75.2456
-San Marcos;Sucre Department;/wiki/San_Marcos;_Sucre;8.65;-75.13333333333334
-San Onofre;Sucre Department;/wiki/San_Onofre;_Sucre;9.733333333333333;-75.53333333333333
-San Pedro;Sucre Department;/wiki/San_Pedro;_Sucre;8.73333;-74.7167
+San Marcos;Sucre Department;/wiki/San_Marcos,_Sucre;8.65;-75.13333333333334
+San Onofre;Sucre Department;/wiki/San_Onofre,_Sucre;9.733333333333333;-75.53333333333333
+San Pedro;Sucre Department;/wiki/San_Pedro,_Sucre;8.73333;-74.7167
 Sincé;Sucre Department;/wiki/Sinc%C3%A9;9.25;-75.15
 Sincelejo;Sucre Department;/wiki/Sincelejo;9.283333333333333;-75.38333333333334
-Sucre;Sucre Department;/wiki/Sucre;_Sucre_Department;8.81389;-74.7253
+Sucre;Sucre Department;/wiki/Sucre,_Sucre_Department;8.81389;-74.7253
 Tolú;Sucre Department;/wiki/Tol%C3%BA;9.533333333333333;-75.58333333333333
 Toluviejo;Sucre Department;/wiki/Toluviejo;9.45;-75.45
-Alpujarra;Tolima Department;/wiki/Alpujarra;_Tolima;3.4166666666666665;-74.91666666666667
-Alvarado;Tolima Department;/wiki/Alvarado;_Tolima;4.566666666666666;-74.95
+Alpujarra;Tolima Department;/wiki/Alpujarra,_Tolima;3.4166666666666665;-74.91666666666667
+Alvarado;Tolima Department;/wiki/Alvarado,_Tolima;4.566666666666666;-74.95
 Ambalema;Tolima Department;/wiki/Ambalema;4.783333333333333;-74.76666666666667
-Anzoátegui;Tolima Department;/wiki/Anzo%C3%A1tegui;_Tolima;4.63389;-75.0972
+Anzoátegui;Tolima Department;/wiki/Anzo%C3%A1tegui,_Tolima;4.63389;-75.0972
 Armero;Tolima Department;/wiki/Armero;4.95;-74.9
 Ataco;Tolima Department;/wiki/Ataco;3.6;-75.38333333333334
-Cajamarca;Tolima Department;/wiki/Cajamarca;_Tolima;4.416666666666667;-75.5
+Cajamarca;Tolima Department;/wiki/Cajamarca,_Tolima;4.416666666666667;-75.5
 Carmen Apicala;Tolima Department;/wiki/Carmen_Apicala;4.15;-74.73333333333333
-Casabianca;Tolima Department;/wiki/Casabianca;_Tolima;5.083333333333333;-75.11666666666666
-Chaparral;Tolima Department;/wiki/Chaparral;_Tolima;3.75;-75.58333333333333
-Coello;Tolima Department;/wiki/Coello;_Tolima;4.333333333333333;-74.91666666666667
+Casabianca;Tolima Department;/wiki/Casabianca,_Tolima;5.083333333333333;-75.11666666666666
+Chaparral;Tolima Department;/wiki/Chaparral,_Tolima;3.75;-75.58333333333333
+Coello;Tolima Department;/wiki/Coello,_Tolima;4.333333333333333;-74.91666666666667
 Coyaima;Tolima Department;/wiki/Coyaima;3.8333333333333335;-75.08333333333333
 Cunday;Tolima Department;/wiki/Cunday;4.083333333333333;-74.66666666666667
-Dolores;Tolima Department;/wiki/Dolores;_Tolima;3.6666666666666665;-74.75
-Espinal;Tolima Department;/wiki/El_Espinal;_Tolima;4.2;-74.83333333333333
+Dolores;Tolima Department;/wiki/Dolores,_Tolima;3.6666666666666665;-74.75
+Espinal;Tolima Department;/wiki/El_Espinal,_Tolima;4.2;-74.83333333333333
 Falán;Tolima Department;/wiki/Fal%C3%A1n;5.133333333333334;-74.95
 Flandes;Tolima Department;/wiki/Flandes;4.283333333333333;-74.8
-Fresno;Tolima Department;/wiki/Fresno;_Tolima;5.15;-75.03333333333333
+Fresno;Tolima Department;/wiki/Fresno,_Tolima;5.15;-75.03333333333333
 Guamo;Tolima Department;/wiki/Guamo;4.083333333333333;-74.91666666666667
 Herveo;Tolima Department;/wiki/Herveo;5.083333333333333;-75.16666666666667
-Honda;Tolima Department;/wiki/Honda;_Tolima;5.2;-74.73333333333333
+Honda;Tolima Department;/wiki/Honda,_Tolima;5.2;-74.73333333333333
 Ibagué;Tolima Department;/wiki/Ibagu%C3%A9;4.433333333333334;-75.23333333333333
 Icononzo;Tolima Department;/wiki/Icononzo;4.183333333333334;-74.53333333333333
-Lérida;Tolima Department;/wiki/L%C3%A9rida;_Tolima;4.9;-74.91666666666667
-Líbano;Tolima Department;/wiki/L%C3%ADbano;_Tolima;4.916666666666667;-75.16666666666667
-Mariquita;Tolima Department;/wiki/Mariquita;_Tolima;5.25;-74.91666666666667
-Melgar;Tolima Department;/wiki/Melgar;_Tolima;4.2;-74.63333333333334
-Murillo;Tolima Department;/wiki/Murillo;_Tolima;4.874;-75.171
+Lérida;Tolima Department;/wiki/L%C3%A9rida,_Tolima;4.9;-74.91666666666667
+Líbano;Tolima Department;/wiki/L%C3%ADbano,_Tolima;4.916666666666667;-75.16666666666667
+Mariquita;Tolima Department;/wiki/Mariquita,_Tolima;5.25;-74.91666666666667
+Melgar;Tolima Department;/wiki/Melgar,_Tolima;4.2;-74.63333333333334
+Murillo;Tolima Department;/wiki/Murillo,_Tolima;4.874;-75.171
 Natagaima;Tolima Department;/wiki/Natagaima;3.5833333333333335;-75.08333333333333
-Ortega;Tolima Department;/wiki/Ortega;_Tolima;3.9166666666666665;-75.25
+Ortega;Tolima Department;/wiki/Ortega,_Tolima;3.9166666666666665;-75.25
 Piedras;Tolima Department;/wiki/Piedras;4.5;-74.91666666666667
 Palocabildo;Tolima Department;/wiki/Palocabildo;5.13333;-75.0333
-Planadas;Tolima Department;/wiki/Planadas
-Prado;Tolima Department;/wiki/Prado;_Tolima;3.75;-74.83333333333333
-Purificación;Tolima Department;/wiki/Purificaci%C3%B3n;_Tolima;3.8666666666666667;-74.93333333333334
+Planadas;Tolima Department;/wiki/Planadas;3.0983945;-75.8572037
+Prado;Tolima Department;/wiki/Prado,_Tolima;3.75;-74.83333333333333
+Purificación;Tolima Department;/wiki/Purificaci%C3%B3n,_Tolima;3.8666666666666667;-74.93333333333334
 Rioblanco;Tolima Department;/wiki/Rioblanco;3.5;-75.83333333333333
-Roncesvalles;Tolima Department;/wiki/Roncesvalles;_Tolima;4.016666666666667;-75.6
-Rovira;Tolima Department;/wiki/Rovira;_Tolima;4.25;-75.33333333333333
-Saldaña;Tolima Department;/wiki/Salda%C3%B1a;_Colombia;3.93472;-75.0203
-San Antonio;Tolima Department;/wiki/San_Antonio;_Tolima;3.9166666666666665;-75.5
-San Luis;Tolima Department;/wiki/San_Luis;_Tolima;4.13611;-75.0994
-Santa Isabel;Tolima Department;/wiki/Santa_Isabel;_Tolima;4.71667;-75.1014
-Suárez;Tolima Department;/wiki/Su%C3%A1rez;_Tolima;4.55;-74.83333333333333
+Roncesvalles;Tolima Department;/wiki/Roncesvalles,_Tolima;4.016666666666667;-75.6
+Rovira;Tolima Department;/wiki/Rovira,_Tolima;4.25;-75.33333333333333
+Saldaña;Tolima Department;/wiki/Salda%C3%B1a,_Colombia;3.93472;-75.0203
+San Antonio;Tolima Department;/wiki/San_Antonio,_Tolima;3.9166666666666665;-75.5
+San Luis;Tolima Department;/wiki/San_Luis,_Tolima;4.13611;-75.0994
+Santa Isabel;Tolima Department;/wiki/Santa_Isabel,_Tolima;4.71667;-75.1014
+Suárez;Tolima Department;/wiki/Su%C3%A1rez,_Tolima;4.55;-74.83333333333333
 Valle de San Juan;Tolima Department;/wiki/Valle_de_San_Juan;4.2;-75.11666666666666
 Venadillo;Tolima Department;/wiki/Venadillo;4.75;-74.91666666666667
-Villahermosa;Tolima Department;/wiki/Villahermosa;_Tolima;5.0;-75.16666666666667
-Villarrica;Tolima Department;/wiki/Villarrica;_Tolima;4.0;-74.58333333333333
-Alcalá;Valle del Cauca Department;/wiki/Alcal%C3%A1;_Valle_del_Cauca;4.666666666666667;-75.75
-Andalucía;Valle del Cauca Department;/wiki/Andaluc%C3%ADa;_Valle_del_Cauca;4.166666666666667;-76.16666666666667
+Villahermosa;Tolima Department;/wiki/Villahermosa,_Tolima;5.0;-75.16666666666667
+Villarrica;Tolima Department;/wiki/Villarrica,_Tolima;4.0;-74.58333333333333
+Alcalá;Valle del Cauca Department;/wiki/Alcal%C3%A1,_Valle_del_Cauca;4.666666666666667;-75.75
+Andalucía;Valle del Cauca Department;/wiki/Andaluc%C3%ADa,_Valle_del_Cauca;4.166666666666667;-76.16666666666667
 Ansermanuevo;Valle del Cauca Department;/wiki/Ansermanuevo;4.8;-76.0
-Argelia;Valle del Cauca Department;/wiki/Argelia;_Valle_del_Cauca;4.666666666666667;-76.66666666666667
-Bolívar;Valle del Cauca Department;/wiki/Bol%C3%ADvar;_Valle_del_Cauca;4.333333333333333;-76.18333333333334
-Buenaventura;Valle del Cauca Department;/wiki/Buenaventura;_Valle_del_Cauca;3.8666666666666667;-77.01666666666667
-Buga;Valle del Cauca Department;/wiki/Buga;_Valle_del_Cauca;3.9;-76.3
+Argelia;Valle del Cauca Department;/wiki/Argelia,_Valle_del_Cauca;4.666666666666667;-76.66666666666667
+Bolívar;Valle del Cauca Department;/wiki/Bol%C3%ADvar,_Valle_del_Cauca;4.333333333333333;-76.18333333333334
+Buenaventura;Valle del Cauca Department;/wiki/Buenaventura,_Valle_del_Cauca;3.8666666666666667;-77.01666666666667
+Buga;Valle del Cauca Department;/wiki/Buga,_Valle_del_Cauca;3.9;-76.3
 Bugalagrande;Valle del Cauca Department;/wiki/Bugalagrande;4.216666666666667;-76.16666666666667
 Caicedonia;Valle del Cauca Department;/wiki/Caicedonia;4.333333333333333;-75.83333333333333
 Cali;Valle del Cauca Department;/wiki/Cali;3.45;-76.51666666666667
-Calima;Valle del Cauca Department;/wiki/Calima;_Valle_del_Cauca;3.9166666666666665;-76.66666666666667
-Candelaria;Valle del Cauca Department;/wiki/Candelaria;_Valle_del_Cauca;3.4;-76.38333333333334
-Cartago;Valle del Cauca Department;/wiki/Cartago;_Valle_del_Cauca;4.7;-75.91666666666667
+Calima;Valle del Cauca Department;/wiki/Calima,_Valle_del_Cauca;3.9166666666666665;-76.66666666666667
+Candelaria;Valle del Cauca Department;/wiki/Candelaria,_Valle_del_Cauca;3.4;-76.38333333333334
+Cartago;Valle del Cauca Department;/wiki/Cartago,_Valle_del_Cauca;4.7;-75.91666666666667
 Dagua;Valle del Cauca Department;/wiki/Dagua;3.6666666666666665;-76.7
-El Aguila;Valle del Cauca Department;/wiki/El_Aguila;_Valle_del_Cauca;4.916666666666667;-76.08333333333333
+El Aguila;Valle del Cauca Department;/wiki/El_Aguila,_Valle_del_Cauca;4.916666666666667;-76.08333333333333
 El Cairo;Valle del Cauca Department;/wiki/El_Cairo;4.75;-76.25
-El Cerrito;Valle del Cauca Department;/wiki/El_Cerrito;_Valle_del_Cauca;3.6666666666666665;-76.16666666666667
+El Cerrito;Valle del Cauca Department;/wiki/El_Cerrito,_Valle_del_Cauca;3.6666666666666665;-76.16666666666667
 El Dovio;Valle del Cauca Department;/wiki/El_Dovio;4.516666666666667;-76.23333333333333
-Florida;Valle del Cauca Department;/wiki/Florida;_Valle_del_Cauca;3.3166666666666664;-76.23333333333333
-Ginebra;Valle del Cauca Department;/wiki/Ginebra;_Valle_del_Cauca;3.75;-76.16666666666667
+Florida;Valle del Cauca Department;/wiki/Florida,_Valle_del_Cauca;3.3166666666666664;-76.23333333333333
+Ginebra;Valle del Cauca Department;/wiki/Ginebra,_Valle_del_Cauca;3.75;-76.16666666666667
 Guacarí;Valle del Cauca Department;/wiki/Guacar%C3%AD;3.7666666666666666;-76.33333333333333
 Jamundí;Valle del Cauca Department;/wiki/Jamund%C3%AD;3.2666666666666666;-76.55
-La Cumbre;Valle del Cauca Department;/wiki/La_Cumbre;_Valle_del_Cauca;3.6333333333333333;-76.56666666666666
-La Unión;Valle del Cauca Department;/wiki/La_Uni%C3%B3n;_Valle_del_Cauca;3.65;-76.56666666666666
-La Victoria;Valle del Cauca Department;/wiki/La_Victoria;_Valle_del_Cauca;4.516666666666667;-76.03333333333333
-Obando;Valle del Cauca Department;/wiki/Obando;_Valle_del_Cauca;4.583333333333333;-75.91666666666667
-Palmira;Valle del Cauca Department;/wiki/Palmira;_Valle_del_Cauca;3.5833333333333335;-76.25
+La Cumbre;Valle del Cauca Department;/wiki/La_Cumbre,_Valle_del_Cauca;3.6333333333333333;-76.56666666666666
+La Unión;Valle del Cauca Department;/wiki/La_Uni%C3%B3n,_Valle_del_Cauca;3.65;-76.56666666666666
+La Victoria;Valle del Cauca Department;/wiki/La_Victoria,_Valle_del_Cauca;4.516666666666667;-76.03333333333333
+Obando;Valle del Cauca Department;/wiki/Obando,_Valle_del_Cauca;4.583333333333333;-75.91666666666667
+Palmira;Valle del Cauca Department;/wiki/Palmira,_Valle_del_Cauca;3.5833333333333335;-76.25
 Pradera;Valle del Cauca Department;/wiki/Pradera;3.4166666666666665;-76.16666666666667
-Restrepo;Valle del Cauca Department;/wiki/Restrepo;_Valle_del_Cauca;3.825;-76.525
-Riofrío;Valle del Cauca Department;/wiki/Riofr%C3%ADo;_Valle_del_Cauca;4.15;-76.28333333333333
+Restrepo;Valle del Cauca Department;/wiki/Restrepo,_Valle_del_Cauca;3.825;-76.525
+Riofrío;Valle del Cauca Department;/wiki/Riofr%C3%ADo,_Valle_del_Cauca;4.15;-76.28333333333333
 Roldanillo;Valle del Cauca Department;/wiki/Roldanillo;4.416666666666667;-76.15
-San Pedro;Valle del Cauca Department;/wiki/San_Pedro;_Valle_del_Cauca;4.0;-76.2292
-Sevilla;Valle del Cauca Department;/wiki/Sevilla;_Valle_del_Cauca;4.26889;-75.9361
-Toro;Valle del Cauca Department;/wiki/Toro;_Valle_del_Cauca;4.6;-76.06666666666666
-Trujillo;Valle del Cauca Department;/wiki/Trujillo;_Valle_del_Cauca;4.25;-76.33333333333333
+San Pedro;Valle del Cauca Department;/wiki/San_Pedro,_Valle_del_Cauca;4.0;-76.2292
+Sevilla;Valle del Cauca Department;/wiki/Sevilla,_Valle_del_Cauca;4.26889;-75.9361
+Toro;Valle del Cauca Department;/wiki/Toro,_Valle_del_Cauca;4.6;-76.06666666666666
+Trujillo;Valle del Cauca Department;/wiki/Trujillo,_Valle_del_Cauca;4.25;-76.33333333333333
 Tuluá;Valle del Cauca Department;/wiki/Tulu%C3%A1;4.083333333333333;-76.2
-Ulloa;Valle del Cauca Department;/wiki/Ulloa;_Valle_del_Cauca;4.716666666666667;-75.75
+Ulloa;Valle del Cauca Department;/wiki/Ulloa,_Valle_del_Cauca;4.716666666666667;-75.75
 Versalles;Valle del Cauca Department;/wiki/Versalles;4.666666666666667;-76.25
 Vijes;Valle del Cauca Department;/wiki/Vijes;3.7;-76.45
 Yotoco;Valle del Cauca Department;/wiki/Yotoco;3.8666666666666667;-76.38333333333334
@@ -1137,6 +1137,6 @@ Pacoa;Vaupés Department;/wiki/Pacoa;0.016666666666666666;-71.0
 Papunahua;Vaupés Department;/wiki/Papunahua;1.9333333333333333;-70.53333333333333
 Yavarate;Vaupés Department;/wiki/Yavarate;0.6166666666666667;-69.2
 Cumaribo;Vichada Department;/wiki/Cumaribo;4.433333333333334;-69.8
-La Primavera;Vichada Department;/wiki/La_Primavera;_Vichada;5.49056;-70.4092
+La Primavera;Vichada Department;/wiki/La_Primavera,_Vichada;5.49056;-70.4092
 Puerto Carreño;Vichada Department;/wiki/Puerto_Carre%C3%B1o;6.183333333333334;-67.46666666666667
-Santa Rosalía;Vichada Department;/wiki/Santa_Rosal%C3%ADa;_Vichada;5.12611;-70.8758
+Santa Rosalía;Vichada Department;/wiki/Santa_Rosal%C3%ADa,_Vichada;5.12611;-70.8758

--- a/backend/db/seeds/files/colombia_municipalities.csv
+++ b/backend/db/seeds/files/colombia_municipalities.csv
@@ -1,1142 +1,1124 @@
-name;department;wiki_link;latitude;longitude
-Leticia;Amazonas Department;/wiki/Leticia,_Colombia;-4.216666666666667;-69.93333333333334
-Puerto Nariño;Amazonas Department;/wiki/Puerto_Nari%C3%B1o;-3.7666666666666666;-70.36666666666666
-El Encanto;Amazonas Department;/wiki/El_Encanto;-1.7666666666666666;-73.2
-La Chorrera;Amazonas Department;/wiki/La_Chorrera,_Colombia;-1.4333333333333333;-72.78333333333333
-La Pedrera;Amazonas Department;/wiki/La_Pedrera,_Amazonas;-1.3166666666666667;-69.56666666666666
-La Victoria;Amazonas Department;/wiki/La_Victoria,_Amazonas;0.05;-71.21666666666667
-Mirití-Paraná;Amazonas Department;/wiki/Mirit%C3%AD-Paran%C3%A1;-0.8833333333333333;-70.98333333333333
-Puerto Alegría;Amazonas Department;/wiki/Puerto_Alegr%C3%ADa;-1.0333333333333334;-74.03333333333333
-Puerto Arica;Amazonas Department;/wiki/Puerto_Arica;-2.1333333333333333;-71.75
-Puerto Santander;Amazonas Department;/wiki/Puerto_Santander,_Amazonas;-0.6166666666666667;-72.38333333333334
-Tarapacá;Amazonas Department;/wiki/Tarapac%C3%A1,_Amazonas;-2.8666666666666667;-69.73333333333333
-Abejorral;Antioquia Department;/wiki/Abejorral;5.783333333333333;-75.41666666666667
-Abriaquí;Antioquia Department;/wiki/Abriaqu%C3%AD;6.633333333333333;-76.06666666666666
-Alejandría;Antioquia Department;/wiki/Alejandr%C3%ADa;6.366666666666666;-75.13333333333334
-Amagá;Antioquia Department;/wiki/Amag%C3%A1;6.05;-75.7
-Amalfi;Antioquia Department;/wiki/Amalfi,_Antioquia;6.916666666666667;-75.08333333333333
-Andes;Antioquia Department;/wiki/Andes,_Antioquia;5.583333333333333;-75.91666666666667
-Angelópolis;Antioquia Department;/wiki/Angel%C3%B3polis;6.133333333333334;-75.7
-Angostura;Antioquia Department;/wiki/Angostura,_Antioquia;6.866666666666667;-75.33333333333333
-Anorí;Antioquia Department;/wiki/Anor%C3%AD;7.066666666666666;-75.13333333333334
-Anzá;Antioquia Department;/wiki/Anz%C3%A1,_Antioquia;6.3;-75.85
-Apartadó;Antioquia Department;/wiki/Apartad%C3%B3;7.883333333333333;-76.63333333333334
-Arboletes;Antioquia Department;/wiki/Arboletes;8.85;-76.41666666666667
-Argelia;Antioquia Department;/wiki/Argelia,_Antioquia;5.733333333333333;-75.13333333333334
-Armenia;Antioquia Department;/wiki/Armenia,_Antioquia;6.15;-75.78333333333333
-Barbosa;Antioquia Department;/wiki/Barbosa,_Antioquia;6.433333333333334;-75.31666666666666
-Bello;Antioquia Department;/wiki/Bello,_Antioquia;6.333333333333333;-75.56666666666666
-Belmira;Antioquia Department;/wiki/Belmira;6.6;-75.66666666666667
-Betania;Antioquia Department;/wiki/Betania,_Antioquia;5.75;-75.96666666666667
-Betulia;Antioquia Department;/wiki/Betulia,_Antioquia;6.1;-75.98333333333333
-Bolívar;Antioquia Department;/wiki/Ciudad_Bol%C3%ADvar,_Antioquia;5.85;-76.03333333333333
-Briceño;Antioquia Department;/wiki/Brice%C3%B1o,_Antioquia;7.1;-75.55
-Buriticá;Antioquia Department;/wiki/Buritic%C3%A1;6.75;-75.91666666666667
-Cáceres;Antioquia Department;/wiki/C%C3%A1ceres,_Antioquia;7.666666666666667;-75.33333333333333
-Caicedo;Antioquia Department;/wiki/Caicedo;6.4;-75.96666666666667
-Caldas;Antioquia Department;/wiki/Caldas,_Antioquia;6.083333333333333;-75.63333333333334
-Campamento;Antioquia Department;/wiki/Campamento,_Antioquia;6.966666666666667;-75.28333333333333
-Cañasgordas;Antioquia Department;/wiki/Ca%C3%B1asgordas;6.733333333333333;-76.01666666666667
-Caracolí;Antioquia Department;/wiki/Caracol%C3%AD;6.4;-74.75
-Caramanta;Antioquia Department;/wiki/Caramanta;5.583333333333333;-75.58333333333333
-Carepa;Antioquia Department;/wiki/Carepa;7.75;-76.65
-El Carmen de Viboral;Antioquia Department;/wiki/El_Carmen_de_Viboral;6.083333333333333;-75.33333333333333
-Carolina del Príncipe;Antioquia Department;/wiki/Carolina_del_Pr%C3%ADncipe,_Antioquia;6.716666666666667;-75.26666666666667
-Caucasia;Antioquia Department;/wiki/Caucasia,_Antioquia;7.983333333333333;-75.2
-Chigorodó;Antioquia Department;/wiki/Chigorod%C3%B3;7.666666666666667;-76.66666666666667
-Cisneros;Antioquia Department;/wiki/Cisneros,_Antioquia;6.533333333333333;-75.08333333333333
-Cocorná;Antioquia Department;/wiki/Cocorn%C3%A1;6.05;-75.18333333333334
-Concepción;Antioquia Department;/wiki/Concepci%C3%B3n,_Antioquia;6.383333333333334;-75.25
-Concordia;Antioquia Department;/wiki/Concordia,_Antioquia;6.033333333333333;-75.9
-Copacabana;Antioquia Department;/wiki/Copacabana,_Antioquia;6.333333333333333;-75.5
-Dabeiba;Antioquia Department;/wiki/Dabeiba;7.0;-76.25
-Don Matías;Antioquia Department;/wiki/Don_Mat%C3%ADas;6.483333333333333;-75.43333333333334
-Ebéjico;Antioquia Department;/wiki/Eb%C3%A9jico;6.333333333333333;-75.76666666666667
-El Bagre;Antioquia Department;/wiki/El_Bagre;7.583333333333333;-74.8
-Entrerríos;Antioquia Department;/wiki/Entrerr%C3%ADos;6.566666666666666;-75.51666666666667
-Envigado;Antioquia Department;/wiki/Envigado;6.166666666666667;-75.56666666666666
-Fredonia;Antioquia Department;/wiki/Fredonia,_Antioquia;5.916666666666667;-75.66666666666667
-Frontino;Antioquia Department;/wiki/Frontino,_Antioquia;6.783333333333333;-76.13333333333334
-Giraldo;Antioquia Department;/wiki/Giraldo,_Antioquia;6.666666666666667;-75.95
-Girardota;Antioquia Department;/wiki/Girardota;6.366666666666666;-75.43333333333334
-Gómez Plata;Antioquia Department;/wiki/G%C3%B3mez_Plata;6.683333333333334;-75.21666666666667
-Granada;Antioquia Department;/wiki/Granada,_Antioquia;6.147;-75.188
-Guadalupe;Antioquia Department;/wiki/Guadalupe,_Antioquia;6.816666666666666;-75.23333333333333
-Guarne;Antioquia Department;/wiki/Guarne;6.266666666666667;-75.43333333333334
-Guatapé;Antioquia Department;/wiki/Guatap%C3%A9;6.233333333333333;-75.16666666666667
-Heliconia;Antioquia Department;/wiki/Heliconia,_Antioquia;6.216666666666667;-75.73333333333333
-Hispania;Antioquia Department;/wiki/Hispania,_Antioquia;5.8;-75.9
-Itagüí;Antioquia Department;/wiki/Itag%C3%BC%C3%AD;6.166666666666667;-75.61666666666666
-Ituango;Antioquia Department;/wiki/Ituango;7.166666666666667;-75.75
-Jardín;Antioquia Department;/wiki/Jard%C3%ADn;5.583333333333333;-75.81666666666666
-Jericó;Antioquia Department;/wiki/Jeric%C3%B3,_Antioquia;5.783333333333333;-75.78333333333333
-La Ceja;Antioquia Department;/wiki/La_Ceja,_Antioquia;6.016666666666667;-75.41666666666667
-La Estrella;Antioquia Department;/wiki/La_Estrella,_Antioquia;6.166666666666667;-75.66666666666667
-La Pintada;Antioquia Department;/wiki/La_Pintada,_Antioquia;5.75;-75.6
-La Unión;Antioquia Department;/wiki/La_Uni%C3%B3n,_Antioquia;5.966666666666667;-75.35
-Liborina;Antioquia Department;/wiki/Liborina;6.683333333333334;-75.81666666666666
-Maceo;Antioquia Department;/wiki/Maceo,_Antioquia;6.55;-74.78333333333333
-Marinilla;Antioquia Department;/wiki/Marinilla;6.166666666666667;-75.33333333333333
-Medellín;Antioquia Department;/wiki/Medell%C3%ADn;6.216666666666667;-75.58333333333333
-Montebello;Antioquia Department;/wiki/Montebello,_Antioquia;5.916666666666667;-75.5
-Murindó;Antioquia Department;/wiki/Murind%C3%B3;6.8;-76.8
-Mutatá;Antioquia Department;/wiki/Mutat%C3%A1;7.233333333333333;-76.43333333333334
-Nariño;Antioquia Department;/wiki/Nari%C3%B1o,_Antioquia;5.6;-75.16666666666667
-Nechí;Antioquia Department;/wiki/Nech%C3%AD;8.1;-74.78333333333333
-Necoclí;Antioquia Department;/wiki/Necocl%C3%AD;8.416666666666666;-76.78333333333333
-Olaya;Antioquia Department;/wiki/Olaya,_Antioquia;6.616666666666667;-75.8
-Peñol;Antioquia Department;/wiki/El_Pe%C3%B1ol,_Antioquia;6.216666666666667;-75.23333333333333
-Peque;Antioquia Department;/wiki/Peque,_Antioquia;7.016666666666667;-75.91666666666667
-Pueblorrico;Antioquia Department;/wiki/Pueblorrico;5.8;-75.85
-Puerto Berrío;Antioquia Department;/wiki/Puerto_Berr%C3%ADo;6.483333333333333;-74.4
-Puerto Nare;Antioquia Department;/wiki/Puerto_Nare;6.183333333333334;-74.58333333333333
-Puerto Triunfo;Antioquia Department;/wiki/Puerto_Triunfo;5.866666666666667;-74.65
-Remedios;Antioquia Department;/wiki/Remedios,_Antioquia;7.016666666666667;-74.68333333333334
-Retiro;Antioquia Department;/wiki/Retiro,_Antioquia;6.05;-75.5
-Rionegro;Antioquia Department;/wiki/Rionegro;6.15;-75.36666666666666
-Sabanalarga;Antioquia Department;/wiki/Sabanalarga,_Antioquia;6.85;-75.81666666666666
-Sabaneta;Antioquia Department;/wiki/Sabaneta,_Antioquia;6.15;-75.6
-Salgar;Antioquia Department;/wiki/Salgar;5.95;-75.96666666666667
-San Andrés;Antioquia Department;/wiki/San_Andr%C3%A9s_de_Cuerquia;6.9;-75.66666666666667
-San Carlos;Antioquia Department;/wiki/San_Carlos,_Antioquia;6.18972;-74.9969
-San Francisco;Antioquia Department;/wiki/San_Francisco,_Antioquia;5.95;-75.1
-San Jerónimo;Antioquia Department;/wiki/San_Jer%C3%B3nimo,_Antioquia;6.433333333333334;-75.71666666666667
-San José de la Montaña;Antioquia Department;/wiki/San_Jos%C3%A9_de_la_Monta%C3%B1a;7.583333333333333;-72.71666666666667
-San Juan de Urabá;Antioquia Department;/wiki/San_Juan_de_Urab%C3%A1;8.766666666666667;-76.53333333333333
-San Luis;Antioquia Department;/wiki/San_Luis,_Antioquia;6.033333333333333;-74.98333333333333
-San Pedro;Antioquia Department;/wiki/San_Pedro_de_los_Milagros;6.45;-75.55
-San Pedro de Urabá;Antioquia Department;/wiki/San_Pedro_de_Urab%C3%A1;8.283333333333333;-76.38333333333334
-San Rafael;Antioquia Department;/wiki/San_Rafael,_Antioquia;6.283333333333333;-75.01666666666667
-San Roque;Antioquia Department;/wiki/San_Roque,_Antioquia;6.483333333333333;-75.01666666666667
-Santa Bárbara;Antioquia Department;/wiki/Santa_B%C3%A1rbara,_Antioquia;5.866666666666667;-75.55
-Santa Fe de Antioquia;Antioquia Department;/wiki/Santa_Fe_de_Antioquia;6.55;-75.81666666666666
-Santa Rosa de Osos;Antioquia Department;/wiki/Santa_Rosa_de_Osos;6.65;-75.46666666666667
-Santo Domingo;Antioquia Department;/wiki/Santo_Domingo,_Antioquia;6.466666666666667;-75.15
-El Santuario;Antioquia Department;/wiki/El_Santuario;6.133333333333334;-75.25
-San Vicente;Antioquia Department;/wiki/San_Vicente,_Antioquia;6.266666666666667;-75.31666666666666
-Segovia;Antioquia Department;/wiki/Segovia,_Antioquia;7.066666666666666;-74.7
-Sonsón;Antioquia Department;/wiki/Sons%C3%B3n;5.7;-75.3
-Sopetrán;Antioquia Department;/wiki/Sopetr%C3%A1n;6.5;-75.73333333333333
-Támesis;Antioquia Department;/wiki/T%C3%A1mesis,_Antioquia;5.666666666666667;-75.71666666666667
-Tarazá;Antioquia Department;/wiki/Taraz%C3%A1;7.583333333333333;-75.4
-Tarso;Antioquia Department;/wiki/Tarso;5.866666666666667;-75.83333333333333
-Titiribí;Antioquia Department;/wiki/Titirib%C3%AD;6.066666666666666;-75.8
-Toledo;Antioquia Department;/wiki/Toledo,_Antioquia;7.0;-75.7
-Turbo;Antioquia Department;/wiki/Turbo,_Colombia;8.1;-76.73333333333333
-Uramita;Antioquia Department;/wiki/Uramita;6.883333333333333;-76.16666666666667
-Urrao;Antioquia Department;/wiki/Urrao;6.3;-76.13333333333334
-Valdivia;Antioquia Department;/wiki/Valdivia,_Antioquia;7.283333333333333;-75.38333333333334
-Valparaíso;Antioquia Department;/wiki/Valpara%C3%ADso,_Antioquia;5.6;-75.61666666666666
-Vegachi;Antioquia Department;/wiki/Vegachi;6.766666666666667;-74.78333333333333
-Venecia;Antioquia Department;/wiki/Venecia,_Antioquia;5.916666666666667;-75.75
-Vigía del Fuerte;Antioquia Department;/wiki/Vig%C3%ADa_del_Fuerte;6.583333333333333;-76.88333333333334
-Yali;Antioquia Department;/wiki/Yali,_Antioquia;6.666666666666667;-74.83333333333333
-Yarumal;Antioquia Department;/wiki/Yarumal;7.0;-75.5
-Yolombó;Antioquia Department;/wiki/Yolomb%C3%B3;6.583333333333333;-75.0
-Yondó;Antioquia Department;/wiki/Yond%C3%B3;7.0;-73.91666666666667
-Zaragoza;Antioquia Department;/wiki/Zaragoza,_Antioquia;7.483333333333333;-74.86666666666666
-Arauca;Arauca Department;/wiki/Arauca,_Arauca;7.083333333333333;-70.75
-Arauquita;Arauca Department;/wiki/Arauquita;7.03028;-71.4356
-Cravo Norte;Arauca Department;/wiki/Cravo_Norte;6.3;-70.2
-Fortul;Arauca Department;/wiki/Fortul;6.79222;-71.7756
-Puerto Rondón;Arauca Department;/wiki/Puerto_Rond%C3%B3n;6.283333333333333;-71.1
-Saravena;Arauca Department;/wiki/Saravena;6.95;-71.86666666666666
-Tame;Arauca Department;/wiki/Tame,_Arauca;6.466666666666667;-71.73333333333333
-Baranoa;Atlántico Department;/wiki/Baranoa;10.8;-74.91666666666667
-Barranquilla;Atlántico Department;/wiki/Barranquilla;10.95;-74.78333333333333
-Campo de la Cruz;Atlántico Department;/wiki/Campo_de_la_Cruz;10.366666666666667;-74.86666666666666
-Candelaria;Atlántico Department;/wiki/Candelaria,_Atl%C3%A1ntico;10.45;-74.86666666666666
-Galapa;Atlántico Department;/wiki/Galapa,_Atl%C3%A1ntico;10.916666666666666;-74.83333333333333
-Juan de Acosta;Atlántico Department;/wiki/Juan_de_Acosta;10.833333333333334;-75.03333333333333
-Luruaco;Atlántico Department;/wiki/Luruaco;10.6;-75.13333333333334
-Malambo;Atlántico Department;/wiki/Malambo,_Atl%C3%A1ntico;10.85;-74.75
-Manatí;Atlántico Department;/wiki/Manat%C3%AD,_Atl%C3%A1ntico;10.433333333333334;-74.95
-Palmar de Varela;Atlántico Department;/wiki/Palmar_de_Varela;10.75;-74.75
-Piojó;Atlántico Department;/wiki/Pioj%C3%B3;10.75;-75.11666666666666
-Polonuevo;Atlántico Department;/wiki/Polonuevo;10.783333333333333;-74.86666666666666
-Ponedera;Atlántico Department;/wiki/Ponedera;10.65;-74.75
-Puerto Colombia;Atlántico Department;/wiki/Puerto_Colombia;11.016666666666667;-74.88333333333334
-Repelón;Atlántico Department;/wiki/Repel%C3%B3n;10.55;-75.13333333333334
-Sabanagrande;Atlántico Department;/wiki/Sabanagrande,_Atl%C3%A1ntico;10.8;-74.75
-Sabanalarga;Atlántico Department;/wiki/Sabanalarga,_Atl%C3%A1ntico;6.85;-75.81666666666666
-Santa Lucia;Atlántico Department;/wiki/Santa_Luc%C3%ADa,_Atl%C3%A1ntico;10.316666666666666;-74.95
-Santo Tomas;Atlántico Department;/wiki/Santo_Tom%C3%A1s,_Atlantico;10.766666666666667;-74.91666666666667
-Soledad;Atlántico Department;/wiki/Soledad,_Atl%C3%A1ntico;10.916666666666666;-74.75
-Suan;Atlántico Department;/wiki/Suan,_Atl%C3%A1ntico;10.333333333333334;-74.88333333333334
-Tubará;Atlántico Department;/wiki/Tubar%C3%A1;10.866666666666667;-74.98333333333333
-Usiacurí;Atlántico Department;/wiki/Usiacur%C3%AD;10.75;-74.98333333333333
-Antonio Nariño;Bogotá, Capital District;/wiki/Antonio_Nari%C3%B1o,_Bogot%C3%A1;4.583333333333333;-74.1
-Barrios Unidos;Bogotá, Capital District;/wiki/Barrios_Unidos;4.666666666666667;-74.06666666666666
-Bosa;Bogotá, Capital District;/wiki/Bosa,_Bogot%C3%A1;4.616666666666667;-74.18333333333334
-Chapinero;Bogotá, Capital District;/wiki/Chapinero;4.633333333333333;-74.05
-Ciudad Bolívar;Bogotá, Capital District;/wiki/Ciudad_Bol%C3%ADvar,_Bogot%C3%A1;4.533333333333333;-74.13333333333334
-Engativá;Bogotá, Capital District;/wiki/Engativ%C3%A1;4.716666666666667;-74.1
-Fontibón;Bogotá, Capital District;/wiki/Fontib%C3%B3n;4.666666666666667;-74.13333333333334
-Kennedy;Bogotá, Capital District;/wiki/Kennedy,_Bogot%C3%A1;4.633333333333333;-74.15
-La Candelaria;Bogotá, Capital District;/wiki/La_Candelaria;4.583333333333333;-74.06666666666666
-Los Mártires;Bogotá, Capital District;/wiki/Los_M%C3%A1rtires;4.6;-74.08333333333333
-Puente Aranda;Bogotá, Capital District;/wiki/Puente_Aranda;4.6;-74.1
-Rafael Uribe Uribe;Bogotá, Capital District;/wiki/Rafael_Uribe_Uribe,_Bogot%C3%A1;4.566666666666666;-74.11666666666666
-San Cristóbal;Bogotá, Capital District;/wiki/San_Crist%C3%B3bal,_Bogot%C3%A1;4.55;-74.08333333333333
-Santa Fe;Bogotá, Capital District;/wiki/Santa_Fe,_Bogot%C3%A1;4.6;-74.06666666666666
-Suba;Bogotá, Capital District;/wiki/Suba,_Bogot%C3%A1;4.741;-74.084
-Sumapaz;Bogotá, Capital District;/wiki/Sumapaz;4.25;-74.16666666666667
-Teusaquillo;Bogotá, Capital District;/wiki/Teusaquillo;4.666666666666667;-74.08333333333333
-Tunjuelito;Bogotá, Capital District;/wiki/Tunjuelito;4.566666666666666;-74.11666666666666
-Usaquén;Bogotá, Capital District;/wiki/Usaqu%C3%A9n;4.716666666666667;-74.03333333333333
-Usme;Bogotá, Capital District;/wiki/Usme;4.433333333333334;-74.15
-Achí;Bolívar Department;/wiki/Ach%C3%AD,_Bol%C3%ADvar;8.566666666666666;-74.55
-Altos del Rosario;Bolívar Department;/wiki/Altos_del_Rosario;8.8;-74.16666666666667
-Arjona;Bolívar Department;/wiki/Arjona,_Colombia;10.25;-75.33333333333333
-Arroyo Hondo;Bolívar Department;/wiki/Arroyo_Hondo,_Bol%C3%ADvar;10.133333333333333;-75.56666666666666
-Barranco de Loba;Bolívar Department;/wiki/Barranco_de_Loba;8.95;-74.11666666666666
-Brazuelo de Papayal;Bolívar Department;/wiki/Brazuelo_de_Papayal;8.95;-73.95
-Calamar;Bolívar Department;/wiki/Calamar,_Bol%C3%ADvar;10.25;-74.9
-Cantagallo;Bolívar Department;/wiki/Cantagallo,_Bol%C3%ADvar;7.366666666666666;-73.9
-Cartagena;Bolívar Department;/wiki/Cartagena,_Colombia;10.4;-75.5
-Cicuco;Bolívar Department;/wiki/Cicuco;9.266666666666667;-74.65
-Clemencia;Bolívar Department;/wiki/Clemencia,_Colombia;10.583333333333334;-75.33333333333333
-Córdoba;Bolívar Department;/wiki/C%C3%B3rdoba,_Bol%C3%ADvar;9.583333333333334;-74.81666666666666
-El Carmen de Bolívar;Bolívar Department;/wiki/El_Carmen_de_Bol%C3%ADvar;9.716666666666667;-75.13333333333334
-El Guamo;Bolívar Department;/wiki/El_Guamo;10.083333333333334;-74.91666666666667
-El Peñón;Bolívar Department;/wiki/El_Pe%C3%B1%C3%B3n,_Bol%C3%ADvar;8.983333333333333;-73.93333333333334
-Hatillo de Loba;Bolívar Department;/wiki/Hatillo_de_Loba;8.95861;-74.0808
-Magangué;Bolívar Department;/wiki/Magangu%C3%A9;9.25;-74.76666666666667
-Mahates;Bolívar Department;/wiki/Mahates;10.233333333333333;-75.18333333333334
-Margarita;Bolívar Department;/wiki/Margarita,_Bol%C3%ADvar;9.083333333333334;-74.2
-María La Baja;Bolívar Department;/wiki/Mar%C3%ADa_La_Baja;10.0;-75.33333333333333
-Mompóx;Bolívar Department;/wiki/Santa_Cruz_de_Mompox;9.233333333333333;-74.41666666666667
-Montecristo;Bolívar Department;/wiki/Montecristo,_Bol%C3%ADvar;8.29944;-74.4756
-Morales;Bolívar Department;/wiki/Morales,_Bol%C3%ADvar;8.31333;-73.8719
-Norosí;Bolívar Department;/wiki/Noros%C3%AD;8.516666666666667;-74.03333333333333
-Pinillos;Bolívar Department;/wiki/Pinillos;8.916666666666666;-74.46666666666667
-Regidor;Bolívar Department;/wiki/Regidor,_Bolivar;8.666666666666666;-73.83333333333333
-Rio Viejo;Bolívar Department;/wiki/Rio_Viejo;8.59;-73.8436
-San Cristóbal;Bolívar Department;/wiki/San_Crist%C3%B3bal,_Bol%C3%ADvar;9.88333;-75.25
-San Estanislao;Bolívar Department;/wiki/San_Estanislao,_Bol%C3%ADvar;10.4;-75.15
-San Fernando;Bolívar Department;/wiki/San_Fernando,_Bol%C3%ADvar;9.266666666666667;-74.53333333333333
-San Jacinto;Bolívar Department;/wiki/San_Jacinto,_Bol%C3%ADvar;9.816666666666666;-75.11666666666666
-San Juan Nepomuceno;Bolívar Department;/wiki/San_Juan_Nepomuceno,_Bol%C3%ADvar;9.95;-75.08333333333333
-San Martín de Loba;Bolívar Department;/wiki/San_Mart%C3%ADn_de_Loba;8.833333333333334;-73.91666666666667
-San Pablo;Bolívar Department;/wiki/San_Pablo,_Bol%C3%ADvar;7.466666666666667;-73.91666666666667
-Santa Catalina;Bolívar Department;/wiki/Santa_Catalina,_Bol%C3%ADvar;10.6;-75.28333333333333
-Santa Rosa;Bolívar Department;/wiki/Santa_Rosa,_Bol%C3%ADvar;10.433333333333334;-75.36666666666666
-Santa Rosa del Sur;Bolívar Department;/wiki/Santa_Rosa_del_Sur;7.966666666666667;-74.05
-Simití;Bolívar Department;/wiki/Simit%C3%AD;7.966666666666667;-73.95
-Soplaviento;Bolívar Department;/wiki/Soplaviento;10.333333333333334;-75.1
-Talaiga Nuevo;Bolívar Department;/wiki/Talaiga_Nuevo;9.30694;-74.5686
-Tiquisio;Bolívar Department;/wiki/Tiquisio;8.566666666666666;-74.26666666666667
-Turbaco;Bolívar Department;/wiki/Turbaco;10.35;-75.33333333333333
-Turbana;Bolívar Department;/wiki/Turbana,_Bol%C3%ADvar;10.283333333333333;-75.45
-Villanueva;Bolívar Department;/wiki/Villanueva,_Bol%C3%ADvar;10.4456;-75.2761
-Zambrano;Bolívar Department;/wiki/Zambrano,_Bol%C3%ADvar;9.75;-74.83333333333333
-Almeida;Boyacá Department;/wiki/Almeida,_Boyac%C3%A1;4.966666666666667;-73.38333333333334
-Aquitania;Boyacá Department;/wiki/Aquitania,_Boyac%C3%A1;5.583333333333333;-72.83333333333333
-Arcabuco;Boyacá Department;/wiki/Arcabuco;5.75;-73.43333333333334
-Belén;Boyacá Department;/wiki/Bel%C3%A9n,_Boyac%C3%A1;6.083333333333333;-72.91666666666667
-Berbeo;Boyacá Department;/wiki/Berbeo;5.216666666666667;-73.11666666666666
-Betéitiva;Boyacá Department;/wiki/Bet%C3%A9itiva;5.916666666666667;-72.81666666666666
-Boavita;Boyacá Department;/wiki/Boavita;6.333333333333333;-72.58333333333333
-Boyacá;Boyacá Department;/wiki/Boyac%C3%A1,_Boyac%C3%A1;5.45;-73.35
-Briceño;Boyacá Department;/wiki/Brice%C3%B1o,_Boyac%C3%A1;5.7;-73.9333
-Buenavista;Boyacá Department;/wiki/Buenavista,_Boyac%C3%A1;5.5;-73.93333333333334
-Busbanzá;Boyacá Department;/wiki/Busbanz%C3%A1;5.816666666666666;-72.86666666666666
-Caldas;Boyacá Department;/wiki/Caldas,_Boyac%C3%A1;5.5575;-73.8686
-Campohermoso;Boyacá Department;/wiki/Campohermoso;5.083333333333333;-73.0
-Cerinza;Boyacá Department;/wiki/Cerinza;6.0;-72.91666666666667
-Chinavita;Boyacá Department;/wiki/Chinavita;5.166666666666667;-73.36666666666666
-Chiquinquirá;Boyacá Department;/wiki/Chiquinquir%C3%A1;5.633333333333333;-73.75
-Chíquiza;Boyacá Department;/wiki/Ch%C3%ADquiza;5.6;-73.48333333333333
-Chiscas;Boyacá Department;/wiki/Chiscas,_Boyac%C3%A1;6.533333333333333;-72.5
-Chita;Boyacá Department;/wiki/Chita,_Boyac%C3%A1;6.166666666666667;-72.41666666666667
-Chitaraque;Boyacá Department;/wiki/Chitaraque;6.083333333333333;-73.36666666666666
-Chivatá;Boyacá Department;/wiki/Chivat%C3%A1;5.533333333333333;-73.26666666666667
-Chivor;Boyacá Department;/wiki/Chivor;4.883333333333333;-73.36666666666666
-Ciénega;Boyacá Department;/wiki/Ci%C3%A9nega,_Boyac%C3%A1;5.4;-73.28333333333333
-Coper;Boyacá Department;/wiki/Coper,_Boyac%C3%A1;5.483333333333333;-74.05
-Corrales;Boyacá Department;/wiki/Corrales,_Boyac%C3%A1;5.866666666666667;-72.83333333333333
-Covarachía;Boyacá Department;/wiki/Covarach%C3%ADa;6.5;-72.75
-Cubará;Boyacá Department;/wiki/Cubar%C3%A1;7.033333333333333;-72.06666666666666
-Cucaita;Boyacá Department;/wiki/Cucaita;5.533333333333333;-73.45
-Cuítiva;Boyacá Department;/wiki/Cu%C3%ADtiva,_Boyac%C3%A1;5.583333333333333;-72.96666666666667
-Cómbita;Boyacá Department;/wiki/C%C3%B3mbita;5.75;-73.25
-Duitama;Boyacá Department;/wiki/Duitama;5.833333333333333;-73.01666666666667
-El Cocuy;Boyacá Department;/wiki/El_Cocuy;6.416666666666667;-72.41666666666667
-El Espino;Boyacá Department;/wiki/El_Espino,_Boyac%C3%A1;6.583333333333333;-72.41666666666667
-Firavitoba;Boyacá Department;/wiki/Firavitoba;5.65;-73.0
-Floresta;Boyacá Department;/wiki/Floresta,_Boyac%C3%A1;5.916666666666667;-72.91666666666667
-Gachantivá;Boyacá Department;/wiki/Gachantiv%C3%A1;5.75;-73.5
-Garagoa;Boyacá Department;/wiki/Garagoa,_Boyac%C3%A1;5.083333333333333;-73.36666666666666
-Guacamayas;Boyacá Department;/wiki/Guacamayas,_Boyac%C3%A1;6.5;-72.5
-Guateque;Boyacá Department;/wiki/Guateque;5.0;-73.46666666666667
-Guayatá;Boyacá Department;/wiki/Guayat%C3%A1;4.966666666666667;-73.48333333333333
-Gámeza;Boyacá Department;/wiki/G%C3%A1meza;5.8;-72.8
-Güicán;Boyacá Department;/wiki/G%C3%BCic%C3%A1n;6.466666666666667;-72.41666666666667
-Iza;Boyacá Department;/wiki/Iza,_Boyac%C3%A1;5.6;-72.98333333333333
-Jenesano;Boyacá Department;/wiki/Jenesano;5.383333333333334;-73.36666666666666
-Jericó;Boyacá Department;/wiki/Jeric%C3%B3,_Boyac%C3%A1;6.14917;-72.555
-La Capilla;Boyacá Department;/wiki/La_Capilla;5.083333333333333;-73.43333333333334
-La Uvita;Boyacá Department;/wiki/La_Uvita;6.333333333333333;-72.5
-La Victoria;Boyacá Department;/wiki/La_Victoria,_Boyac%C3%A1;5.52278;-74.2328
-Labranzagrande;Boyacá Department;/wiki/Labranzagrande;5.566666666666666;-72.56666666666666
-Macanal;Boyacá Department;/wiki/Macanal;4.966666666666667;-73.31666666666666
-Maripí;Boyacá Department;/wiki/Marip%C3%AD;5.55;-74.01666666666667
-Miraflores;Boyacá Department;/wiki/Miraflores,_Boyac%C3%A1;5.183333333333334;-73.13333333333334
-Mongua;Boyacá Department;/wiki/Mongua;5.75;-72.8
-Monguí;Boyacá Department;/wiki/Mongu%C3%AD;5.75;-72.83333333333333
-Moniquirá;Boyacá Department;/wiki/Moniquir%C3%A1;5.916666666666667;-73.5
-Motavita;Boyacá Department;/wiki/Motavita;5.566666666666666;-73.36666666666666
-Muzo;Boyacá Department;/wiki/Muzo;5.516666666666667;-74.1
-Nobsa;Boyacá Department;/wiki/Nobsa;5.766666666666667;-72.95
-Nuevo Colón;Boyacá Department;/wiki/Nuevo_Col%C3%B3n,_Boyac%C3%A1;5.35;-73.46666666666667
-Oicatá;Boyacá Department;/wiki/Oicat%C3%A1;5.583333333333333;-73.31666666666666
-Otanche;Boyacá Department;/wiki/Otanche;5.75;-74.25
-Pachavita;Boyacá Department;/wiki/Pachavita;5.133333333333334;-73.4
-Paipa;Boyacá Department;/wiki/Paipa;5.833333333333333;-73.15
-Pajarito;Boyacá Department;/wiki/Pajarito,_Boyac%C3%A1;5.416666666666667;-72.66666666666667
-Panqueba;Boyacá Department;/wiki/Panqueba;6.433333333333334;-72.46666666666667
-Pauna;Boyacá Department;/wiki/Pauna;5.666666666666667;-73.98333333333333
-Paya;Boyacá Department;/wiki/Paya,_Boyac%C3%A1;5.633333333333333;-72.43333333333334
-Paz de Río;Boyacá Department;/wiki/Paz_de_R%C3%ADo;5.983333333333333;-72.75
-Pesca;Boyacá Department;/wiki/Pesca;5.583333333333333;-73.05
-Pisba;Boyacá Department;/wiki/Pisba,_Boyac%C3%A1;5.716666666666667;-72.48333333333333
-Puerto Boyacá;Boyacá Department;/wiki/Puerto_Boyac%C3%A1;6.0;-74.41666666666667
-Páez;Boyacá Department;/wiki/P%C3%A1ez,_Boyac%C3%A1;5.10444;-73.0556
-Quípama;Boyacá Department;/wiki/Qu%C3%ADpama;5.516666666666667;-74.18333333333334
-Ramiriquí;Boyacá Department;/wiki/Ramiriqu%C3%AD;5.4;-73.33333333333333
-Rondón;Boyacá Department;/wiki/Rond%C3%B3n,_Boyac%C3%A1;5.35;-73.2
-Ráquira;Boyacá Department;/wiki/R%C3%A1quira;5.533333333333333;-73.63333333333334
-Saboyá;Boyacá Department;/wiki/Saboy%C3%A1;5.7;-73.76666666666667
-Samacá;Boyacá Department;/wiki/Samac%C3%A1;5.5;-73.48333333333333
-San Eduardo;Boyacá Department;/wiki/San_Eduardo,_Boyac%C3%A1;5.216666666666667;-73.06666666666666
-San José de Pare;Boyacá Department;/wiki/San_Jos%C3%A9_de_Pare;6.016666666666667;-73.55
-San Luis de Gaceno;Boyacá Department;/wiki/San_Luis_de_Gaceno;4.816666666666666;-73.16666666666667
-San Mateo;Boyacá Department;/wiki/San_Mateo,_Boyac%C3%A1;6.4;-72.55
-San Miguel de Sema;Boyacá Department;/wiki/San_Miguel_de_Sema;5.55;-73.75
-San Pablo de Borbur;Boyacá Department;/wiki/San_Pablo_de_Borbur;5.75;-74.08333333333333
-Santa María;Boyacá Department;/wiki/Santa_Mar%C3%ADa,_Boyac%C3%A1;4.85;-73.25
-Santa Rosa de Viterbo;Boyacá Department;/wiki/Santa_Rosa_de_Viterbo,_Boyac%C3%A1;5.883333333333333;-72.98333333333333
-Santa Sofía;Boyacá Department;/wiki/Santa_Sof%C3%ADa,_Boyac%C3%A1;5.75;-73.58333333333333
-Santana;Boyacá Department;/wiki/Santana,_Boyac%C3%A1;6.05;-73.46666666666667
-Sativanorte;Boyacá Department;/wiki/Sativanorte;6.116666666666666;-72.7
-Sativasur;Boyacá Department;/wiki/Sativasur;6.083333333333333;-72.73333333333333
-Siachoque;Boyacá Department;/wiki/Siachoque;5.5;-73.23333333333333
-Soatá;Boyacá Department;/wiki/Soat%C3%A1,_Boyac%C3%A1;6.333333333333333;-72.66666666666667
-Socha;Boyacá Department;/wiki/Socha;6.0;-72.66666666666667
-Socotá;Boyacá Department;/wiki/Socot%C3%A1;6.05;-72.63333333333334
-Sogamoso;Boyacá Department;/wiki/Sogamoso;5.716666666666667;-72.91666666666667
-Somondoco;Boyacá Department;/wiki/Somondoco;4.98778;-73.4361
-Sora;Boyacá Department;/wiki/Sora,_Boyac%C3%A1;5.566666666666666;-73.43333333333334
-Soracá;Boyacá Department;/wiki/Sorac%C3%A1;5.5;-73.31666666666666
-Sotaquirá;Boyacá Department;/wiki/Sotaquir%C3%A1;5.766666666666667;-73.25
-Susacón;Boyacá Department;/wiki/Susac%C3%B3n;6.233333333333333;-72.7
-Sutamarchán;Boyacá Department;/wiki/Sutamarch%C3%A1n;5.6;-73.63333333333334
-Sutatenza;Boyacá Department;/wiki/Sutatenza;5.016666666666667;-73.45
-Sáchica;Boyacá Department;/wiki/S%C3%A1chica;5.583333333333333;-73.55
-Tasco;Boyacá Department;/wiki/Tasco,_Boyac%C3%A1;5.916666666666667;-72.78333333333333
-Tenza;Boyacá Department;/wiki/Tenza;5.083333333333333;-73.41666666666667
-Tibaná;Boyacá Department;/wiki/Tiban%C3%A1;5.316666666666666;-73.4
-Tibasosa;Boyacá Department;/wiki/Tibasosa;5.833333333333333;-72.96666666666667
-Tinjacá;Boyacá Department;/wiki/Tinjac%C3%A1;5.566666666666666;-73.65
-Tipacoque;Boyacá Department;/wiki/Tipacoque;6.416666666666667;-72.7
-Toca;Boyacá Department;/wiki/Toca,_Boyac%C3%A1;5.566666666666666;-73.2
-Togüí, Boyacá;Boyacá Department;/wiki/Tog%C3%BC%C3%AD,_Boyac%C3%A1;5.933333333333334;-73.5
-Tota;Boyacá Department;/wiki/Tota,_Boyac%C3%A1;5.566666666666666;-72.98333333333333
-Tunja;Boyacá Department;/wiki/Tunja;5.533333333333333;-73.36666666666666
-Tununguá;Boyacá Department;/wiki/Tunungu%C3%A1;5.733333333333333;-73.93333333333334
-Turmequé;Boyacá Department;/wiki/Turmequ%C3%A9;5.316666666666666;-73.5
-Tuta;Boyacá Department;/wiki/Tuta,_Boyac%C3%A1;5.7;-73.23333333333333
-Tutazá;Boyacá Department;/wiki/Tutaz%C3%A1;6.05;-72.86666666666666
-Tópaga;Boyacá Department;/wiki/T%C3%B3paga,_Boyac%C3%A1;5.766666666666667;-72.83333333333333
-Úmbita;Boyacá Department;/wiki/%C3%9Ambita;5.216666666666667;-73.46666666666667
-Ventaquemada;Boyacá Department;/wiki/Ventaquemada;5.416666666666667;-73.5
-Villa de Leyva;Boyacá Department;/wiki/Villa_de_Leyva;5.633333333333333;-73.53333333333333
-Viracachá;Boyacá Department;/wiki/Viracach%C3%A1;5.433333333333334;-73.3
-Zetaquirá;Boyacá Department;/wiki/Zetaquir%C3%A1;5.35;-73.16666666666667
-Aguadas;Caldas Department;/wiki/Aguadas,_Caldas;5.616666666666667;-75.46666666666667
-Anserma;Caldas Department;/wiki/Anserma,_Caldas;5.233333333333333;-75.78333333333333
-Aranzazu;Caldas Department;/wiki/Aranzazu,_Caldas;5.3;-75.45
-Belalcázar;Caldas Department;/wiki/Belalc%C3%A1zar,_Caldas;5.0;-75.81666666666666
-Chinchiná;Caldas Department;/wiki/Chinchin%C3%A1,_Caldas;5.0;-75.58333333333333
-Filadelfia;Caldas Department;/wiki/Filadelfia,_Caldas;5.3;-75.6
-La Dorada;Caldas Department;/wiki/La_Dorada,_Caldas;5.45;-74.65
-La Merced;Caldas Department;/wiki/La_Merced,_Caldas;5.383333333333334;-75.53333333333333
-Manizales;Caldas Department;/wiki/Manizales;5.1;-75.55
-Manzanares;Caldas Department;/wiki/Manzanares,_Caldas;5.25;-75.15
-Marmato;Caldas Department;/wiki/Marmato,_Caldas;5.5;-75.58333333333333
-Marquetalia;Caldas Department;/wiki/Marquetalia,_Caldas;5.333333333333333;-75.0
-Marulanda;Caldas Department;/wiki/Marulanda,_Caldas;5.283333333333333;-75.26666666666667
-Neira;Caldas Department;/wiki/Neira,_Caldas;5.15;-75.51666666666667
-Norcasia;Caldas Department;/wiki/Norcasia,_Caldas;5.566666666666666;-74.88333333333334
-Pácora;Caldas Department;/wiki/P%C3%A1cora,_Caldas;5.516666666666667;-75.45
-Palestina;Caldas Department;/wiki/Palestina,_Caldas;5.083333333333333;-75.66666666666667
-Pensilvania;Caldas Department;/wiki/Pensilvania,_Caldas;5.5;-75.08333333333333
-Riosucio;Caldas Department;/wiki/Riosucio,_Caldas;5.416666666666667;-75.7
-Risaralda;Caldas Department;/wiki/Risaralda,_Caldas;5.166666666666667;-75.75
-Salamina;Caldas Department;/wiki/Salamina,_Caldas;5.4;-75.48333333333333
-Samaná;Caldas Department;/wiki/Saman%C3%A1,_Caldas;5.583333333333333;-74.91666666666667
-San José;Caldas Department;/wiki/San_Jos%C3%A9,_Caldas;5.083333333333333;-75.78333333333333
-Supía;Caldas Department;/wiki/Sup%C3%ADa,_Caldas;5.466666666666667;-75.65
-Victoria;Caldas Department;/wiki/Victoria,_Caldas;5.416666666666667;-74.83333333333333
-Villamaría;Caldas Department;/wiki/Villamar%C3%ADa,_Caldas;5.0;-75.5
-Viterbo;Caldas Department;/wiki/Viterbo,_Caldas;5.066666666666666;-75.88333333333334
-Albania;Caquetá Department;/wiki/Albania,_Caquet%C3%A1;1.33167;-75.8822
-Belén de Andaquies;Caquetá Department;/wiki/Bel%C3%A9n_de_Andaquies;1.41611;-75.8725
-Cartagena del Chairá;Caquetá Department;/wiki/Cartagena_del_Chair%C3%A1;1.35;-74.83333333333333
-Curillo;Caquetá Department;/wiki/Curillo;1.0333333333333334;-75.91666666666667
-El Doncello;Caquetá Department;/wiki/El_Doncello;1.6833333333333333;-75.28333333333333
-El Paujil;Caquetá Department;/wiki/El_Paujil;1.56444;-75.3319
-Florencia;Caquetá Department;/wiki/Florencia,_Caquet%C3%A1;1.6;-75.6
-La Montañita;Caquetá Department;/wiki/La_Monta%C3%B1ita;1.5833333333333335;-75.25
-Milán;Caquetá Department;/wiki/Mil%C3%A1n,_Caquet%C3%A1;1.2833333333333332;-75.5
-Morelia;Caquetá Department;/wiki/Morelia,_Caquet%C3%A1;1.4875;-75.725
-Puerto Rico;Caquetá Department;/wiki/Puerto_Rico,_Caquet%C3%A1;1.91417;-75.145
-San José de la Fragua;Caquetá Department;/wiki/San_Jos%C3%A9_de_la_Fragua;1.3166666666666667;-75.96666666666667
-San Vicente del Caguán;Caquetá Department;/wiki/San_Vicente_del_Cagu%C3%A1n;2.1166666666666667;-74.76666666666667
-Solano;Caquetá Department;/wiki/Solano,_Caquet%C3%A1;0.6833333333333333;-75.25
-Solita;Caquetá Department;/wiki/Solita,_Caquet%C3%A1;0.8666666666666667;-75.65
-Valparaíso;Caquetá Department;/wiki/Valpara%C3%ADso,_Caquet%C3%A1;1.19917;-75.7097
-Aguazul;Casanare Department;/wiki/Aguazul;5.17306;-72.5547
-Chámeza;Casanare Department;/wiki/Ch%C3%A1meza;5.216666666666667;-72.88333333333334
-Hato Corozal;Casanare Department;/wiki/Hato_Corozal;3.183333333333333;-73.75
-La Salina;Casanare Department;/wiki/La_Salina;6.13056;-72.3378
-Maní;Casanare Department;/wiki/Man%C3%AD,_Casanare;4.816666666666666;-72.28333333333333
-Monterrey;Casanare Department;/wiki/Monterrey,_Casanare;4.87833;-72.8972
-Nunchía;Casanare Department;/wiki/Nunch%C3%ADa;5.633333333333333;-72.2
-Orocué;Casanare Department;/wiki/Orocu%C3%A9;1.8;-72.75
-Paz de Ariporo;Casanare Department;/wiki/Paz_de_Ariporo;5.883333333333333;-71.9
-Pore;Casanare Department;/wiki/Pore,_Casanare;5.72722;-71.9947
-Recetor;Casanare Department;/wiki/Recetor;5.233333333333333;-72.76666666666667
-Sabanalarga;Casanare Department;/wiki/Sabanalarga,_Casanare;4.85361;-73.0431
-Sácama;Casanare Department;/wiki/S%C3%A1cama;6.1;-72.25
-San Luis de Palenque;Casanare Department;/wiki/San_Luis_de_Palenque;5.416666666666667;-71.73333333333333
-Támara;Casanare Department;/wiki/T%C3%A1mara,_Casanare;5.82972;-72.1633
-Tauramena;Casanare Department;/wiki/Tauramena;5.016666666666667;-72.75
-Trinidad;Casanare Department;/wiki/Trinidad,_Casanare;5.40889;-71.6622
-Villanueva;Casanare Department;/wiki/Villanueva,_Casanare;4.6;-72.91666666666667
-Yopal;Casanare Department;/wiki/Yopal;5.35;-72.4
-Almaguer;Cauca Department;/wiki/Almaguer,_Cauca;1.9166666666666665;-76.86666666666666
-Argelia;Cauca Department;/wiki/Argelia,_Cauca;2.2333333333333334;-77.26666666666667
-Balboa;Cauca Department;/wiki/Balboa,_Cauca;2.033333333333333;-77.21666666666667
-Bolívar;Cauca Department;/wiki/Bol%C3%ADvar,_Cauca;1.97083;-76.9694
-Buenos Aires;Cauca Department;/wiki/Buenos_Aires,_Cauca;2.9166666666666665;-76.66666666666667
-Cajibio;Cauca Department;/wiki/Cajibio,_Cauca;2.6333333333333333;-76.63333333333334
-Caldono;Cauca Department;/wiki/Caldono,_Cauca;2.8;-76.53333333333333
-Caloto;Cauca Department;/wiki/Caloto,_Cauca;3.033333333333333;-76.41666666666667
-Corinto;Cauca Department;/wiki/Corinto,_Cauca;3.1666666666666665;-76.25
-El Tambo;Cauca Department;/wiki/El_Tambo,_Cauca;2.45417;-76.8178
-Florencia;Cauca Department;/wiki/Florencia,_Cauca;1.6666666666666665;-77.06666666666666
-Guachené;Cauca Department;/wiki/Guachen%C3%A9;3.1333333333333333;-76.38333333333334
-Guapi;Cauca Department;/wiki/Guapi,_Cauca;2.5666666666666664;-77.88333333333334
-Inza;Cauca Department;/wiki/Inza,_Cauca;2.55;-76.06666666666666
-Jambalo;Cauca Department;/wiki/Jambalo,_Cauca;2.85;-76.31666666666666
-La Sierra;Cauca Department;/wiki/La_Sierra,_Cauca;2.25;-76.83333333333333
-La Vega;Cauca Department;/wiki/La_Vega,_Cauca;2.0;-76.76666666666667
-López de Micay;Cauca Department;/wiki/L%C3%B3pez_de_Micay;3.0;-77.25
-Mercaderes;Cauca Department;/wiki/Mercaderes,_Cauca;1.8;-77.16666666666667
-Miranda;Cauca Department;/wiki/Miranda,_Cauca;3.25;-76.25
-Morales;Cauca Department;/wiki/Morales,_Cauca;2.76028;-76.6339
-Padilla;Cauca Department;/wiki/Padilla,_Cauca;3.2333333333333334;-76.31666666666666
-Páez;Cauca Department;/wiki/P%C3%A1ez,_Cauca;2.65472;-75.9928
-Patía;Cauca Department;/wiki/Pat%C3%ADa,_Cauca;2.1666666666666665;-77.08333333333333
-Piamonte;Cauca Department;/wiki/Piamonte;1.1158;-76.3261
-Piendamó;Cauca Department;/wiki/Piendam%C3%B3,_Cauca;2.6333333333333333;-76.51666666666667
-Popayán;Cauca Department;/wiki/Popay%C3%A1n;2.45;-76.6
-Puerto Tejada;Cauca Department;/wiki/Puerto_Tejada,_Cauca;3.25;-76.41666666666667
-Purace;Cauca Department;/wiki/Purace,_Cauca;2.25;-76.41666666666667
-Rosas;Cauca Department;/wiki/Rosas,_Cauca;2.2666666666666666;-76.75
-San Sebastián;Cauca Department;/wiki/San_Sebasti%C3%A1n,_Cauca;1.8333333333333335;-76.76666666666667
-Santander de Quilichao;Cauca Department;/wiki/Santander_de_Quilichao;3.0166666666666666;-76.48333333333333
-Santa Rosa;Cauca Department;/wiki/Santa_Rosa,_Cauca;1.72944;-76.6044
-Silvia;Cauca Department;/wiki/Silvia,_Cauca;2.6166666666666667;-76.38333333333334
-Sotará;Cauca Department;/wiki/Sotar%C3%A1,_Cauca;2.25;-76.58333333333333
-Suarez;Cauca Department;/wiki/Suarez,_Cauca;2.95889;-76.6953
-Sucre;Cauca Department;/wiki/Sucre,_Cauca;2.033333333333333;-76.91666666666667
-Timbío;Cauca Department;/wiki/Timb%C3%ADo;2.3333333333333335;-76.68333333333334
-Timbiqui;Cauca Department;/wiki/Timbiqui,_Cauca;2.7666666666666666;-77.63333333333334
-Toribío;Cauca Department;/wiki/Torib%C3%ADo,_Cauca;2.95;-76.26666666666667
-Totoro;Cauca Department;/wiki/Totoro,_Cauca;2.5833333333333335;-76.33333333333333
-Villa Rica;Cauca Department;/wiki/Villa_Rica,_Cauca;2.5166666666666666;-76.85
-Aguachica;Cesar Department;/wiki/Aguachica;8.316666666666666;-73.63333333333334
-Astrea;Cesar Department;/wiki/Astrea,_Cesar;9.5;-73.98333333333333
-Becerril;Cesar Department;/wiki/Becerril;9.7;-73.28333333333333
-Bosconia;Cesar Department;/wiki/Bosconia;9.97611;-73.8903
-Chimichagua;Cesar Department;/wiki/Chimichagua;9.25;-73.81666666666666
-Chiriguaná;Cesar Department;/wiki/Chiriguan%C3%A1;9.366666666666667;-73.6
-Codazzi;Cesar Department;/wiki/Agust%C3%ADn_Codazzi,_Cesar;10.033333333333333;-73.23333333333333
-Curumaní;Cesar Department;/wiki/Curuman%C3%AD;9.2;-73.55
-El Copey;Cesar Department;/wiki/El_Copey;10.15;-73.96666666666667
-El Paso;Cesar Department;/wiki/El_Paso,_Cesar;9.66222;-73.7519
-Gamarra;Cesar Department;/wiki/Gamarra,_Cesar;8.333333333333334;-73.66666666666667
-González;Cesar Department;/wiki/Gonz%C3%A1lez,_Cesar;8.4;-73.33333333333333
-La Gloria;Cesar Department;/wiki/La_Gloria,_Cesar;8.583333333333334;-73.58333333333333
-La Jagua de Ibirico;Cesar Department;/wiki/La_Jagua_de_Ibirico,_Cesar;9.566666666666666;-73.33333333333333
-Manaure;Cesar Department;/wiki/Manaure,_Cesar;11.783333333333333;-72.45
-Pailitas;Cesar Department;/wiki/Pailitas;8.966666666666667;-73.63333333333334
-Pelaya;Cesar Department;/wiki/Pelaya;8.683333333333334;-73.66666666666667
-Pueblo Bello;Cesar Department;/wiki/Pueblo_Bello;10.416666666666666;-73.58333333333333
-Rio de Oro;Cesar Department;/wiki/R%C3%ADo_de_Oro,_Cesar;8.0;-73.5
-Los Robles La Paz;Cesar Department;/wiki/Los_Robles_La_Paz;10.383333333333333;-73.16666666666667
-San Alberto;Cesar Department;/wiki/San_Alberto,_Cesar;7.7525;-73.3892
-San Diego;Cesar Department;/wiki/San_Diego,_Cesar;10.3375;-73.1825
-San Martín;Cesar Department;/wiki/San_Mart%C3%ADn,_Cesar;8.033333333333333;-73.5
-Tamalameque;Cesar Department;/wiki/Tamalameque;8.833333333333334;-73.58333333333333
-Valledupar;Cesar Department;/wiki/Valledupar;10.483333333333333;-73.25
-Acandí;Chocó Department;/wiki/Acand%C3%AD;8.533333333333333;-77.23333333333333
-Alto Baudó;Chocó Department;/wiki/Alto_Baud%C3%B3;5.533333333333333;-77.0
-Atrato;Chocó Department;/wiki/Atrato;10.066666666666666;-74.2
-Bagadó;Chocó Department;/wiki/Bagad%C3%B3;5.416666666666667;-76.41666666666667
-Bahía Solano;Chocó Department;/wiki/Bah%C3%ADa_Solano;6.216666666666667;-77.4
-Bajo Baudó;Chocó Department;/wiki/Bajo_Baud%C3%B3;4.95;-77.36666666666666
-Bojayá;Chocó Department;/wiki/Bojay%C3%A1;6.516666666666667;-76.96666666666667
-Cértegui;Chocó Department;/wiki/C%C3%A9rtegui;5.4;-76.6
-Condoto;Chocó Department;/wiki/Condoto;5.1;-76.65
-El Cantón de San Pablo;Chocó Department;/wiki/El_Cant%C3%B3n_de_San_Pablo;5.333333333333333;-76.73333333333333
-El Carmen de Atrato;Chocó Department;/wiki/El_Carmen_de_Atrato;5.88778;-75.1642
-El Carmen del Darién;Chocó Department;/wiki/El_Carmen_del_Dari%C3%A9n;7.15;-76.96666666666667
-Istmina;Chocó Department;/wiki/Istmina;5.166666666666667;-76.68333333333334
-Juradó;Chocó Department;/wiki/Jurad%C3%B3;7.11139;-77.7714
-Litoral del San Juan;Chocó Department;/wiki/Litoral_del_San_Juan;4.25861;-77.3675
-Lloró;Chocó Department;/wiki/Llor%C3%B3;5.5;-76.53333333333333
-Medio Atrato;Chocó Department;/wiki/Medio_Atrato;5.983333333333333;-76.76666666666667
-Medio Baudó;Chocó Department;/wiki/Medio_Baud%C3%B3;5.05;-77.05
-Medio San Juan;Chocó Department;/wiki/Medio_San_Juan;5.1;-76.6833
-Nóvita;Chocó Department;/wiki/N%C3%B3vita;4.95;-76.61666666666666
-Nuquí;Chocó Department;/wiki/Nuqu%C3%AD;5.716666666666667;-77.26666666666667
-Quibdó;Chocó Department;/wiki/Quibd%C3%B3;5.683333333333334;-76.65
-Río Iró;Chocó Department;/wiki/R%C3%ADo_Ir%C3%B3;5.18333;-76.4833
-Río Quito;Chocó Department;/wiki/R%C3%ADo_Quito;5.466666666666667;-76.73333333333333
-Riosucio;Chocó Department;/wiki/Riosucio,_Choc%C3%B3;7.4406;-77.1189
-San José del Palmar;Chocó Department;/wiki/San_Jos%C3%A9_del_Palmar;4.966666666666667;-76.23333333333333
-Sipí;Chocó Department;/wiki/Sip%C3%AD;4.65;-76.48333333333333
-Tadó;Chocó Department;/wiki/Tad%C3%B3;5.266666666666667;-76.56666666666666
-Unguía;Chocó Department;/wiki/Ungu%C3%ADa;8.05;-77.1
-Unión Panamericana;Chocó Department;/wiki/Uni%C3%B3n_Panamericana;5.266666666666667;-76.61666666666666
-Ayapel;Córdoba Department;/wiki/Ayapel;8.316666666666666;-75.15
-Buenavista;Córdoba Department;/wiki/Buenavista,_C%C3%B3rdoba;8.68333;-75.25
-Canalete;Córdoba Department;/wiki/Canalete;8.783333333333333;-76.23333333333333
-Cereté;Córdoba Department;/wiki/Ceret%C3%A9;8.883333333333333;-75.8
-Chimá;Córdoba Department;/wiki/Chim%C3%A1;9.15;-75.63333333333334
-Chinú;Córdoba Department;/wiki/Chin%C3%BA;9.083333333333334;-75.33333333333333
-Ciénaga de Oro;Córdoba Department;/wiki/Ci%C3%A9naga_de_Oro;8.883333333333333;-75.61666666666666
-Cotorra;Córdoba Department;/wiki/Cotorra;9.05;-75.8
-La Apartada;Córdoba Department;/wiki/La_Apartada;8.10056;-75.3825
-Lorica;Córdoba Department;/wiki/Santa_Cruz_de_Lorica;9.216666666666667;-75.81666666666666
-Los Córdobas;Córdoba Department;/wiki/Los_C%C3%B3rdobas;8.9;-76.36666666666666
-Momil;Córdoba Department;/wiki/Momil;9.233333333333333;-75.68333333333334
-Moñitos;Córdoba Department;/wiki/Mo%C3%B1itos;9.25028;-76.1325
-Montelíbano;Córdoba Department;/wiki/Montel%C3%ADbano;7.966666666666667;-75.41666666666667
-Montería;Córdoba Department;/wiki/Monter%C3%ADa;8.75;-75.88333333333334
-Planeta Rica;Córdoba Department;/wiki/Planeta_Rica;8.4;-75.56666666666666
-Pueblo Nuevo;Córdoba Department;/wiki/Pueblo_Nuevo,_C%C3%B3rdoba;8.50083;-75.5072
-Puerto Escondido;Córdoba Department;/wiki/Puerto_Escondido,_C%C3%B3rdoba;8.95;-76.25
-Puerto Libertador;Córdoba Department;/wiki/Puerto_Libertador;7.90667;-75.6733
-Purísima;Córdoba Department;/wiki/Pur%C3%ADsima;9.233333333333333;-75.73333333333333
-Sahagún;Córdoba Department;/wiki/Sahag%C3%BAn,_C%C3%B3rdoba;8.95;-75.45
-San Andrés de Sotavento;Córdoba Department;/wiki/San_Andr%C3%A9s_de_Sotavento;9.15;-75.5
-San Antero;Córdoba Department;/wiki/San_Antero;9.383333333333333;-75.75
-San Bernardo del Viento;Córdoba Department;/wiki/San_Bernardo_del_Viento;9.35;-75.95
-San Carlos;Córdoba Department;/wiki/San_Carlos,_C%C3%B3rdoba;8.80056;-75.7022
-San José de Uré;Córdoba Department;/wiki/San_Jos%C3%A9_de_Ur%C3%A9;7.783333333333333;-75.53333333333333
-San Pelayo;Córdoba Department;/wiki/San_Pelayo,_Colombia;8.966666666666667;-75.85
-Tierralta;Córdoba Department;/wiki/Tierralta;7.916666666666667;-76.16666666666667
-Tuchín;Córdoba Department;/wiki/Tuch%C3%ADn;9.183333333333334;-75.55
-Valencia;Córdoba Department;/wiki/Valencia,_C%C3%B3rdoba;8.3;-76.16666666666667
-Agua de Dios;Cundinamarca Department;/wiki/Agua_de_Dios;4.366666666666666;-74.66666666666667
-Albán;Cundinamarca Department;/wiki/Alb%C3%A1n,_Cundinamarca;4.866666666666667;-74.43333333333334
-Anapoima;Cundinamarca Department;/wiki/Anapoima;4.55;-74.53333333333333
-Anolaima;Cundinamarca Department;/wiki/Anolaima;4.75;-74.45
-Apulo;Cundinamarca Department;/wiki/Apulo;4.516666666666667;-74.58333333333333
-Arbeláez;Cundinamarca Department;/wiki/Arbel%C3%A1ez;4.266666666666667;-74.4
-Beltrán;Cundinamarca Department;/wiki/Beltr%C3%A1n,_Cundinamarca;4.8;-74.73333333333333
-Bituima;Cundinamarca Department;/wiki/Bituima;4.866666666666667;-74.53333333333333
-Bojacá;Cundinamarca Department;/wiki/Bojac%C3%A1;4.733333333333333;-74.33333333333333
-Cabrera;Cundinamarca Department;/wiki/Cabrera,_Cundinamarca;3.966666666666667;-74.48333333333333
-Cachipay;Cundinamarca Department;/wiki/Cachipay,_Cundinamarca;4.716666666666667;-74.43333333333334
-Cajicá;Cundinamarca Department;/wiki/Cajic%C3%A1;4.916666666666667;-74.03333333333333
-Caparrapí;Cundinamarca Department;/wiki/Caparrap%C3%AD;5.333333333333333;-74.48333333333333
-Cáqueza;Cundinamarca Department;/wiki/C%C3%A1queza;4.4;-73.93333333333334
-Carmen de Carupa;Cundinamarca Department;/wiki/Carmen_de_Carupa;5.35;-73.9
-Chaguaní;Cundinamarca Department;/wiki/Chaguan%C3%AD;4.933333333333334;-74.58333333333333
-Chipaque;Cundinamarca Department;/wiki/Chipaque;4.433333333333334;-74.03333333333333
-Choachí;Cundinamarca Department;/wiki/Choach%C3%AD;4.516666666666667;-73.91666666666667
-Chocontá;Cundinamarca Department;/wiki/Chocont%C3%A1;5.133333333333334;-73.66666666666667
-Chía;Cundinamarca Department;/wiki/Ch%C3%ADa,_Cundinamarca;4.85;-74.05
-Cogua;Cundinamarca Department;/wiki/Cogua;5.066666666666666;-73.98333333333333
-Cota;Cundinamarca Department;/wiki/Cota,_Cundinamarca;4.816666666666666;-74.1
-Cucunubá;Cundinamarca Department;/wiki/Cucunub%C3%A1;5.25;-73.75
-El Colegio;Cundinamarca Department;/wiki/El_Colegio;4.566666666666666;-74.43333333333334
-El Peñón;Cundinamarca Department;/wiki/El_Pe%C3%B1%C3%B3n,_Cundinamarca;5.25;-74.28333333333333
-El Rosal;Cundinamarca Department;/wiki/El_Rosal,_Cundinamarca;4.85;-74.25
-Facatativá;Cundinamarca Department;/wiki/Facatativ%C3%A1;4.816666666666666;-74.36666666666666
-Fómeque;Cundinamarca Department;/wiki/F%C3%B3meque;4.483333333333333;-73.88333333333334
-Fosca;Cundinamarca Department;/wiki/Fosca,_Cundinamarca;4.333333333333333;-73.93333333333334
-Funza;Cundinamarca Department;/wiki/Funza;4.716666666666667;-74.21666666666667
-Fusagasugá;Cundinamarca Department;/wiki/Fusagasug%C3%A1;4.333333333333333;-74.35
-Fúquene;Cundinamarca Department;/wiki/F%C3%BAquene;5.4;-73.78333333333333
-Gachalá;Cundinamarca Department;/wiki/Gachal%C3%A1;4.683333333333334;-73.51666666666667
-Gachancipá;Cundinamarca Department;/wiki/Gachancip%C3%A1;4.983333333333333;-73.86666666666666
-Gachetá;Cundinamarca Department;/wiki/Gachet%C3%A1;4.816666666666666;-73.63333333333334
-Gama;Cundinamarca Department;/wiki/Gama,_Cundinamarca;4.75;-73.6
-Girardot;Cundinamarca Department;/wiki/Girardot,_Cundinamarca;4.3;-74.8
-Granada;Cundinamarca Department;/wiki/Granada,_Cundinamarca;4.516666666666667;-74.35
-Guachetá;Cundinamarca Department;/wiki/Guachet%C3%A1;5.383333333333334;-73.68333333333334
-Guaduas;Cundinamarca Department;/wiki/Guaduas;5.066666666666666;-74.58333333333333
-Guasca;Cundinamarca Department;/wiki/Guasca;4.85;-73.86666666666666
-Guataquí;Cundinamarca Department;/wiki/Guataqu%C3%AD;4.516666666666667;-74.78333333333333
-Guatavita;Cundinamarca Department;/wiki/Guatavita;4.933333333333334;-73.83333333333333
-Guayabal de Síquima;Cundinamarca Department;/wiki/Guayabal_de_S%C3%ADquima;4.866666666666667;-74.46666666666667
-Guayabetal;Cundinamarca Department;/wiki/Guayabetal;4.2;-73.8
-Gutiérrez;Cundinamarca Department;/wiki/Guti%C3%A9rrez,_Cundinamarca;4.25;-74.0
-Jerusalen;Cundinamarca Department;/wiki/Jerusal%C3%A9n,_Cundinamarca;4.55;-74.68333333333334
-Junín;Cundinamarca Department;/wiki/Jun%C3%ADn,_Cundinamarca;4.783333333333333;-73.8
-La Calera;Cundinamarca Department;/wiki/La_Calera,_Cundinamarca;4.75;-73.91666666666667
-La Mesa;Cundinamarca Department;/wiki/La_Mesa,_Cundinamarca;4.616666666666667;-74.45
-La Palma;Cundinamarca Department;/wiki/La_Palma,_Cundinamarca;5.35;-74.38333333333334
-La Peña;Cundinamarca Department;/wiki/La_Pe%C3%B1a,_Cundinamarca;5.183333333333334;-74.38333333333334
-La Vega;Cundinamarca Department;/wiki/La_Vega,_Cundinamarca;4.983333333333333;-74.33333333333333
-Lenguazaque;Cundinamarca Department;/wiki/Lenguazaque;5.3;-73.7
-Machetá;Cundinamarca Department;/wiki/Machet%C3%A1;5.066666666666666;-73.6
-Madrid;Cundinamarca Department;/wiki/Madrid,_Cundinamarca;4.733333333333333;-74.26666666666667
-Manta;Cundinamarca Department;/wiki/Manta,_Cundinamarca;5.083333333333333;-73.58333333333333
-Medina;Cundinamarca Department;/wiki/Medina,_Cundinamarca;4.5;-73.33333333333333
-Mosquera;Cundinamarca Department;/wiki/Mosquera,_Cundinamarca;4.7;-74.21666666666667
-Nariño;Cundinamarca Department;/wiki/Nari%C3%B1o,_Cundinamarca;4.383333333333334;-74.81666666666666
-Nemocón;Cundinamarca Department;/wiki/Nemoc%C3%B3n;5.05;-73.88333333333334
-Nilo;Cundinamarca Department;/wiki/Nilo,_Cundinamarca;4.3;-74.61666666666666
-Nimaima;Cundinamarca Department;/wiki/Nimaima;5.116666666666666;-74.38333333333334
-Nocaima;Cundinamarca Department;/wiki/Nocaima;5.066666666666666;-74.36666666666666
-Pacho;Cundinamarca Department;/wiki/Pacho;5.116666666666666;-74.15
-Paime;Cundinamarca Department;/wiki/Paime;5.366666666666666;-74.15
-Pandi;Cundinamarca Department;/wiki/Pandi,_Cundinamarca;4.183333333333334;-74.48333333333333
-Paratebueno;Cundinamarca Department;/wiki/Paratebueno;4.366666666666666;-73.2
-Pasca;Cundinamarca Department;/wiki/Pasca;4.3;-74.3
-Puerto Salgar;Cundinamarca Department;/wiki/Puerto_Salgar;5.5;-74.58333333333333
-Pulí;Cundinamarca Department;/wiki/Pul%C3%AD,_Cundinamarca;4.683333333333334;-74.71666666666667
-Quebradanegra;Cundinamarca Department;/wiki/Quebradanegra;5.116666666666666;-74.46666666666667
-Quetame;Cundinamarca Department;/wiki/Quetame;4.316666666666666;-73.85
-Quipile;Cundinamarca Department;/wiki/Quipile;4.733333333333333;-74.56666666666666
-Ricaurte;Cundinamarca Department;/wiki/Ricaurte,_Cundinamarca;4.266666666666667;-74.76666666666667
-San Antonio del Tequendama;Cundinamarca Department;/wiki/San_Antonio_del_Tequendama;4.616666666666667;-74.35
-San Bernardo;Cundinamarca Department;/wiki/San_Bernardo,_Cundinamarca;4.166666666666667;-74.41666666666667
-San Cayetano;Cundinamarca Department;/wiki/San_Cayetano,_Cundinamarca;5.316666666666666;-74.01666666666667
-San Francisco;Cundinamarca Department;/wiki/San_Francisco,_Cundinamarca;4.966666666666667;-74.28333333333333
-San Juan de Rioseco;Cundinamarca Department;/wiki/San_Juan_de_Rioseco;4.833333333333333;-74.61666666666666
-Sasaima;Cundinamarca Department;/wiki/Sasaima;4.95;-74.43333333333334
-Sesquilé;Cundinamarca Department;/wiki/Sesquil%C3%A9;5.033333333333333;-73.78333333333333
-Sibaté;Cundinamarca Department;/wiki/Sibat%C3%A9;4.483333333333333;-74.25
-Silvania;Cundinamarca Department;/wiki/Silvania,_Colombia;4.4;-74.38333333333334
-Simijaca;Cundinamarca Department;/wiki/Simijaca;5.5;-73.85
-Soacha;Cundinamarca Department;/wiki/Soacha;4.583333333333333;-74.21666666666667
-Sopó;Cundinamarca Department;/wiki/Sop%C3%B3;4.916666666666667;-73.93333333333334
-Subachoque;Cundinamarca Department;/wiki/Subachoque;4.916666666666667;-74.16666666666667
-Suesca;Cundinamarca Department;/wiki/Suesca;5.1;-73.8
-Supatá;Cundinamarca Department;/wiki/Supat%C3%A1;5.05;-74.23333333333333
-Susa;Cundinamarca Department;/wiki/Susa,_Cundinamarca;5.45;-73.8
-Sutatausa;Cundinamarca Department;/wiki/Sutatausa;5.233333333333333;-73.85
-Tabio;Cundinamarca Department;/wiki/Tabio;4.9;-74.08333333333333
-Tausa;Cundinamarca Department;/wiki/Tausa;5.183333333333334;-73.88333333333334
-Tena;Cundinamarca Department;/wiki/Tena,_Cundinamarca;4.65;-74.38333333333334
-Tenjo;Cundinamarca Department;/wiki/Tenjo;4.916666666666667;-74.16666666666667
-Tibacuy;Cundinamarca Department;/wiki/Tibacuy;4.333333333333333;-74.45
-Tibiritá;Cundinamarca Department;/wiki/Tibirit%C3%A1;5.05;-73.5
-Tocaima;Cundinamarca Department;/wiki/Tocaima;4.5;-74.66666666666667
-Tocancipá;Cundinamarca Department;/wiki/Tocancip%C3%A1;4.95;-73.9
-Topaipí;Cundinamarca Department;/wiki/Topaip%C3%AD;5.333333333333333;-74.3
-Ubalá;Cundinamarca Department;/wiki/Ubal%C3%A1;4.733333333333333;-73.53333333333333
-Ubaque;Cundinamarca Department;/wiki/Ubaque;4.466666666666667;-73.93333333333334
-Ubaté;Cundinamarca Department;/wiki/Ubat%C3%A9;5.3;-73.8
-Une;Cundinamarca Department;/wiki/Une;4.4;-74.01666666666667
-Útica;Cundinamarca Department;/wiki/%C3%9Atica;5.183333333333334;-74.48333333333333
-Venecia;Cundinamarca Department;/wiki/Venecia,_Cundinamarca;4.083333333333333;-74.46666666666667
-Vergara;Cundinamarca Department;/wiki/Vergara,_Cundinamarca;5.166666666666667;-74.33333333333333
-Vianí;Cundinamarca Department;/wiki/Vian%C3%AD;4.866666666666667;-74.55
-Villagómez;Cundinamarca Department;/wiki/Villag%C3%B3mez;5.283333333333333;-74.2
-Villapinzón;Cundinamarca Department;/wiki/Villapinz%C3%B3n;5.216666666666667;-73.6
-Villeta;Cundinamarca Department;/wiki/Villeta,_Cundinamarca;5.0;-74.46666666666667
-Viotá;Cundinamarca Department;/wiki/Viot%C3%A1;4.433333333333334;-74.51666666666667
-Yacopí;Cundinamarca Department;/wiki/Yacop%C3%AD;5.466666666666667;-74.33333333333333
-Zipacón;Cundinamarca Department;/wiki/Zipac%C3%B3n;4.75;-74.36666666666666
-Zipaquirá;Cundinamarca Department;/wiki/Zipaquir%C3%A1;5.033333333333333;-74.0
-Albania;La Guajira Department;/wiki/Albania,_La_Guajira;11.1597;-72.5856
-Barrancas;La Guajira Department;/wiki/Barrancas,_La_Guajira;11.0;-72.75
-Dibulla;La Guajira Department;/wiki/Dibulla,_La_Guajira;11.266666666666667;-73.3
-Distracción;La Guajira Department;/wiki/Distracci%C3%B3n,_La_Guajira;10.9;-72.88333333333334
-El Molino;La Guajira Department;/wiki/El_Molino,_La_Guajira;10.6533;-72.9242
-Fonseca;La Guajira Department;/wiki/Fonseca,_La_Guajira;10.833333333333334;-72.83333333333333
-Hatonuevo;La Guajira Department;/wiki/Hatonuevo;11.0694;-72.7669
-La Jagua del Pilar;La Guajira Department;/wiki/La_Jagua_del_Pilar;10.516666666666667;-73.08333333333333
-Maicao;La Guajira Department;/wiki/Maicao;11.366666666666667;-72.23333333333333
-Manaure;La Guajira Department;/wiki/Manaure,_La_Guajira;11.766666666666667;-72.43333333333334
-Riohacha;La Guajira Department;/wiki/Riohacha_Municipality;11.551770;-72.909752
-San Juan del Cesar;La Guajira Department;/wiki/San_Juan_del_Cesar;10.766666666666667;-73.0
-Uribia;La Guajira Department;/wiki/Uribia,_La_Guajira;11.916666666666666;-72.0
-Urumita;La Guajira Department;/wiki/Urumita;10.566666666666666;-73.01666666666667
-Villanueva;La Guajira Department;/wiki/Villanueva,_La_Guajira;10.6;-72.98333333333333
-Barranco Minas;Guainía Department;/wiki/Barranco_Minas;3.4833333333333334;-69.8
-Cacahual;Guainía Department;/wiki/Cacahual;7.58322;-75.46466
-Inirida;Guainía Department;/wiki/In%C3%ADrida,_Guain%C3%ADa;3.85;-67.91666666666667
-La Guadalupe;Guainía Department;/wiki/La_Guadalupe;1.2333333333333334;-66.85
-Morichal Nuevo;Guainía Department;/wiki/Morichal_Nuevo;2.21667;-70.0333
-Pana Pana;Guainía Department;/wiki/Pana_Pana;1.85;-69.0
-Puerto Colombia;Guainía Department;/wiki/Puerto_Colombia,_Guain%C3%ADa;2.72028;-67.5644
-San Felipe;Guainía Department;/wiki/San_Felipe,_Guain%C3%ADa;2.90556;-67.0856
-Calamar;Guaviare Department;/wiki/Calamar,_Guaviare;1.9166666666666665;-72.55
-El Retorno;Guaviare Department;/wiki/El_Retorno;2.33056;-72.6278
-Miraflores;Guaviare Department;/wiki/Miraflores,_Guaviare;1.33667;-71.9511
-San José del Guaviare;Guaviare Department;/wiki/San_Jos%C3%A9_del_Guaviare;2.5666666666666664;-72.63333333333334
-Acevedo;Huila Department;/wiki/Acevedo,_Huila;1.81917;-75.8964
-Agrado;Huila Department;/wiki/Agrado;4.583333333333333;-74.06666666666666
-Aipe;Huila Department;/wiki/Aipe;3.216666666666667;-75.23333333333333
-Algeciras;Huila Department;/wiki/Algeciras,_Huila;2.533333333333333;-75.31666666666666
-Altamira;Huila Department;/wiki/Altamira,_Huila;2.06278;-75.7872
-Baraya;Huila Department;/wiki/Baraya;3.15;-75.05
-Campoalegre;Huila Department;/wiki/Campoalegre;2.6833333333333336;-75.31666666666666
-Colombia;Huila Department;/wiki/Colombia,_Huila;3.37778;-74.8078
-Elias;Huila Department;/wiki/Elias,_Huila;2.0166666666666666;-75.93333333333334
-Garzón;Huila Department;/wiki/Garz%C3%B3n,_Huila;2.1666666666666665;-75.65
-Gigante;Huila Department;/wiki/Gigante,_Huila;2.38667;-75.5461
-Guadalupe;Huila Department;/wiki/Guadalupe,_Huila;2.025;-75.7572
-Hobo;Huila Department;/wiki/Hobo,_Huila;2.5833333333333335;-75.45
-Iquira;Huila Department;/wiki/Iquira;2.65;-75.65
-Isnos;Huila Department;/wiki/Isnos;1.9333333333333333;-76.23333333333333
-La Argentina;Huila Department;/wiki/La_Argentina,_Huila;2.19611;-75.98
-La Plata;Huila Department;/wiki/La_Plata,_Huila;2.3833333333333333;-75.9
-Nataga;Huila Department;/wiki/Nataga;2.55;-75.83333333333333
-Neiva;Huila Department;/wiki/Neiva,_Huila;2.9333333333333336;-75.26666666666667
-Oporapa;Huila Department;/wiki/Oporapa;2.05;-75.96666666666667
-Paicol;Huila Department;/wiki/Paicol;2.4333333333333336;-75.76666666666667
-Palermo;Huila Department;/wiki/Palermo,_Huila;2.8833333333333333;-75.43333333333334
-Palestina;Huila Department;/wiki/Palestina,_Huila;1.75;-76.0667
-Pital;Huila Department;/wiki/Pital,_Huila;2.987;-75.826
-Pitalito;Huila Department;/wiki/Pitalito;1.8833333333333333;-76.03333333333333
-Rivera;Huila Department;/wiki/Rivera,_Huila;2.78528;-75.2589
-Saladoblanco;Huila Department;/wiki/Saladoblanco;2.0166666666666666;-76.05
-San Agustín;Huila Department;/wiki/San_Agust%C3%ADn,_Huila;1.9;-76.28333333333333
-Santa María;Huila Department;/wiki/Santa_Mar%C3%ADa,_Huila;2.95;-75.65
-Suaza;Huila Department;/wiki/Suaza;1.9833333333333334;-75.81666666666666
-Tarqui;Huila Department;/wiki/Tarqui,_Huila;2.1;-75.81666666666666
-Tello;Huila Department;/wiki/Tello,_Huila;3.066666666666667;-75.13333333333334
-Teruel;Huila Department;/wiki/Teruel,_Huila;2.75;-75.56666666666666
-Tesalia;Huila Department;/wiki/Tesalia;2.4833333333333334;-75.73333333333333
-Timaná;Huila Department;/wiki/Timan%C3%A1;1.9833333333333334;-75.95
-Villavieja;Huila Department;/wiki/Villavieja,_Huila;3.216666666666667;-75.21666666666667
-Yaguara;Huila Department;/wiki/Yaguara;2.66611;-75.5186
-Algarrobo;Magdalena Department;/wiki/Algarrobo,_Magdalena;10.1;-74.2667
-Aracataca;Magdalena Department;/wiki/Aracataca;10.583333333333334;-74.18333333333334
-Ariguaní;Magdalena Department;/wiki/Ariguan%C3%AD;9.85;-74.2386
-Cerro San Antonio;Magdalena Department;/wiki/Cerro_San_Antonio;10.333333333333334;-74.86666666666666
-Chibolo;Magdalena Department;/wiki/Chibolo;10.016666666666667;-74.61666666666666
-Ciénaga;Magdalena Department;/wiki/Ci%C3%A9naga,_Magdalena;11.0;-74.25
-Concordia;Magdalena Department;/wiki/Concordia,_Magdalena;10.2667;-74.8333
-El Banco;Magdalena Department;/wiki/El_Banco;8.983333333333333;-73.96666666666667
-El Piñón;Magdalena Department;/wiki/El_Pi%C3%B1%C3%B3n;10.333333333333334;-74.66666666666667
-El Retén;Magdalena Department;/wiki/El_Ret%C3%A9n;10.616666666666667;-74.26666666666667
-Fundación;Magdalena Department;/wiki/Fundaci%C3%B3n;10.516666666666667;-74.18333333333334
-Guamal;Magdalena Department;/wiki/Guamal;9.14722;-74.23
-Nueva Granada;Magdalena Department;/wiki/Nueva_Granada,_Magdalena;9.80306;-74.3903
-Pedraza;Magdalena Department;/wiki/Pedraza,_Magdalena;10.183333333333334;-74.91666666666667
-Pinto;Magdalena Department;/wiki/Pinto,_Magdalena;9.433333333333334;-74.7
-Pijiño;Magdalena Department;/wiki/Piji%C3%B1o;9.333333333333334;-74.45
-Pivijay;Magdalena Department;/wiki/Pivijay;10.466666666666667;-74.61666666666666
-Plato;Magdalena Department;/wiki/Plato,_Magdalena;9.783333333333333;-74.78333333333333
-Pueblo Viejo;Magdalena Department;/wiki/Pueblo_Viejo,_Magdalena;10.9972;-74.2875
-Remolino;Magdalena Department;/wiki/Remolino;10.666666666666666;-74.58333333333333
-Sabanas de San Ángel;Magdalena Department;/wiki/Sabanas_de_San_%C3%81ngel;10.0333;-74.2167
-Salamina;Magdalena Department;/wiki/Salamina,_Magdalena;10.4933;-74.7983
-San Sebastián de Buenavista;Magdalena Department;/wiki/San_Sebasti%C3%A1n_de_Buenavista;9.233333333333333;-74.35
-Santa Ana;Magdalena Department;/wiki/Santa_Ana,_Magdalena;9.319;-74.57
-Santa Marta;Magdalena Department;/wiki/Santa_Marta;11.233333333333333;-74.2
-San Zenón;Magdalena Department;/wiki/San_Zen%C3%B3n;9.333333333333334;-74.3
-Sitionuevo;Magdalena Department;/wiki/Sitionuevo;10.783333333333333;-74.71666666666667
-Tenerife;Magdalena Department;/wiki/Tenerife,_Magdalena;10.0;-74.66666666666667
-Zapayán;Magdalena Department;/wiki/Zapay%C3%A1n;10.1708;-74.7194
-Zona Bananera;Magdalena Department;/wiki/Zona_Bananera,_Magdalena;10.7647;-74.1586
-Acacías;Meta Department;/wiki/Acac%C3%ADas;3.9833333333333334;-73.75
-Barranca de Upía;Meta Department;/wiki/Barranca_de_Up%C3%ADa;4.583333333333333;-72.96666666666667
-Cabuyaro;Meta Department;/wiki/Cabuyaro;4.283333333333333;-72.78333333333333
-Castilla la Nueva;Meta Department;/wiki/Castilla_la_Nueva,_Meta;3.8333333333333335;-73.68333333333334
-Cubarral;Meta Department;/wiki/Cubarral;3.783333333333333;-73.83333333333333
-Cumaral;Meta Department;/wiki/Cumaral;4.266666666666667;-73.48333333333333
-El Calvario;Meta Department;/wiki/El_Calvario;4.416666666666667;-73.66666666666667
-El Castillo;Meta Department;/wiki/El_Castillo,_Meta;3.56806;-73.7839
-El Dorado;Meta Department;/wiki/El_Dorado,_Meta;3.74167;-73.8389
-Fuente de Oro;Meta Department;/wiki/Fuente_de_Oro;3.466666666666667;-73.61666666666666
-Granada;Meta Department;/wiki/Granada,_Meta;3.533333333333333;-73.7
-Guamal;Meta Department;/wiki/Guamal,_Meta;3.88;-73.7656
-La Macarena;Meta Department;/wiki/La_Macarena,_Meta;2.1666666666666665;-73.78333333333333
-La Uribe;Meta Department;/wiki/La_Uribe;3.2333333333333334;-74.35
-Lejanías;Meta Department;/wiki/Lejan%C3%ADas;3.5166666666666666;-74.01666666666667
-Mapiripán;Meta Department;/wiki/Mapirip%C3%A1n;2.8833333333333333;-72.13333333333334
-Mesetas;Meta Department;/wiki/Mesetas;3.37806;-74.0447
-Puerto Concordia;Meta Department;/wiki/Puerto_Concordia;2.6833333333333336;-72.76666666666667
-Puerto Gaitán;Meta Department;/wiki/Puerto_Gait%C3%A1n;4.31417;-72.0825
-Puerto Lleras;Meta Department;/wiki/Puerto_Lleras;3.2666666666666666;-73.36666666666666
-Puerto López;Meta Department;/wiki/Puerto_L%C3%B3pez,_Meta;4.083333333333333;-72.96666666666667
-Puerto Rico;Meta Department;/wiki/Puerto_Rico,_Meta;2.9333333333333336;-73.2
-Restrepo;Meta Department;/wiki/Restrepo,_Meta;4.25;-73.5667
-San Carlos de Guaroa;Meta Department;/wiki/San_Carlos_de_Guaroa;3.7;-73.23333333333333
-San Juan de Arama;Meta Department;/wiki/San_Juan_de_Arama;3.3666666666666667;-73.86666666666666
-San Juanito;Meta Department;/wiki/San_Juanito,_Meta;4.45861;-73.6731
-San Martín;Meta Department;/wiki/San_Mart%C3%ADn,_Meta;3.69444;-73.6936
-Villavicencio;Meta Department;/wiki/Villavicencio;4.15;-73.63333333333334
-Vista Hermosa;Meta Department;/wiki/Vista_Hermosa,_Meta;3.1166666666666667;-73.75
-Albán;Nariño Department;/wiki/Alb%C3%A1n;1.4666666666666668;-77.08333333333333
-Aldana;Nariño Department;/wiki/Aldana;0.8833333333333333;-77.7
-Ancuya;Nariño Department;/wiki/Ancuya;1.2666666666666666;-77.53333333333333
-Arboleda;Nariño Department;/wiki/Arboleda;1.50333;-77.0878
-Barbacoas;Nariño Department;/wiki/Barbacoas,_Nari%C3%B1o;1.6666666666666665;-78.13333333333334
-Belén;Nariño Department;/wiki/Bel%C3%A9n,_Nari%C3%B1o;1.66417;-77.0175
-Buesaco;Nariño Department;/wiki/Buesaco;1.3833333333333333;-77.16666666666667
-Chachagüí;Nariño Department;/wiki/Chachag%C3%BC%C3%AD;1.3605;-77.2835
-Colón;Nariño Department;/wiki/Col%C3%B3n,_Nari%C3%B1o;1.6333333333333333;-77.01666666666667
-Consaca;Nariño Department;/wiki/Consaca;1.2;-77.46666666666667
-Contadero;Nariño Department;/wiki/Contadero;0.91;-77.5506
-Córdoba;Nariño Department;/wiki/C%C3%B3rdoba,_Nari%C3%B1o;0.855;-77.5211
-Cuaspud;Nariño Department;/wiki/Cuaspud;0.865833;-77.7294
-Cumbal;Nariño Department;/wiki/Cumbal;0.9;-77.78333333333333
-Cumbitara;Nariño Department;/wiki/Cumbitara;1.67694;-77.3253
-El Charco;Nariño Department;/wiki/El_Charco;2.466666666666667;-78.1
-El Peñol;Nariño Department;/wiki/El_Pe%C3%B1ol,_Nari%C3%B1o;1.45;-77.43333333333334
-El Rosario;Nariño Department;/wiki/El_Rosario,_Nari%C3%B1o;1.7333333333333334;-77.33333333333333
-El Tablón;Nariño Department;/wiki/El_Tabl%C3%B3n;1.4166666666666667;-77.08333333333333
-El Tambo;Nariño Department;/wiki/El_Tambo,_Nari%C3%B1o;1.41306;-77.3981
-Francisco Pizarro;Nariño Department;/wiki/Francisco_Pizarro,_Nari%C3%B1o;2.1;-78.71666666666667
-Funes;Nariño Department;/wiki/Funes,_Nari%C3%B1o;1.0;-77.45
-Guachucal;Nariño Department;/wiki/Guachucal;0.9666666666666667;-77.73333333333333
-Guaitarilla;Nariño Department;/wiki/Guaitarilla;1.13333;-77.5564
-Gualmatán;Nariño Department;/wiki/Gualmat%C3%A1n;0.919167;-77.5661
-Iles;Nariño Department;/wiki/Iles,_Nari%C3%B1o;0.9666666666666667;-77.51666666666667
-Imués;Nariño Department;/wiki/Imu%C3%A9s;1.0666666666666667;-77.5
-Ipiales;Nariño Department;/wiki/Ipiales;0.8166666666666667;-77.63333333333334
-La Cruz;Nariño Department;/wiki/La_Cruz,_Nari%C3%B1o;1.60472;-76.9742
-La Florida;Nariño Department;/wiki/La_Florida,_Nari%C3%B1o;1.30167;-77.4106
-La Llanada;Nariño Department;/wiki/La_Llanada;1.47778;-77.5839
-La Tola;Nariño Department;/wiki/La_Tola;2.4166666666666665;-78.25
-La Unión;Nariño Department;/wiki/La_Uni%C3%B3n,_Nari%C3%B1o;1.6019;-77.1317
-Leiva;Nariño Department;/wiki/Leiva,_Nari%C3%B1o;1.9375;-77.3081
-Linares;Nariño Department;/wiki/Linares,_Nari%C3%B1o;1.35;-77.53333333333333
-Los Andes;Nariño Department;/wiki/Los_Andes,_Nari%C3%B1o;1.4833333333333334;-77.51666666666667
-Magüí Payán;Nariño Department;/wiki/Mag%C3%BC%C3%AD_Pay%C3%A1n;1.9333333333333333;-78.2
-Mallama;Nariño Department;/wiki/Mallama;1.1333333333333333;-77.85
-Mosquera;Nariño Department;/wiki/Mosquera,_Nari%C3%B1o;2.49028;-78.4953
-Nariño;Nariño Department;/wiki/Nari%C3%B1o,_Nari%C3%B1o;1.26667;-77.3667
-Olaya Herrera;Nariño Department;/wiki/Olaya_Herrera;2.3333333333333335;-78.31666666666666
-Ospina;Nariño Department;/wiki/Ospina;1.05;-77.55
-Pasto;Nariño Department;/wiki/Pasto,_Colombia;1.2;-77.26666666666667
-Policarpa;Nariño Department;/wiki/Policarpa,_Nari%C3%B1o;1.6333333333333333;-77.46666666666667
-Potosí;Nariño Department;/wiki/Potos%C3%AD,_Nari%C3%B1o;0.8;-77.56666666666666
-Providencia;Nariño Department;/wiki/Providencia,_Nari%C3%B1o;1.2333333333333334;-77.58333333333333
-Puerres;Nariño Department;/wiki/Puerres;0.8666666666666667;-77.5
-Pupiales;Nariño Department;/wiki/Pupiales;0.8666666666666667;-77.65
-Ricaurte;Nariño Department;/wiki/Ricaurte,_Nari%C3%B1o;1.2;-77.98333333333333
-Roberto Payán;Nariño Department;/wiki/Roberto_Pay%C3%A1n;1.6833333333333333;-78.23333333333333
-Samaniego;Nariño Department;/wiki/Samaniego,_Nari%C3%B1o;1.35;-77.6
-San Bernardo;Nariño Department;/wiki/San_Bernardo,_Nari%C3%B1o;1.5;-77.03333333333333
-Sandona;Nariño Department;/wiki/Sandona;1.2833333333333332;-77.46666666666667
-San Lorenzo;Nariño Department;/wiki/San_Lorenzo,_Nari%C3%B1o;1.50389;-77.2178
-San Pablo;Nariño Department;/wiki/San_Pablo,_Nari%C3%B1o;1.6725;-77.0139
-San Pedro de Cartago;Nariño Department;/wiki/San_Pedro_de_Cartago;1.5666666666666667;-77.11666666666666
-Santa Barbara;Nariño Department;/wiki/Santa_Barbara,_Nari%C3%B1o;2.44444;-77.9717
-Santacruz;Nariño Department;/wiki/Santacruz,_Nari%C3%B1o;1.2166666666666668;-77.66666666666667
-Sapuyes;Nariño Department;/wiki/Sapuyes;1.0333333333333334;-77.61666666666666
-Taminango;Nariño Department;/wiki/Taminango;1.5666666666666667;-77.28333333333333
-Tangua;Nariño Department;/wiki/Tangua,_Nari%C3%B1o;1.1;-77.4
-Tumaco;Nariño Department;/wiki/Tumaco;1.8;-78.75
-Túquerres;Nariño Department;/wiki/T%C3%BAquerres;1.0833333333333333;-77.61666666666666
-Yacuanquer;Nariño Department;/wiki/Yacuanquer;1.1166666666666667;-77.4
-Abrego;Norte de Santander Department;/wiki/Abrego;8.0;-73.2
-Arboledas;Norte de Santander Department;/wiki/Arboledas;7.666666666666667;-72.75
-Bochalema;Norte de Santander Department;/wiki/Bochalema;7.666666666666667;-72.58333333333333
-Bucarasica;Norte de Santander Department;/wiki/Bucarasica;8.05;-72.86666666666666
-Cachira;Norte de Santander Department;/wiki/Cachira;7.75;-73.16666666666667
-Cácota;Norte de Santander Department;/wiki/C%C3%A1cota;7.266666666666667;-72.65
-Chinácota;Norte de Santander Department;/wiki/Chin%C3%A1cota;7.616666666666667;-72.6
-Chitagá;Norte de Santander Department;/wiki/Chitag%C3%A1;7.133333333333334;-72.66666666666667
-Convención;Norte de Santander Department;/wiki/Convenci%C3%B3n;8.833333333333334;-73.2
-Cúcuta;Norte de Santander Department;/wiki/C%C3%BAcuta;7.883333333333333;-72.5
-Cucutilla;Norte de Santander Department;/wiki/Cucutilla;7.55;-72.78333333333333
-Durania;Norte de Santander Department;/wiki/Durania;7.71722;-72.66
-El Carmen;Norte de Santander Department;/wiki/El_Carmen,_Norte_de_Santander;8.51278;-73.4508
-El Tarra;Norte de Santander Department;/wiki/El_Tarra;8.0475;-73.0836
-El Zulia;Norte de Santander Department;/wiki/El_Zulia;7.933333333333334;-72.6
-Gramalote;Norte de Santander Department;/wiki/Gramalote;7.916666666666667;-72.75
-Hacari;Norte de Santander Department;/wiki/Hacari;8.316666666666666;-73.15
-Herrán;Norte de Santander Department;/wiki/Herr%C3%A1n;7.516666666666667;-72.48333333333333
-La Esperanza;Norte de Santander Department;/wiki/La_Esperanza,_Norte_de_Santander;7.63917;-73.3358
-La Playa;Norte de Santander Department;/wiki/La_Playa_de_Bel%C3%A9n;8.25;-73.16666666666667
-Labateca;Norte de Santander Department;/wiki/Labateca;7.333333333333333;-72.5
-Los Patios;Norte de Santander Department;/wiki/Los_Patios;7.833333333333333;-72.51666666666667
-Lourdes;Norte de Santander Department;/wiki/Lourdes,_Norte_de_Santander;7.966666666666667;-72.83333333333333
-Mutiscua;Norte de Santander Department;/wiki/Mutiscua;7.333333333333333;-72.71666666666667
-Ocaña;Norte de Santander Department;/wiki/Oca%C3%B1a,_Norte_de_Santander;8.233333333333333;-73.35
-Pamplona;Norte de Santander Department;/wiki/Pamplona,_Norte_de_Santander;7.366666666666666;-72.65
-Pamplonita;Norte de Santander Department;/wiki/Pamplonita;7.5;-72.58333333333333
-Puerto Santander;Norte de Santander Department;/wiki/Puerto_Santander,_Norte_de_Santander;8.36361;-72.4075
-Ragonvalia;Norte de Santander Department;/wiki/Ragonvalia;7.583333333333333;-72.48333333333333
-Salazar de las Palmas;Norte de Santander Department;/wiki/Salazar_de_las_Palmas;7.766666666666667;-72.8
-San Calixto;Norte de Santander Department;/wiki/San_Calixto;8.4;-73.21666666666667
-San Cayetano;Norte de Santander Department;/wiki/San_Cayetano,_Norte_de_Santander;7.88028;-72.6278
-Santiago;Norte de Santander Department;/wiki/Santiago,_Norte_de_Santander;7.916666666666667;-72.66666666666667
-Sardinata;Norte de Santander Department;/wiki/Sardinata;8.083333333333334;-72.8
-Silos;Norte de Santander Department;/wiki/Silos,_Norte_de_Santander;7.2;-72.76666666666667
-Teorama;Norte de Santander Department;/wiki/Teorama;8.433333333333334;-72.28333333333333
-Tibú;Norte de Santander Department;/wiki/Tib%C3%BA;8.65;-72.73333333333333
-Toledo;Norte de Santander Department;/wiki/Toledo,_Norte_de_Santander;7.31306;-72.4875
-Villa Caro;Norte de Santander Department;/wiki/Villa_Caro;7.91694;-72.9764
-Villa del Rosario;Norte de Santander Department;/wiki/Villa_del_Rosario,_Norte_de_Santander;7.833333333333333;-72.46666666666667
-Colón;Putumayo Department;/wiki/Col%C3%B3n,_Putumayo;1.1833333333333333;-76.96666666666667
-Mocoa;Putumayo Department;/wiki/Mocoa;1.15;-76.63333333333334
-Orito;Putumayo Department;/wiki/Orito;0.65;-76.86666666666666
-Puerto Asís;Putumayo Department;/wiki/Puerto_As%C3%ADs;0.5166666666666667;-76.5
-Puerto Caicedo;Putumayo Department;/wiki/Puerto_Caicedo;0.6833333333333333;-76.6
-Puerto Guzmán;Putumayo Department;/wiki/Puerto_Guzm%C3%A1n;0.9666666666666667;-76.58333333333333
-Puerto Leguízamo;Putumayo Department;/wiki/Puerto_Legu%C3%ADzamo;-0.18333333333333332;-74.76666666666667
-San Francisco;Putumayo Department;/wiki/San_Francisco,_Putumayo;1.1666666666666667;-76.86666666666666
-San Miguel;Putumayo Department;/wiki/San_Miguel,_Putumayo;0.3333333333333333;-76.9
-Santiago;Putumayo Department;/wiki/Santiago,_Putumayo;1.1333333333333333;-77.0
-Sibundoy;Putumayo Department;/wiki/Sibundoy;1.2;-76.91666666666667
-Valle del Guamez;Putumayo Department;/wiki/Valle_del_Guamez;0.4166666666666667;-76.9
-Villa Garzón;Putumayo Department;/wiki/Villa_Garz%C3%B3n;1.0166666666666666;-76.6
-Armenia;Quindío Department;/wiki/Armenia,_Colombia;4.53;-75.68
-Buenavista;Quindío Department;/wiki/Buenavista,_Quind%C3%ADo;4.533333333333333;-75.68333333333334
-Calarcá;Quindío Department;/wiki/Calarc%C3%A1;4.533333333333333;-75.65
-Circasia;Quindío Department;/wiki/Circasia,_Quind%C3%ADo;4.616666666666667;-75.63333333333334
-Córdoba;Quindío Department;/wiki/C%C3%B3rdoba,_Quind%C3%ADo;4.383333333333334;-75.68333333333334
-Filandia;Quindío Department;/wiki/Filandia,_Quind%C3%ADo;4.666666666666667;-75.63333333333334
-Génova;Quindío Department;/wiki/G%C3%A9nova,_Quind%C3%ADo;4.25;-75.66666666666667
-La Tebaida;Quindío Department;/wiki/La_Tebaida,_Quind%C3%ADo;4.45;-75.8
-Montenegro;Quindío Department;/wiki/Montenegro,_Quind%C3%ADo;4.56714;-75.75038
-Pijao;Quindío Department;/wiki/Pijao,_Quind%C3%ADo;4.333333333333333;-75.7
-Quimbaya;Quindío Department;/wiki/Quimbaya,_Quind%C3%ADo;4.633333333333333;-75.75
-Salento;Quindío Department;/wiki/Salento,_Quind%C3%ADo;4.633333333333333;-75.56666666666666
-Apía;Risaralda Department;/wiki/Ap%C3%ADa,_Risaralda;5.1;-75.95
-Balboa;Risaralda Department;/wiki/Balboa,_Risaralda;4.916666666666667;-75.95
-Belén de Umbría;Risaralda Department;/wiki/Bel%C3%A9n_de_Umbr%C3%ADa;5.2;-75.86666666666666
-Dosquebradas;Risaralda Department;/wiki/Dosquebradas;4.833333333333333;-75.68333333333334
-Guática;Risaralda Department;/wiki/Gu%C3%A1tica;5.316666666666666;-75.8
-La Celia;Risaralda Department;/wiki/La_Celia;5.0;-76.0
-La Virginia;Risaralda Department;/wiki/La_Virginia;4.916666666666667;-75.83333333333333
-Marsella;Risaralda Department;/wiki/Marsella;4.916666666666667;-75.75
-Mistrató;Risaralda Department;/wiki/Mistrat%C3%B3;5.3;-75.88333333333334
-Pereira;Risaralda Department;/wiki/Pereira,_Colombia;4.8;-75.68333333333334
-Pueblo Rico;Risaralda Department;/wiki/Pueblo_Rico,_Risaralda;5.25;-76.16666666666667
-Quinchía;Risaralda Department;/wiki/Quinch%C3%ADa;5.333333333333333;-75.71666666666667
-Santa Rosa de Cabal;Risaralda Department;/wiki/Santa_Rosa_de_Cabal;4.866666666666667;-75.61666666666666
-Santuario;Risaralda Department;/wiki/Santuario,_Risaralda;5.066666666666666;-75.95
-Providencia and Santa Catalina Islands;San Andrés and Providencia Department;/wiki/Providencia_and_Santa_Catalina_Islands;13.533333333333333;-81.35
-San Andrés;San Andrés and Providencia Department;/wiki/San_Andr%C3%A9s,_San_Andr%C3%A9s_y_Providencia;12.583333333333334;-81.7
-Aguada;Santander Department;/wiki/Aguada,_Santander;6.25;-73.46666666666667
-Albania;Santander Department;/wiki/Albania,_Santander;5.76139;-73.9178
-Aratoca;Santander Department;/wiki/Aratoca;6.7;-73.01666666666667
-Barbosa;Santander Department;/wiki/Barbosa,_Santander;5.933;-73.621
-Barichara;Santander Department;/wiki/Barichara;6.633333333333333;-73.23333333333333
-Barrancabermeja;Santander Department;/wiki/Barrancabermeja;7.066666666666666;-73.85
-Betulia;Santander Department;/wiki/Betulia,_Santander;6.9;-73.28333333333333
-Bolívar;Santander Department;/wiki/Bol%C3%ADvar,_Santander;5.983333333333333;-73.76666666666667
-Bucaramanga;Santander Department;/wiki/Bucaramanga;7.133333333333334;-73.13333333333334
-Cabrera;Santander Department;/wiki/Cabrera,_Santander;6.583333333333333;-73.23333333333333
-California;Santander Department;/wiki/California,_Santander;7.35;-72.96666666666667
-Capitanejo;Santander Department;/wiki/Capitanejo,_Santander;6.533333333333333;-72.7
-Carcasí;Santander Department;/wiki/Carcas%C3%AD;6.633333333333333;-72.63333333333334
-Cepitá;Santander Department;/wiki/Cepit%C3%A1;6.75;-72.98333333333333
-Cerrito;Santander Department;/wiki/Cerrito,_Santander;6.845;-72.698
-Charalá;Santander Department;/wiki/Charal%C3%A1;6.25;-73.08333333333333
-Charta;Santander Department;/wiki/Charta;7.283333333333333;-72.96666666666667
-Chima;Santander Department;/wiki/Chima_(town);6.35078;-73.37116
-Chipatá;Santander Department;/wiki/Chipat%C3%A1,_Santander;6.05;-73.63333333333334
-Cimitarra;Santander Department;/wiki/Cimitarra;6.316666666666666;-73.95
-Concepción;Santander Department;/wiki/Concepci%C3%B3n,_Santander;6.766666666666667;-72.68333333333334
-Confines;Santander Department;/wiki/Confines;6.416666666666667;-73.16666666666667
-Contratación;Santander Department;/wiki/Contrataci%C3%B3n;6.283333333333333;-73.48333333333333
-Coromoro;Santander Department;/wiki/Coromoro;6.3;-73.03333333333333
-Curití;Santander Department;/wiki/Curit%C3%AD;6.666666666666667;-73.0
-El Carmen;Santander Department;/wiki/El_Carmen,_Santander;6.69806;-73.5111
-El Guacamayo;Santander Department;/wiki/El_Guacamayo;6.333333333333333;-73.46666666666667
-El Peñón;Santander Department;/wiki/El_Pe%C3%B1%C3%B3n,_Santander;5.89222;-73.7403
-El Playón;Santander Department;/wiki/El_Play%C3%B3n,_Santander;7.47667;-73.2081
-Encino;Santander Department;/wiki/Encino,_Santander;6.133333333333334;-73.08333333333333
-Enciso;Santander Department;/wiki/Enciso,_Santander;6.75;-72.63333333333334
-Florián;Santander Department;/wiki/Flori%C3%A1n;5.80472;-73.9742
-Floridablanca;Santander Department;/wiki/Floridablanca,_Santander;7.216666666666667;-73.06666666666666
-Galán;Santander Department;/wiki/Gal%C3%A1n,_Santander;6.7;-73.3
-Gámbita;Santander Department;/wiki/G%C3%A1mbita;6.0;-73.25
-Girón;Santander Department;/wiki/San_Juan_de_Gir%C3%B3n;7.066666666666666;-73.16666666666667
-Guaca;Santander Department;/wiki/Guaca,_Santander;6.883333333333333;-72.86666666666666
-Guadalupe;Santander Department;/wiki/Guadalupe,_Santander;6.247;-73.418
-Guapotá;Santander Department;/wiki/Guapot%C3%A1;6.383333333333334;-73.25
-Guavatá;Santander Department;/wiki/Guavat%C3%A1;5.95;-73.7
-Güepsa;Santander Department;/wiki/G%C3%BCepsa;6.016666666666667;-73.56666666666666
-Hato;Santander Department;/wiki/Hato,_Santander;6.583333333333333;-73.33333333333333
-Jesus María;Santander Department;/wiki/Jesus_Mar%C3%ADa,_Santander;5.883333333333333;-73.78333333333333
-Jordán;Santander Department;/wiki/Jord%C3%A1n,_Santander;6.75;-73.06666666666666
-La Belleza;Santander Department;/wiki/La_Belleza;5.86139;-73.9683
-Landázuri;Santander Department;/wiki/Land%C3%A1zuri;6.216666666666667;-73.8
-La Paz;Santander Department;/wiki/La_Paz,_Santander;6.166666666666667;-73.58333333333333
-Lebrija;Santander Department;/wiki/Lebrija,_Santander;7.416666666666667;-73.41666666666667
-Los Santos;Santander Department;/wiki/Los_Santos,_Santander;6.916666666666667;-73.08333333333333
-Macaravita;Santander Department;/wiki/Macaravita;6.5;-72.6
-Málaga;Santander Department;/wiki/M%C3%A1laga,_Santander;6.783333333333333;-72.66666666666667
-Matanza;Santander Department;/wiki/Matanza,_Santander;7.416666666666667;-73.08333333333333
-Mogotes;Santander Department;/wiki/Mogotes;6.483333333333333;-72.96666666666667
-Molagavita;Santander Department;/wiki/Molagavita;6.683333333333334;-72.81666666666666
-Ocamonte;Santander Department;/wiki/Ocamonte;6.333333333333333;-73.11666666666666
-Oiba;Santander Department;/wiki/Oiba;6.266666666666667;-73.3
-Onzaga;Santander Department;/wiki/Onzaga;6.35;-72.81666666666666
-Palmar;Santander Department;/wiki/Palmar,_Santander;6.583333333333333;-73.25
-Palmas Socorro;Santander Department;/wiki/Palmas_Socorro;6.40722;-73.2883
-Páramo;Santander Department;/wiki/P%C3%A1ramo,_Santander;6.5;-73.13333333333334
-Piedecuesta;Santander Department;/wiki/Piedecuesta;7.083333333333333;-73.0
-Pinchote;Santander Department;/wiki/Pinchote;6.533333333333333;-73.18333333333334
-Puente Nacional;Santander Department;/wiki/Puente_Nacional,_Santander;5.883333333333333;-73.68333333333334
-Puerto Parra;Santander Department;/wiki/Puerto_Parra;6.65;-74.06666666666666
-Puerto Wilches;Santander Department;/wiki/Puerto_Wilches;7.35;-73.9
-Rionegro;Santander Department;/wiki/Rionegro,_Santander;7.15361;-73.1536
-Sabana de Torres;Santander Department;/wiki/Sabana_de_Torres;7.4;-73.5
-San Andrés;Santander Department;/wiki/San_Andr%C3%A9s,_Santander;6.81278;-72.8536
-San Benito;Santander Department;/wiki/San_Benito,_Santander;6.120270;-73.496689
-San Gil;Santander Department;/wiki/San_Gil;6.55;-73.13333333333334
-San Joaquín;Santander Department;/wiki/San_Joaqu%C3%ADn,_Santander;6.4710188;-72.8451961
-San José de Miranda;Santander Department;/wiki/San_Jos%C3%A9_de_Miranda;6.65;-72.71666666666667
-San Miguel;Santander Department;/wiki/San_Miguel,_Santander;6.566666666666666;-72.63333333333334
-Santa Bárbara;Santander Department;/wiki/Santa_B%C3%A1rbara,_Santander;6.983333333333333;-72.9
-Santa Helena del Opón;Santander Department;/wiki/Santa_Helena_del_Op%C3%B3n;6.333333333333333;-73.6
-San Vicente de Chucurí;Santander Department;/wiki/San_Vicente_de_Chucur%C3%AD;6.883333333333333;-73.41666666666667
-Simacota;Santander Department;/wiki/Simacota;6.45;-73.33333333333333
-Socorro;Santander Department;/wiki/Socorro,_Santander;6.533333333333333;-73.2
-Suaita;Santander Department;/wiki/Suaita;6.1257536;-73.3627147
-Sucre;Santander Department;/wiki/Sucre,_Santander;5.923;-73.795
-Surata;Santander Department;/wiki/Surata;7.366666666666666;-72.98333333333333
-Tona;Santander Department;/wiki/Tona,_Santander;7.25;-72.9
-Valle de San José;Santander Department;/wiki/Valle_de_San_Jos%C3%A9;6.4475;-73.1436
-Vélez;Santander Department;/wiki/V%C3%A9lez,_Santander;6.0103333333333335;-73.67633331666667
-Vetas;Santander Department;/wiki/Vetas;7.33333;-72.8667
-Villanueva;Santander Department;/wiki/Villanueva,_Santander;6.67417;-73.1778
-Zapatoca;Santander Department;/wiki/Zapatoca;6.816666666666666;-73.26666666666667
-Buenavista;Sucre Department;/wiki/Buenavista,_Sucre;9.32222;-74.9772
-Caimito;Sucre Department;/wiki/Caimito,_Sucre;8.833333333333334;-75.16666666666667
-Chalán;Sucre Department;/wiki/Chal%C3%A1n;9.55;-75.31666666666666
-Colosó;Sucre Department;/wiki/Colos%C3%B3;9.5;-75.35
-Corozal;Sucre Department;/wiki/Corozal,_Sucre;9.333333333333334;-75.25
-Coveñas;Sucre Department;/wiki/Cove%C3%B1as;9.416666666666666;-75.7
-El Roble;Sucre Department;/wiki/El_Roble,_Sucre;9.1;-75.2
-Galeras;Sucre Department;/wiki/Galeras,_Sucre;9.166666666666666;-75.05
-Guaranda;Sucre Department;/wiki/Guaranda,_Sucre;8.466666666666667;-75.53333333333333
-La Unión;Sucre Department;/wiki/La_Uni%C3%B3n,_Sucre;8.86056;-75.2806
-Los Palmitos;Sucre Department;/wiki/Los_Palmitos;9.38111;-75.2714
-Majagual;Sucre Department;/wiki/Majagual,_Sucre;8.5;-74.66666666666667
-Morroa;Sucre Department;/wiki/Morroa;9.333333333333334;-75.31666666666666
-Ovejas;Sucre Department;/wiki/Ovejas;9.5;-75.16666666666667
-Palmito;Sucre Department;/wiki/Palmito,_Sucre;9.333333333333334;-75.55
-Sampués;Sucre Department;/wiki/Sampu%C3%A9s;9.183333333333334;-75.38333333333334
-San Benito Abad;Sucre Department;/wiki/San_Benito_Abad;8.933333333333334;-75.03333333333333
-San Juan Betulia;Sucre Department;/wiki/San_Juan_Betulia;9.27556;-75.2456
-San Marcos;Sucre Department;/wiki/San_Marcos,_Sucre;8.65;-75.13333333333334
-San Onofre;Sucre Department;/wiki/San_Onofre,_Sucre;9.733333333333333;-75.53333333333333
-San Pedro;Sucre Department;/wiki/San_Pedro,_Sucre;8.73333;-74.7167
-Sincé;Sucre Department;/wiki/Sinc%C3%A9;9.25;-75.15
-Sincelejo;Sucre Department;/wiki/Sincelejo;9.283333333333333;-75.38333333333334
-Sucre;Sucre Department;/wiki/Sucre,_Sucre_Department;8.81389;-74.7253
-Tolú;Sucre Department;/wiki/Tol%C3%BA;9.533333333333333;-75.58333333333333
-Toluviejo;Sucre Department;/wiki/Toluviejo;9.45;-75.45
-Alpujarra;Tolima Department;/wiki/Alpujarra,_Tolima;3.4166666666666665;-74.91666666666667
-Alvarado;Tolima Department;/wiki/Alvarado,_Tolima;4.566666666666666;-74.95
-Ambalema;Tolima Department;/wiki/Ambalema;4.783333333333333;-74.76666666666667
-Anzoátegui;Tolima Department;/wiki/Anzo%C3%A1tegui,_Tolima;4.63389;-75.0972
-Armero;Tolima Department;/wiki/Armero;4.95;-74.9
-Ataco;Tolima Department;/wiki/Ataco;3.6;-75.38333333333334
-Cajamarca;Tolima Department;/wiki/Cajamarca,_Tolima;4.416666666666667;-75.5
-Carmen Apicala;Tolima Department;/wiki/Carmen_Apicala;4.15;-74.73333333333333
-Casabianca;Tolima Department;/wiki/Casabianca,_Tolima;5.083333333333333;-75.11666666666666
-Chaparral;Tolima Department;/wiki/Chaparral,_Tolima;3.75;-75.58333333333333
-Coello;Tolima Department;/wiki/Coello,_Tolima;4.333333333333333;-74.91666666666667
-Coyaima;Tolima Department;/wiki/Coyaima;3.8333333333333335;-75.08333333333333
-Cunday;Tolima Department;/wiki/Cunday;4.083333333333333;-74.66666666666667
-Dolores;Tolima Department;/wiki/Dolores,_Tolima;3.6666666666666665;-74.75
-Espinal;Tolima Department;/wiki/El_Espinal,_Tolima;4.2;-74.83333333333333
-Falán;Tolima Department;/wiki/Fal%C3%A1n;5.133333333333334;-74.95
-Flandes;Tolima Department;/wiki/Flandes;4.283333333333333;-74.8
-Fresno;Tolima Department;/wiki/Fresno,_Tolima;5.15;-75.03333333333333
-Guamo;Tolima Department;/wiki/Guamo;4.083333333333333;-74.91666666666667
-Herveo;Tolima Department;/wiki/Herveo;5.083333333333333;-75.16666666666667
-Honda;Tolima Department;/wiki/Honda,_Tolima;5.2;-74.73333333333333
-Ibagué;Tolima Department;/wiki/Ibagu%C3%A9;4.433333333333334;-75.23333333333333
-Icononzo;Tolima Department;/wiki/Icononzo;4.183333333333334;-74.53333333333333
-Lérida;Tolima Department;/wiki/L%C3%A9rida,_Tolima;4.9;-74.91666666666667
-Líbano;Tolima Department;/wiki/L%C3%ADbano,_Tolima;4.916666666666667;-75.16666666666667
-Mariquita;Tolima Department;/wiki/Mariquita,_Tolima;5.25;-74.91666666666667
-Melgar;Tolima Department;/wiki/Melgar,_Tolima;4.2;-74.63333333333334
-Murillo;Tolima Department;/wiki/Murillo,_Tolima;4.874;-75.171
-Natagaima;Tolima Department;/wiki/Natagaima;3.5833333333333335;-75.08333333333333
-Ortega;Tolima Department;/wiki/Ortega,_Tolima;3.9166666666666665;-75.25
-Piedras;Tolima Department;/wiki/Piedras;4.5;-74.91666666666667
-Palocabildo;Tolima Department;/wiki/Palocabildo;5.13333;-75.0333
-Planadas;Tolima Department;/wiki/Planadas;3.0983945;-75.8572037
-Prado;Tolima Department;/wiki/Prado,_Tolima;3.75;-74.83333333333333
-Purificación;Tolima Department;/wiki/Purificaci%C3%B3n,_Tolima;3.8666666666666667;-74.93333333333334
-Rioblanco;Tolima Department;/wiki/Rioblanco;3.5;-75.83333333333333
-Roncesvalles;Tolima Department;/wiki/Roncesvalles,_Tolima;4.016666666666667;-75.6
-Rovira;Tolima Department;/wiki/Rovira,_Tolima;4.25;-75.33333333333333
-Saldaña;Tolima Department;/wiki/Salda%C3%B1a,_Colombia;3.93472;-75.0203
-San Antonio;Tolima Department;/wiki/San_Antonio,_Tolima;3.9166666666666665;-75.5
-San Luis;Tolima Department;/wiki/San_Luis,_Tolima;4.13611;-75.0994
-Santa Isabel;Tolima Department;/wiki/Santa_Isabel,_Tolima;4.71667;-75.1014
-Suárez;Tolima Department;/wiki/Su%C3%A1rez,_Tolima;4.55;-74.83333333333333
-Valle de San Juan;Tolima Department;/wiki/Valle_de_San_Juan;4.2;-75.11666666666666
-Venadillo;Tolima Department;/wiki/Venadillo;4.75;-74.91666666666667
-Villahermosa;Tolima Department;/wiki/Villahermosa,_Tolima;5.0;-75.16666666666667
-Villarrica;Tolima Department;/wiki/Villarrica,_Tolima;4.0;-74.58333333333333
-Alcalá;Valle del Cauca Department;/wiki/Alcal%C3%A1,_Valle_del_Cauca;4.666666666666667;-75.75
-Andalucía;Valle del Cauca Department;/wiki/Andaluc%C3%ADa,_Valle_del_Cauca;4.166666666666667;-76.16666666666667
-Ansermanuevo;Valle del Cauca Department;/wiki/Ansermanuevo;4.8;-76.0
-Argelia;Valle del Cauca Department;/wiki/Argelia,_Valle_del_Cauca;4.666666666666667;-76.66666666666667
-Bolívar;Valle del Cauca Department;/wiki/Bol%C3%ADvar,_Valle_del_Cauca;4.333333333333333;-76.18333333333334
-Buenaventura;Valle del Cauca Department;/wiki/Buenaventura,_Valle_del_Cauca;3.8666666666666667;-77.01666666666667
-Buga;Valle del Cauca Department;/wiki/Buga,_Valle_del_Cauca;3.9;-76.3
-Bugalagrande;Valle del Cauca Department;/wiki/Bugalagrande;4.216666666666667;-76.16666666666667
-Caicedonia;Valle del Cauca Department;/wiki/Caicedonia;4.333333333333333;-75.83333333333333
-Cali;Valle del Cauca Department;/wiki/Cali;3.45;-76.51666666666667
-Calima;Valle del Cauca Department;/wiki/Calima,_Valle_del_Cauca;3.9166666666666665;-76.66666666666667
-Candelaria;Valle del Cauca Department;/wiki/Candelaria,_Valle_del_Cauca;3.4;-76.38333333333334
-Cartago;Valle del Cauca Department;/wiki/Cartago,_Valle_del_Cauca;4.7;-75.91666666666667
-Dagua;Valle del Cauca Department;/wiki/Dagua;3.6666666666666665;-76.7
-El Aguila;Valle del Cauca Department;/wiki/El_Aguila,_Valle_del_Cauca;4.916666666666667;-76.08333333333333
-El Cairo;Valle del Cauca Department;/wiki/El_Cairo;4.75;-76.25
-El Cerrito;Valle del Cauca Department;/wiki/El_Cerrito,_Valle_del_Cauca;3.6666666666666665;-76.16666666666667
-El Dovio;Valle del Cauca Department;/wiki/El_Dovio;4.516666666666667;-76.23333333333333
-Florida;Valle del Cauca Department;/wiki/Florida,_Valle_del_Cauca;3.3166666666666664;-76.23333333333333
-Ginebra;Valle del Cauca Department;/wiki/Ginebra,_Valle_del_Cauca;3.75;-76.16666666666667
-Guacarí;Valle del Cauca Department;/wiki/Guacar%C3%AD;3.7666666666666666;-76.33333333333333
-Jamundí;Valle del Cauca Department;/wiki/Jamund%C3%AD;3.2666666666666666;-76.55
-La Cumbre;Valle del Cauca Department;/wiki/La_Cumbre,_Valle_del_Cauca;3.6333333333333333;-76.56666666666666
-La Unión;Valle del Cauca Department;/wiki/La_Uni%C3%B3n,_Valle_del_Cauca;3.65;-76.56666666666666
-La Victoria;Valle del Cauca Department;/wiki/La_Victoria,_Valle_del_Cauca;4.516666666666667;-76.03333333333333
-Obando;Valle del Cauca Department;/wiki/Obando,_Valle_del_Cauca;4.583333333333333;-75.91666666666667
-Palmira;Valle del Cauca Department;/wiki/Palmira,_Valle_del_Cauca;3.5833333333333335;-76.25
-Pradera;Valle del Cauca Department;/wiki/Pradera;3.4166666666666665;-76.16666666666667
-Restrepo;Valle del Cauca Department;/wiki/Restrepo,_Valle_del_Cauca;3.825;-76.525
-Riofrío;Valle del Cauca Department;/wiki/Riofr%C3%ADo,_Valle_del_Cauca;4.15;-76.28333333333333
-Roldanillo;Valle del Cauca Department;/wiki/Roldanillo;4.416666666666667;-76.15
-San Pedro;Valle del Cauca Department;/wiki/San_Pedro,_Valle_del_Cauca;4.0;-76.2292
-Sevilla;Valle del Cauca Department;/wiki/Sevilla,_Valle_del_Cauca;4.26889;-75.9361
-Toro;Valle del Cauca Department;/wiki/Toro,_Valle_del_Cauca;4.6;-76.06666666666666
-Trujillo;Valle del Cauca Department;/wiki/Trujillo,_Valle_del_Cauca;4.25;-76.33333333333333
-Tuluá;Valle del Cauca Department;/wiki/Tulu%C3%A1;4.083333333333333;-76.2
-Ulloa;Valle del Cauca Department;/wiki/Ulloa,_Valle_del_Cauca;4.716666666666667;-75.75
-Versalles;Valle del Cauca Department;/wiki/Versalles;4.666666666666667;-76.25
-Vijes;Valle del Cauca Department;/wiki/Vijes;3.7;-76.45
-Yotoco;Valle del Cauca Department;/wiki/Yotoco;3.8666666666666667;-76.38333333333334
-Yumbo;Valle del Cauca Department;/wiki/Yumbo;3.5833333333333335;-76.46666666666667
-Zarzal;Valle del Cauca Department;/wiki/Zarzal;4.383333333333334;-76.06666666666666
-Caruru;Vaupés Department;/wiki/Caruru;1.0;-71.3
-Mitú;Vaupés Department;/wiki/Mit%C3%BA;1.1833333333333333;-70.16666666666667
-Taraira;Vaupés Department;/wiki/Taraira;-0.55;-69.63333333333334
-Acaricuara;Vaupés Department;/wiki/Acaricuara;0.7;-70.23333333333333
-Villa Fátima;Vaupés Department;/wiki/Villa_F%C3%A1tima;0.9727;-69.95
-Pacoa;Vaupés Department;/wiki/Pacoa;0.016666666666666666;-71.0
-Papunahua;Vaupés Department;/wiki/Papunahua;1.9333333333333333;-70.53333333333333
-Yavarate;Vaupés Department;/wiki/Yavarate;0.6166666666666667;-69.2
-Cumaribo;Vichada Department;/wiki/Cumaribo;4.433333333333334;-69.8
-La Primavera;Vichada Department;/wiki/La_Primavera,_Vichada;5.49056;-70.4092
-Puerto Carreño;Vichada Department;/wiki/Puerto_Carre%C3%B1o;6.183333333333334;-67.46666666666667
-Santa Rosalía;Vichada Department;/wiki/Santa_Rosal%C3%ADa,_Vichada;5.12611;-70.8758
+name;department
+El Encanto;Amazonas
+La Chorrera;Amazonas
+La Pedrera;Amazonas
+La Victoria (Pacoa);Amazonas
+Leticia;Amazonas
+Mirití-paraná (Campoamor);Amazonas
+Puerto Alegría;Amazonas
+Puerto Arica;Amazonas
+Puerto Nariño;Amazonas
+Santander (Araracuara);Amazonas
+Tarapacá;Amazonas
+Abejorral;Antioquia
+Abriaquí;Antioquia
+Alejandría;Antioquia
+Amagá;Antioquia
+Amalfi;Antioquia
+Andes;Antioquia
+Angelópolis;Antioquia
+Angostura;Antioquia
+Anorí;Antioquia
+Anzá;Antioquia
+Apartadó;Antioquia
+Arboletes;Antioquia
+Argelia;Antioquia
+Armenia;Antioquia
+Barbosa;Antioquia
+Bello;Antioquia
+Belmira;Antioquia
+Betania;Antioquia
+Betulia;Antioquia
+Briceño;Antioquia
+Buriticá;Antioquia
+Cáceres;Antioquia
+Caicedo;Antioquia
+Caldas;Antioquia
+Campamento;Antioquia
+Cañasgordas;Antioquia
+Caracolí;Antioquia
+Caramanta;Antioquia
+Carepa;Antioquia
+Carmen De Viboral;Antioquia
+Carolina;Antioquia
+Caucasia;Antioquia
+Chigorodó;Antioquia
+Cisneros;Antioquia
+Ciudad Bolívar;Antioquia
+Cocorná;Antioquia
+Concepción;Antioquia
+Concordia;Antioquia
+Copacabana;Antioquia
+Dabeiba;Antioquia
+Don Matías;Antioquia
+Ebéjico;Antioquia
+El Bagre;Antioquia
+Entrerrios;Antioquia
+Envigado;Antioquia
+Fredonia;Antioquia
+Frontino;Antioquia
+Giraldo;Antioquia
+Girardota;Antioquia
+Gómez Plata;Antioquia
+Granada;Antioquia
+Guadalupe;Antioquia
+Guarne;Antioquia
+Guatapé;Antioquia
+Heliconia;Antioquia
+Hispania;Antioquia
+Itagüí;Antioquia
+Ituango;Antioquia
+Jardín;Antioquia
+Jericó;Antioquia
+La Ceja;Antioquia
+La Estrella;Antioquia
+La Pintada;Antioquia
+La Unión;Antioquia
+Liborina;Antioquia
+Maceo;Antioquia
+Marinilla;Antioquia
+Medellín;Antioquia
+Montebello;Antioquia
+Murindó;Antioquia
+Mutatá;Antioquia
+Nariño;Antioquia
+Nechí;Antioquia
+Necoclí;Antioquia
+Olaya;Antioquia
+Peñol;Antioquia
+Peque;Antioquia
+Pueblorrico;Antioquia
+Puerto Berrío;Antioquia
+Puerto Nare;Antioquia
+Puerto Triunfo;Antioquia
+Remedios;Antioquia
+Retiro;Antioquia
+Rionegro;Antioquia
+Sabanalarga;Antioquia
+Sabaneta;Antioquia
+Salgar;Antioquia
+San Andrés;Antioquia
+San Carlos;Antioquia
+San Francisco;Antioquia
+San Jerónimo;Antioquia
+San José De La Montaña;Antioquia
+San Juan De Urabá;Antioquia
+San Luis;Antioquia
+San Pedro;Antioquia
+San Pedro De Urabá;Antioquia
+San Rafael;Antioquia
+San Roque;Antioquia
+San Vicente;Antioquia
+Santa Bárbara;Antioquia
+Santa Fe De Antioquia;Antioquia
+Santa Rosa De Osos;Antioquia
+Santo Domingo;Antioquia
+Santuario;Antioquia
+Segovia;Antioquia
+Sonsón;Antioquia
+Sopetrán;Antioquia
+Támesis;Antioquia
+Tarazá;Antioquia
+Tarso;Antioquia
+Titiribí;Antioquia
+Toledo;Antioquia
+Turbo;Antioquia
+Uramita;Antioquia
+Urrao;Antioquia
+Valdivia;Antioquia
+Valparaiso;Antioquia
+Vegachí;Antioquia
+Venecia;Antioquia
+Vigia Del Fuerte;Antioquia
+Yalí;Antioquia
+Yarumal;Antioquia
+Yolombó;Antioquia
+Yondó (Casabe);Antioquia
+Zaragoza;Antioquia
+Arauca;Antioquia
+Arauquita;Arauca
+Cravo Norte;Arauca
+Fortul;Arauca
+Puerto Rondón;Arauca
+Saravena;Arauca
+Tame;Arauca
+Baranoa;Atlántico
+Barranquilla;Atlántico
+Campo De La Cruz;Atlántico
+Candelaria;Atlántico
+Galapa;Atlántico
+Juan De Acosta;Atlántico
+Luruaco;Atlántico
+Malambo;Atlántico
+Manatí;Atlántico
+Palmar De Varela;Atlántico
+Piojó;Atlántico
+Polonuevo;Atlántico
+Ponedera;Atlántico
+Puerto Colombia;Atlántico
+Repelón;Atlántico
+Sabanagrande;Atlántico
+Sabanalarga;Atlántico
+Santa Lucía;Atlántico
+Santo Tomás;Atlántico
+Soledad;Atlántico
+Suan;Atlántico
+Tubará;Atlántico
+Usiacurí;Atlántico
+Achí;Bolívar
+Altos Del Rosario;Bolívar
+Arenal;Bolívar
+Arjona;Bolívar
+Arroyohondo;Bolívar
+Barranco De Loba;Bolívar
+Calamar;Bolívar
+Cantagallo;Bolívar
+Cartagena De Indias;Bolívar
+Cicuco;Bolívar
+Clemencia;Bolívar
+Córdoba;Bolívar
+El Carmen De Bolívar;Bolívar
+El Guamo;Bolívar
+El Peñón;Bolívar
+Hatillo De Loba;Bolívar
+Magangué;Bolívar
+Mahates;Bolívar
+Margarita;Bolívar
+María La Baja;Bolívar
+Mompós;Bolívar
+Montecristo;Bolívar
+Morales;Bolívar
+Norosi;Bolívar
+Pinillos;Bolívar
+Regidor;Bolívar
+Rioviejo;Bolívar
+San Cristobal;Bolívar
+San Estanislao;Bolívar
+San Fernando;Bolívar
+San Jacinto;Bolívar
+San Jacinto Del Cauca;Bolívar
+San Juan Nepomuceno;Bolívar
+San Martin De Loba;Bolívar
+San Pablo;Bolívar
+Santa Catalina;Bolívar
+Santa Rosa;Bolívar
+Santa Rosa Del Sur;Bolívar
+Simití;Bolívar
+Soplaviento;Bolívar
+Talaigua Nuevo;Bolívar
+Tiquisio (Puerto Rico);Bolívar
+Turbaco;Bolívar
+Turbana;Bolívar
+Villanueva;Bolívar
+Zambrano;Bolívar
+Almeida;Boyacá
+Aquitania;Boyacá
+Arcabuco;Boyacá
+Belén;Boyacá
+Berbeo;Boyacá
+Betéitiva;Boyacá
+Boavita;Boyacá
+Boyacá;Boyacá
+Briceño;Boyacá
+Buenavista;Boyacá
+Busbanzá;Boyacá
+Caldas;Boyacá
+Campohermoso;Boyacá
+Cerinza;Boyacá
+Chinavita;Boyacá
+Chiquinquirá;Boyacá
+Chíquiza;Boyacá
+Chiscas;Boyacá
+Chita;Boyacá
+Chitaraque;Boyacá
+Chivatá;Boyacá
+Chivor;Boyacá
+Ciénega;Boyacá
+Cómbita;Boyacá
+Coper;Boyacá
+Corrales;Boyacá
+Covarachía;Boyacá
+Cubará;Boyacá
+Cucaita;Boyacá
+Cuítiva;Boyacá
+Duitama;Boyacá
+El Cocuy;Boyacá
+El Espino;Boyacá
+Firavitoba;Boyacá
+Floresta;Boyacá
+Gachantivá;Boyacá
+Gámeza;Boyacá
+Garagoa;Boyacá
+Guacamayas;Boyacá
+Guateque;Boyacá
+Guayatá;Boyacá
+Guicán;Boyacá
+Iza;Boyacá
+Jenesano;Boyacá
+Jericó;Boyacá
+La Capilla;Boyacá
+La Uvita;Boyacá
+La Victoria;Boyacá
+Labranzagrande;Boyacá
+Macanal;Boyacá
+Maripí;Boyacá
+Miraflores;Boyacá
+Mongua;Boyacá
+Monguí;Boyacá
+Moniquirá;Boyacá
+Motavita;Boyacá
+Muzo;Boyacá
+Nobsa;Boyacá
+Nuevo Colón;Boyacá
+Oicatá;Boyacá
+Otanche;Boyacá
+Pachavita;Boyacá
+Páez;Boyacá
+Paipa;Boyacá
+Pajarito;Boyacá
+Panqueba;Boyacá
+Pauna;Boyacá
+Paya;Boyacá
+Paz De Rio;Boyacá
+Pesca;Boyacá
+Pisva;Boyacá
+Puerto Boyacá;Boyacá
+Quípama;Boyacá
+Ramiriquí;Boyacá
+Ráquira;Boyacá
+Rondón;Boyacá
+Saboyá;Boyacá
+Sáchica;Boyacá
+Samacá;Boyacá
+San Eduardo;Boyacá
+San José De Pare;Boyacá
+San Luis De Gaceno;Boyacá
+San Mateo;Boyacá
+San Miguel De Sema;Boyacá
+San Pablo De Borbur;Boyacá
+Santa María;Boyacá
+Santa Rosa De Viterbo;Boyacá
+Santa Sofía;Boyacá
+Santana;Boyacá
+Sativanorte;Boyacá
+Sativasur;Boyacá
+Siachoque;Boyacá
+Soatá;Boyacá
+Socha;Boyacá
+Socotá;Boyacá
+Sogamoso;Boyacá
+Somondoco;Boyacá
+Sora;Boyacá
+Soracá;Boyacá
+Sotaquirá;Boyacá
+Susacón;Boyacá
+Sutamarchán;Boyacá
+Sutatenza;Boyacá
+Tasco;Boyacá
+Tenza;Boyacá
+Tibaná;Boyacá
+Tibasosa;Boyacá
+Tinjacá;Boyacá
+Tipacoque;Boyacá
+Toca;Boyacá
+Togüí;Boyacá
+Tópaga;Boyacá
+Tota;Boyacá
+Tunja;Boyacá
+Tununguá;Boyacá
+Turmequé;Boyacá
+Tuta;Boyacá
+Tutazá;Boyacá
+Úmbita;Boyacá
+Ventaquemada;Boyacá
+Villa De Leiva;Boyacá
+Viracachá;Boyacá
+Zetaquirá;Boyacá
+Aguadas;Caldas
+Anserma;Caldas
+Aranzazu;Caldas
+Belalcazar;Caldas
+Chinchiná;Caldas
+Filadelfia;Caldas
+La Dorada;Caldas
+La Merced;Caldas
+Manizales;Caldas
+Manzanares;Caldas
+Marmato;Caldas
+Marquetalia;Caldas
+Marulanda;Caldas
+Neira;Caldas
+Norcasia;Caldas
+Pácora;Caldas
+Palestina;Caldas
+Pensilvania;Caldas
+Riosucio;Caldas
+Risaralda;Caldas
+Salamina;Caldas
+Samaná;Caldas
+San José;Caldas
+Supia;Caldas
+Victoria;Caldas
+Villamaria;Caldas
+Viterbo;Caldas
+Albania;Caquetá
+Belén De Los Andaquíes;Caquetá
+Cartagena Del Chairá;Caquetá
+Curillo;Caquetá
+El Doncello;Caquetá
+El Paujil;Caquetá
+Florencia;Caquetá
+Milán;Caquetá
+Montañita;Caquetá
+Morelia;Caquetá
+Puerto Rico;Caquetá
+San José Del Fragua;Caquetá
+San Vicente Del Caguán;Caquetá
+Solano;Caquetá
+Solita;Caquetá
+Valparaíso;Caquetá
+Aguazul;Casanare
+Chámeza;Casanare
+Hato Corozal;Casanare
+La Salina;Casanare
+Maní;Casanare
+Monterrey;Casanare
+Nunchía;Casanare
+Orocué;Casanare
+Paz de Ariporo;Casanare
+Pore;Casanare
+Recetor;Casanare
+Sabanalarga;Casanare
+Sácama;Casanare
+San Luis De Palenque;Casanare
+Támara;Casanare
+Tauramena;Casanare
+Trinidad;Casanare
+Villanueva;Casanare
+Yopal;Casanare
+Almaguer;Cauca
+Argelia;Cauca
+Balboa;Cauca
+Bolívar;Cauca
+Buenos Aires;Cauca
+Cajibío;Cauca
+Caldono;Cauca
+Caloto;Cauca
+Corinto;Cauca
+El Tambo;Cauca
+Florencia;Cauca
+Guachene;Cauca
+Guapi;Cauca
+Inzá;Cauca
+Jambaló;Cauca
+La Sierra;Cauca
+La Vega;Cauca
+López;Cauca
+Mercaderes;Cauca
+Miranda;Cauca
+Morales;Cauca
+Padilla;Cauca
+Páez (Belalcázar);Cauca
+Patía (El Bordo);Cauca
+Piamonte;Cauca
+Piendamó;Cauca
+Popayán;Cauca
+Puerto Tejada;Cauca
+Puracé (Coconuco);Cauca
+Rosas;Cauca
+San Sebastián;Cauca
+Santa Rosa;Cauca
+Santander De Quilichao;Cauca
+Silvia;Cauca
+Sotará (Paispamba);Cauca
+Suárez;Cauca
+Sucre;Cauca
+Timbío;Cauca
+Timbiquí;Cauca
+Toribío;Cauca
+Totoró;Cauca
+Villa Rica;Cauca
+Aguachica;Cesar
+Agustín Codazzi;Cesar
+Astrea;Cesar
+Becerrill;Cesar
+Bosconia;Cesar
+Chimichagua;Cesar
+Chiriguaná;Cesar
+Curumaní;Cesar
+El Copey;Cesar
+El Paso;Cesar
+Gamarra;Cesar
+González;Cesar
+La Gloria;Cesar
+La Jagua De Ibirico;Cesar
+La Paz;Cesar
+Manaure Balcón Del Cesar;Cesar
+Pailitas;Cesar
+Pelaya;Cesar
+Pueblo Bello;Cesar
+Rio De Oro;Cesar
+San Alberto;Cesar
+San Diego;Cesar
+San Martín;Cesar
+Tamalameque;Cesar
+Valledupar;Cesar
+Acandí;Chocó
+Alto Baudó (Pie De Pato);Chocó
+Atrato (Yuto);Chocó
+Bagadó;Chocó
+Bahía Solano (Mutis);Chocó
+Bajo Baudó (Pizarro);Chocó
+Bojayá (Bellavista);Chocó
+Carmen Del Darién (Curbaradó);Chocó
+Cértegui;Chocó
+Condoto;Chocó
+El Cantón Del San Pablo (Managrú);Chocó
+El Carmen;Chocó
+El Litoral Del San Juán (Docordó);Chocó
+Istmina;Chocó
+Juradó;Chocó
+Lloró;Chocó
+Medio Atrato (Beté);Chocó
+Medio Baudó(boca De Pepé);Chocó
+Medio San Juan (Andagoya);Chocó
+Nóvita;Chocó
+Nuquí;Chocó
+Quibdó;Chocó
+Rio Iró (Santa Rita);Chocó
+Rio Quito (Paimadó);Chocó
+Riosucio;Chocó
+San José Del Palmar;Chocó
+Sipí;Chocó
+Tadó;Chocó
+Unguía;Chocó
+Unión Panamericana ( Animas);Chocó
+Ayapel;Córdoba
+Buenavista;Córdoba
+Canalete;Córdoba
+Cereté;Córdoba
+Chima;Córdoba
+Chinú;Córdoba
+Ciénaga De Oro;Córdoba
+Cotorra;Córdoba
+La Apartada;Córdoba
+Lorica;Córdoba
+Los Córdobas;Córdoba
+Momil;Córdoba
+Moñitos;Córdoba
+Montelíbano;Córdoba
+Montería;Córdoba
+Planeta Rica;Córdoba
+Pueblo Nuevo;Córdoba
+Puerto Escondido;Córdoba
+Puerto Libertador;Córdoba
+Purísima;Córdoba
+Sahagún;Córdoba
+San Andrés De Sotavento;Córdoba
+San Antero;Córdoba
+San Bernardo Del Viento;Córdoba
+San Carlos;Córdoba
+San Jose De Ure;Córdoba
+San Pelayo;Córdoba
+Tierralta;Córdoba
+Tuchín;Córdoba
+Valencia;Córdoba
+Agua De Dios;Cundinamarca
+Albán;Cundinamarca
+Anapoima;Cundinamarca
+Anolaima;Cundinamarca
+Apulo;Cundinamarca
+Arbeláez;Cundinamarca
+Beltrán;Cundinamarca
+Bituima;Cundinamarca
+Bogotá, D.c.;Cundinamarca
+Bojacá;Cundinamarca
+Cabrera;Cundinamarca
+Cachipay;Cundinamarca
+Cajicá;Cundinamarca
+Caparrapí;Cundinamarca
+Cáqueza;Cundinamarca
+Carmen De Carupa;Cundinamarca
+Chaguaní;Cundinamarca
+Chía;Cundinamarca
+Chipaque;Cundinamarca
+Choachí;Cundinamarca
+Chocontá;Cundinamarca
+Cogua;Cundinamarca
+Cota;Cundinamarca
+Cucunubá;Cundinamarca
+El Colegio;Cundinamarca
+El Peñón;Cundinamarca
+El Rosal;Cundinamarca
+Facatativá;Cundinamarca
+Fómeque;Cundinamarca
+Fosca;Cundinamarca
+Funza;Cundinamarca
+Fúquene;Cundinamarca
+Fusagasugá;Cundinamarca
+Gachalá;Cundinamarca
+Gachancipá;Cundinamarca
+Gachetá;Cundinamarca
+Gama;Cundinamarca
+Girardot;Cundinamarca
+Granada;Cundinamarca
+Guachetá;Cundinamarca
+Guaduas;Cundinamarca
+Guasca;Cundinamarca
+Guataquí;Cundinamarca
+Guatavita;Cundinamarca
+Guayabal De Síquima;Cundinamarca
+Guayabetal;Cundinamarca
+Gutiérrez;Cundinamarca
+Jerusalén;Cundinamarca
+Junín;Cundinamarca
+La Calera;Cundinamarca
+La Mesa;Cundinamarca
+La Palma;Cundinamarca
+La Peña;Cundinamarca
+La Vega;Cundinamarca
+Lenguazaque;Cundinamarca
+Machetá;Cundinamarca
+Madrid;Cundinamarca
+Manta;Cundinamarca
+Medina;Cundinamarca
+Mosquera;Cundinamarca
+Nariño;Cundinamarca
+Nemocón;Cundinamarca
+Nilo;Cundinamarca
+Nimaima;Cundinamarca
+Nocaima;Cundinamarca
+Pacho;Cundinamarca
+Paime;Cundinamarca
+Pandi;Cundinamarca
+Paratebueno;Cundinamarca
+Pasca;Cundinamarca
+Puerto Salgar;Cundinamarca
+Pulí;Cundinamarca
+Quebradanegra;Cundinamarca
+Quetame;Cundinamarca
+Quipile;Cundinamarca
+Ricaurte;Cundinamarca
+San Antonio De Tequendama;Cundinamarca
+San Bernardo;Cundinamarca
+San Cayetano;Cundinamarca
+San Francisco;Cundinamarca
+San Juan De Rioseco;Cundinamarca
+Sasaima;Cundinamarca
+Sesquilé;Cundinamarca
+Sibaté;Cundinamarca
+Silvania;Cundinamarca
+Simijaca;Cundinamarca
+Soacha;Cundinamarca
+Sopó;Cundinamarca
+Subachoque;Cundinamarca
+Suesca;Cundinamarca
+Supatá;Cundinamarca
+Susa;Cundinamarca
+Sutatausa;Cundinamarca
+Tabio;Cundinamarca
+Tausa;Cundinamarca
+Tena;Cundinamarca
+Tenjo;Cundinamarca
+Tibacuy;Cundinamarca
+Tibirita;Cundinamarca
+Tocaima;Cundinamarca
+Tocancipá;Cundinamarca
+Topaipí;Cundinamarca
+Ubalá;Cundinamarca
+Ubaque;Cundinamarca
+Ubaté;Cundinamarca
+Une;Cundinamarca
+Útica;Cundinamarca
+Venecia;Cundinamarca
+Vergara;Cundinamarca
+Vianí;Cundinamarca
+Villagómez;Cundinamarca
+Villapinzón;Cundinamarca
+Villeta;Cundinamarca
+Viotá;Cundinamarca
+Yacopí;Cundinamarca
+Zipacón;Cundinamarca
+Zipaquirá;Cundinamarca
+Barranco Mina;Guainía
+Cacahual;Guainía
+Inírida;Guainía
+La Guadalupe;Guainía
+Mapiripana;Guainía
+Morichal (Morichal Nuevo);Guainía
+Paná-paná (Campo Alegre);Guainía
+Puerto Colombia;Guainía
+San Felipe;Guainía
+Calamar;Guaviare
+El Retorno;Guaviare
+Miraflores;Guaviare
+San José Del Guaviare;Guaviare
+Acevedo;Huila
+Agrado;Huila
+Aipe;Huila
+Algeciras;Huila
+Altamira;Huila
+Baraya;Huila
+Campoalegre;Huila
+Colombia;Huila
+Elías;Huila
+Garzón;Huila
+Gigante;Huila
+Guadalupe;Huila
+Hobo;Huila
+Íquira;Huila
+Isnos;Huila
+La Argentina;Huila
+La Plata;Huila
+Nátaga;Huila
+Neiva;Huila
+Oporapa;Huila
+Paicol;Huila
+Palermo;Huila
+Palestina;Huila
+Pital;Huila
+Pitalito;Huila
+Rivera;Huila
+Saladoblanco;Huila
+San Agustín;Huila
+Santa María;Huila
+Suaza;Huila
+Tarqui;Huila
+Tello;Huila
+Teruel;Huila
+Tesalia;Huila
+Timaná;Huila
+Villavieja;Huila
+Yaguará;Huila
+Albania;La Guajira
+Barrancas;La Guajira
+Dibulla;La Guajira
+Distracción;La Guajira
+El Molino;La Guajira
+Fonseca;La Guajira
+Hato Nuevo;La Guajira
+La Jagua Del Pilar;La Guajira
+Maicao;La Guajira
+Manaure;La Guajira
+Riohacha;La Guajira
+San Juan Del Cesar;La Guajira
+Uribia;La Guajira
+Urumita;La Guajira
+Villanueva;La Guajira
+Algarrobo;Magdalena
+Aracataca;Magdalena
+Ariguaní (El Dificil);Magdalena
+Cerro De San Antonio;Magdalena
+Chivolo;Magdalena
+Ciénaga;Magdalena
+Concordia;Magdalena
+El Banco;Magdalena
+El Piñón;Magdalena
+El Retén;Magdalena
+Fundación;Magdalena
+Guamal;Magdalena
+Nueva Granada;Magdalena
+Pedraza;Magdalena
+Pijiño Del Carmen;Magdalena
+Pivijay;Magdalena
+Plato;Magdalena
+Puebloviejo;Magdalena
+Remolino;Magdalena
+Sabanas De San Angel;Magdalena
+Salamina;Magdalena
+San Sebastián De Buenavista;Magdalena
+San Zenón;Magdalena
+Santa Ana;Magdalena
+Santa Bárbara De Pinto;Magdalena
+Santa Marta;Magdalena
+Sitionuevo;Magdalena
+Tenerife;Magdalena
+Zapayán;Magdalena
+Zona Bananera;Magdalena
+Acacías;Meta
+Barranca De Upía;Meta
+Cabuyaro;Meta
+Castilla La Nueva;Meta
+Cubarral;Meta
+Cumaral;Meta
+El Calvario;Meta
+El Castillo;Meta
+El Dorado;Meta
+Fuente De Oro;Meta
+Granada;Meta
+Guamal;Meta
+La Macarena;Meta
+Lejanías;Meta
+Mapiripán;Meta
+Mesetas;Meta
+Puerto Concordia;Meta
+Puerto Gaitán;Meta
+Puerto Lleras;Meta
+Puerto López;Meta
+Puerto Rico;Meta
+Restrepo;Meta
+San Carlos De Guaroa;Meta
+San Juan De Arama;Meta
+San Juanito;Meta
+San Martín;Meta
+Uribe;Meta
+Villavicencio;Meta
+Vistahermosa;Meta
+Albán (San José);Nariño
+Aldana;Nariño
+Ancuya;Nariño
+Arboleda (Berruecos);Nariño
+Barbacoas;Nariño
+Belén;Nariño
+Buesaco;Nariño
+Chachaguí;Nariño
+Colón (Génova);Nariño
+Consacá;Nariño
+Contadero;Nariño
+Córdoba;Nariño
+Cuaspud (Carlosama);Nariño
+Cumbal;Nariño
+Cumbitara;Nariño
+El Charco;Nariño
+El Peñol;Nariño
+El Rosario;Nariño
+El Tablón;Nariño
+El Tambo;Nariño
+Francisco Pizarro (Salahonda);Nariño
+Funes;Nariño
+Guachucal;Nariño
+Guaitarilla;Nariño
+Gualmatán;Nariño
+Iles;Nariño
+Imués;Nariño
+Ipiales;Nariño
+La Cruz;Nariño
+La Florida;Nariño
+La Llanada;Nariño
+La Tola;Nariño
+La Unión;Nariño
+Leiva;Nariño
+Linares;Nariño
+Los Andes (Sotomayor);Nariño
+Magüí (Payán);Nariño
+Mallama (Piedrancha);Nariño
+Mosquera;Nariño
+Nariño;Nariño
+Olaya Herrera (Bocas De Satinga);Nariño
+Ospina;Nariño
+Pasto;Nariño
+Policarpa;Nariño
+Potosí;Nariño
+Providencia;Nariño
+Puerres;Nariño
+Pupiales;Nariño
+Ricaurte;Nariño
+Roberto Payán (San José);Nariño
+Samaniego;Nariño
+San Bernardo;Nariño
+San Lorenzo;Nariño
+San Pablo;Nariño
+San Pedro De Cartago (Cartago);Nariño
+Sandoná;Nariño
+Santa Bárbara (Iscuandé);Nariño
+Santa Cruz (Guachavés);Nariño
+Sapuyes;Nariño
+Taminango;Nariño
+Tangua;Nariño
+Tumaco;Nariño
+Tumaco;Nariño
+Túquerres;Nariño
+Yacuanquer;Nariño
+Ábrego;Norte De Santander
+Arboledas;Norte De Santander
+Bochalema;Norte De Santander
+Bucarasica;Norte De Santander
+Cáchira;Norte De Santander
+Cácota;Norte De Santander
+Chinácota;Norte De Santander
+Chitagá;Norte De Santander
+Convención;Norte De Santander
+Cúcuta;Norte De Santander
+Cucutilla;Norte De Santander
+Durania;Norte De Santander
+El Carmen;Norte De Santander
+El Tarra;Norte De Santander
+El Zulia;Norte De Santander
+Gramalote;Norte De Santander
+Hacarí;Norte De Santander
+Herrán;Norte De Santander
+La Esperanza;Norte De Santander
+La Playa;Norte De Santander
+Labateca;Norte De Santander
+Los Patios;Norte De Santander
+Lourdes;Norte De Santander
+Mutiscua;Norte De Santander
+Ocaña;Norte De Santander
+Pamplona;Norte De Santander
+Pamplonita;Norte De Santander
+Puerto Santander;Norte De Santander
+Ragonvalia;Norte De Santander
+Salazar;Norte De Santander
+San Calixto;Norte De Santander
+San Cayetano;Norte De Santander
+Santiago;Norte De Santander
+Sardinata;Norte De Santander
+Silos;Norte De Santander
+Teorama;Norte De Santander
+Tibú;Norte De Santander
+Toledo;Norte De Santander
+Villa Caro;Norte De Santander
+Villa Del Rosario;Norte De Santander
+Colón;Putumayo
+Mocoa;Putumayo
+Orito;Putumayo
+Puerto Asís;Putumayo
+Puerto Caicedo;Putumayo
+Puerto Guzmán;Putumayo
+Puerto Leguízamo;Putumayo
+San Francisco;Putumayo
+San Miguel (La Dorada);Putumayo
+Santiago;Putumayo
+Sibundoy;Putumayo
+Valle Del Guamuez (La Hormiga);Putumayo
+Villagarzón;Putumayo
+Armenia;Quindío
+Buenavista;Quindío
+Calarcá;Quindío
+Circasia;Quindío
+Córdoba;Quindío
+Filandia;Quindío
+Génova;Quindío
+La Tebaida;Quindío
+Montenegro;Quindío
+Pijao;Quindío
+Quimbaya;Quindío
+Salento;Quindío
+Apía;Risaralda
+Balboa;Risaralda
+Belén De Umbría;Risaralda
+Dosquebradas;Risaralda
+Guática;Risaralda
+La Celia;Risaralda
+La Virginia;Risaralda
+Marsella;Risaralda
+Mistrató;Risaralda
+Pereira;Risaralda
+Pueblo Rico;Risaralda
+Quinchía;Risaralda
+Santa Rosa De Cabal;Risaralda
+Santuario;Risaralda
+San Andrés;San Andrés Providencia Y Santa Catalina
+Providencia y Santa Isabel;San Andrés Providencia Y Santa Catalina
+Aguada;Santander
+Albania;Santander
+Aratoca;Santander
+Barbosa;Santander
+Barichara;Santander
+Barrancabermeja;Santander
+Betulia;Santander
+Bolivar;Santander
+Bucaramanga;Santander
+Cabrera;Santander
+California;Santander
+Capitanejo;Santander
+Carcasí;Santander
+Cepitá;Santander
+Cerrito;Santander
+Charalá;Santander
+Charta;Santander
+Chima;Santander
+Chipatá;Santander
+Cimitarra;Santander
+Concepción;Santander
+Confines;Santander
+Contratación;Santander
+Coromoro;Santander
+Curití;Santander
+El Carmen;Santander
+El Guacamayo;Santander
+El Peñón;Santander
+El Playón;Santander
+Encino;Santander
+Enciso;Santander
+Florián;Santander
+Floridablanca;Santander
+Galán;Santander
+Gámbita;Santander
+Girón;Santander
+Guaca;Santander
+Guadalupe;Santander
+Guapotá;Santander
+Guavatá;Santander
+Güepsa;Santander
+Hato;Santander
+Jesús María;Santander
+Jordán;Santander
+La Belleza;Santander
+La Paz;Santander
+Landázuri;Santander
+Lebrija;Santander
+Los Santos;Santander
+Macaravita;Santander
+Málaga;Santander
+Matanza;Santander
+Mogotes;Santander
+Molagavita;Santander
+Ocamonte;Santander
+Oiba;Santander
+Onzaga;Santander
+Palmar;Santander
+Palmas Del Socorro;Santander
+Páramo;Santander
+Piedecuesta;Santander
+Pinchote;Santander
+Puente Nacional;Santander
+Puerto Parra;Santander
+Puerto Wilches;Santander
+Rionegro;Santander
+Sabana De Torres;Santander
+San Andrés;Santander
+San Benito;Santander
+San Gil;Santander
+San Joaquín;Santander
+San José De Miranda;Santander
+San Miguel;Santander
+San Vicente De Chucurí;Santander
+Santa Bárbara;Santander
+Santa Helena Del Opón;Santander
+Simacota;Santander
+Socorro;Santander
+Suaita;Santander
+Sucre;Santander
+Suratá;Santander
+Tona;Santander
+Valle De San José;Santander
+Vélez;Santander
+Vetas;Santander
+Villanueva;Santander
+Zapatoca;Santander
+Buenavista;Sucre
+Caimito;Sucre
+Chalán;Sucre
+Colosó;Sucre
+Corozal;Sucre
+Coveñas;Sucre
+El Roble;Sucre
+Galeras;Sucre
+Guaranda;Sucre
+La Unión;Sucre
+Los Palmitos;Sucre
+Majagual;Sucre
+Morroa;Sucre
+Ovejas;Sucre
+Palmito;Sucre
+Sampués;Sucre
+San Benito Abad;Sucre
+San Juan De Betulia (Betulia);Sucre
+San Marcos;Sucre
+San Onofre;Sucre
+San Pedro;Sucre
+Sincé;Sucre
+Sincelejo;Sucre
+Sucre;Sucre
+Tolú;Sucre
+Toluviejo;Sucre
+Alpujarra;Tolima
+Alvarado;Tolima
+Ambalema;Tolima
+Anzoátegui;Tolima
+Armero (Guayabal);Tolima
+Ataco;Tolima
+Cajamarca;Tolima
+Carmen De Apicalá;Tolima
+Casabianca;Tolima
+Chaparral;Tolima
+Coello;Tolima
+Coyaima;Tolima
+Cunday;Tolima
+Dolores;Tolima
+Espinal;Tolima
+Falan;Tolima
+Flandes;Tolima
+Fresno;Tolima
+Guamo;Tolima
+Herveo;Tolima
+Honda;Tolima
+Ibagué;Tolima
+Icononzo;Tolima
+Lérida;Tolima
+Líbano;Tolima
+Mariquita;Tolima
+Melgar;Tolima
+Murillo;Tolima
+Natagaima;Tolima
+Ortega;Tolima
+Palocabildo;Tolima
+Piedras;Tolima
+Planadas;Tolima
+Prado;Tolima
+Purificación;Tolima
+Rioblanco;Tolima
+Roncesvalles;Tolima
+Rovira;Tolima
+Saldaña;Tolima
+San Antonio;Tolima
+San Luis;Tolima
+Santa Isabel;Tolima
+Suárez;Tolima
+Valle De San Juan;Tolima
+Venadillo;Tolima
+Villahermosa;Tolima
+Villarrica;Tolima
+Alcalá;Valle Del Cauca
+Andalucía;Valle Del Cauca
+Ansermanuevo;Valle Del Cauca
+Argelia;Valle Del Cauca
+Bolívar;Valle Del Cauca
+Buenaventura;Valle Del Cauca
+Buga;Valle Del Cauca
+Bugalagrande;Valle Del Cauca
+Caicedonia;Valle Del Cauca
+Cali;Valle Del Cauca
+Calima (El Darién);Valle Del Cauca
+Candelaria;Valle Del Cauca
+Cartago;Valle Del Cauca
+Dagua;Valle Del Cauca
+El Águila;Valle Del Cauca
+El Cairo;Valle Del Cauca
+El Cerrito;Valle Del Cauca
+El Dovio;Valle Del Cauca
+Florida;Valle Del Cauca
+Ginebra;Valle Del Cauca
+Guacarí;Valle Del Cauca
+Jamundí;Valle Del Cauca
+La Cumbre;Valle Del Cauca
+La Unión;Valle Del Cauca
+La Victoria;Valle Del Cauca
+Obando;Valle Del Cauca
+Palmira;Valle Del Cauca
+Pradera;Valle Del Cauca
+Restrepo;Valle Del Cauca
+Riofrío;Valle Del Cauca
+Roldanillo;Valle Del Cauca
+San Pedro;Valle Del Cauca
+Sevilla;Valle Del Cauca
+Toro;Valle Del Cauca
+Trujillo;Valle Del Cauca
+Tuluá;Valle Del Cauca
+Ulloa;Valle Del Cauca
+Versalles;Valle Del Cauca
+Vijes;Valle Del Cauca
+Yotoco;Valle Del Cauca
+Yumbo;Valle Del Cauca
+Zarzal;Valle Del Cauca
+Carurú;Vaupés
+Mitú;Vaupés
+Pacoa (Cor. Departamental);Vaupés
+Papunaua(cor. Departamental);Vaupés
+Taraira;Vaupés
+Yavaraté (Cor. Departamental);Vaupés
+Cumaribo;Vichada
+La Primavera;Vichada
+Puerto Carreño;Vichada
+Santa Rosalía;Vichada

--- a/backend/db/seeds/files/colombia_regions.csv
+++ b/backend/db/seeds/files/colombia_regions.csv
@@ -1,0 +1,1142 @@
+municipality;Cordillera Oriental;Piedemonte Amazónico - Macizo;Transición Pacífico - Caribe;Transición Orinoquía;Cordillera Central;Pacífico - Marino Costero;Caribe;Orinoquía;Corazón Amazonía
+Leticia;False;False;False;False;False;False;False;False;False
+Puerto Nariño;False;False;False;False;False;False;False;False;True
+El Encanto;False;False;False;False;False;False;False;False;False
+La Chorrera;False;False;False;False;False;False;False;False;False
+La Pedrera;False;False;False;False;False;False;False;False;True
+La Victoria;False;False;False;False;False;False;False;False;True
+Mirití-Paraná;False;False;False;False;False;False;False;False;True
+Puerto Alegría;False;False;False;False;False;False;False;False;False
+Puerto Arica;False;False;False;False;False;False;False;False;False
+Puerto Santander;False;False;False;False;False;False;False;False;True
+Tarapacá;False;False;False;False;False;False;False;False;True
+Abejorral;False;False;False;False;False;False;False;False;False
+Abriaquí;False;False;False;False;False;False;False;False;False
+Alejandría;False;False;False;False;False;False;False;False;False
+Amagá;False;False;False;False;False;False;False;False;False
+Amalfi;False;False;False;False;False;False;False;False;False
+Andes;False;False;False;False;False;False;False;False;False
+Angelópolis;False;False;False;False;False;False;False;False;False
+Angostura;False;False;False;False;False;False;False;False;False
+Anorí;False;False;False;False;False;False;False;False;False
+Anzá;False;False;False;False;False;False;False;False;False
+Apartadó;False;False;True;False;False;False;False;False;False
+Arboletes;False;False;True;False;False;False;False;False;False
+Argelia;False;False;False;False;False;False;False;False;False
+Armenia;False;False;False;False;False;False;False;False;False
+Barbosa;False;False;False;False;False;False;False;False;False
+Bello;False;False;False;False;False;False;False;False;False
+Belmira;False;False;False;False;False;False;False;False;False
+Betania;False;False;False;False;False;False;False;False;False
+Betulia;False;False;False;False;False;False;False;False;False
+Bolívar;False;False;False;False;False;False;False;False;False
+Briceño;False;False;False;False;False;False;False;False;False
+Buriticá;False;False;False;False;False;False;False;False;False
+Cáceres;False;False;False;False;False;False;False;False;False
+Caicedo;False;False;False;False;False;False;False;False;False
+Caldas;False;False;False;False;False;False;False;False;False
+Campamento;False;False;False;False;False;False;False;False;False
+Cañasgordas;False;False;False;False;False;False;False;False;False
+Caracolí;False;False;False;False;False;False;False;False;False
+Caramanta;False;False;False;False;False;False;False;False;False
+Carepa;False;False;True;False;False;False;False;False;False
+El Carmen de Viboral;False;False;False;False;False;False;False;False;False
+Carolina del Príncipe;False;False;False;False;False;False;False;False;False
+Caucasia;False;False;False;False;False;False;False;False;False
+Chigorodó;False;False;True;False;False;False;False;False;False
+Cisneros;False;False;False;False;False;False;False;False;False
+Cocorná;False;False;False;False;False;False;False;False;False
+Concepción;False;False;False;False;False;False;False;False;False
+Concordia;False;False;False;False;False;False;False;False;False
+Copacabana;False;False;False;False;False;False;False;False;False
+Dabeiba;False;False;False;False;False;False;False;False;False
+Don Matías;False;False;False;False;False;False;False;False;False
+Ebéjico;False;False;False;False;False;False;False;False;False
+El Bagre;False;False;False;False;False;False;False;False;False
+Entrerríos;False;False;False;False;False;False;False;False;False
+Envigado;False;False;False;False;False;False;False;False;False
+Fredonia;False;False;False;False;False;False;False;False;False
+Frontino;False;False;False;False;False;False;False;False;False
+Giraldo;False;False;False;False;False;False;False;False;False
+Girardota;False;False;False;False;False;False;False;False;False
+Gómez Plata;False;False;False;False;False;False;False;False;False
+Granada;False;False;False;False;False;False;False;False;False
+Guadalupe;False;False;False;False;False;False;False;False;False
+Guarne;False;False;False;False;False;False;False;False;False
+Guatapé;False;False;False;False;False;False;False;False;False
+Heliconia;False;False;False;False;False;False;False;False;False
+Hispania;False;False;False;False;False;False;False;False;False
+Itagüí;False;False;False;False;False;False;False;False;False
+Ituango;False;False;False;False;False;False;False;False;False
+Jardín;False;False;False;False;False;False;False;False;False
+Jericó;False;False;False;False;False;False;False;False;False
+La Ceja;False;False;False;False;False;False;False;False;False
+La Estrella;False;False;False;False;False;False;False;False;False
+La Pintada;False;False;False;False;False;False;False;False;False
+La Unión;False;False;False;False;False;False;False;False;False
+Liborina;False;False;False;False;False;False;False;False;False
+Maceo;False;False;False;False;False;False;False;False;False
+Marinilla;False;False;False;False;False;False;False;False;False
+Medellín;False;False;False;False;False;False;False;False;False
+Montebello;False;False;False;False;False;False;False;False;False
+Murindó;False;False;False;False;False;False;False;False;False
+Mutatá;False;False;False;False;False;False;False;False;False
+Nariño;False;False;False;False;False;False;False;False;False
+Nechí;False;False;False;False;False;False;False;False;False
+Necoclí;False;False;True;False;False;False;False;False;False
+Olaya;False;False;False;False;False;False;False;False;False
+Peñol;False;False;False;False;False;False;False;False;False
+Peque;False;False;False;False;False;False;False;False;False
+Pueblorrico;False;False;False;False;False;False;False;False;False
+Puerto Berrío;False;False;False;False;False;False;False;False;False
+Puerto Nare;False;False;False;False;False;False;False;False;False
+Puerto Triunfo;False;False;False;False;False;False;False;False;False
+Remedios;False;False;False;False;False;False;False;False;False
+Retiro;False;False;False;False;False;False;False;False;False
+Rionegro;False;False;False;False;False;False;False;False;False
+Sabanalarga;False;False;False;False;False;False;False;False;False
+Sabaneta;False;False;False;False;False;False;False;False;False
+Salgar;False;False;False;False;False;False;False;False;False
+San Andrés;False;False;False;False;False;False;False;False;False
+San Carlos;False;False;False;False;False;False;False;False;False
+San Francisco;False;False;False;False;False;False;False;False;False
+San Jerónimo;False;False;False;False;False;False;False;False;False
+San José de la Montaña;False;False;False;False;False;False;False;False;False
+San Juan de Urabá;False;False;True;False;False;False;False;False;False
+San Luis;False;False;False;False;False;False;False;False;False
+San Pedro;False;False;False;False;False;False;False;False;False
+San Pedro de Urabá;False;False;False;False;False;False;False;False;False
+San Rafael;False;False;False;False;False;False;False;False;False
+San Roque;False;False;False;False;False;False;False;False;False
+Santa Bárbara;False;False;False;False;False;False;False;False;False
+Santa Fe de Antioquia;False;False;False;False;False;False;False;False;False
+Santa Rosa de Osos;False;False;False;False;False;False;False;False;False
+Santo Domingo;False;False;False;False;False;False;False;False;False
+El Santuario;False;False;False;False;False;False;False;False;False
+San Vicente;False;False;False;False;False;False;False;False;False
+Segovia;False;False;False;False;False;False;False;False;False
+Sonsón;False;False;False;False;False;False;False;False;False
+Sopetrán;False;False;False;False;False;False;False;False;False
+Támesis;False;False;False;False;False;False;False;False;False
+Tarazá;False;False;False;False;False;False;False;False;False
+Tarso;False;False;False;False;False;False;False;False;False
+Titiribí;False;False;False;False;False;False;False;False;False
+Toledo;False;False;False;False;False;False;False;False;False
+Turbo;False;False;True;False;False;False;False;False;False
+Uramita;False;False;False;False;False;False;False;False;False
+Urrao;False;False;False;False;False;False;False;False;False
+Valdivia;False;False;False;False;False;False;False;False;False
+Valparaíso;False;False;False;False;False;False;False;False;False
+Vegachi;False;False;False;False;False;False;False;False;False
+Venecia;False;False;False;False;False;False;False;False;False
+Vigía del Fuerte;False;False;False;False;False;False;False;False;False
+Yali;False;False;False;False;False;False;False;False;False
+Yarumal;False;False;False;False;False;False;False;False;False
+Yolombó;False;False;False;False;False;False;False;False;False
+Yondó;False;False;False;False;False;False;False;False;False
+Zaragoza;False;False;False;False;False;False;False;False;False
+Arauca;False;False;False;False;False;False;False;False;False
+Arauquita;False;False;False;False;False;False;False;False;False
+Cravo Norte;False;False;False;False;False;False;False;False;False
+Fortul;False;False;False;False;False;False;False;False;False
+Puerto Rondón;False;False;False;False;False;False;False;False;False
+Saravena;False;False;False;False;False;False;False;False;False
+Tame;False;False;False;False;False;False;False;False;False
+Baranoa;False;False;False;False;False;False;False;False;False
+Barranquilla;False;False;False;False;False;False;True;False;False
+Campo de la Cruz;False;False;False;False;False;False;False;False;False
+Candelaria;False;False;False;False;False;False;False;False;False
+Galapa;False;False;False;False;False;False;True;False;False
+Juan de Acosta;False;False;False;False;False;False;False;False;False
+Luruaco;False;False;False;False;False;False;False;False;False
+Malambo;False;False;False;False;False;False;False;False;False
+Manatí;False;False;False;False;False;False;False;False;False
+Palmar de Varela;False;False;False;False;False;False;False;False;False
+Piojó;False;False;False;False;False;False;False;False;False
+Polonuevo;False;False;False;False;False;False;False;False;False
+Ponedera;False;False;False;False;False;False;False;False;False
+Puerto Colombia;False;False;False;False;False;False;True;False;False
+Repelón;False;False;False;False;False;False;False;False;False
+Sabanagrande;False;False;False;False;False;False;False;False;False
+Sabanalarga;False;False;False;False;False;False;False;False;False
+Santa Lucia;False;False;False;False;False;False;False;False;False
+Santo Tomas;False;False;False;False;False;False;False;False;False
+Soledad;False;False;False;False;False;False;False;False;False
+Suan;False;False;False;False;False;False;False;False;False
+Tubará;False;False;False;False;False;False;False;False;False
+Usiacurí;False;False;False;False;False;False;False;False;False
+Antonio Nariño;False;False;False;False;False;False;False;False;False
+Barrios Unidos;False;False;False;False;False;False;False;False;False
+Bosa;False;False;False;False;False;False;False;False;False
+Chapinero;False;False;False;False;False;False;False;False;False
+Ciudad Bolívar;False;False;False;False;False;False;False;False;False
+Engativá;False;False;False;False;False;False;False;False;False
+Fontibón;False;False;False;False;False;False;False;False;False
+Kennedy;False;False;False;False;False;False;False;False;False
+La Candelaria;False;False;False;False;False;False;False;False;False
+Los Mártires;False;False;False;False;False;False;False;False;False
+Puente Aranda;False;False;False;False;False;False;False;False;False
+Rafael Uribe Uribe;False;False;False;False;False;False;False;False;False
+San Cristóbal;False;False;False;False;False;False;False;False;False
+Santa Fe;False;False;False;False;False;False;False;False;False
+Suba;False;False;False;False;False;False;False;False;False
+Sumapaz;False;False;False;True;False;False;False;False;False
+Teusaquillo;False;False;False;False;False;False;False;False;False
+Tunjuelito;False;False;False;False;False;False;False;False;False
+Usaquén;False;False;False;False;False;False;False;False;False
+Usme;False;False;False;False;False;False;False;False;False
+Achí;False;False;False;False;False;False;False;False;False
+Altos del Rosario;False;False;False;False;False;False;False;False;False
+Arjona;False;False;False;False;False;False;False;False;False
+Arroyo Hondo;False;False;False;False;False;False;False;False;False
+Barranco de Loba;False;False;False;False;False;False;False;False;False
+Brazuelo de Papayal;False;False;False;False;False;False;False;False;False
+Calamar;False;False;False;False;False;False;True;False;False
+Cantagallo;False;False;False;False;False;False;False;False;False
+Cartagena;False;False;False;False;False;False;False;False;False
+Cicuco;False;False;False;False;False;False;False;False;False
+Clemencia;False;False;False;False;False;False;False;False;False
+Córdoba;False;False;False;False;False;False;False;False;False
+El Carmen de Bolívar;False;False;False;False;False;False;False;False;False
+El Guamo;False;False;False;False;False;False;False;False;False
+El Peñón;False;False;False;False;False;False;False;False;False
+Hatillo de Loba;False;False;False;False;False;False;False;False;False
+Magangué;False;False;False;False;False;False;False;False;False
+Mahates;False;False;False;False;False;False;False;False;False
+Margarita;False;False;False;False;False;False;False;False;False
+María La Baja;False;False;False;False;False;False;False;False;False
+Mompóx;False;False;False;False;False;False;False;False;False
+Montecristo;False;False;False;False;False;False;False;False;False
+Morales;False;False;False;False;False;False;False;False;False
+Norosí;False;False;False;False;False;False;False;False;False
+Pinillos;False;False;False;False;False;False;False;False;False
+Regidor;False;False;False;False;False;False;False;False;False
+Rio Viejo;False;False;False;False;False;False;False;False;False
+San Cristóbal;False;False;False;False;False;False;False;False;False
+San Estanislao;False;False;False;False;False;False;False;False;False
+San Fernando;False;False;False;False;False;False;False;False;False
+San Jacinto;False;False;False;False;False;False;False;False;False
+San Juan Nepomuceno;False;False;False;False;False;False;False;False;False
+San Martín de Loba;False;False;False;False;False;False;False;False;False
+San Pablo;False;False;False;False;False;False;False;False;False
+Santa Catalina;False;False;False;False;False;False;False;False;False
+Santa Rosa;False;False;False;False;False;False;False;False;False
+Santa Rosa del Sur;False;False;False;False;False;False;False;False;False
+Simití;False;False;False;False;False;False;False;False;False
+Soplaviento;False;False;False;False;False;False;False;False;False
+Talaiga Nuevo;False;False;False;False;False;False;False;False;False
+Tiquisio;False;False;False;False;False;False;False;False;False
+Turbaco;False;False;False;False;False;False;False;False;False
+Turbana;False;False;False;False;False;False;False;False;False
+Villanueva;False;False;False;False;False;False;False;False;False
+Zambrano;False;False;False;False;False;False;False;False;False
+Almeida;False;False;False;False;False;False;False;False;False
+Aquitania;True;False;False;False;False;False;False;False;False
+Arcabuco;True;False;False;False;False;False;False;False;False
+Belén;True;False;False;False;False;False;False;False;False
+Berbeo;False;False;False;False;False;False;False;False;False
+Betéitiva;True;False;False;False;False;False;False;False;False
+Boavita;False;False;False;False;False;False;False;False;False
+Boyacá;False;False;False;False;False;False;False;False;False
+Briceño;False;False;False;False;False;False;False;False;False
+Buenavista;False;False;False;False;False;False;False;False;False
+Busbanzá;False;False;False;False;False;False;False;False;False
+Caldas;False;False;False;False;False;False;False;False;False
+Campohermoso;False;False;False;False;False;False;False;False;False
+Cerinza;True;False;False;False;False;False;False;False;False
+Chinavita;False;False;False;False;False;False;False;False;False
+Chiquinquirá;False;False;False;False;False;False;False;False;False
+Chíquiza;False;False;False;False;False;False;False;False;False
+Chiscas;True;False;False;False;False;False;False;False;False
+Chita;True;False;False;False;False;False;False;False;False
+Chitaraque;False;False;False;False;False;False;False;False;False
+Chivatá;False;False;False;False;False;False;False;False;False
+Chivor;False;False;False;False;False;False;False;False;False
+Ciénega;False;False;False;False;False;False;False;False;False
+Coper;False;False;False;False;False;False;False;False;False
+Corrales;True;False;False;False;False;False;False;False;False
+Covarachía;True;False;False;False;False;False;False;False;False
+Cubará;True;False;False;False;False;False;False;False;False
+Cucaita;False;False;False;False;False;False;False;False;False
+Cuítiva;True;False;False;False;False;False;False;False;False
+Cómbita;False;False;False;False;False;False;False;False;False
+Duitama;False;False;False;False;False;False;False;False;False
+El Cocuy;True;False;False;False;False;False;False;False;False
+El Espino;True;False;False;False;False;False;False;False;False
+Firavitoba;False;False;False;False;False;False;False;False;False
+Floresta;False;False;False;False;False;False;False;False;False
+Gachantivá;False;False;False;False;False;False;False;False;False
+Garagoa;False;False;False;False;False;False;False;False;False
+Guacamayas;True;False;False;False;False;False;False;False;False
+Guateque;False;False;False;False;False;False;False;False;False
+Guayatá;False;False;False;False;False;False;False;False;False
+Gámeza;True;False;False;False;False;False;False;False;False
+Güicán;True;False;False;False;False;False;False;False;False
+Iza;True;False;False;False;False;False;False;False;False
+Jenesano;False;False;False;False;False;False;False;False;False
+Jericó;True;False;False;False;False;False;False;False;False
+La Capilla;False;False;False;False;False;False;False;False;False
+La Uvita;False;False;False;False;False;False;False;False;False
+La Victoria;False;False;False;False;False;False;False;False;False
+Labranzagrande;False;False;False;False;False;False;False;False;False
+Macanal;False;False;False;False;False;False;False;False;False
+Maripí;False;False;False;False;False;False;False;False;False
+Miraflores;False;False;False;False;False;False;False;False;False
+Mongua;True;False;False;False;False;False;False;False;False
+Monguí;False;False;False;False;False;False;False;False;False
+Moniquirá;False;False;False;False;False;False;False;False;False
+Motavita;False;False;False;False;False;False;False;False;False
+Muzo;False;False;False;False;False;False;False;False;False
+Nobsa;False;False;False;False;False;False;False;False;False
+Nuevo Colón;False;False;False;False;False;False;False;False;False
+Oicatá;False;False;False;False;False;False;False;False;False
+Otanche;False;False;False;False;False;False;False;False;False
+Pachavita;False;False;False;False;False;False;False;False;False
+Paipa;True;False;False;False;False;False;False;False;False
+Pajarito;False;False;False;False;False;False;False;False;False
+Panqueba;True;False;False;False;False;False;False;False;False
+Pauna;False;False;False;False;False;False;False;False;False
+Paya;False;False;False;False;False;False;False;False;False
+Paz de Río;True;False;False;False;False;False;False;False;False
+Pesca;True;False;False;False;False;False;False;False;False
+Pisba;False;False;False;False;False;False;False;False;False
+Puerto Boyacá;False;False;False;False;False;False;False;False;False
+Páez;False;False;False;False;False;False;False;False;False
+Quípama;False;False;False;False;False;False;False;False;False
+Ramiriquí;False;False;False;False;False;False;False;False;False
+Rondón;False;False;False;False;False;False;False;False;False
+Ráquira;False;False;False;False;False;False;False;False;False
+Saboyá;False;False;False;False;False;False;False;False;False
+Samacá;False;False;False;False;False;False;False;False;False
+San Eduardo;False;False;False;False;False;False;False;False;False
+San José de Pare;False;False;False;False;False;False;False;False;False
+San Luis de Gaceno;False;False;False;False;False;False;False;False;False
+San Mateo;False;False;False;False;False;False;False;False;False
+San Miguel de Sema;False;False;False;False;False;False;False;False;False
+San Pablo de Borbur;False;False;False;False;False;False;False;False;False
+Santa María;False;False;False;True;False;False;False;False;False
+Santa Rosa de Viterbo;False;False;False;False;False;False;False;False;False
+Santa Sofía;False;False;False;False;False;False;False;False;False
+Santana;False;False;False;False;False;False;False;False;False
+Sativanorte;True;False;False;False;False;False;False;False;False
+Sativasur;True;False;False;False;False;False;False;False;False
+Siachoque;False;False;False;False;False;False;False;False;False
+Soatá;True;False;False;False;False;False;False;False;False
+Socha;True;False;False;False;False;False;False;False;False
+Socotá;True;False;False;False;False;False;False;False;False
+Sogamoso;False;False;False;False;False;False;False;False;False
+Somondoco;False;False;False;False;False;False;False;False;False
+Sora;False;False;False;False;False;False;False;False;False
+Soracá;False;False;False;False;False;False;False;False;False
+Sotaquirá;False;False;False;False;False;False;False;False;False
+Susacón;True;False;False;False;False;False;False;False;False
+Sutamarchán;False;False;False;False;False;False;False;False;False
+Sutatenza;False;False;False;False;False;False;False;False;False
+Sáchica;False;False;False;False;False;False;False;False;False
+Tasco;True;False;False;False;False;False;False;False;False
+Tenza;False;False;False;False;False;False;False;False;False
+Tibaná;False;False;False;False;False;False;False;False;False
+Tibasosa;False;False;False;False;False;False;False;False;False
+Tinjacá;False;False;False;False;False;False;False;False;False
+Tipacoque;False;False;False;False;False;False;False;False;False
+Toca;False;False;False;False;False;False;False;False;False
+Togüí, Boyacá;False;False;False;False;False;False;False;False;False
+Tota;True;False;False;False;False;False;False;False;False
+Tunja;False;False;False;False;False;False;False;False;False
+Tununguá;False;False;False;False;False;False;False;False;False
+Turmequé;False;False;False;False;False;False;False;False;False
+Tuta;False;False;False;False;False;False;False;False;False
+Tutazá;True;False;False;False;False;False;False;False;False
+Tópaga;False;False;False;False;False;False;False;False;False
+Úmbita;False;False;False;False;False;False;False;False;False
+Ventaquemada;False;False;False;False;False;False;False;False;False
+Villa de Leyva;False;False;False;False;False;False;False;False;False
+Viracachá;False;False;False;False;False;False;False;False;False
+Zetaquirá;False;False;False;False;False;False;False;False;False
+Aguadas;False;False;False;False;False;False;False;False;False
+Anserma;False;False;False;False;False;False;False;False;False
+Aranzazu;False;False;False;False;False;False;False;False;False
+Belalcázar;False;False;False;False;False;False;False;False;False
+Chinchiná;False;False;False;False;True;False;False;False;False
+Filadelfia;False;False;False;False;False;False;False;False;False
+La Dorada;False;False;False;False;False;False;False;False;False
+La Merced;False;False;False;False;False;False;False;False;False
+Manizales;False;False;False;False;True;False;False;False;False
+Manzanares;False;False;False;False;False;False;False;False;False
+Marmato;False;False;False;False;False;False;False;False;False
+Marquetalia;False;False;False;False;False;False;False;False;False
+Marulanda;False;False;False;False;False;False;False;False;False
+Neira;False;False;False;False;True;False;False;False;False
+Norcasia;False;False;False;False;False;False;False;False;False
+Pácora;False;False;False;False;False;False;False;False;False
+Palestina;False;False;False;False;False;False;False;False;False
+Pensilvania;False;False;False;False;False;False;False;False;False
+Riosucio;False;False;False;False;False;False;False;False;False
+Risaralda;False;False;False;False;True;False;False;False;False
+Salamina;False;False;False;False;False;False;False;False;False
+Samaná;False;False;False;False;False;False;False;False;False
+San José;False;False;False;False;False;False;False;False;False
+Supía;False;False;False;False;False;False;False;False;False
+Victoria;False;False;False;False;False;False;False;False;False
+Villamaría;False;False;False;False;True;False;False;False;False
+Viterbo;False;False;False;False;False;False;False;False;False
+Albania;False;True;False;False;False;False;False;False;False
+Belén de Andaquies;False;True;False;False;False;False;False;False;False
+Cartagena del Chairá;False;False;False;False;False;False;False;False;False
+Curillo;False;True;False;False;False;False;False;False;False
+El Doncello;False;False;False;False;False;False;False;False;False
+El Paujil;False;False;False;False;False;False;False;False;False
+Florencia;False;False;False;False;False;False;False;False;False
+La Montañita;False;False;False;False;False;False;False;False;False
+Milán;False;False;False;False;False;False;False;False;False
+Morelia;False;False;False;False;False;False;False;False;False
+Puerto Rico;False;False;False;False;False;False;False;False;False
+San José de la Fragua;False;True;False;False;False;False;False;False;False
+San Vicente del Caguán;False;False;False;False;False;False;False;False;False
+Solano;False;False;False;False;False;False;False;False;True
+Solita;False;False;False;False;False;False;False;False;False
+Valparaíso;False;False;False;False;False;False;False;False;False
+Aguazul;False;False;False;False;False;False;False;False;False
+Chámeza;False;False;False;False;False;False;False;False;False
+Hato Corozal;False;False;False;False;False;False;False;False;False
+La Salina;True;False;False;False;False;False;False;False;False
+Maní;False;False;False;False;False;False;False;False;False
+Monterrey;False;False;False;False;False;False;False;False;False
+Nunchía;False;False;False;False;False;False;False;False;False
+Orocué;False;False;False;False;False;False;False;False;True
+Paz de Ariporo;True;False;False;False;False;False;False;False;False
+Pore;False;False;False;False;False;False;False;False;False
+Recetor;False;False;False;False;False;False;False;False;False
+Sabanalarga;False;False;False;False;False;False;False;False;False
+Sácama;True;False;False;False;False;False;False;False;False
+San Luis de Palenque;False;False;False;False;False;False;False;False;False
+Támara;True;False;False;False;False;False;False;False;False
+Tauramena;False;False;False;False;False;False;False;False;False
+Trinidad;False;False;False;False;False;False;False;False;False
+Villanueva;False;False;False;False;False;False;False;False;False
+Yopal;False;False;False;False;False;False;False;False;False
+Almaguer;False;False;False;False;False;False;False;False;False
+Argelia;False;False;False;False;False;False;False;False;False
+Balboa;False;False;False;False;False;False;False;False;False
+Bolívar;False;False;False;False;False;False;False;False;False
+Buenos Aires;False;False;False;False;False;False;False;False;False
+Cajibio;False;False;False;False;False;False;False;False;False
+Caldono;False;False;False;False;False;False;False;False;False
+Caloto;False;False;False;False;False;False;False;False;False
+Corinto;False;False;False;False;True;False;False;False;False
+El Tambo;False;False;False;False;False;False;False;False;False
+Florencia;False;False;False;False;False;False;False;False;False
+Guachené;False;False;False;False;False;False;False;False;False
+Guapi;False;False;False;False;False;True;False;False;False
+Inza;False;False;False;False;False;False;False;False;False
+Jambalo;False;False;False;False;False;False;False;False;False
+La Sierra;False;False;False;False;False;False;False;False;False
+La Vega;False;False;False;False;False;False;False;False;False
+López de Micay;False;False;False;False;False;False;False;False;False
+Mercaderes;False;False;False;False;False;False;False;False;False
+Miranda;False;False;False;False;True;False;False;False;False
+Morales;False;False;False;False;False;False;False;False;False
+Padilla;False;False;False;False;True;False;False;False;False
+Páez;False;False;False;False;False;False;False;False;False
+Patía;False;False;False;False;False;False;False;False;False
+Piamonte;False;True;False;False;False;False;False;False;False
+Piendamó;False;False;False;False;False;False;False;False;False
+Popayán;False;False;False;False;False;False;False;False;False
+Puerto Tejada;False;False;False;False;False;False;False;False;False
+Purace;False;False;False;False;True;False;False;False;False
+Rosas;False;False;False;False;False;False;False;False;False
+San Sebastián;False;False;False;False;False;False;False;False;False
+Santander de Quilichao;False;False;False;False;False;False;False;False;False
+Santa Rosa;False;True;False;False;False;False;False;False;False
+Silvia;False;False;False;False;False;False;False;False;False
+Sotará;False;False;False;False;False;False;False;False;False
+Suarez;False;False;False;False;False;False;False;False;False
+Sucre;False;False;False;False;False;False;False;False;False
+Timbío;False;False;False;False;False;False;False;False;False
+Timbiqui;False;False;False;False;False;False;False;False;False
+Toribío;False;False;False;False;False;False;False;False;False
+Totoro;False;False;False;False;False;False;False;False;False
+Villa Rica;False;False;False;False;False;False;False;False;False
+Aguachica;False;False;False;False;False;False;False;False;False
+Astrea;False;False;False;False;False;False;False;False;False
+Becerril;False;False;False;False;False;False;False;False;False
+Bosconia;False;False;False;False;False;False;False;False;False
+Chimichagua;False;False;False;False;False;False;False;False;False
+Chiriguaná;False;False;False;False;False;False;False;False;False
+Codazzi;False;False;False;False;False;False;True;False;False
+Curumaní;False;False;False;False;False;False;False;False;False
+El Copey;False;False;False;False;False;False;False;False;False
+El Paso;False;False;False;False;False;False;False;False;False
+Gamarra;False;False;False;False;False;False;False;False;False
+González;False;False;False;False;False;False;False;False;False
+La Gloria;False;False;False;False;False;False;False;False;False
+La Jagua de Ibirico;False;False;False;False;False;False;False;False;False
+Manaure;False;False;False;False;False;False;False;False;False
+Pailitas;False;False;False;False;False;False;False;False;False
+Pelaya;False;False;False;False;False;False;False;False;False
+Pueblo Bello;False;False;False;False;False;False;True;False;False
+Rio de Oro;False;False;False;False;False;False;False;False;False
+Los Robles La Paz;False;False;False;False;False;False;True;False;False
+San Alberto;False;False;False;False;False;False;False;False;False
+San Diego;False;False;False;False;False;False;True;False;False
+San Martín;False;False;False;False;False;False;False;False;False
+Tamalameque;False;False;False;False;False;False;False;False;False
+Valledupar;False;False;False;False;False;False;True;False;False
+Acandí;False;False;True;False;False;False;False;False;False
+Alto Baudó;False;False;False;False;False;False;False;False;False
+Atrato;False;False;False;False;False;False;False;False;False
+Bagadó;False;False;False;False;False;False;False;False;False
+Bahía Solano;False;False;False;False;False;True;False;False;False
+Bajo Baudó;False;False;False;False;False;True;False;False;False
+Bojayá;False;False;False;False;False;False;False;False;False
+Cértegui;False;False;False;False;False;False;False;False;False
+Condoto;False;False;False;False;False;False;False;False;False
+El Cantón de San Pablo;False;False;False;False;False;False;False;False;False
+El Carmen de Atrato;False;False;False;False;False;False;False;False;False
+El Carmen del Darién;False;False;False;False;False;False;False;False;False
+Istmina;False;False;False;False;False;False;False;False;False
+Juradó;False;False;False;False;False;True;False;False;False
+Litoral del San Juan;False;False;False;False;False;True;False;False;False
+Lloró;False;False;False;False;False;False;False;False;False
+Medio Atrato;False;False;False;False;False;False;False;False;False
+Medio Baudó;False;False;False;False;False;False;False;False;False
+Medio San Juan;False;False;False;False;False;False;False;False;False
+Nóvita;False;False;False;False;False;False;False;False;False
+Nuquí;False;False;False;False;False;True;False;False;False
+Quibdó;False;False;False;False;False;False;False;False;False
+Río Iró;False;False;False;False;False;False;False;False;False
+Río Quito;False;False;False;False;False;False;False;False;False
+Riosucio;False;False;False;False;False;False;False;False;False
+San José del Palmar;False;False;False;False;False;False;False;False;False
+Sipí;False;False;False;False;False;False;False;False;False
+Tadó;False;False;False;False;False;False;False;False;False
+Unguía;False;False;True;False;False;False;False;False;False
+Unión Panamericana;False;False;False;False;False;False;False;False;False
+Ayapel;False;False;False;False;False;False;False;False;False
+Buenavista;False;False;False;False;False;False;False;False;False
+Canalete;False;False;False;False;False;False;False;False;False
+Cereté;False;False;False;False;False;False;False;False;False
+Chimá;False;False;False;False;False;False;False;False;False
+Chinú;False;False;False;False;False;False;False;False;False
+Ciénaga de Oro;False;False;False;False;False;False;False;False;False
+Cotorra;False;False;False;False;False;False;False;False;False
+La Apartada;False;False;False;False;False;False;False;False;False
+Lorica;False;False;False;False;False;False;False;False;False
+Los Córdobas;False;False;False;False;False;False;False;False;False
+Momil;False;False;False;False;False;False;False;False;False
+Moñitos;False;False;False;False;False;False;False;False;False
+Montelíbano;False;False;False;False;False;False;False;False;False
+Montería;False;False;False;False;False;False;False;False;False
+Planeta Rica;False;False;False;False;False;False;False;False;False
+Pueblo Nuevo;False;False;False;False;False;False;False;False;False
+Puerto Escondido;False;False;False;False;False;False;False;False;False
+Puerto Libertador;False;False;False;False;False;False;False;False;False
+Purísima;False;False;False;False;False;False;False;False;False
+Sahagún;False;False;False;False;False;False;False;False;False
+San Andrés de Sotavento;False;False;False;False;False;False;False;False;False
+San Antero;False;False;False;False;False;False;False;False;False
+San Bernardo del Viento;False;False;False;False;False;False;False;False;False
+San Carlos;False;False;False;False;False;False;False;False;False
+San José de Uré;False;False;False;False;False;False;False;False;False
+San Pelayo;False;False;False;False;False;False;False;False;False
+Tierralta;False;False;False;False;False;False;False;False;False
+Tuchín;False;False;False;False;False;False;False;False;False
+Valencia;False;False;False;False;False;False;False;False;False
+Agua de Dios;False;False;False;False;False;False;False;False;False
+Albán;False;False;False;False;False;False;False;False;False
+Anapoima;False;False;False;False;False;False;False;False;False
+Anolaima;False;False;False;False;False;False;False;False;False
+Apulo;False;False;False;False;False;False;False;False;False
+Arbeláez;False;False;False;False;False;False;False;False;False
+Beltrán;False;False;False;False;False;False;False;False;False
+Bituima;False;False;False;False;False;False;False;False;False
+Bojacá;False;False;False;False;False;False;False;False;False
+Cabrera;False;False;False;False;False;False;False;False;False
+Cachipay;False;False;False;False;False;False;False;False;False
+Cajicá;False;False;False;False;False;False;False;False;False
+Caparrapí;False;False;False;False;False;False;False;False;False
+Cáqueza;False;False;False;False;False;False;False;False;False
+Carmen de Carupa;False;False;False;False;False;False;False;False;False
+Chaguaní;False;False;False;False;False;False;False;False;False
+Chipaque;False;False;False;False;False;False;False;False;False
+Choachí;False;False;False;False;False;False;False;False;False
+Chocontá;False;False;False;False;False;False;False;False;False
+Chía;False;False;False;False;False;False;False;False;False
+Cogua;False;False;False;False;False;False;False;False;False
+Cota;False;False;False;False;False;False;False;False;False
+Cucunubá;False;False;False;False;False;False;False;False;False
+El Colegio;False;False;False;False;False;False;False;False;False
+El Peñón;False;False;False;False;False;False;False;False;False
+El Rosal;False;False;False;False;False;False;False;False;False
+Facatativá;False;False;False;False;False;False;False;False;False
+Fómeque;False;False;False;False;False;False;False;False;False
+Fosca;False;False;False;False;False;False;False;False;False
+Funza;False;False;False;False;False;False;False;False;False
+Fusagasugá;False;False;False;False;False;False;False;False;False
+Fúquene;False;False;False;False;False;False;False;False;False
+Gachalá;False;False;False;False;False;False;False;False;False
+Gachancipá;False;False;False;False;False;False;False;False;False
+Gachetá;False;False;False;False;False;False;False;False;False
+Gama;False;False;False;False;False;False;False;False;False
+Girardot;False;False;False;False;False;False;False;False;False
+Granada;False;False;False;False;False;False;False;False;False
+Guachetá;False;False;False;False;False;False;False;False;False
+Guaduas;False;False;False;False;False;False;False;False;False
+Guasca;False;False;False;False;False;False;False;False;False
+Guataquí;False;False;False;False;False;False;False;False;False
+Guatavita;False;False;False;False;False;False;False;False;False
+Guayabal de Síquima;False;False;False;False;False;False;False;False;False
+Guayabetal;False;False;False;True;False;False;False;False;False
+Gutiérrez;False;False;False;True;False;False;False;False;False
+Jerusalen;False;False;False;False;False;False;False;False;False
+Junín;False;False;False;True;False;False;False;False;False
+La Calera;False;False;False;False;False;False;False;False;False
+La Mesa;False;False;False;False;False;False;False;False;False
+La Palma;False;False;False;False;False;False;False;False;False
+La Peña;False;False;False;False;False;False;False;False;False
+La Vega;False;False;False;False;False;False;False;False;False
+Lenguazaque;False;False;False;False;False;False;False;False;False
+Machetá;False;False;False;False;False;False;False;False;False
+Madrid;False;False;False;False;False;False;False;False;False
+Manta;False;False;False;False;False;False;False;False;False
+Medina;False;False;False;False;False;False;False;False;False
+Mosquera;False;False;False;False;False;False;False;False;False
+Nariño;False;False;False;False;False;False;False;False;False
+Nemocón;False;False;False;False;False;False;False;False;False
+Nilo;False;False;False;False;False;False;False;False;False
+Nimaima;False;False;False;False;False;False;False;False;False
+Nocaima;False;False;False;False;False;False;False;False;False
+Pacho;False;False;False;False;False;False;False;False;False
+Paime;False;False;False;False;False;False;False;False;False
+Pandi;False;False;False;False;False;False;False;False;False
+Paratebueno;False;False;False;False;False;False;False;False;False
+Pasca;False;False;False;False;False;False;False;False;False
+Puerto Salgar;False;False;False;False;False;False;False;False;False
+Pulí;False;False;False;False;False;False;False;False;False
+Quebradanegra;False;False;False;False;False;False;False;False;False
+Quetame;False;False;False;False;False;False;False;False;False
+Quipile;False;False;False;False;False;False;False;False;False
+Ricaurte;False;False;False;False;False;False;False;False;False
+San Antonio del Tequendama;False;False;False;False;False;False;False;False;False
+San Bernardo;False;False;False;False;False;False;False;False;False
+San Cayetano;False;False;False;False;False;False;False;False;False
+San Francisco;False;False;False;False;False;False;False;False;False
+San Juan de Rioseco;False;False;False;False;False;False;False;False;False
+Sasaima;False;False;False;False;False;False;False;False;False
+Sesquilé;False;False;False;False;False;False;False;False;False
+Sibaté;False;False;False;False;False;False;False;False;False
+Silvania;False;False;False;False;False;False;False;False;False
+Simijaca;False;False;False;False;False;False;False;False;False
+Soacha;False;False;False;False;False;False;False;False;False
+Sopó;False;False;False;False;False;False;False;False;False
+Subachoque;False;False;False;False;False;False;False;False;False
+Suesca;False;False;False;False;False;False;False;False;False
+Supatá;False;False;False;False;False;False;False;False;False
+Susa;False;False;False;False;False;False;False;False;False
+Sutatausa;False;False;False;False;False;False;False;False;False
+Tabio;False;False;False;False;False;False;False;False;False
+Tausa;False;False;False;False;False;False;False;False;False
+Tena;False;False;False;False;False;False;False;False;False
+Tenjo;False;False;False;False;False;False;False;False;False
+Tibacuy;False;False;False;False;False;False;False;False;False
+Tibiritá;False;False;False;False;False;False;False;False;False
+Tocaima;False;False;False;False;False;False;False;False;False
+Tocancipá;False;False;False;False;False;False;False;False;False
+Topaipí;False;False;False;False;False;False;False;False;False
+Ubalá;False;False;False;False;False;False;False;False;False
+Ubaque;False;False;False;False;False;False;False;False;False
+Ubaté;False;False;False;False;False;False;False;False;False
+Une;False;False;False;False;False;False;False;False;False
+Útica;False;False;False;False;False;False;False;False;False
+Venecia;False;False;False;False;False;False;False;False;False
+Vergara;False;False;False;False;False;False;False;False;False
+Vianí;False;False;False;False;False;False;False;False;False
+Villagómez;False;False;False;False;False;False;False;False;False
+Villapinzón;False;False;False;False;False;False;False;False;False
+Villeta;False;False;False;False;False;False;False;False;False
+Viotá;False;False;False;False;False;False;False;False;False
+Yacopí;False;False;False;False;False;False;False;False;False
+Zipacón;False;False;False;False;False;False;False;False;False
+Zipaquirá;False;False;False;False;False;False;False;False;False
+Albania;False;False;False;False;False;False;True;False;False
+Barrancas;False;False;False;False;False;False;True;False;False
+Dibulla;False;False;False;False;False;False;True;False;False
+Distracción;False;False;False;False;False;False;True;False;False
+El Molino;False;False;False;False;False;False;True;False;False
+Fonseca;False;False;False;False;False;False;True;False;False
+Hatonuevo;False;False;False;False;False;False;True;False;False
+La Jagua del Pilar;False;False;False;False;False;False;True;False;False
+Maicao;False;False;False;False;False;False;False;False;False
+Manaure;False;False;False;False;False;False;False;False;False
+Riohacha;False;False;False;False;False;False;True;False;False
+San Juan del Cesar;False;False;False;False;False;False;True;False;False
+Uribia;False;False;False;False;False;False;False;False;False
+Urumita;False;False;False;False;False;False;True;False;False
+Villanueva;False;False;False;False;False;False;True;False;False
+Barranco Minas;False;False;False;False;False;False;False;False;False
+Cacahual;False;False;False;False;False;False;False;False;False
+Inirida;False;False;False;False;False;False;False;True;False
+La Guadalupe;False;False;False;False;False;False;False;False;False
+Morichal Nuevo;False;False;False;False;False;False;False;False;False
+Pana Pana;False;False;False;False;False;False;False;False;False
+Puerto Colombia;False;False;False;False;False;False;False;False;False
+San Felipe;False;False;False;False;False;False;False;False;False
+Calamar;False;False;False;False;False;False;False;False;False
+El Retorno;False;False;False;False;False;False;False;False;False
+Miraflores;False;False;False;False;False;False;False;False;False
+San José del Guaviare;False;False;False;True;False;False;False;False;False
+Acevedo;False;False;False;False;False;False;False;False;False
+Agrado;False;False;False;False;False;False;False;False;False
+Aipe;False;False;False;False;False;False;False;False;False
+Algeciras;False;False;False;False;False;False;False;False;False
+Altamira;False;False;False;False;False;False;False;False;False
+Baraya;False;False;False;False;False;False;False;False;False
+Campoalegre;False;False;False;False;False;False;False;False;False
+Colombia;False;False;False;False;False;False;False;False;False
+Elias;False;False;False;False;False;False;False;False;False
+Garzón;False;False;False;False;False;False;False;False;False
+Gigante;False;False;False;False;False;False;False;False;False
+Guadalupe;False;False;False;False;False;False;False;False;False
+Hobo;False;False;False;False;False;False;False;False;False
+Iquira;False;False;False;False;False;False;False;False;False
+Isnos;False;False;False;False;False;False;False;False;False
+La Argentina;False;True;False;False;False;False;False;False;False
+La Plata;False;False;False;False;False;False;False;False;False
+Nataga;False;False;False;False;False;False;False;False;False
+Neiva;False;False;False;False;False;False;False;False;False
+Oporapa;False;True;False;False;False;False;False;False;False
+Paicol;False;False;False;False;False;False;False;False;False
+Palermo;False;False;False;False;False;False;False;False;False
+Palestina;False;False;False;False;False;False;False;False;False
+Pital;False;False;False;False;True;False;False;False;False
+Pitalito;False;False;False;False;False;False;False;False;False
+Rivera;False;False;False;False;False;False;False;False;False
+Saladoblanco;False;True;False;False;False;False;False;False;False
+San Agustín;False;False;False;False;False;False;False;False;False
+Santa María;False;False;False;False;True;False;False;False;False
+Suaza;False;False;False;False;False;False;False;False;False
+Tarqui;False;True;False;False;False;False;False;False;False
+Tello;False;False;False;False;False;False;False;False;False
+Teruel;False;False;False;False;True;False;False;False;False
+Tesalia;False;False;False;False;False;False;False;False;False
+Timaná;False;False;False;False;False;False;False;False;False
+Villavieja;False;False;False;False;False;False;False;False;False
+Yaguara;False;False;False;False;False;False;False;False;False
+Algarrobo;False;False;False;False;False;False;False;False;False
+Aracataca;False;False;False;False;False;False;True;False;False
+Ariguaní;False;False;False;False;False;False;False;False;False
+Cerro San Antonio;False;False;False;False;False;False;True;False;False
+Chibolo;False;False;False;False;False;False;False;False;False
+Ciénaga;False;False;False;False;False;False;True;False;False
+Concordia;False;False;False;False;False;False;True;False;False
+El Banco;False;False;False;False;False;False;False;False;False
+El Piñón;False;False;False;False;False;False;True;False;False
+El Retén;False;False;False;False;False;False;True;False;False
+Fundación;False;False;False;False;False;False;False;False;False
+Guamal;False;False;False;False;False;False;False;False;False
+Nueva Granada;False;False;False;False;False;False;False;False;False
+Pedraza;False;False;False;False;False;False;True;False;False
+Pinto;False;False;False;False;False;False;False;False;False
+Pijiño;False;False;False;False;False;False;False;False;False
+Pivijay;False;False;False;False;False;False;True;False;False
+Plato;False;False;False;False;False;False;False;False;False
+Pueblo Viejo;False;False;False;False;False;False;True;False;False
+Remolino;False;False;False;False;False;False;True;False;False
+Sabanas de San Ángel;False;False;False;False;False;False;False;False;False
+Salamina;False;False;False;False;False;False;True;False;False
+San Sebastián de Buenavista;False;False;False;False;False;False;False;False;False
+Santa Ana;False;False;False;False;False;False;False;False;False
+Santa Marta;False;False;False;False;False;False;True;False;False
+San Zenón;False;False;False;False;False;False;False;False;False
+Sitionuevo;False;False;False;False;False;False;True;False;False
+Tenerife;False;False;False;False;False;False;False;False;False
+Zapayán;False;False;False;False;False;False;False;False;False
+Zona Bananera;False;False;False;False;False;False;True;False;False
+Acacías;False;False;False;False;False;False;False;False;False
+Barranca de Upía;False;False;False;False;False;False;False;False;False
+Cabuyaro;False;False;False;False;False;False;False;False;False
+Castilla la Nueva;False;False;False;False;False;False;False;False;False
+Cubarral;False;False;False;False;False;False;False;False;False
+Cumaral;False;False;False;False;False;False;False;False;False
+El Calvario;False;False;False;True;False;False;False;False;False
+El Castillo;False;False;False;True;False;False;False;False;False
+El Dorado;False;False;False;False;False;False;False;False;False
+Fuente de Oro;False;False;False;False;False;False;False;False;False
+Granada;False;False;False;False;False;False;False;False;False
+Guamal;False;False;False;False;False;False;False;False;False
+La Macarena;False;False;False;False;False;False;False;False;False
+La Uribe;False;False;False;True;False;False;False;False;False
+Lejanías;False;False;False;False;False;False;False;False;False
+Mapiripán;False;False;False;False;False;False;False;False;False
+Mesetas;False;False;False;True;False;False;False;False;False
+Puerto Concordia;False;False;False;False;False;False;False;False;False
+Puerto Gaitán;False;False;False;False;False;False;False;False;False
+Puerto Lleras;False;False;False;False;False;False;False;False;False
+Puerto López;False;False;False;False;False;False;False;False;False
+Puerto Rico;False;False;False;False;False;False;False;False;False
+Restrepo;False;False;False;False;False;False;False;False;False
+San Carlos de Guaroa;False;False;False;False;False;False;False;False;False
+San Juan de Arama;False;False;False;False;False;False;False;False;False
+San Juanito;False;False;False;True;False;False;False;False;False
+San Martín;False;False;False;False;False;False;False;False;False
+Villavicencio;False;False;False;False;False;False;False;False;False
+Vista Hermosa;False;False;False;False;False;False;False;False;False
+Albán;False;False;False;False;False;False;False;False;False
+Aldana;False;False;False;False;False;False;False;False;False
+Ancuya;False;False;False;False;False;False;False;False;False
+Arboleda;False;False;False;False;False;False;False;False;False
+Barbacoas;False;False;False;False;False;False;False;False;False
+Belén;False;False;False;False;False;False;False;False;False
+Buesaco;False;False;False;False;False;False;False;False;False
+Chachagüí;False;False;False;False;False;False;False;False;False
+Colón;False;False;False;False;False;False;False;False;False
+Consaca;False;False;False;False;False;False;False;False;False
+Contadero;False;False;False;False;False;False;False;False;False
+Córdoba;False;False;False;False;False;False;False;False;False
+Cuaspud;False;False;False;False;False;False;False;False;False
+Cumbal;False;False;False;False;False;False;False;False;False
+Cumbitara;False;False;False;False;False;False;False;False;False
+El Charco;False;False;False;False;False;True;False;False;False
+El Peñol;False;False;False;False;False;False;False;False;False
+El Rosario;False;False;False;False;False;False;False;False;False
+El Tablón;False;False;False;False;False;False;False;False;False
+El Tambo;False;False;False;False;False;False;False;False;False
+Francisco Pizarro;False;False;False;False;False;True;False;False;False
+Funes;False;False;False;False;False;False;False;False;False
+Guachucal;False;False;False;False;False;False;False;False;False
+Guaitarilla;False;False;False;False;False;False;False;False;False
+Gualmatán;False;False;False;False;False;False;False;False;False
+Iles;False;False;False;False;False;False;False;False;False
+Imués;False;False;False;False;False;False;False;False;False
+Ipiales;False;False;False;False;False;False;False;False;False
+La Cruz;False;False;False;False;False;False;False;False;False
+La Florida;False;False;False;False;False;False;False;False;False
+La Llanada;False;False;False;False;False;False;False;False;False
+La Tola;False;False;False;False;False;True;False;False;False
+La Unión;False;False;False;False;False;False;False;False;False
+Leiva;False;False;False;False;False;False;False;False;False
+Linares;False;False;False;False;False;False;False;False;False
+Los Andes;False;False;False;False;False;False;False;False;False
+Magüí Payán;False;False;False;False;False;False;False;False;False
+Mallama;False;False;False;False;False;False;False;False;False
+Mosquera;False;False;False;False;False;True;False;False;False
+Nariño;False;False;False;False;False;False;False;False;False
+Olaya Herrera;False;False;False;False;False;True;False;False;False
+Ospina;False;False;False;False;False;False;False;False;False
+Pasto;False;True;False;False;False;False;False;False;False
+Policarpa;False;False;False;False;False;False;False;False;False
+Potosí;False;False;False;False;False;False;False;False;False
+Providencia;False;False;False;False;False;False;False;False;False
+Puerres;False;False;False;False;False;False;False;False;False
+Pupiales;False;False;False;False;False;False;False;False;False
+Ricaurte;False;False;False;False;False;False;False;False;False
+Roberto Payán;False;False;False;False;False;False;False;False;False
+Samaniego;False;False;False;False;False;False;False;False;False
+San Bernardo;False;False;False;False;False;False;False;False;False
+Sandona;False;False;False;False;False;False;False;False;False
+San Lorenzo;False;False;False;False;False;False;False;False;False
+San Pablo;False;False;False;False;False;False;False;False;False
+San Pedro de Cartago;False;False;False;False;False;False;False;False;False
+Santa Barbara;False;False;False;False;False;True;False;False;False
+Santacruz;False;False;False;False;False;False;False;False;False
+Sapuyes;False;False;False;False;False;False;False;False;False
+Taminango;False;False;False;False;False;False;False;False;False
+Tangua;False;False;False;False;False;False;False;False;False
+Tumaco;False;False;False;False;False;True;False;False;False
+Túquerres;False;False;False;False;False;False;False;False;False
+Yacuanquer;False;False;False;False;False;False;False;False;False
+Abrego;True;False;False;False;False;False;False;False;False
+Arboledas;False;False;False;False;False;False;False;False;False
+Bochalema;False;False;False;False;False;False;False;False;False
+Bucarasica;False;False;False;False;False;False;False;False;False
+Cachira;False;False;False;False;False;False;False;False;False
+Cácota;True;False;False;False;False;False;False;False;False
+Chinácota;False;False;False;False;False;False;False;False;False
+Chitagá;True;False;False;False;False;False;False;False;False
+Convención;False;False;False;False;False;False;False;False;False
+Cúcuta;False;False;False;False;False;False;False;False;False
+Cucutilla;True;False;False;False;False;False;False;False;False
+Durania;False;False;False;False;False;False;False;False;False
+El Carmen;False;False;False;False;False;False;False;False;False
+El Tarra;True;False;False;False;False;False;False;False;False
+El Zulia;False;False;False;False;False;False;False;False;False
+Gramalote;False;False;False;False;False;False;False;False;False
+Hacari;False;False;False;False;False;False;False;False;False
+Herrán;False;False;False;False;False;False;False;False;False
+La Esperanza;False;False;False;False;False;False;False;False;False
+La Playa;False;False;False;False;False;False;False;False;False
+Labateca;True;False;False;False;False;False;False;False;False
+Los Patios;False;False;False;False;False;False;False;False;False
+Lourdes;False;False;False;False;False;False;False;False;False
+Mutiscua;True;False;False;False;False;False;False;False;False
+Ocaña;False;False;False;False;False;False;False;False;False
+Pamplona;False;False;False;False;False;False;False;False;False
+Pamplonita;False;False;False;False;False;False;False;False;False
+Puerto Santander;False;False;False;False;False;False;False;False;False
+Ragonvalia;False;False;False;False;False;False;False;False;False
+Salazar de las Palmas;True;False;False;False;False;False;False;False;False
+San Calixto;False;False;False;False;False;False;False;False;False
+San Cayetano;False;False;False;False;False;False;False;False;False
+Santiago;False;False;False;False;False;False;False;False;False
+Sardinata;False;False;False;False;False;False;False;False;False
+Silos;True;False;False;False;False;False;False;False;False
+Teorama;False;False;False;False;False;False;False;False;False
+Tibú;False;False;False;False;False;False;False;False;False
+Toledo;True;False;False;False;False;False;False;False;False
+Villa Caro;True;False;False;False;False;False;False;False;False
+Villa del Rosario;False;False;False;False;False;False;False;False;False
+Colón;False;True;False;False;False;False;False;False;False
+Mocoa;False;False;False;False;False;False;False;False;False
+Orito;False;False;False;False;False;False;False;False;False
+Puerto Asís;False;False;False;False;False;False;False;False;False
+Puerto Caicedo;False;False;False;False;False;False;False;False;False
+Puerto Guzmán;False;False;False;False;False;False;False;False;False
+Puerto Leguízamo;False;False;False;False;False;False;False;False;True
+San Francisco;False;True;False;False;False;False;False;False;False
+San Miguel;False;False;False;False;False;False;False;False;False
+Santiago;False;True;False;False;False;False;False;False;False
+Sibundoy;False;True;False;False;False;False;False;False;False
+Valle del Guamez;False;False;False;False;False;False;False;False;False
+Villa Garzón;False;False;False;False;False;False;False;False;False
+Armenia;False;False;False;False;False;False;False;False;False
+Buenavista;False;False;False;False;False;False;False;False;False
+Calarcá;False;False;False;False;False;False;False;False;False
+Circasia;False;False;False;False;False;False;False;False;False
+Córdoba;False;False;False;False;False;False;False;False;False
+Filandia;False;False;False;False;True;False;False;False;False
+Génova;False;False;False;False;False;False;False;False;False
+La Tebaida;False;False;False;False;False;False;False;False;False
+Montenegro;False;False;False;False;False;False;False;False;False
+Pijao;False;False;False;False;False;False;False;False;False
+Quimbaya;False;False;False;False;False;False;False;False;False
+Salento;False;False;False;False;True;False;False;False;False
+Apía;False;False;False;False;False;False;False;False;False
+Balboa;False;False;False;False;False;False;False;False;False
+Belén de Umbría;False;False;False;False;False;False;False;False;False
+Dosquebradas;False;False;False;False;True;False;False;False;False
+Guática;False;False;False;False;False;False;False;False;False
+La Celia;False;False;False;False;False;False;False;False;False
+La Virginia;False;False;False;False;False;False;False;False;False
+Marsella;False;False;False;False;False;False;False;False;False
+Mistrató;False;False;False;False;False;False;False;False;False
+Pereira;False;False;False;False;False;False;False;False;False
+Pueblo Rico;False;False;False;False;False;False;False;False;False
+Quinchía;False;False;False;False;False;False;False;False;False
+Santa Rosa de Cabal;False;False;False;False;True;False;False;False;False
+Santuario;False;False;False;False;False;False;False;False;False
+Providencia and Santa Catalina Islands;False;False;False;False;False;False;False;False;False
+San Andrés;False;False;False;False;False;False;False;False;False
+Aguada;False;False;False;False;False;False;False;False;False
+Albania;False;False;False;False;False;False;False;False;False
+Aratoca;False;False;False;False;False;False;False;False;False
+Barbosa;False;False;False;False;False;False;False;False;False
+Barichara;False;False;False;False;False;False;False;False;False
+Barrancabermeja;False;False;False;False;False;False;False;False;False
+Betulia;False;False;False;False;False;False;False;False;False
+Bolívar;False;False;False;False;False;False;False;False;False
+Bucaramanga;False;False;False;False;False;False;False;False;False
+Cabrera;False;False;False;False;False;False;False;False;False
+California;False;False;False;False;False;False;False;False;False
+Capitanejo;False;False;False;False;False;False;False;False;False
+Carcasí;False;False;False;False;False;False;False;False;False
+Cepitá;False;False;False;False;False;False;False;False;False
+Cerrito;False;False;False;False;False;False;False;False;False
+Charalá;False;False;False;False;False;False;False;False;False
+Charta;False;False;False;False;False;False;False;False;False
+Chima;False;False;False;False;False;False;False;False;False
+Chipatá;False;False;False;False;False;False;False;False;False
+Cimitarra;False;False;False;False;False;False;False;False;False
+Concepción;False;False;False;False;False;False;False;False;False
+Confines;False;False;False;False;False;False;False;False;False
+Contratación;False;False;False;False;False;False;False;False;False
+Coromoro;False;False;False;False;False;False;False;False;False
+Curití;False;False;False;False;False;False;False;False;False
+El Carmen;False;False;False;False;False;False;False;False;False
+El Guacamayo;False;False;False;False;False;False;False;False;False
+El Peñón;False;False;False;False;False;False;False;False;False
+El Playón;False;False;False;False;False;False;False;False;False
+Encino;False;False;False;False;False;False;False;False;False
+Enciso;True;False;False;False;False;False;False;False;False
+Florián;False;False;False;False;False;False;False;False;False
+Floridablanca;False;False;False;False;False;False;False;False;False
+Galán;False;False;False;False;False;False;False;False;False
+Gámbita;True;False;False;False;False;False;False;False;False
+Girón;False;False;False;False;False;False;False;False;False
+Guaca;False;False;False;False;False;False;False;False;False
+Guadalupe;False;False;False;False;False;False;False;False;False
+Guapotá;False;False;False;False;False;False;False;False;False
+Guavatá;False;False;False;False;False;False;False;False;False
+Güepsa;False;False;False;False;False;False;False;False;False
+Hato;False;False;False;False;False;False;False;False;False
+Jesus María;False;False;False;False;False;False;False;False;False
+Jordán;False;False;False;False;False;False;False;False;False
+La Belleza;False;False;False;False;False;False;False;False;False
+Landázuri;False;False;False;False;False;False;False;False;False
+La Paz;False;False;False;False;False;False;False;False;False
+Lebrija;False;False;False;False;False;False;False;False;False
+Los Santos;False;False;False;False;False;False;False;False;False
+Macaravita;False;False;False;False;False;False;False;False;False
+Málaga;False;False;False;False;False;False;False;False;False
+Matanza;False;False;False;False;False;False;False;False;False
+Mogotes;True;False;False;False;False;False;False;False;False
+Molagavita;False;False;False;False;False;False;False;False;False
+Ocamonte;False;False;False;False;False;False;False;False;False
+Oiba;False;False;False;False;False;False;False;False;False
+Onzaga;True;False;False;False;False;False;False;False;False
+Palmar;False;False;False;False;False;False;False;False;False
+Palmas Socorro;False;False;False;False;False;False;False;False;False
+Páramo;False;False;False;False;False;False;False;False;False
+Piedecuesta;True;False;False;False;False;False;False;False;False
+Pinchote;False;False;False;False;False;False;False;False;False
+Puente Nacional;False;False;False;False;False;False;False;False;False
+Puerto Parra;False;False;False;False;False;False;False;False;False
+Puerto Wilches;False;False;False;False;False;False;False;False;False
+Rionegro;False;False;False;False;False;False;False;False;False
+Sabana de Torres;False;False;False;False;False;False;False;False;False
+San Andrés;False;False;False;False;False;False;False;False;False
+San Benito;False;False;False;False;False;False;False;False;False
+San Gil;False;False;False;False;False;False;False;False;False
+San Joaquín;True;False;False;False;False;False;False;False;False
+San José de Miranda;False;False;False;False;False;False;False;False;False
+San Miguel;True;False;False;False;False;False;False;False;False
+Santa Bárbara;True;False;False;False;False;False;False;False;False
+Santa Helena del Opón;False;False;False;False;False;False;False;False;False
+San Vicente de Chucurí;False;False;False;False;False;False;False;False;False
+Simacota;False;False;False;False;False;False;False;False;False
+Socorro;False;False;False;False;False;False;False;False;False
+Suaita;False;False;False;False;False;False;False;False;False
+Sucre;False;False;False;False;False;False;False;False;False
+Surata;False;False;False;False;False;False;False;False;False
+Tona;True;False;False;False;False;False;False;False;False
+Valle de San José;False;False;False;False;False;False;False;False;False
+Vélez;False;False;False;False;False;False;False;False;False
+Vetas;True;False;False;False;False;False;False;False;False
+Villanueva;False;False;False;False;False;False;False;False;False
+Zapatoca;False;False;False;False;False;False;False;False;False
+Buenavista;False;False;False;False;False;False;False;False;False
+Caimito;False;False;False;False;False;False;False;False;False
+Chalán;False;False;False;False;False;False;False;False;False
+Colosó;False;False;False;False;False;False;False;False;False
+Corozal;False;False;False;False;False;False;False;False;False
+Coveñas;False;False;False;False;False;False;False;False;False
+El Roble;False;False;False;False;False;False;False;False;False
+Galeras;False;False;False;False;False;False;False;False;False
+Guaranda;False;False;False;False;False;False;False;False;False
+La Unión;False;False;False;False;False;False;False;False;False
+Los Palmitos;False;False;False;False;False;False;False;False;False
+Majagual;False;False;False;False;False;False;False;False;False
+Morroa;False;False;False;False;False;False;False;False;False
+Ovejas;False;False;False;False;False;False;False;False;False
+Palmito;False;False;False;False;False;False;False;False;False
+Sampués;False;False;False;False;False;False;False;False;False
+San Benito Abad;False;False;False;False;False;False;False;False;False
+San Juan Betulia;False;False;False;False;False;False;False;False;False
+San Marcos;False;False;False;False;False;False;False;False;False
+San Onofre;False;False;False;False;False;False;False;False;False
+San Pedro;False;False;False;False;False;False;False;False;False
+Sincé;False;False;False;False;False;False;False;False;False
+Sincelejo;False;False;False;False;False;False;False;False;False
+Sucre;False;False;False;False;False;False;False;False;False
+Tolú;False;False;False;False;False;False;False;False;False
+Toluviejo;False;False;False;False;False;False;False;False;False
+Alpujarra;False;False;False;False;False;False;False;False;False
+Alvarado;False;False;False;False;False;False;False;False;False
+Ambalema;False;False;False;False;False;False;False;False;False
+Anzoátegui;False;False;False;False;True;False;False;False;False
+Armero;False;False;False;False;False;False;False;False;False
+Ataco;False;False;False;False;False;False;False;False;False
+Cajamarca;False;False;False;False;True;False;False;False;False
+Carmen Apicala;False;False;False;False;False;False;False;False;False
+Casabianca;False;False;False;False;False;False;False;False;False
+Chaparral;False;False;False;False;False;False;False;False;False
+Coello;False;False;False;False;False;False;False;False;False
+Coyaima;False;False;False;False;False;False;False;False;False
+Cunday;False;False;False;False;False;False;False;False;False
+Dolores;False;False;False;False;False;False;False;False;False
+Espinal;False;False;False;False;False;False;False;False;False
+Falán;False;False;False;False;False;False;False;False;False
+Flandes;False;False;False;False;False;False;False;False;False
+Fresno;False;False;False;False;False;False;False;False;False
+Guamo;False;False;False;False;False;False;False;False;False
+Herveo;False;False;False;False;False;False;False;False;False
+Honda;False;False;False;False;False;False;False;False;False
+Ibagué;False;False;False;False;True;False;False;False;False
+Icononzo;False;False;False;False;False;False;False;False;False
+Lérida;False;False;False;False;False;False;False;False;False
+Líbano;False;False;False;False;True;False;False;False;False
+Mariquita;False;False;False;False;False;False;False;False;False
+Melgar;False;False;False;False;False;False;False;False;False
+Murillo;False;False;False;False;True;False;False;False;False
+Natagaima;False;False;False;False;False;False;False;False;False
+Ortega;False;False;False;False;False;False;False;False;False
+Piedras;False;False;False;False;False;False;False;False;False
+Palocabildo;False;False;False;False;False;False;False;False;False
+Planadas;False;False;False;False;True;False;False;False;False
+Prado;False;False;False;False;False;False;False;False;False
+Purificación;False;False;False;False;False;False;False;False;False
+Rioblanco;False;False;False;False;True;False;False;False;False
+Roncesvalles;False;False;False;False;False;False;False;False;False
+Rovira;False;False;False;False;False;False;False;False;False
+Saldaña;False;False;False;False;False;False;False;False;False
+San Antonio;False;False;False;False;False;False;False;False;False
+San Luis;False;False;False;False;False;False;False;False;False
+Santa Isabel;False;False;False;False;True;False;False;False;False
+Suárez;False;False;False;False;False;False;False;False;False
+Valle de San Juan;False;False;False;False;False;False;False;False;False
+Venadillo;False;False;False;False;True;False;False;False;False
+Villahermosa;False;False;False;False;False;False;False;False;False
+Villarrica;False;False;False;False;False;False;False;False;False
+Alcalá;False;False;False;False;False;False;False;False;False
+Andalucía;False;False;False;False;True;False;False;False;False
+Ansermanuevo;False;False;False;False;False;False;False;False;False
+Argelia;False;False;False;False;False;False;False;False;False
+Bolívar;False;False;False;False;False;False;False;False;False
+Buenaventura;False;False;False;False;False;True;False;False;False
+Buga;False;False;False;False;True;False;False;False;False
+Bugalagrande;False;False;False;False;True;False;False;False;False
+Caicedonia;False;False;False;False;False;False;False;False;False
+Cali;False;False;False;False;False;False;False;False;False
+Calima;False;False;False;False;False;False;False;False;False
+Candelaria;False;False;False;False;False;False;False;False;False
+Cartago;False;False;False;False;False;False;False;False;False
+Dagua;False;False;False;False;False;False;False;False;False
+El Aguila;False;False;False;False;False;False;False;False;False
+El Cairo;False;False;False;False;False;False;False;False;False
+El Cerrito;False;False;False;False;True;False;False;False;False
+El Dovio;False;False;False;False;False;False;False;False;False
+Florida;False;False;False;False;False;False;False;False;False
+Ginebra;False;False;False;False;True;False;False;False;False
+Guacarí;False;False;False;False;False;False;False;False;False
+Jamundí;False;False;False;False;False;False;False;False;False
+La Cumbre;False;False;False;False;False;False;False;False;False
+La Unión;False;False;False;False;False;False;False;False;False
+La Victoria;False;False;False;False;False;False;False;False;False
+Obando;False;False;False;False;False;False;False;False;False
+Palmira;False;False;False;False;False;False;False;False;False
+Pradera;False;False;False;False;False;False;False;False;False
+Restrepo;False;False;False;False;False;False;False;False;False
+Riofrío;False;False;False;False;False;False;False;False;False
+Roldanillo;False;False;False;False;False;False;False;False;False
+San Pedro;False;False;False;False;True;False;False;False;False
+Sevilla;False;False;False;False;False;False;False;False;False
+Toro;False;False;False;False;False;False;False;False;False
+Trujillo;False;False;False;False;False;False;False;False;False
+Tuluá;False;False;False;False;False;False;False;False;False
+Ulloa;False;False;False;False;False;False;False;False;False
+Versalles;False;False;False;False;False;False;False;False;False
+Vijes;False;False;False;False;False;False;False;False;False
+Yotoco;False;False;False;False;False;False;False;False;False
+Yumbo;False;False;False;False;False;False;False;False;False
+Zarzal;False;False;False;False;False;False;False;False;False
+Caruru;False;False;False;False;False;False;False;False;False
+Mitú;False;False;False;False;False;False;False;False;False
+Taraira;False;False;False;False;False;False;False;False;True
+Acaricuara;False;False;False;False;False;False;False;False;False
+Villa Fátima;False;False;False;False;False;False;False;False;False
+Pacoa;False;False;False;False;False;False;False;False;True
+Papunahua;False;False;False;False;False;False;False;False;False
+Yavarate;False;False;False;False;False;False;False;False;False
+Cumaribo;False;False;False;False;False;False;False;False;False
+La Primavera;False;False;False;False;False;False;False;False;False
+Puerto Carreño;False;False;False;False;False;False;False;True;False
+Santa Rosalía;False;False;False;False;False;False;False;False;False

--- a/backend/db/seeds/files/colombia_regions.csv
+++ b/backend/db/seeds/files/colombia_regions.csv
@@ -1,15 +1,15 @@
 municipality;Cordillera Oriental;Piedemonte Amazónico - Macizo;Transición Pacífico - Caribe;Transición Orinoquía;Cordillera Central;Pacífico - Marino Costero;Caribe;Orinoquía;Corazón Amazonía
-Leticia;False;False;False;False;False;False;False;False;False
-Puerto Nariño;False;False;False;False;False;False;False;False;True
 El Encanto;False;False;False;False;False;False;False;False;False
 La Chorrera;False;False;False;False;False;False;False;False;False
-La Pedrera;False;False;False;False;False;False;False;False;True
-La Victoria;False;False;False;False;False;False;False;False;True
-Mirití-Paraná;False;False;False;False;False;False;False;False;True
+La Pedrera;False;False;False;False;False;False;False;False;False
+La Victoria (Pacoa);False;False;False;False;False;False;False;False;False
+Leticia;False;False;False;False;False;False;False;False;False
+Mirití-paraná (Campoamor);False;False;False;False;False;False;False;False;False
 Puerto Alegría;False;False;False;False;False;False;False;False;False
 Puerto Arica;False;False;False;False;False;False;False;False;False
-Puerto Santander;False;False;False;False;False;False;False;False;True
-Tarapacá;False;False;False;False;False;False;False;False;True
+Puerto Nariño;False;False;False;False;False;False;False;False;False
+Santander (Araracuara);False;False;False;False;False;False;False;False;False
+Tarapacá;False;False;False;False;False;False;False;False;False
 Abejorral;False;False;False;False;False;False;False;False;False
 Abriaquí;False;False;False;False;False;False;False;False;False
 Alejandría;False;False;False;False;False;False;False;False;False
@@ -20,8 +20,8 @@ Angelópolis;False;False;False;False;False;False;False;False;False
 Angostura;False;False;False;False;False;False;False;False;False
 Anorí;False;False;False;False;False;False;False;False;False
 Anzá;False;False;False;False;False;False;False;False;False
-Apartadó;False;False;True;False;False;False;False;False;False
-Arboletes;False;False;True;False;False;False;False;False;False
+Apartadó;False;False;False;False;False;False;False;False;False
+Arboletes;False;False;False;False;False;False;False;False;False
 Argelia;False;False;False;False;False;False;False;False;False
 Armenia;False;False;False;False;False;False;False;False;False
 Barbosa;False;False;False;False;False;False;False;False;False
@@ -29,7 +29,6 @@ Bello;False;False;False;False;False;False;False;False;False
 Belmira;False;False;False;False;False;False;False;False;False
 Betania;False;False;False;False;False;False;False;False;False
 Betulia;False;False;False;False;False;False;False;False;False
-Bolívar;False;False;False;False;False;False;False;False;False
 Briceño;False;False;False;False;False;False;False;False;False
 Buriticá;False;False;False;False;False;False;False;False;False
 Cáceres;False;False;False;False;False;False;False;False;False
@@ -39,12 +38,13 @@ Campamento;False;False;False;False;False;False;False;False;False
 Cañasgordas;False;False;False;False;False;False;False;False;False
 Caracolí;False;False;False;False;False;False;False;False;False
 Caramanta;False;False;False;False;False;False;False;False;False
-Carepa;False;False;True;False;False;False;False;False;False
-El Carmen de Viboral;False;False;False;False;False;False;False;False;False
-Carolina del Príncipe;False;False;False;False;False;False;False;False;False
+Carepa;False;False;False;False;False;False;False;False;False
+Carmen De Viboral;False;False;False;False;False;False;False;False;False
+Carolina;False;False;False;False;False;False;False;False;False
 Caucasia;False;False;False;False;False;False;False;False;False
-Chigorodó;False;False;True;False;False;False;False;False;False
+Chigorodó;False;False;False;False;False;False;False;False;False
 Cisneros;False;False;False;False;False;False;False;False;False
+Ciudad Bolívar;False;False;False;False;False;False;False;False;False
 Cocorná;False;False;False;False;False;False;False;False;False
 Concepción;False;False;False;False;False;False;False;False;False
 Concordia;False;False;False;False;False;False;False;False;False
@@ -53,7 +53,7 @@ Dabeiba;False;False;False;False;False;False;False;False;False
 Don Matías;False;False;False;False;False;False;False;False;False
 Ebéjico;False;False;False;False;False;False;False;False;False
 El Bagre;False;False;False;False;False;False;False;False;False
-Entrerríos;False;False;False;False;False;False;False;False;False
+Entrerrios;False;False;False;False;False;False;False;False;False
 Envigado;False;False;False;False;False;False;False;False;False
 Fredonia;False;False;False;False;False;False;False;False;False
 Frontino;False;False;False;False;False;False;False;False;False
@@ -83,7 +83,7 @@ Murindó;False;False;False;False;False;False;False;False;False
 Mutatá;False;False;False;False;False;False;False;False;False
 Nariño;False;False;False;False;False;False;False;False;False
 Nechí;False;False;False;False;False;False;False;False;False
-Necoclí;False;False;True;False;False;False;False;False;False
+Necoclí;False;False;False;False;False;False;False;False;False
 Olaya;False;False;False;False;False;False;False;False;False
 Peñol;False;False;False;False;False;False;False;False;False
 Peque;False;False;False;False;False;False;False;False;False
@@ -101,19 +101,19 @@ San Andrés;False;False;False;False;False;False;False;False;False
 San Carlos;False;False;False;False;False;False;False;False;False
 San Francisco;False;False;False;False;False;False;False;False;False
 San Jerónimo;False;False;False;False;False;False;False;False;False
-San José de la Montaña;False;False;False;False;False;False;False;False;False
-San Juan de Urabá;False;False;True;False;False;False;False;False;False
+San José De La Montaña;False;False;False;False;False;False;False;False;False
+San Juan De Urabá;False;False;False;False;False;False;False;False;False
 San Luis;False;False;False;False;False;False;False;False;False
 San Pedro;False;False;False;False;False;False;False;False;False
-San Pedro de Urabá;False;False;False;False;False;False;False;False;False
+San Pedro De Urabá;False;False;False;False;False;False;False;False;False
 San Rafael;False;False;False;False;False;False;False;False;False
 San Roque;False;False;False;False;False;False;False;False;False
-Santa Bárbara;False;False;False;False;False;False;False;False;False
-Santa Fe de Antioquia;False;False;False;False;False;False;False;False;False
-Santa Rosa de Osos;False;False;False;False;False;False;False;False;False
-Santo Domingo;False;False;False;False;False;False;False;False;False
-El Santuario;False;False;False;False;False;False;False;False;False
 San Vicente;False;False;False;False;False;False;False;False;False
+Santa Bárbara;False;False;False;False;False;False;False;False;False
+Santa Fe De Antioquia;False;False;False;False;False;False;False;False;False
+Santa Rosa De Osos;False;False;False;False;False;False;False;False;False
+Santo Domingo;False;False;False;False;False;False;False;False;False
+Santuario;False;False;False;False;False;False;False;False;False
 Segovia;False;False;False;False;False;False;False;False;False
 Sonsón;False;False;False;False;False;False;False;False;False
 Sopetrán;False;False;False;False;False;False;False;False;False
@@ -122,18 +122,18 @@ Tarazá;False;False;False;False;False;False;False;False;False
 Tarso;False;False;False;False;False;False;False;False;False
 Titiribí;False;False;False;False;False;False;False;False;False
 Toledo;False;False;False;False;False;False;False;False;False
-Turbo;False;False;True;False;False;False;False;False;False
+Turbo;False;False;False;False;False;False;False;False;False
 Uramita;False;False;False;False;False;False;False;False;False
 Urrao;False;False;False;False;False;False;False;False;False
 Valdivia;False;False;False;False;False;False;False;False;False
-Valparaíso;False;False;False;False;False;False;False;False;False
-Vegachi;False;False;False;False;False;False;False;False;False
+Valparaiso;False;False;False;False;False;False;False;False;False
+Vegachí;False;False;False;False;False;False;False;False;False
 Venecia;False;False;False;False;False;False;False;False;False
-Vigía del Fuerte;False;False;False;False;False;False;False;False;False
-Yali;False;False;False;False;False;False;False;False;False
+Vigia Del Fuerte;False;False;False;False;False;False;False;False;False
+Yalí;False;False;False;False;False;False;False;False;False
 Yarumal;False;False;False;False;False;False;False;False;False
 Yolombó;False;False;False;False;False;False;False;False;False
-Yondó;False;False;False;False;False;False;False;False;False
+Yondó (Casabe);False;False;False;False;False;False;False;False;False
 Zaragoza;False;False;False;False;False;False;False;False;False
 Arauca;False;False;False;False;False;False;False;False;False
 Arauquita;False;False;False;False;False;False;False;False;False
@@ -143,99 +143,80 @@ Puerto Rondón;False;False;False;False;False;False;False;False;False
 Saravena;False;False;False;False;False;False;False;False;False
 Tame;False;False;False;False;False;False;False;False;False
 Baranoa;False;False;False;False;False;False;False;False;False
-Barranquilla;False;False;False;False;False;False;True;False;False
-Campo de la Cruz;False;False;False;False;False;False;False;False;False
+Barranquilla;False;False;False;False;False;False;False;False;False
+Campo De La Cruz;False;False;False;False;False;False;False;False;False
 Candelaria;False;False;False;False;False;False;False;False;False
-Galapa;False;False;False;False;False;False;True;False;False
-Juan de Acosta;False;False;False;False;False;False;False;False;False
+Galapa;False;False;False;False;False;False;False;False;False
+Juan De Acosta;False;False;False;False;False;False;False;False;False
 Luruaco;False;False;False;False;False;False;False;False;False
 Malambo;False;False;False;False;False;False;False;False;False
 Manatí;False;False;False;False;False;False;False;False;False
-Palmar de Varela;False;False;False;False;False;False;False;False;False
+Palmar De Varela;False;False;False;False;False;False;False;False;False
 Piojó;False;False;False;False;False;False;False;False;False
 Polonuevo;False;False;False;False;False;False;False;False;False
 Ponedera;False;False;False;False;False;False;False;False;False
-Puerto Colombia;False;False;False;False;False;False;True;False;False
+Puerto Colombia;False;False;False;False;False;False;False;False;False
 Repelón;False;False;False;False;False;False;False;False;False
 Sabanagrande;False;False;False;False;False;False;False;False;False
 Sabanalarga;False;False;False;False;False;False;False;False;False
-Santa Lucia;False;False;False;False;False;False;False;False;False
-Santo Tomas;False;False;False;False;False;False;False;False;False
+Santa Lucía;False;False;False;False;False;False;False;False;False
+Santo Tomás;False;False;False;False;False;False;False;False;False
 Soledad;False;False;False;False;False;False;False;False;False
 Suan;False;False;False;False;False;False;False;False;False
 Tubará;False;False;False;False;False;False;False;False;False
 Usiacurí;False;False;False;False;False;False;False;False;False
-Antonio Nariño;False;False;False;False;False;False;False;False;False
-Barrios Unidos;False;False;False;False;False;False;False;False;False
-Bosa;False;False;False;False;False;False;False;False;False
-Chapinero;False;False;False;False;False;False;False;False;False
-Ciudad Bolívar;False;False;False;False;False;False;False;False;False
-Engativá;False;False;False;False;False;False;False;False;False
-Fontibón;False;False;False;False;False;False;False;False;False
-Kennedy;False;False;False;False;False;False;False;False;False
-La Candelaria;False;False;False;False;False;False;False;False;False
-Los Mártires;False;False;False;False;False;False;False;False;False
-Puente Aranda;False;False;False;False;False;False;False;False;False
-Rafael Uribe Uribe;False;False;False;False;False;False;False;False;False
-San Cristóbal;False;False;False;False;False;False;False;False;False
-Santa Fe;False;False;False;False;False;False;False;False;False
-Suba;False;False;False;False;False;False;False;False;False
-Sumapaz;False;False;False;True;False;False;False;False;False
-Teusaquillo;False;False;False;False;False;False;False;False;False
-Tunjuelito;False;False;False;False;False;False;False;False;False
-Usaquén;False;False;False;False;False;False;False;False;False
-Usme;False;False;False;False;False;False;False;False;False
 Achí;False;False;False;False;False;False;False;False;False
-Altos del Rosario;False;False;False;False;False;False;False;False;False
+Altos Del Rosario;False;False;False;False;False;False;False;False;False
+Arenal;False;False;False;False;False;False;False;False;False
 Arjona;False;False;False;False;False;False;False;False;False
-Arroyo Hondo;False;False;False;False;False;False;False;False;False
-Barranco de Loba;False;False;False;False;False;False;False;False;False
-Brazuelo de Papayal;False;False;False;False;False;False;False;False;False
-Calamar;False;False;False;False;False;False;True;False;False
+Arroyohondo;False;False;False;False;False;False;False;False;False
+Barranco De Loba;False;False;False;False;False;False;False;False;False
+Calamar;False;False;False;False;False;False;False;False;False
 Cantagallo;False;False;False;False;False;False;False;False;False
-Cartagena;False;False;False;False;False;False;False;False;False
+Cartagena De Indias;False;False;False;False;False;False;False;False;False
 Cicuco;False;False;False;False;False;False;False;False;False
 Clemencia;False;False;False;False;False;False;False;False;False
 Córdoba;False;False;False;False;False;False;False;False;False
-El Carmen de Bolívar;False;False;False;False;False;False;False;False;False
+El Carmen De Bolívar;False;False;False;False;False;False;False;False;False
 El Guamo;False;False;False;False;False;False;False;False;False
 El Peñón;False;False;False;False;False;False;False;False;False
-Hatillo de Loba;False;False;False;False;False;False;False;False;False
+Hatillo De Loba;False;False;False;False;False;False;False;False;False
 Magangué;False;False;False;False;False;False;False;False;False
 Mahates;False;False;False;False;False;False;False;False;False
 Margarita;False;False;False;False;False;False;False;False;False
 María La Baja;False;False;False;False;False;False;False;False;False
-Mompóx;False;False;False;False;False;False;False;False;False
+Mompós;False;False;False;False;False;False;False;False;False
 Montecristo;False;False;False;False;False;False;False;False;False
 Morales;False;False;False;False;False;False;False;False;False
-Norosí;False;False;False;False;False;False;False;False;False
+Norosi;False;False;False;False;False;False;False;False;False
 Pinillos;False;False;False;False;False;False;False;False;False
 Regidor;False;False;False;False;False;False;False;False;False
-Rio Viejo;False;False;False;False;False;False;False;False;False
-San Cristóbal;False;False;False;False;False;False;False;False;False
+Rioviejo;False;False;False;False;False;False;False;False;False
+San Cristobal;False;False;False;False;False;False;False;False;False
 San Estanislao;False;False;False;False;False;False;False;False;False
 San Fernando;False;False;False;False;False;False;False;False;False
 San Jacinto;False;False;False;False;False;False;False;False;False
+San Jacinto Del Cauca;False;False;False;False;False;False;False;False;False
 San Juan Nepomuceno;False;False;False;False;False;False;False;False;False
-San Martín de Loba;False;False;False;False;False;False;False;False;False
+San Martin De Loba;False;False;False;False;False;False;False;False;False
 San Pablo;False;False;False;False;False;False;False;False;False
 Santa Catalina;False;False;False;False;False;False;False;False;False
 Santa Rosa;False;False;False;False;False;False;False;False;False
-Santa Rosa del Sur;False;False;False;False;False;False;False;False;False
+Santa Rosa Del Sur;False;False;False;False;False;False;False;False;False
 Simití;False;False;False;False;False;False;False;False;False
 Soplaviento;False;False;False;False;False;False;False;False;False
-Talaiga Nuevo;False;False;False;False;False;False;False;False;False
-Tiquisio;False;False;False;False;False;False;False;False;False
+Talaigua Nuevo;False;False;False;False;False;False;False;False;False
+Tiquisio (Puerto Rico);False;False;False;False;False;False;False;False;False
 Turbaco;False;False;False;False;False;False;False;False;False
 Turbana;False;False;False;False;False;False;False;False;False
 Villanueva;False;False;False;False;False;False;False;False;False
 Zambrano;False;False;False;False;False;False;False;False;False
 Almeida;False;False;False;False;False;False;False;False;False
-Aquitania;True;False;False;False;False;False;False;False;False
-Arcabuco;True;False;False;False;False;False;False;False;False
-Belén;True;False;False;False;False;False;False;False;False
+Aquitania;False;False;False;False;False;False;False;False;False
+Arcabuco;False;False;False;False;False;False;False;False;False
+Belén;False;False;False;False;False;False;False;False;False
 Berbeo;False;False;False;False;False;False;False;False;False
-Betéitiva;True;False;False;False;False;False;False;False;False
+Betéitiva;False;False;False;False;False;False;False;False;False
 Boavita;False;False;False;False;False;False;False;False;False
 Boyacá;False;False;False;False;False;False;False;False;False
 Briceño;False;False;False;False;False;False;False;False;False
@@ -243,38 +224,38 @@ Buenavista;False;False;False;False;False;False;False;False;False
 Busbanzá;False;False;False;False;False;False;False;False;False
 Caldas;False;False;False;False;False;False;False;False;False
 Campohermoso;False;False;False;False;False;False;False;False;False
-Cerinza;True;False;False;False;False;False;False;False;False
+Cerinza;False;False;False;False;False;False;False;False;False
 Chinavita;False;False;False;False;False;False;False;False;False
 Chiquinquirá;False;False;False;False;False;False;False;False;False
 Chíquiza;False;False;False;False;False;False;False;False;False
-Chiscas;True;False;False;False;False;False;False;False;False
-Chita;True;False;False;False;False;False;False;False;False
+Chiscas;False;False;False;False;False;False;False;False;False
+Chita;False;False;False;False;False;False;False;False;False
 Chitaraque;False;False;False;False;False;False;False;False;False
 Chivatá;False;False;False;False;False;False;False;False;False
 Chivor;False;False;False;False;False;False;False;False;False
 Ciénega;False;False;False;False;False;False;False;False;False
-Coper;False;False;False;False;False;False;False;False;False
-Corrales;True;False;False;False;False;False;False;False;False
-Covarachía;True;False;False;False;False;False;False;False;False
-Cubará;True;False;False;False;False;False;False;False;False
-Cucaita;False;False;False;False;False;False;False;False;False
-Cuítiva;True;False;False;False;False;False;False;False;False
 Cómbita;False;False;False;False;False;False;False;False;False
+Coper;False;False;False;False;False;False;False;False;False
+Corrales;False;False;False;False;False;False;False;False;False
+Covarachía;False;False;False;False;False;False;False;False;False
+Cubará;False;False;False;False;False;False;False;False;False
+Cucaita;False;False;False;False;False;False;False;False;False
+Cuítiva;False;False;False;False;False;False;False;False;False
 Duitama;False;False;False;False;False;False;False;False;False
-El Cocuy;True;False;False;False;False;False;False;False;False
-El Espino;True;False;False;False;False;False;False;False;False
+El Cocuy;False;False;False;False;False;False;False;False;False
+El Espino;False;False;False;False;False;False;False;False;False
 Firavitoba;False;False;False;False;False;False;False;False;False
 Floresta;False;False;False;False;False;False;False;False;False
 Gachantivá;False;False;False;False;False;False;False;False;False
+Gámeza;False;False;False;False;False;False;False;False;False
 Garagoa;False;False;False;False;False;False;False;False;False
-Guacamayas;True;False;False;False;False;False;False;False;False
+Guacamayas;False;False;False;False;False;False;False;False;False
 Guateque;False;False;False;False;False;False;False;False;False
 Guayatá;False;False;False;False;False;False;False;False;False
-Gámeza;True;False;False;False;False;False;False;False;False
-Güicán;True;False;False;False;False;False;False;False;False
-Iza;True;False;False;False;False;False;False;False;False
+Guicán;False;False;False;False;False;False;False;False;False
+Iza;False;False;False;False;False;False;False;False;False
 Jenesano;False;False;False;False;False;False;False;False;False
-Jericó;True;False;False;False;False;False;False;False;False
+Jericó;False;False;False;False;False;False;False;False;False
 La Capilla;False;False;False;False;False;False;False;False;False
 La Uvita;False;False;False;False;False;False;False;False;False
 La Victoria;False;False;False;False;False;False;False;False;False
@@ -282,7 +263,7 @@ Labranzagrande;False;False;False;False;False;False;False;False;False
 Macanal;False;False;False;False;False;False;False;False;False
 Maripí;False;False;False;False;False;False;False;False;False
 Miraflores;False;False;False;False;False;False;False;False;False
-Mongua;True;False;False;False;False;False;False;False;False
+Mongua;False;False;False;False;False;False;False;False;False
 Monguí;False;False;False;False;False;False;False;False;False
 Moniquirá;False;False;False;False;False;False;False;False;False
 Motavita;False;False;False;False;False;False;False;False;False
@@ -292,125 +273,125 @@ Nuevo Colón;False;False;False;False;False;False;False;False;False
 Oicatá;False;False;False;False;False;False;False;False;False
 Otanche;False;False;False;False;False;False;False;False;False
 Pachavita;False;False;False;False;False;False;False;False;False
-Paipa;True;False;False;False;False;False;False;False;False
+Páez;False;False;False;False;False;False;False;False;False
+Paipa;False;False;False;False;False;False;False;False;False
 Pajarito;False;False;False;False;False;False;False;False;False
-Panqueba;True;False;False;False;False;False;False;False;False
+Panqueba;False;False;False;False;False;False;False;False;False
 Pauna;False;False;False;False;False;False;False;False;False
 Paya;False;False;False;False;False;False;False;False;False
-Paz de Río;True;False;False;False;False;False;False;False;False
-Pesca;True;False;False;False;False;False;False;False;False
-Pisba;False;False;False;False;False;False;False;False;False
+Paz De Rio;False;False;False;False;False;False;False;False;False
+Pesca;False;False;False;False;False;False;False;False;False
+Pisva;False;False;False;False;False;False;False;False;False
 Puerto Boyacá;False;False;False;False;False;False;False;False;False
-Páez;False;False;False;False;False;False;False;False;False
 Quípama;False;False;False;False;False;False;False;False;False
 Ramiriquí;False;False;False;False;False;False;False;False;False
-Rondón;False;False;False;False;False;False;False;False;False
 Ráquira;False;False;False;False;False;False;False;False;False
+Rondón;False;False;False;False;False;False;False;False;False
 Saboyá;False;False;False;False;False;False;False;False;False
+Sáchica;False;False;False;False;False;False;False;False;False
 Samacá;False;False;False;False;False;False;False;False;False
 San Eduardo;False;False;False;False;False;False;False;False;False
-San José de Pare;False;False;False;False;False;False;False;False;False
-San Luis de Gaceno;False;False;False;False;False;False;False;False;False
+San José De Pare;False;False;False;False;False;False;False;False;False
+San Luis De Gaceno;False;False;False;False;False;False;False;False;False
 San Mateo;False;False;False;False;False;False;False;False;False
-San Miguel de Sema;False;False;False;False;False;False;False;False;False
-San Pablo de Borbur;False;False;False;False;False;False;False;False;False
-Santa María;False;False;False;True;False;False;False;False;False
-Santa Rosa de Viterbo;False;False;False;False;False;False;False;False;False
+San Miguel De Sema;False;False;False;False;False;False;False;False;False
+San Pablo De Borbur;False;False;False;False;False;False;False;False;False
+Santa María;False;False;False;False;False;False;False;False;False
+Santa Rosa De Viterbo;False;False;False;False;False;False;False;False;False
 Santa Sofía;False;False;False;False;False;False;False;False;False
 Santana;False;False;False;False;False;False;False;False;False
-Sativanorte;True;False;False;False;False;False;False;False;False
-Sativasur;True;False;False;False;False;False;False;False;False
+Sativanorte;False;False;False;False;False;False;False;False;False
+Sativasur;False;False;False;False;False;False;False;False;False
 Siachoque;False;False;False;False;False;False;False;False;False
-Soatá;True;False;False;False;False;False;False;False;False
-Socha;True;False;False;False;False;False;False;False;False
-Socotá;True;False;False;False;False;False;False;False;False
+Soatá;False;False;False;False;False;False;False;False;False
+Socha;False;False;False;False;False;False;False;False;False
+Socotá;False;False;False;False;False;False;False;False;False
 Sogamoso;False;False;False;False;False;False;False;False;False
 Somondoco;False;False;False;False;False;False;False;False;False
 Sora;False;False;False;False;False;False;False;False;False
 Soracá;False;False;False;False;False;False;False;False;False
 Sotaquirá;False;False;False;False;False;False;False;False;False
-Susacón;True;False;False;False;False;False;False;False;False
+Susacón;False;False;False;False;False;False;False;False;False
 Sutamarchán;False;False;False;False;False;False;False;False;False
 Sutatenza;False;False;False;False;False;False;False;False;False
-Sáchica;False;False;False;False;False;False;False;False;False
-Tasco;True;False;False;False;False;False;False;False;False
+Tasco;False;False;False;False;False;False;False;False;False
 Tenza;False;False;False;False;False;False;False;False;False
 Tibaná;False;False;False;False;False;False;False;False;False
 Tibasosa;False;False;False;False;False;False;False;False;False
 Tinjacá;False;False;False;False;False;False;False;False;False
 Tipacoque;False;False;False;False;False;False;False;False;False
 Toca;False;False;False;False;False;False;False;False;False
-Togüí, Boyacá;False;False;False;False;False;False;False;False;False
-Tota;True;False;False;False;False;False;False;False;False
+Togüí;False;False;False;False;False;False;False;False;False
+Tópaga;False;False;False;False;False;False;False;False;False
+Tota;False;False;False;False;False;False;False;False;False
 Tunja;False;False;False;False;False;False;False;False;False
 Tununguá;False;False;False;False;False;False;False;False;False
 Turmequé;False;False;False;False;False;False;False;False;False
 Tuta;False;False;False;False;False;False;False;False;False
-Tutazá;True;False;False;False;False;False;False;False;False
-Tópaga;False;False;False;False;False;False;False;False;False
+Tutazá;False;False;False;False;False;False;False;False;False
 Úmbita;False;False;False;False;False;False;False;False;False
 Ventaquemada;False;False;False;False;False;False;False;False;False
-Villa de Leyva;False;False;False;False;False;False;False;False;False
+Villa De Leiva;False;False;False;False;False;False;False;False;False
 Viracachá;False;False;False;False;False;False;False;False;False
 Zetaquirá;False;False;False;False;False;False;False;False;False
 Aguadas;False;False;False;False;False;False;False;False;False
 Anserma;False;False;False;False;False;False;False;False;False
 Aranzazu;False;False;False;False;False;False;False;False;False
-Belalcázar;False;False;False;False;False;False;False;False;False
-Chinchiná;False;False;False;False;True;False;False;False;False
+Belalcazar;False;False;False;False;False;False;False;False;False
+Chinchiná;False;False;False;False;False;False;False;False;False
 Filadelfia;False;False;False;False;False;False;False;False;False
 La Dorada;False;False;False;False;False;False;False;False;False
 La Merced;False;False;False;False;False;False;False;False;False
-Manizales;False;False;False;False;True;False;False;False;False
+Manizales;False;False;False;False;False;False;False;False;False
 Manzanares;False;False;False;False;False;False;False;False;False
 Marmato;False;False;False;False;False;False;False;False;False
 Marquetalia;False;False;False;False;False;False;False;False;False
 Marulanda;False;False;False;False;False;False;False;False;False
-Neira;False;False;False;False;True;False;False;False;False
+Neira;False;False;False;False;False;False;False;False;False
 Norcasia;False;False;False;False;False;False;False;False;False
 Pácora;False;False;False;False;False;False;False;False;False
 Palestina;False;False;False;False;False;False;False;False;False
 Pensilvania;False;False;False;False;False;False;False;False;False
 Riosucio;False;False;False;False;False;False;False;False;False
-Risaralda;False;False;False;False;True;False;False;False;False
+Risaralda;False;False;False;False;False;False;False;False;False
 Salamina;False;False;False;False;False;False;False;False;False
 Samaná;False;False;False;False;False;False;False;False;False
 San José;False;False;False;False;False;False;False;False;False
-Supía;False;False;False;False;False;False;False;False;False
+Supia;False;False;False;False;False;False;False;False;False
 Victoria;False;False;False;False;False;False;False;False;False
-Villamaría;False;False;False;False;True;False;False;False;False
+Villamaria;False;False;False;False;False;False;False;False;False
 Viterbo;False;False;False;False;False;False;False;False;False
-Albania;False;True;False;False;False;False;False;False;False
-Belén de Andaquies;False;True;False;False;False;False;False;False;False
-Cartagena del Chairá;False;False;False;False;False;False;False;False;False
-Curillo;False;True;False;False;False;False;False;False;False
+Albania;False;False;False;False;False;False;False;False;False
+Belén De Los Andaquíes;False;False;False;False;False;False;False;False;False
+Cartagena Del Chairá;False;False;False;False;False;False;False;False;False
+Curillo;False;False;False;False;False;False;False;False;False
 El Doncello;False;False;False;False;False;False;False;False;False
 El Paujil;False;False;False;False;False;False;False;False;False
 Florencia;False;False;False;False;False;False;False;False;False
-La Montañita;False;False;False;False;False;False;False;False;False
 Milán;False;False;False;False;False;False;False;False;False
+Montañita;False;False;False;False;False;False;False;False;False
 Morelia;False;False;False;False;False;False;False;False;False
 Puerto Rico;False;False;False;False;False;False;False;False;False
-San José de la Fragua;False;True;False;False;False;False;False;False;False
-San Vicente del Caguán;False;False;False;False;False;False;False;False;False
-Solano;False;False;False;False;False;False;False;False;True
+San José Del Fragua;False;False;False;False;False;False;False;False;False
+San Vicente Del Caguán;False;False;False;False;False;False;False;False;False
+Solano;False;False;False;False;False;False;False;False;False
 Solita;False;False;False;False;False;False;False;False;False
 Valparaíso;False;False;False;False;False;False;False;False;False
 Aguazul;False;False;False;False;False;False;False;False;False
 Chámeza;False;False;False;False;False;False;False;False;False
 Hato Corozal;False;False;False;False;False;False;False;False;False
-La Salina;True;False;False;False;False;False;False;False;False
+La Salina;False;False;False;False;False;False;False;False;False
 Maní;False;False;False;False;False;False;False;False;False
 Monterrey;False;False;False;False;False;False;False;False;False
 Nunchía;False;False;False;False;False;False;False;False;False
-Orocué;False;False;False;False;False;False;False;False;True
-Paz de Ariporo;True;False;False;False;False;False;False;False;False
+Orocué;False;False;False;False;False;False;False;False;False
+Paz de Ariporo;False;False;False;False;False;False;False;False;False
 Pore;False;False;False;False;False;False;False;False;False
 Recetor;False;False;False;False;False;False;False;False;False
 Sabanalarga;False;False;False;False;False;False;False;False;False
-Sácama;True;False;False;False;False;False;False;False;False
-San Luis de Palenque;False;False;False;False;False;False;False;False;False
-Támara;True;False;False;False;False;False;False;False;False
+Sácama;False;False;False;False;False;False;False;False;False
+San Luis De Palenque;False;False;False;False;False;False;False;False;False
+Támara;False;False;False;False;False;False;False;False;False
 Tauramena;False;False;False;False;False;False;False;False;False
 Trinidad;False;False;False;False;False;False;False;False;False
 Villanueva;False;False;False;False;False;False;False;False;False
@@ -420,105 +401,105 @@ Argelia;False;False;False;False;False;False;False;False;False
 Balboa;False;False;False;False;False;False;False;False;False
 Bolívar;False;False;False;False;False;False;False;False;False
 Buenos Aires;False;False;False;False;False;False;False;False;False
-Cajibio;False;False;False;False;False;False;False;False;False
+Cajibío;False;False;False;False;False;False;False;False;False
 Caldono;False;False;False;False;False;False;False;False;False
 Caloto;False;False;False;False;False;False;False;False;False
-Corinto;False;False;False;False;True;False;False;False;False
+Corinto;False;False;False;False;False;False;False;False;False
 El Tambo;False;False;False;False;False;False;False;False;False
 Florencia;False;False;False;False;False;False;False;False;False
-Guachené;False;False;False;False;False;False;False;False;False
-Guapi;False;False;False;False;False;True;False;False;False
-Inza;False;False;False;False;False;False;False;False;False
-Jambalo;False;False;False;False;False;False;False;False;False
+Guachene;False;False;False;False;False;False;False;False;False
+Guapi;False;False;False;False;False;False;False;False;False
+Inzá;False;False;False;False;False;False;False;False;False
+Jambaló;False;False;False;False;False;False;False;False;False
 La Sierra;False;False;False;False;False;False;False;False;False
 La Vega;False;False;False;False;False;False;False;False;False
-López de Micay;False;False;False;False;False;False;False;False;False
+López;False;False;False;False;False;False;False;False;False
 Mercaderes;False;False;False;False;False;False;False;False;False
-Miranda;False;False;False;False;True;False;False;False;False
+Miranda;False;False;False;False;False;False;False;False;False
 Morales;False;False;False;False;False;False;False;False;False
-Padilla;False;False;False;False;True;False;False;False;False
-Páez;False;False;False;False;False;False;False;False;False
-Patía;False;False;False;False;False;False;False;False;False
-Piamonte;False;True;False;False;False;False;False;False;False
+Padilla;False;False;False;False;False;False;False;False;False
+Páez (Belalcázar);False;False;False;False;False;False;False;False;False
+Patía (El Bordo);False;False;False;False;False;False;False;False;False
+Piamonte;False;False;False;False;False;False;False;False;False
 Piendamó;False;False;False;False;False;False;False;False;False
 Popayán;False;False;False;False;False;False;False;False;False
 Puerto Tejada;False;False;False;False;False;False;False;False;False
-Purace;False;False;False;False;True;False;False;False;False
+Puracé (Coconuco);False;False;False;False;False;False;False;False;False
 Rosas;False;False;False;False;False;False;False;False;False
 San Sebastián;False;False;False;False;False;False;False;False;False
-Santander de Quilichao;False;False;False;False;False;False;False;False;False
-Santa Rosa;False;True;False;False;False;False;False;False;False
+Santa Rosa;False;False;False;False;False;False;False;False;False
+Santander De Quilichao;False;False;False;False;False;False;False;False;False
 Silvia;False;False;False;False;False;False;False;False;False
-Sotará;False;False;False;False;False;False;False;False;False
-Suarez;False;False;False;False;False;False;False;False;False
+Sotará (Paispamba);False;False;False;False;False;False;False;False;False
+Suárez;False;False;False;False;False;False;False;False;False
 Sucre;False;False;False;False;False;False;False;False;False
 Timbío;False;False;False;False;False;False;False;False;False
-Timbiqui;False;False;False;False;False;False;False;False;False
+Timbiquí;False;False;False;False;False;False;False;False;False
 Toribío;False;False;False;False;False;False;False;False;False
-Totoro;False;False;False;False;False;False;False;False;False
+Totoró;False;False;False;False;False;False;False;False;False
 Villa Rica;False;False;False;False;False;False;False;False;False
 Aguachica;False;False;False;False;False;False;False;False;False
+Agustín Codazzi;False;False;False;False;False;False;False;False;False
 Astrea;False;False;False;False;False;False;False;False;False
-Becerril;False;False;False;False;False;False;False;False;False
+Becerrill;False;False;False;False;False;False;False;False;False
 Bosconia;False;False;False;False;False;False;False;False;False
 Chimichagua;False;False;False;False;False;False;False;False;False
 Chiriguaná;False;False;False;False;False;False;False;False;False
-Codazzi;False;False;False;False;False;False;True;False;False
 Curumaní;False;False;False;False;False;False;False;False;False
 El Copey;False;False;False;False;False;False;False;False;False
 El Paso;False;False;False;False;False;False;False;False;False
 Gamarra;False;False;False;False;False;False;False;False;False
 González;False;False;False;False;False;False;False;False;False
 La Gloria;False;False;False;False;False;False;False;False;False
-La Jagua de Ibirico;False;False;False;False;False;False;False;False;False
-Manaure;False;False;False;False;False;False;False;False;False
+La Jagua De Ibirico;False;False;False;False;False;False;False;False;False
+La Paz;False;False;False;False;False;False;False;False;False
+Manaure Balcón Del Cesar;False;False;False;False;False;False;False;False;False
 Pailitas;False;False;False;False;False;False;False;False;False
 Pelaya;False;False;False;False;False;False;False;False;False
-Pueblo Bello;False;False;False;False;False;False;True;False;False
-Rio de Oro;False;False;False;False;False;False;False;False;False
-Los Robles La Paz;False;False;False;False;False;False;True;False;False
+Pueblo Bello;False;False;False;False;False;False;False;False;False
+Rio De Oro;False;False;False;False;False;False;False;False;False
 San Alberto;False;False;False;False;False;False;False;False;False
-San Diego;False;False;False;False;False;False;True;False;False
+San Diego;False;False;False;False;False;False;False;False;False
 San Martín;False;False;False;False;False;False;False;False;False
 Tamalameque;False;False;False;False;False;False;False;False;False
-Valledupar;False;False;False;False;False;False;True;False;False
-Acandí;False;False;True;False;False;False;False;False;False
-Alto Baudó;False;False;False;False;False;False;False;False;False
-Atrato;False;False;False;False;False;False;False;False;False
+Valledupar;False;False;False;False;False;False;False;False;False
+Acandí;False;False;False;False;False;False;False;False;False
+Alto Baudó (Pie De Pato);False;False;False;False;False;False;False;False;False
+Atrato (Yuto);False;False;False;False;False;False;False;False;False
 Bagadó;False;False;False;False;False;False;False;False;False
-Bahía Solano;False;False;False;False;False;True;False;False;False
-Bajo Baudó;False;False;False;False;False;True;False;False;False
-Bojayá;False;False;False;False;False;False;False;False;False
+Bahía Solano (Mutis);False;False;False;False;False;False;False;False;False
+Bajo Baudó (Pizarro);False;False;False;False;False;False;False;False;False
+Bojayá (Bellavista);False;False;False;False;False;False;False;False;False
+Carmen Del Darién (Curbaradó);False;False;False;False;False;False;False;False;False
 Cértegui;False;False;False;False;False;False;False;False;False
 Condoto;False;False;False;False;False;False;False;False;False
-El Cantón de San Pablo;False;False;False;False;False;False;False;False;False
-El Carmen de Atrato;False;False;False;False;False;False;False;False;False
-El Carmen del Darién;False;False;False;False;False;False;False;False;False
+El Cantón Del San Pablo (Managrú);False;False;False;False;False;False;False;False;False
+El Carmen;False;False;False;False;False;False;False;False;False
+El Litoral Del San Juán (Docordó);False;False;False;False;False;False;False;False;False
 Istmina;False;False;False;False;False;False;False;False;False
-Juradó;False;False;False;False;False;True;False;False;False
-Litoral del San Juan;False;False;False;False;False;True;False;False;False
+Juradó;False;False;False;False;False;False;False;False;False
 Lloró;False;False;False;False;False;False;False;False;False
-Medio Atrato;False;False;False;False;False;False;False;False;False
-Medio Baudó;False;False;False;False;False;False;False;False;False
-Medio San Juan;False;False;False;False;False;False;False;False;False
+Medio Atrato (Beté);False;False;False;False;False;False;False;False;False
+Medio Baudó(boca De Pepé);False;False;False;False;False;False;False;False;False
+Medio San Juan (Andagoya);False;False;False;False;False;False;False;False;False
 Nóvita;False;False;False;False;False;False;False;False;False
-Nuquí;False;False;False;False;False;True;False;False;False
+Nuquí;False;False;False;False;False;False;False;False;False
 Quibdó;False;False;False;False;False;False;False;False;False
-Río Iró;False;False;False;False;False;False;False;False;False
-Río Quito;False;False;False;False;False;False;False;False;False
+Rio Iró (Santa Rita);False;False;False;False;False;False;False;False;False
+Rio Quito (Paimadó);False;False;False;False;False;False;False;False;False
 Riosucio;False;False;False;False;False;False;False;False;False
-San José del Palmar;False;False;False;False;False;False;False;False;False
+San José Del Palmar;False;False;False;False;False;False;False;False;False
 Sipí;False;False;False;False;False;False;False;False;False
 Tadó;False;False;False;False;False;False;False;False;False
-Unguía;False;False;True;False;False;False;False;False;False
-Unión Panamericana;False;False;False;False;False;False;False;False;False
+Unguía;False;False;False;False;False;False;False;False;False
+Unión Panamericana ( Animas);False;False;False;False;False;False;False;False;False
 Ayapel;False;False;False;False;False;False;False;False;False
 Buenavista;False;False;False;False;False;False;False;False;False
 Canalete;False;False;False;False;False;False;False;False;False
 Cereté;False;False;False;False;False;False;False;False;False
-Chimá;False;False;False;False;False;False;False;False;False
+Chima;False;False;False;False;False;False;False;False;False
 Chinú;False;False;False;False;False;False;False;False;False
-Ciénaga de Oro;False;False;False;False;False;False;False;False;False
+Ciénaga De Oro;False;False;False;False;False;False;False;False;False
 Cotorra;False;False;False;False;False;False;False;False;False
 La Apartada;False;False;False;False;False;False;False;False;False
 Lorica;False;False;False;False;False;False;False;False;False
@@ -533,16 +514,16 @@ Puerto Escondido;False;False;False;False;False;False;False;False;False
 Puerto Libertador;False;False;False;False;False;False;False;False;False
 Purísima;False;False;False;False;False;False;False;False;False
 Sahagún;False;False;False;False;False;False;False;False;False
-San Andrés de Sotavento;False;False;False;False;False;False;False;False;False
+San Andrés De Sotavento;False;False;False;False;False;False;False;False;False
 San Antero;False;False;False;False;False;False;False;False;False
-San Bernardo del Viento;False;False;False;False;False;False;False;False;False
+San Bernardo Del Viento;False;False;False;False;False;False;False;False;False
 San Carlos;False;False;False;False;False;False;False;False;False
-San José de Uré;False;False;False;False;False;False;False;False;False
+San Jose De Ure;False;False;False;False;False;False;False;False;False
 San Pelayo;False;False;False;False;False;False;False;False;False
 Tierralta;False;False;False;False;False;False;False;False;False
 Tuchín;False;False;False;False;False;False;False;False;False
 Valencia;False;False;False;False;False;False;False;False;False
-Agua de Dios;False;False;False;False;False;False;False;False;False
+Agua De Dios;False;False;False;False;False;False;False;False;False
 Albán;False;False;False;False;False;False;False;False;False
 Anapoima;False;False;False;False;False;False;False;False;False
 Anolaima;False;False;False;False;False;False;False;False;False
@@ -550,18 +531,19 @@ Apulo;False;False;False;False;False;False;False;False;False
 Arbeláez;False;False;False;False;False;False;False;False;False
 Beltrán;False;False;False;False;False;False;False;False;False
 Bituima;False;False;False;False;False;False;False;False;False
+Bogotá, D.c.;False;False;False;False;False;False;False;False;False
 Bojacá;False;False;False;False;False;False;False;False;False
 Cabrera;False;False;False;False;False;False;False;False;False
 Cachipay;False;False;False;False;False;False;False;False;False
 Cajicá;False;False;False;False;False;False;False;False;False
 Caparrapí;False;False;False;False;False;False;False;False;False
 Cáqueza;False;False;False;False;False;False;False;False;False
-Carmen de Carupa;False;False;False;False;False;False;False;False;False
+Carmen De Carupa;False;False;False;False;False;False;False;False;False
 Chaguaní;False;False;False;False;False;False;False;False;False
+Chía;False;False;False;False;False;False;False;False;False
 Chipaque;False;False;False;False;False;False;False;False;False
 Choachí;False;False;False;False;False;False;False;False;False
 Chocontá;False;False;False;False;False;False;False;False;False
-Chía;False;False;False;False;False;False;False;False;False
 Cogua;False;False;False;False;False;False;False;False;False
 Cota;False;False;False;False;False;False;False;False;False
 Cucunubá;False;False;False;False;False;False;False;False;False
@@ -572,8 +554,8 @@ Facatativá;False;False;False;False;False;False;False;False;False
 Fómeque;False;False;False;False;False;False;False;False;False
 Fosca;False;False;False;False;False;False;False;False;False
 Funza;False;False;False;False;False;False;False;False;False
-Fusagasugá;False;False;False;False;False;False;False;False;False
 Fúquene;False;False;False;False;False;False;False;False;False
+Fusagasugá;False;False;False;False;False;False;False;False;False
 Gachalá;False;False;False;False;False;False;False;False;False
 Gachancipá;False;False;False;False;False;False;False;False;False
 Gachetá;False;False;False;False;False;False;False;False;False
@@ -585,11 +567,11 @@ Guaduas;False;False;False;False;False;False;False;False;False
 Guasca;False;False;False;False;False;False;False;False;False
 Guataquí;False;False;False;False;False;False;False;False;False
 Guatavita;False;False;False;False;False;False;False;False;False
-Guayabal de Síquima;False;False;False;False;False;False;False;False;False
-Guayabetal;False;False;False;True;False;False;False;False;False
-Gutiérrez;False;False;False;True;False;False;False;False;False
-Jerusalen;False;False;False;False;False;False;False;False;False
-Junín;False;False;False;True;False;False;False;False;False
+Guayabal De Síquima;False;False;False;False;False;False;False;False;False
+Guayabetal;False;False;False;False;False;False;False;False;False
+Gutiérrez;False;False;False;False;False;False;False;False;False
+Jerusalén;False;False;False;False;False;False;False;False;False
+Junín;False;False;False;False;False;False;False;False;False
 La Calera;False;False;False;False;False;False;False;False;False
 La Mesa;False;False;False;False;False;False;False;False;False
 La Palma;False;False;False;False;False;False;False;False;False
@@ -617,11 +599,11 @@ Quebradanegra;False;False;False;False;False;False;False;False;False
 Quetame;False;False;False;False;False;False;False;False;False
 Quipile;False;False;False;False;False;False;False;False;False
 Ricaurte;False;False;False;False;False;False;False;False;False
-San Antonio del Tequendama;False;False;False;False;False;False;False;False;False
+San Antonio De Tequendama;False;False;False;False;False;False;False;False;False
 San Bernardo;False;False;False;False;False;False;False;False;False
 San Cayetano;False;False;False;False;False;False;False;False;False
 San Francisco;False;False;False;False;False;False;False;False;False
-San Juan de Rioseco;False;False;False;False;False;False;False;False;False
+San Juan De Rioseco;False;False;False;False;False;False;False;False;False
 Sasaima;False;False;False;False;False;False;False;False;False
 Sesquilé;False;False;False;False;False;False;False;False;False
 Sibaté;False;False;False;False;False;False;False;False;False
@@ -639,7 +621,7 @@ Tausa;False;False;False;False;False;False;False;False;False
 Tena;False;False;False;False;False;False;False;False;False
 Tenjo;False;False;False;False;False;False;False;False;False
 Tibacuy;False;False;False;False;False;False;False;False;False
-Tibiritá;False;False;False;False;False;False;False;False;False
+Tibirita;False;False;False;False;False;False;False;False;False
 Tocaima;False;False;False;False;False;False;False;False;False
 Tocancipá;False;False;False;False;False;False;False;False;False
 Topaipí;False;False;False;False;False;False;False;False;False
@@ -658,33 +640,19 @@ Viotá;False;False;False;False;False;False;False;False;False
 Yacopí;False;False;False;False;False;False;False;False;False
 Zipacón;False;False;False;False;False;False;False;False;False
 Zipaquirá;False;False;False;False;False;False;False;False;False
-Albania;False;False;False;False;False;False;True;False;False
-Barrancas;False;False;False;False;False;False;True;False;False
-Dibulla;False;False;False;False;False;False;True;False;False
-Distracción;False;False;False;False;False;False;True;False;False
-El Molino;False;False;False;False;False;False;True;False;False
-Fonseca;False;False;False;False;False;False;True;False;False
-Hatonuevo;False;False;False;False;False;False;True;False;False
-La Jagua del Pilar;False;False;False;False;False;False;True;False;False
-Maicao;False;False;False;False;False;False;False;False;False
-Manaure;False;False;False;False;False;False;False;False;False
-Riohacha;False;False;False;False;False;False;True;False;False
-San Juan del Cesar;False;False;False;False;False;False;True;False;False
-Uribia;False;False;False;False;False;False;False;False;False
-Urumita;False;False;False;False;False;False;True;False;False
-Villanueva;False;False;False;False;False;False;True;False;False
-Barranco Minas;False;False;False;False;False;False;False;False;False
+Barranco Mina;False;False;False;False;False;False;False;False;False
 Cacahual;False;False;False;False;False;False;False;False;False
-Inirida;False;False;False;False;False;False;False;True;False
+Inírida;False;False;False;False;False;False;False;False;False
 La Guadalupe;False;False;False;False;False;False;False;False;False
-Morichal Nuevo;False;False;False;False;False;False;False;False;False
-Pana Pana;False;False;False;False;False;False;False;False;False
+Mapiripana;False;False;False;False;False;False;False;False;False
+Morichal (Morichal Nuevo);False;False;False;False;False;False;False;False;False
+Paná-paná (Campo Alegre);False;False;False;False;False;False;False;False;False
 Puerto Colombia;False;False;False;False;False;False;False;False;False
 San Felipe;False;False;False;False;False;False;False;False;False
 Calamar;False;False;False;False;False;False;False;False;False
 El Retorno;False;False;False;False;False;False;False;False;False
 Miraflores;False;False;False;False;False;False;False;False;False
-San José del Guaviare;False;False;False;True;False;False;False;False;False
+San José Del Guaviare;False;False;False;False;False;False;False;False;False
 Acevedo;False;False;False;False;False;False;False;False;False
 Agrado;False;False;False;False;False;False;False;False;False
 Aipe;False;False;False;False;False;False;False;False;False
@@ -693,115 +661,130 @@ Altamira;False;False;False;False;False;False;False;False;False
 Baraya;False;False;False;False;False;False;False;False;False
 Campoalegre;False;False;False;False;False;False;False;False;False
 Colombia;False;False;False;False;False;False;False;False;False
-Elias;False;False;False;False;False;False;False;False;False
+Elías;False;False;False;False;False;False;False;False;False
 Garzón;False;False;False;False;False;False;False;False;False
 Gigante;False;False;False;False;False;False;False;False;False
 Guadalupe;False;False;False;False;False;False;False;False;False
 Hobo;False;False;False;False;False;False;False;False;False
-Iquira;False;False;False;False;False;False;False;False;False
+Íquira;False;False;False;False;False;False;False;False;False
 Isnos;False;False;False;False;False;False;False;False;False
-La Argentina;False;True;False;False;False;False;False;False;False
+La Argentina;False;False;False;False;False;False;False;False;False
 La Plata;False;False;False;False;False;False;False;False;False
-Nataga;False;False;False;False;False;False;False;False;False
+Nátaga;False;False;False;False;False;False;False;False;False
 Neiva;False;False;False;False;False;False;False;False;False
-Oporapa;False;True;False;False;False;False;False;False;False
+Oporapa;False;False;False;False;False;False;False;False;False
 Paicol;False;False;False;False;False;False;False;False;False
 Palermo;False;False;False;False;False;False;False;False;False
 Palestina;False;False;False;False;False;False;False;False;False
-Pital;False;False;False;False;True;False;False;False;False
+Pital;False;False;False;False;False;False;False;False;False
 Pitalito;False;False;False;False;False;False;False;False;False
 Rivera;False;False;False;False;False;False;False;False;False
-Saladoblanco;False;True;False;False;False;False;False;False;False
+Saladoblanco;False;False;False;False;False;False;False;False;False
 San Agustín;False;False;False;False;False;False;False;False;False
-Santa María;False;False;False;False;True;False;False;False;False
+Santa María;False;False;False;False;False;False;False;False;False
 Suaza;False;False;False;False;False;False;False;False;False
-Tarqui;False;True;False;False;False;False;False;False;False
+Tarqui;False;False;False;False;False;False;False;False;False
 Tello;False;False;False;False;False;False;False;False;False
-Teruel;False;False;False;False;True;False;False;False;False
+Teruel;False;False;False;False;False;False;False;False;False
 Tesalia;False;False;False;False;False;False;False;False;False
 Timaná;False;False;False;False;False;False;False;False;False
 Villavieja;False;False;False;False;False;False;False;False;False
-Yaguara;False;False;False;False;False;False;False;False;False
+Yaguará;False;False;False;False;False;False;False;False;False
+Albania;False;False;False;False;False;False;False;False;False
+Barrancas;False;False;False;False;False;False;False;False;False
+Dibulla;False;False;False;False;False;False;False;False;False
+Distracción;False;False;False;False;False;False;False;False;False
+El Molino;False;False;False;False;False;False;False;False;False
+Fonseca;False;False;False;False;False;False;False;False;False
+Hato Nuevo;False;False;False;False;False;False;False;False;False
+La Jagua Del Pilar;False;False;False;False;False;False;False;False;False
+Maicao;False;False;False;False;False;False;False;False;False
+Manaure;False;False;False;False;False;False;False;False;False
+Riohacha;False;False;False;False;False;False;False;False;False
+San Juan Del Cesar;False;False;False;False;False;False;False;False;False
+Uribia;False;False;False;False;False;False;False;False;False
+Urumita;False;False;False;False;False;False;False;False;False
+Villanueva;False;False;False;False;False;False;False;False;False
 Algarrobo;False;False;False;False;False;False;False;False;False
-Aracataca;False;False;False;False;False;False;True;False;False
-Ariguaní;False;False;False;False;False;False;False;False;False
-Cerro San Antonio;False;False;False;False;False;False;True;False;False
-Chibolo;False;False;False;False;False;False;False;False;False
-Ciénaga;False;False;False;False;False;False;True;False;False
-Concordia;False;False;False;False;False;False;True;False;False
+Aracataca;False;False;False;False;False;False;False;False;False
+Ariguaní (El Dificil);False;False;False;False;False;False;False;False;False
+Cerro De San Antonio;False;False;False;False;False;False;False;False;False
+Chivolo;False;False;False;False;False;False;False;False;False
+Ciénaga;False;False;False;False;False;False;False;False;False
+Concordia;False;False;False;False;False;False;False;False;False
 El Banco;False;False;False;False;False;False;False;False;False
-El Piñón;False;False;False;False;False;False;True;False;False
-El Retén;False;False;False;False;False;False;True;False;False
+El Piñón;False;False;False;False;False;False;False;False;False
+El Retén;False;False;False;False;False;False;False;False;False
 Fundación;False;False;False;False;False;False;False;False;False
 Guamal;False;False;False;False;False;False;False;False;False
 Nueva Granada;False;False;False;False;False;False;False;False;False
-Pedraza;False;False;False;False;False;False;True;False;False
-Pinto;False;False;False;False;False;False;False;False;False
-Pijiño;False;False;False;False;False;False;False;False;False
-Pivijay;False;False;False;False;False;False;True;False;False
+Pedraza;False;False;False;False;False;False;False;False;False
+Pijiño Del Carmen;False;False;False;False;False;False;False;False;False
+Pivijay;False;False;False;False;False;False;False;False;False
 Plato;False;False;False;False;False;False;False;False;False
-Pueblo Viejo;False;False;False;False;False;False;True;False;False
-Remolino;False;False;False;False;False;False;True;False;False
-Sabanas de San Ángel;False;False;False;False;False;False;False;False;False
-Salamina;False;False;False;False;False;False;True;False;False
-San Sebastián de Buenavista;False;False;False;False;False;False;False;False;False
-Santa Ana;False;False;False;False;False;False;False;False;False
-Santa Marta;False;False;False;False;False;False;True;False;False
+Puebloviejo;False;False;False;False;False;False;False;False;False
+Remolino;False;False;False;False;False;False;False;False;False
+Sabanas De San Angel;False;False;False;False;False;False;False;False;False
+Salamina;False;False;False;False;False;False;False;False;False
+San Sebastián De Buenavista;False;False;False;False;False;False;False;False;False
 San Zenón;False;False;False;False;False;False;False;False;False
-Sitionuevo;False;False;False;False;False;False;True;False;False
+Santa Ana;False;False;False;False;False;False;False;False;False
+Santa Bárbara De Pinto;False;False;False;False;False;False;False;False;False
+Santa Marta;False;False;False;False;False;False;False;False;False
+Sitionuevo;False;False;False;False;False;False;False;False;False
 Tenerife;False;False;False;False;False;False;False;False;False
 Zapayán;False;False;False;False;False;False;False;False;False
-Zona Bananera;False;False;False;False;False;False;True;False;False
+Zona Bananera;False;False;False;False;False;False;False;False;False
 Acacías;False;False;False;False;False;False;False;False;False
-Barranca de Upía;False;False;False;False;False;False;False;False;False
+Barranca De Upía;False;False;False;False;False;False;False;False;False
 Cabuyaro;False;False;False;False;False;False;False;False;False
-Castilla la Nueva;False;False;False;False;False;False;False;False;False
+Castilla La Nueva;False;False;False;False;False;False;False;False;False
 Cubarral;False;False;False;False;False;False;False;False;False
 Cumaral;False;False;False;False;False;False;False;False;False
-El Calvario;False;False;False;True;False;False;False;False;False
-El Castillo;False;False;False;True;False;False;False;False;False
+El Calvario;False;False;False;False;False;False;False;False;False
+El Castillo;False;False;False;False;False;False;False;False;False
 El Dorado;False;False;False;False;False;False;False;False;False
-Fuente de Oro;False;False;False;False;False;False;False;False;False
+Fuente De Oro;False;False;False;False;False;False;False;False;False
 Granada;False;False;False;False;False;False;False;False;False
 Guamal;False;False;False;False;False;False;False;False;False
 La Macarena;False;False;False;False;False;False;False;False;False
-La Uribe;False;False;False;True;False;False;False;False;False
 Lejanías;False;False;False;False;False;False;False;False;False
 Mapiripán;False;False;False;False;False;False;False;False;False
-Mesetas;False;False;False;True;False;False;False;False;False
+Mesetas;False;False;False;False;False;False;False;False;False
 Puerto Concordia;False;False;False;False;False;False;False;False;False
 Puerto Gaitán;False;False;False;False;False;False;False;False;False
 Puerto Lleras;False;False;False;False;False;False;False;False;False
 Puerto López;False;False;False;False;False;False;False;False;False
 Puerto Rico;False;False;False;False;False;False;False;False;False
 Restrepo;False;False;False;False;False;False;False;False;False
-San Carlos de Guaroa;False;False;False;False;False;False;False;False;False
-San Juan de Arama;False;False;False;False;False;False;False;False;False
-San Juanito;False;False;False;True;False;False;False;False;False
+San Carlos De Guaroa;False;False;False;False;False;False;False;False;False
+San Juan De Arama;False;False;False;False;False;False;False;False;False
+San Juanito;False;False;False;False;False;False;False;False;False
 San Martín;False;False;False;False;False;False;False;False;False
+Uribe;False;False;False;False;False;False;False;False;False
 Villavicencio;False;False;False;False;False;False;False;False;False
-Vista Hermosa;False;False;False;False;False;False;False;False;False
-Albán;False;False;False;False;False;False;False;False;False
+Vistahermosa;False;False;False;False;False;False;False;False;False
+Albán (San José);False;False;False;False;False;False;False;False;False
 Aldana;False;False;False;False;False;False;False;False;False
 Ancuya;False;False;False;False;False;False;False;False;False
-Arboleda;False;False;False;False;False;False;False;False;False
+Arboleda (Berruecos);False;False;False;False;False;False;False;False;False
 Barbacoas;False;False;False;False;False;False;False;False;False
 Belén;False;False;False;False;False;False;False;False;False
 Buesaco;False;False;False;False;False;False;False;False;False
-Chachagüí;False;False;False;False;False;False;False;False;False
-Colón;False;False;False;False;False;False;False;False;False
-Consaca;False;False;False;False;False;False;False;False;False
+Chachaguí;False;False;False;False;False;False;False;False;False
+Colón (Génova);False;False;False;False;False;False;False;False;False
+Consacá;False;False;False;False;False;False;False;False;False
 Contadero;False;False;False;False;False;False;False;False;False
 Córdoba;False;False;False;False;False;False;False;False;False
-Cuaspud;False;False;False;False;False;False;False;False;False
+Cuaspud (Carlosama);False;False;False;False;False;False;False;False;False
 Cumbal;False;False;False;False;False;False;False;False;False
 Cumbitara;False;False;False;False;False;False;False;False;False
-El Charco;False;False;False;False;False;True;False;False;False
+El Charco;False;False;False;False;False;False;False;False;False
 El Peñol;False;False;False;False;False;False;False;False;False
 El Rosario;False;False;False;False;False;False;False;False;False
 El Tablón;False;False;False;False;False;False;False;False;False
 El Tambo;False;False;False;False;False;False;False;False;False
-Francisco Pizarro;False;False;False;False;False;True;False;False;False
+Francisco Pizarro (Salahonda);False;False;False;False;False;False;False;False;False
 Funes;False;False;False;False;False;False;False;False;False
 Guachucal;False;False;False;False;False;False;False;False;False
 Guaitarilla;False;False;False;False;False;False;False;False;False
@@ -812,108 +795,109 @@ Ipiales;False;False;False;False;False;False;False;False;False
 La Cruz;False;False;False;False;False;False;False;False;False
 La Florida;False;False;False;False;False;False;False;False;False
 La Llanada;False;False;False;False;False;False;False;False;False
-La Tola;False;False;False;False;False;True;False;False;False
+La Tola;False;False;False;False;False;False;False;False;False
 La Unión;False;False;False;False;False;False;False;False;False
 Leiva;False;False;False;False;False;False;False;False;False
 Linares;False;False;False;False;False;False;False;False;False
-Los Andes;False;False;False;False;False;False;False;False;False
-Magüí Payán;False;False;False;False;False;False;False;False;False
-Mallama;False;False;False;False;False;False;False;False;False
-Mosquera;False;False;False;False;False;True;False;False;False
+Los Andes (Sotomayor);False;False;False;False;False;False;False;False;False
+Magüí (Payán);False;False;False;False;False;False;False;False;False
+Mallama (Piedrancha);False;False;False;False;False;False;False;False;False
+Mosquera;False;False;False;False;False;False;False;False;False
 Nariño;False;False;False;False;False;False;False;False;False
-Olaya Herrera;False;False;False;False;False;True;False;False;False
+Olaya Herrera (Bocas De Satinga);False;False;False;False;False;False;False;False;False
 Ospina;False;False;False;False;False;False;False;False;False
-Pasto;False;True;False;False;False;False;False;False;False
+Pasto;False;False;False;False;False;False;False;False;False
 Policarpa;False;False;False;False;False;False;False;False;False
 Potosí;False;False;False;False;False;False;False;False;False
 Providencia;False;False;False;False;False;False;False;False;False
 Puerres;False;False;False;False;False;False;False;False;False
 Pupiales;False;False;False;False;False;False;False;False;False
 Ricaurte;False;False;False;False;False;False;False;False;False
-Roberto Payán;False;False;False;False;False;False;False;False;False
+Roberto Payán (San José);False;False;False;False;False;False;False;False;False
 Samaniego;False;False;False;False;False;False;False;False;False
 San Bernardo;False;False;False;False;False;False;False;False;False
-Sandona;False;False;False;False;False;False;False;False;False
 San Lorenzo;False;False;False;False;False;False;False;False;False
 San Pablo;False;False;False;False;False;False;False;False;False
-San Pedro de Cartago;False;False;False;False;False;False;False;False;False
-Santa Barbara;False;False;False;False;False;True;False;False;False
-Santacruz;False;False;False;False;False;False;False;False;False
+San Pedro De Cartago (Cartago);False;False;False;False;False;False;False;False;False
+Sandoná;False;False;False;False;False;False;False;False;False
+Santa Bárbara (Iscuandé);False;False;False;False;False;False;False;False;False
+Santa Cruz (Guachavés);False;False;False;False;False;False;False;False;False
 Sapuyes;False;False;False;False;False;False;False;False;False
 Taminango;False;False;False;False;False;False;False;False;False
 Tangua;False;False;False;False;False;False;False;False;False
-Tumaco;False;False;False;False;False;True;False;False;False
+Tumaco;False;False;False;False;False;False;False;False;False
+Tumaco;False;False;False;False;False;False;False;False;False
 Túquerres;False;False;False;False;False;False;False;False;False
 Yacuanquer;False;False;False;False;False;False;False;False;False
-Abrego;True;False;False;False;False;False;False;False;False
+Ábrego;False;False;False;False;False;False;False;False;False
 Arboledas;False;False;False;False;False;False;False;False;False
 Bochalema;False;False;False;False;False;False;False;False;False
 Bucarasica;False;False;False;False;False;False;False;False;False
-Cachira;False;False;False;False;False;False;False;False;False
-Cácota;True;False;False;False;False;False;False;False;False
+Cáchira;False;False;False;False;False;False;False;False;False
+Cácota;False;False;False;False;False;False;False;False;False
 Chinácota;False;False;False;False;False;False;False;False;False
-Chitagá;True;False;False;False;False;False;False;False;False
+Chitagá;False;False;False;False;False;False;False;False;False
 Convención;False;False;False;False;False;False;False;False;False
 Cúcuta;False;False;False;False;False;False;False;False;False
-Cucutilla;True;False;False;False;False;False;False;False;False
+Cucutilla;False;False;False;False;False;False;False;False;False
 Durania;False;False;False;False;False;False;False;False;False
 El Carmen;False;False;False;False;False;False;False;False;False
-El Tarra;True;False;False;False;False;False;False;False;False
+El Tarra;False;False;False;False;False;False;False;False;False
 El Zulia;False;False;False;False;False;False;False;False;False
 Gramalote;False;False;False;False;False;False;False;False;False
-Hacari;False;False;False;False;False;False;False;False;False
+Hacarí;False;False;False;False;False;False;False;False;False
 Herrán;False;False;False;False;False;False;False;False;False
 La Esperanza;False;False;False;False;False;False;False;False;False
 La Playa;False;False;False;False;False;False;False;False;False
-Labateca;True;False;False;False;False;False;False;False;False
+Labateca;False;False;False;False;False;False;False;False;False
 Los Patios;False;False;False;False;False;False;False;False;False
 Lourdes;False;False;False;False;False;False;False;False;False
-Mutiscua;True;False;False;False;False;False;False;False;False
+Mutiscua;False;False;False;False;False;False;False;False;False
 Ocaña;False;False;False;False;False;False;False;False;False
 Pamplona;False;False;False;False;False;False;False;False;False
 Pamplonita;False;False;False;False;False;False;False;False;False
 Puerto Santander;False;False;False;False;False;False;False;False;False
 Ragonvalia;False;False;False;False;False;False;False;False;False
-Salazar de las Palmas;True;False;False;False;False;False;False;False;False
+Salazar;False;False;False;False;False;False;False;False;False
 San Calixto;False;False;False;False;False;False;False;False;False
 San Cayetano;False;False;False;False;False;False;False;False;False
 Santiago;False;False;False;False;False;False;False;False;False
 Sardinata;False;False;False;False;False;False;False;False;False
-Silos;True;False;False;False;False;False;False;False;False
+Silos;False;False;False;False;False;False;False;False;False
 Teorama;False;False;False;False;False;False;False;False;False
 Tibú;False;False;False;False;False;False;False;False;False
-Toledo;True;False;False;False;False;False;False;False;False
-Villa Caro;True;False;False;False;False;False;False;False;False
-Villa del Rosario;False;False;False;False;False;False;False;False;False
-Colón;False;True;False;False;False;False;False;False;False
+Toledo;False;False;False;False;False;False;False;False;False
+Villa Caro;False;False;False;False;False;False;False;False;False
+Villa Del Rosario;False;False;False;False;False;False;False;False;False
+Colón;False;False;False;False;False;False;False;False;False
 Mocoa;False;False;False;False;False;False;False;False;False
 Orito;False;False;False;False;False;False;False;False;False
 Puerto Asís;False;False;False;False;False;False;False;False;False
 Puerto Caicedo;False;False;False;False;False;False;False;False;False
 Puerto Guzmán;False;False;False;False;False;False;False;False;False
-Puerto Leguízamo;False;False;False;False;False;False;False;False;True
-San Francisco;False;True;False;False;False;False;False;False;False
-San Miguel;False;False;False;False;False;False;False;False;False
-Santiago;False;True;False;False;False;False;False;False;False
-Sibundoy;False;True;False;False;False;False;False;False;False
-Valle del Guamez;False;False;False;False;False;False;False;False;False
-Villa Garzón;False;False;False;False;False;False;False;False;False
+Puerto Leguízamo;False;False;False;False;False;False;False;False;False
+San Francisco;False;False;False;False;False;False;False;False;False
+San Miguel (La Dorada);False;False;False;False;False;False;False;False;False
+Santiago;False;False;False;False;False;False;False;False;False
+Sibundoy;False;False;False;False;False;False;False;False;False
+Valle Del Guamuez (La Hormiga);False;False;False;False;False;False;False;False;False
+Villagarzón;False;False;False;False;False;False;False;False;False
 Armenia;False;False;False;False;False;False;False;False;False
 Buenavista;False;False;False;False;False;False;False;False;False
 Calarcá;False;False;False;False;False;False;False;False;False
 Circasia;False;False;False;False;False;False;False;False;False
 Córdoba;False;False;False;False;False;False;False;False;False
-Filandia;False;False;False;False;True;False;False;False;False
+Filandia;False;False;False;False;False;False;False;False;False
 Génova;False;False;False;False;False;False;False;False;False
 La Tebaida;False;False;False;False;False;False;False;False;False
 Montenegro;False;False;False;False;False;False;False;False;False
 Pijao;False;False;False;False;False;False;False;False;False
 Quimbaya;False;False;False;False;False;False;False;False;False
-Salento;False;False;False;False;True;False;False;False;False
+Salento;False;False;False;False;False;False;False;False;False
 Apía;False;False;False;False;False;False;False;False;False
 Balboa;False;False;False;False;False;False;False;False;False
-Belén de Umbría;False;False;False;False;False;False;False;False;False
-Dosquebradas;False;False;False;False;True;False;False;False;False
+Belén De Umbría;False;False;False;False;False;False;False;False;False
+Dosquebradas;False;False;False;False;False;False;False;False;False
 Guática;False;False;False;False;False;False;False;False;False
 La Celia;False;False;False;False;False;False;False;False;False
 La Virginia;False;False;False;False;False;False;False;False;False
@@ -922,10 +906,10 @@ Mistrató;False;False;False;False;False;False;False;False;False
 Pereira;False;False;False;False;False;False;False;False;False
 Pueblo Rico;False;False;False;False;False;False;False;False;False
 Quinchía;False;False;False;False;False;False;False;False;False
-Santa Rosa de Cabal;False;False;False;False;True;False;False;False;False
+Santa Rosa De Cabal;False;False;False;False;False;False;False;False;False
 Santuario;False;False;False;False;False;False;False;False;False
-Providencia and Santa Catalina Islands;False;False;False;False;False;False;False;False;False
 San Andrés;False;False;False;False;False;False;False;False;False
+Providencia y Santa Isabel;False;False;False;False;False;False;False;False;False
 Aguada;False;False;False;False;False;False;False;False;False
 Albania;False;False;False;False;False;False;False;False;False
 Aratoca;False;False;False;False;False;False;False;False;False
@@ -933,7 +917,7 @@ Barbosa;False;False;False;False;False;False;False;False;False
 Barichara;False;False;False;False;False;False;False;False;False
 Barrancabermeja;False;False;False;False;False;False;False;False;False
 Betulia;False;False;False;False;False;False;False;False;False
-Bolívar;False;False;False;False;False;False;False;False;False
+Bolivar;False;False;False;False;False;False;False;False;False
 Bucaramanga;False;False;False;False;False;False;False;False;False
 Cabrera;False;False;False;False;False;False;False;False;False
 California;False;False;False;False;False;False;False;False;False
@@ -956,11 +940,11 @@ El Guacamayo;False;False;False;False;False;False;False;False;False
 El Peñón;False;False;False;False;False;False;False;False;False
 El Playón;False;False;False;False;False;False;False;False;False
 Encino;False;False;False;False;False;False;False;False;False
-Enciso;True;False;False;False;False;False;False;False;False
+Enciso;False;False;False;False;False;False;False;False;False
 Florián;False;False;False;False;False;False;False;False;False
 Floridablanca;False;False;False;False;False;False;False;False;False
 Galán;False;False;False;False;False;False;False;False;False
-Gámbita;True;False;False;False;False;False;False;False;False
+Gámbita;False;False;False;False;False;False;False;False;False
 Girón;False;False;False;False;False;False;False;False;False
 Guaca;False;False;False;False;False;False;False;False;False
 Guadalupe;False;False;False;False;False;False;False;False;False
@@ -968,49 +952,49 @@ Guapotá;False;False;False;False;False;False;False;False;False
 Guavatá;False;False;False;False;False;False;False;False;False
 Güepsa;False;False;False;False;False;False;False;False;False
 Hato;False;False;False;False;False;False;False;False;False
-Jesus María;False;False;False;False;False;False;False;False;False
+Jesús María;False;False;False;False;False;False;False;False;False
 Jordán;False;False;False;False;False;False;False;False;False
 La Belleza;False;False;False;False;False;False;False;False;False
-Landázuri;False;False;False;False;False;False;False;False;False
 La Paz;False;False;False;False;False;False;False;False;False
+Landázuri;False;False;False;False;False;False;False;False;False
 Lebrija;False;False;False;False;False;False;False;False;False
 Los Santos;False;False;False;False;False;False;False;False;False
 Macaravita;False;False;False;False;False;False;False;False;False
 Málaga;False;False;False;False;False;False;False;False;False
 Matanza;False;False;False;False;False;False;False;False;False
-Mogotes;True;False;False;False;False;False;False;False;False
+Mogotes;False;False;False;False;False;False;False;False;False
 Molagavita;False;False;False;False;False;False;False;False;False
 Ocamonte;False;False;False;False;False;False;False;False;False
 Oiba;False;False;False;False;False;False;False;False;False
-Onzaga;True;False;False;False;False;False;False;False;False
+Onzaga;False;False;False;False;False;False;False;False;False
 Palmar;False;False;False;False;False;False;False;False;False
-Palmas Socorro;False;False;False;False;False;False;False;False;False
+Palmas Del Socorro;False;False;False;False;False;False;False;False;False
 Páramo;False;False;False;False;False;False;False;False;False
-Piedecuesta;True;False;False;False;False;False;False;False;False
+Piedecuesta;False;False;False;False;False;False;False;False;False
 Pinchote;False;False;False;False;False;False;False;False;False
 Puente Nacional;False;False;False;False;False;False;False;False;False
 Puerto Parra;False;False;False;False;False;False;False;False;False
 Puerto Wilches;False;False;False;False;False;False;False;False;False
 Rionegro;False;False;False;False;False;False;False;False;False
-Sabana de Torres;False;False;False;False;False;False;False;False;False
+Sabana De Torres;False;False;False;False;False;False;False;False;False
 San Andrés;False;False;False;False;False;False;False;False;False
 San Benito;False;False;False;False;False;False;False;False;False
 San Gil;False;False;False;False;False;False;False;False;False
-San Joaquín;True;False;False;False;False;False;False;False;False
-San José de Miranda;False;False;False;False;False;False;False;False;False
-San Miguel;True;False;False;False;False;False;False;False;False
-Santa Bárbara;True;False;False;False;False;False;False;False;False
-Santa Helena del Opón;False;False;False;False;False;False;False;False;False
-San Vicente de Chucurí;False;False;False;False;False;False;False;False;False
+San Joaquín;False;False;False;False;False;False;False;False;False
+San José De Miranda;False;False;False;False;False;False;False;False;False
+San Miguel;False;False;False;False;False;False;False;False;False
+San Vicente De Chucurí;False;False;False;False;False;False;False;False;False
+Santa Bárbara;False;False;False;False;False;False;False;False;False
+Santa Helena Del Opón;False;False;False;False;False;False;False;False;False
 Simacota;False;False;False;False;False;False;False;False;False
 Socorro;False;False;False;False;False;False;False;False;False
 Suaita;False;False;False;False;False;False;False;False;False
 Sucre;False;False;False;False;False;False;False;False;False
-Surata;False;False;False;False;False;False;False;False;False
-Tona;True;False;False;False;False;False;False;False;False
-Valle de San José;False;False;False;False;False;False;False;False;False
+Suratá;False;False;False;False;False;False;False;False;False
+Tona;False;False;False;False;False;False;False;False;False
+Valle De San José;False;False;False;False;False;False;False;False;False
 Vélez;False;False;False;False;False;False;False;False;False
-Vetas;True;False;False;False;False;False;False;False;False
+Vetas;False;False;False;False;False;False;False;False;False
 Villanueva;False;False;False;False;False;False;False;False;False
 Zapatoca;False;False;False;False;False;False;False;False;False
 Buenavista;False;False;False;False;False;False;False;False;False
@@ -1030,7 +1014,7 @@ Ovejas;False;False;False;False;False;False;False;False;False
 Palmito;False;False;False;False;False;False;False;False;False
 Sampués;False;False;False;False;False;False;False;False;False
 San Benito Abad;False;False;False;False;False;False;False;False;False
-San Juan Betulia;False;False;False;False;False;False;False;False;False
+San Juan De Betulia (Betulia);False;False;False;False;False;False;False;False;False
 San Marcos;False;False;False;False;False;False;False;False;False
 San Onofre;False;False;False;False;False;False;False;False;False
 San Pedro;False;False;False;False;False;False;False;False;False
@@ -1042,11 +1026,11 @@ Toluviejo;False;False;False;False;False;False;False;False;False
 Alpujarra;False;False;False;False;False;False;False;False;False
 Alvarado;False;False;False;False;False;False;False;False;False
 Ambalema;False;False;False;False;False;False;False;False;False
-Anzoátegui;False;False;False;False;True;False;False;False;False
-Armero;False;False;False;False;False;False;False;False;False
+Anzoátegui;False;False;False;False;False;False;False;False;False
+Armero (Guayabal);False;False;False;False;False;False;False;False;False
 Ataco;False;False;False;False;False;False;False;False;False
-Cajamarca;False;False;False;False;True;False;False;False;False
-Carmen Apicala;False;False;False;False;False;False;False;False;False
+Cajamarca;False;False;False;False;False;False;False;False;False
+Carmen De Apicalá;False;False;False;False;False;False;False;False;False
 Casabianca;False;False;False;False;False;False;False;False;False
 Chaparral;False;False;False;False;False;False;False;False;False
 Coello;False;False;False;False;False;False;False;False;False
@@ -1054,58 +1038,58 @@ Coyaima;False;False;False;False;False;False;False;False;False
 Cunday;False;False;False;False;False;False;False;False;False
 Dolores;False;False;False;False;False;False;False;False;False
 Espinal;False;False;False;False;False;False;False;False;False
-Falán;False;False;False;False;False;False;False;False;False
+Falan;False;False;False;False;False;False;False;False;False
 Flandes;False;False;False;False;False;False;False;False;False
 Fresno;False;False;False;False;False;False;False;False;False
 Guamo;False;False;False;False;False;False;False;False;False
 Herveo;False;False;False;False;False;False;False;False;False
 Honda;False;False;False;False;False;False;False;False;False
-Ibagué;False;False;False;False;True;False;False;False;False
+Ibagué;False;False;False;False;False;False;False;False;False
 Icononzo;False;False;False;False;False;False;False;False;False
 Lérida;False;False;False;False;False;False;False;False;False
-Líbano;False;False;False;False;True;False;False;False;False
+Líbano;False;False;False;False;False;False;False;False;False
 Mariquita;False;False;False;False;False;False;False;False;False
 Melgar;False;False;False;False;False;False;False;False;False
-Murillo;False;False;False;False;True;False;False;False;False
+Murillo;False;False;False;False;False;False;False;False;False
 Natagaima;False;False;False;False;False;False;False;False;False
 Ortega;False;False;False;False;False;False;False;False;False
-Piedras;False;False;False;False;False;False;False;False;False
 Palocabildo;False;False;False;False;False;False;False;False;False
-Planadas;False;False;False;False;True;False;False;False;False
+Piedras;False;False;False;False;False;False;False;False;False
+Planadas;False;False;False;False;False;False;False;False;False
 Prado;False;False;False;False;False;False;False;False;False
 Purificación;False;False;False;False;False;False;False;False;False
-Rioblanco;False;False;False;False;True;False;False;False;False
+Rioblanco;False;False;False;False;False;False;False;False;False
 Roncesvalles;False;False;False;False;False;False;False;False;False
 Rovira;False;False;False;False;False;False;False;False;False
 Saldaña;False;False;False;False;False;False;False;False;False
 San Antonio;False;False;False;False;False;False;False;False;False
 San Luis;False;False;False;False;False;False;False;False;False
-Santa Isabel;False;False;False;False;True;False;False;False;False
+Santa Isabel;False;False;False;False;False;False;False;False;False
 Suárez;False;False;False;False;False;False;False;False;False
-Valle de San Juan;False;False;False;False;False;False;False;False;False
-Venadillo;False;False;False;False;True;False;False;False;False
+Valle De San Juan;False;False;False;False;False;False;False;False;False
+Venadillo;False;False;False;False;False;False;False;False;False
 Villahermosa;False;False;False;False;False;False;False;False;False
 Villarrica;False;False;False;False;False;False;False;False;False
 Alcalá;False;False;False;False;False;False;False;False;False
-Andalucía;False;False;False;False;True;False;False;False;False
+Andalucía;False;False;False;False;False;False;False;False;False
 Ansermanuevo;False;False;False;False;False;False;False;False;False
 Argelia;False;False;False;False;False;False;False;False;False
 Bolívar;False;False;False;False;False;False;False;False;False
-Buenaventura;False;False;False;False;False;True;False;False;False
-Buga;False;False;False;False;True;False;False;False;False
-Bugalagrande;False;False;False;False;True;False;False;False;False
+Buenaventura;False;False;False;False;False;False;False;False;False
+Buga;False;False;False;False;False;False;False;False;False
+Bugalagrande;False;False;False;False;False;False;False;False;False
 Caicedonia;False;False;False;False;False;False;False;False;False
 Cali;False;False;False;False;False;False;False;False;False
-Calima;False;False;False;False;False;False;False;False;False
+Calima (El Darién);False;False;False;False;False;False;False;False;False
 Candelaria;False;False;False;False;False;False;False;False;False
 Cartago;False;False;False;False;False;False;False;False;False
 Dagua;False;False;False;False;False;False;False;False;False
-El Aguila;False;False;False;False;False;False;False;False;False
+El Águila;False;False;False;False;False;False;False;False;False
 El Cairo;False;False;False;False;False;False;False;False;False
-El Cerrito;False;False;False;False;True;False;False;False;False
+El Cerrito;False;False;False;False;False;False;False;False;False
 El Dovio;False;False;False;False;False;False;False;False;False
 Florida;False;False;False;False;False;False;False;False;False
-Ginebra;False;False;False;False;True;False;False;False;False
+Ginebra;False;False;False;False;False;False;False;False;False
 Guacarí;False;False;False;False;False;False;False;False;False
 Jamundí;False;False;False;False;False;False;False;False;False
 La Cumbre;False;False;False;False;False;False;False;False;False
@@ -1117,7 +1101,7 @@ Pradera;False;False;False;False;False;False;False;False;False
 Restrepo;False;False;False;False;False;False;False;False;False
 Riofrío;False;False;False;False;False;False;False;False;False
 Roldanillo;False;False;False;False;False;False;False;False;False
-San Pedro;False;False;False;False;True;False;False;False;False
+San Pedro;False;False;False;False;False;False;False;False;False
 Sevilla;False;False;False;False;False;False;False;False;False
 Toro;False;False;False;False;False;False;False;False;False
 Trujillo;False;False;False;False;False;False;False;False;False
@@ -1128,15 +1112,13 @@ Vijes;False;False;False;False;False;False;False;False;False
 Yotoco;False;False;False;False;False;False;False;False;False
 Yumbo;False;False;False;False;False;False;False;False;False
 Zarzal;False;False;False;False;False;False;False;False;False
-Caruru;False;False;False;False;False;False;False;False;False
+Carurú;False;False;False;False;False;False;False;False;False
 Mitú;False;False;False;False;False;False;False;False;False
-Taraira;False;False;False;False;False;False;False;False;True
-Acaricuara;False;False;False;False;False;False;False;False;False
-Villa Fátima;False;False;False;False;False;False;False;False;False
-Pacoa;False;False;False;False;False;False;False;False;True
-Papunahua;False;False;False;False;False;False;False;False;False
-Yavarate;False;False;False;False;False;False;False;False;False
+Pacoa (Cor. Departamental);False;False;False;False;False;False;False;False;False
+Papunaua(cor. Departamental);False;False;False;False;False;False;False;False;False
+Taraira;False;False;False;False;False;False;False;False;False
+Yavaraté (Cor. Departamental);False;False;False;False;False;False;False;False;False
 Cumaribo;False;False;False;False;False;False;False;False;False
 La Primavera;False;False;False;False;False;False;False;False;False
-Puerto Carreño;False;False;False;False;False;False;False;True;False
+Puerto Carreño;False;False;False;False;False;False;False;False;False
 Santa Rosalía;False;False;False;False;False;False;False;False;False

--- a/backend/spec/factories/location.rb
+++ b/backend/spec/factories/location.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :location do
-    location_type { "state" }
+    location_type { "country" }
 
     sequence(:name) do |n|
       Faker::Config.random = Random.new(n)
@@ -8,5 +8,25 @@ FactoryBot.define do
     end
 
     parent { nil }
+
+    trait :with_municipalities do
+      transient do
+        municipalities_count { 2 }
+      end
+
+      after(:create) do |location, evaluator|
+        department = create :location, parent: location, location_type: "department"
+        evaluator.municipalities_count.times do
+          create :location, :with_region, parent: department, location_type: "municipality"
+        end
+      end
+    end
+
+    trait :with_region do
+      after(:create) do |location|
+        region = create :location, location_type: "region"
+        create :location_member, location: location, member: region
+      end
+    end
   end
 end

--- a/backend/spec/factories/location_member.rb
+++ b/backend/spec/factories/location_member.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :location_member do
+    location
+    member factory: :location
+  end
+end

--- a/backend/spec/fixtures/files/dummy_colombia_departments.csv
+++ b/backend/spec/fixtures/files/dummy_colombia_departments.csv
@@ -1,3 +1,3 @@
-name;wiki_link
-Amazonas Department;/wiki/Amazonas_Department
-Antioquia Department;/wiki/Antioquia_Department
+name
+Amazonas
+Antioquia

--- a/backend/spec/fixtures/files/dummy_colombia_municipalities.csv
+++ b/backend/spec/fixtures/files/dummy_colombia_municipalities.csv
@@ -1,5 +1,5 @@
-name;department;wiki_link;latitude;longitude
-Leticia;Amazonas Department;/wiki/Leticia;_Colombia;-4.216666666666667;-69.93333333333334
-Puerto Nariño;Amazonas Department;/wiki/Puerto_Nari%C3%B1o;-3.7666666666666666;-70.36666666666666
-Abejorral;Antioquia Department;/wiki/Abejorral;5.783333333333333;-75.41666666666667
-Abriaquí;Antioquia Department;/wiki/Abriaqu%C3%AD;6.633333333333333;-76.06666666666666
+name;department
+Leticia;Amazonas
+Puerto Nariño;Amazonas
+Abejorral;Antioquia
+Abriaquí;Antioquia

--- a/backend/spec/fixtures/files/dummy_colombia_regions.csv
+++ b/backend/spec/fixtures/files/dummy_colombia_regions.csv
@@ -1,0 +1,5 @@
+municipality;Cordillera Oriental;Piedemonte Amazónico - Macizo;Transición Pacífico - Caribe
+Leticia;False;True;False
+Puerto Nariño;False;True;False
+Abejorral;True;False;False
+Abriaquí;True;False;False

--- a/backend/spec/fixtures/snapshots/api/v1/enums.json
+++ b/backend/spec/fixtures/snapshots/api/v1/enums.json
@@ -231,6 +231,34 @@
       "attributes": {
         "name": "HNWI or Celebrity"
       }
+    },
+    {
+      "id": "country",
+      "type": "location_type",
+      "attributes": {
+        "name": "Country"
+      }
+    },
+    {
+      "id": "department",
+      "type": "location_type",
+      "attributes": {
+        "name": "Department"
+      }
+    },
+    {
+      "id": "municipality",
+      "type": "location_type",
+      "attributes": {
+        "name": "Municipality"
+      }
+    },
+    {
+      "id": "region",
+      "type": "location_type",
+      "attributes": {
+        "name": "Region"
+      }
     }
   ]
 }

--- a/backend/spec/fixtures/snapshots/api/v1/get-location-include-relationships.json
+++ b/backend/spec/fixtures/snapshots/api/v1/get-location-include-relationships.json
@@ -1,0 +1,34 @@
+{
+  "data": {
+    "id": "4debca7f-9251-403f-b893-ff0e78bd6af4",
+    "type": "location",
+    "attributes": {
+      "name": "Hane, Lehner and Goyette"
+    },
+    "relationships": {
+      "parent": {
+        "data": {
+          "id": "5331a4ba-ef75-4b7f-8cdd-8ec39e692bbd",
+          "type": "location"
+        }
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "5331a4ba-ef75-4b7f-8cdd-8ec39e692bbd",
+      "type": "location",
+      "attributes": {
+        "name": "Bartoletti and Sons"
+      },
+      "relationships": {
+        "parent": {
+          "data": {
+            "id": "b031e422-5eaf-4b34-86ab-ac4171830671",
+            "type": "location"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/backend/spec/fixtures/snapshots/api/v1/get-location-sparse-fieldset.json
+++ b/backend/spec/fixtures/snapshots/api/v1/get-location-sparse-fieldset.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "id": "4debca7f-9251-403f-b893-ff0e78bd6af4",
+    "type": "location",
+    "attributes": {
+      "name": "Hane, Lehner and Goyette"
+    },
+    "relationships": {
+    }
+  }
+}

--- a/backend/spec/fixtures/snapshots/api/v1/get-location.json
+++ b/backend/spec/fixtures/snapshots/api/v1/get-location.json
@@ -1,0 +1,26 @@
+{
+  "data": {
+    "id": "4debca7f-9251-403f-b893-ff0e78bd6af4",
+    "type": "location",
+    "attributes": {
+      "name": "Hane, Lehner and Goyette",
+      "location_type": "municipality"
+    },
+    "relationships": {
+      "parent": {
+        "data": {
+          "id": "5331a4ba-ef75-4b7f-8cdd-8ec39e692bbd",
+          "type": "location"
+        }
+      },
+      "regions": {
+        "data": [
+          {
+            "id": "b5debe16-a4ab-4811-ac48-3b480af1fc56",
+            "type": "location"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/backend/spec/fixtures/snapshots/api/v1/locations-filter-by-location-type.json
+++ b/backend/spec/fixtures/snapshots/api/v1/locations-filter-by-location-type.json
@@ -1,0 +1,22 @@
+{
+  "data": [
+    {
+      "id": "e0688667-b935-43ed-80f1-226d66a03902",
+      "type": "location",
+      "attributes": {
+        "name": "Kutch-Spencer",
+        "location_type": "country"
+      },
+      "relationships": {
+        "parent": {
+          "data": null
+        },
+        "regions": {
+          "data": [
+
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/backend/spec/fixtures/snapshots/api/v1/locations-filter-by-parent-id.json
+++ b/backend/spec/fixtures/snapshots/api/v1/locations-filter-by-parent-id.json
@@ -1,0 +1,25 @@
+{
+  "data": [
+    {
+      "id": "fc1aace7-f1ee-488a-820f-cd5d017663d5",
+      "type": "location",
+      "attributes": {
+        "name": "Bartoletti and Sons",
+        "location_type": "department"
+      },
+      "relationships": {
+        "parent": {
+          "data": {
+            "id": "e0688667-b935-43ed-80f1-226d66a03902",
+            "type": "location"
+          }
+        },
+        "regions": {
+          "data": [
+
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/backend/spec/fixtures/snapshots/api/v1/locations-include-relationships.json
+++ b/backend/spec/fixtures/snapshots/api/v1/locations-include-relationships.json
@@ -1,0 +1,141 @@
+{
+  "data": [
+    {
+      "id": "a74413c8-d1f0-479f-a0b9-50cfd7194358",
+      "type": "location",
+      "attributes": {
+        "name": "Kutch-Spencer"
+      },
+      "relationships": {
+        "parent": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "28150e8d-b428-45e7-9a3e-97ddd9eba267",
+      "type": "location",
+      "attributes": {
+        "name": "Bartoletti and Sons"
+      },
+      "relationships": {
+        "parent": {
+          "data": {
+            "id": "a74413c8-d1f0-479f-a0b9-50cfd7194358",
+            "type": "location"
+          }
+        }
+      }
+    },
+    {
+      "id": "8868aa8c-2f5d-4e5d-a95a-f9cbde9e6458",
+      "type": "location",
+      "attributes": {
+        "name": "Hane, Lehner and Goyette"
+      },
+      "relationships": {
+        "parent": {
+          "data": {
+            "id": "28150e8d-b428-45e7-9a3e-97ddd9eba267",
+            "type": "location"
+          }
+        }
+      }
+    },
+    {
+      "id": "33041b37-2885-4789-863e-1b3065217cb6",
+      "type": "location",
+      "attributes": {
+        "name": "Hilpert, Waters and Johnston"
+      },
+      "relationships": {
+        "parent": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "15a5d5ac-66c2-451c-951d-7ed2dfa43f45",
+      "type": "location",
+      "attributes": {
+        "name": "Jacobson, Fritsch and Stanton"
+      },
+      "relationships": {
+        "parent": {
+          "data": {
+            "id": "28150e8d-b428-45e7-9a3e-97ddd9eba267",
+            "type": "location"
+          }
+        }
+      }
+    },
+    {
+      "id": "4e9d9bd2-adbb-4e14-b1fe-353191d806d1",
+      "type": "location",
+      "attributes": {
+        "name": "Keebler, Kub and Zemlak"
+      },
+      "relationships": {
+        "parent": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "435fa71f-a803-44dd-a9f7-981d37d96f9b",
+      "type": "location",
+      "attributes": {
+        "name": "Becker LLC"
+      },
+      "relationships": {
+        "parent": {
+          "data": {
+            "id": "28150e8d-b428-45e7-9a3e-97ddd9eba267",
+            "type": "location"
+          }
+        }
+      }
+    },
+    {
+      "id": "9cff335c-3f37-4c28-bf57-b82df46d3903",
+      "type": "location",
+      "attributes": {
+        "name": "Runolfsson and Sons"
+      },
+      "relationships": {
+        "parent": {
+          "data": null
+        }
+      }
+    }
+  ],
+  "included": [
+    {
+      "id": "a74413c8-d1f0-479f-a0b9-50cfd7194358",
+      "type": "location",
+      "attributes": {
+        "name": "Kutch-Spencer"
+      },
+      "relationships": {
+        "parent": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "28150e8d-b428-45e7-9a3e-97ddd9eba267",
+      "type": "location",
+      "attributes": {
+        "name": "Bartoletti and Sons"
+      },
+      "relationships": {
+        "parent": {
+          "data": {
+            "id": "a74413c8-d1f0-479f-a0b9-50cfd7194358",
+            "type": "location"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/backend/spec/fixtures/snapshots/api/v1/locations-sparse-fieldset.json
+++ b/backend/spec/fixtures/snapshots/api/v1/locations-sparse-fieldset.json
@@ -1,0 +1,76 @@
+{
+  "data": [
+    {
+      "id": "a74413c8-d1f0-479f-a0b9-50cfd7194358",
+      "type": "location",
+      "attributes": {
+        "name": "Kutch-Spencer"
+      },
+      "relationships": {
+      }
+    },
+    {
+      "id": "28150e8d-b428-45e7-9a3e-97ddd9eba267",
+      "type": "location",
+      "attributes": {
+        "name": "Bartoletti and Sons"
+      },
+      "relationships": {
+      }
+    },
+    {
+      "id": "8868aa8c-2f5d-4e5d-a95a-f9cbde9e6458",
+      "type": "location",
+      "attributes": {
+        "name": "Hane, Lehner and Goyette"
+      },
+      "relationships": {
+      }
+    },
+    {
+      "id": "33041b37-2885-4789-863e-1b3065217cb6",
+      "type": "location",
+      "attributes": {
+        "name": "Hilpert, Waters and Johnston"
+      },
+      "relationships": {
+      }
+    },
+    {
+      "id": "15a5d5ac-66c2-451c-951d-7ed2dfa43f45",
+      "type": "location",
+      "attributes": {
+        "name": "Jacobson, Fritsch and Stanton"
+      },
+      "relationships": {
+      }
+    },
+    {
+      "id": "4e9d9bd2-adbb-4e14-b1fe-353191d806d1",
+      "type": "location",
+      "attributes": {
+        "name": "Keebler, Kub and Zemlak"
+      },
+      "relationships": {
+      }
+    },
+    {
+      "id": "435fa71f-a803-44dd-a9f7-981d37d96f9b",
+      "type": "location",
+      "attributes": {
+        "name": "Becker LLC"
+      },
+      "relationships": {
+      }
+    },
+    {
+      "id": "9cff335c-3f37-4c28-bf57-b82df46d3903",
+      "type": "location",
+      "attributes": {
+        "name": "Runolfsson and Sons"
+      },
+      "relationships": {
+      }
+    }
+  ]
+}

--- a/backend/spec/fixtures/snapshots/api/v1/locations.json
+++ b/backend/spec/fixtures/snapshots/api/v1/locations.json
@@ -1,0 +1,169 @@
+{
+  "data": [
+    {
+      "id": "a74413c8-d1f0-479f-a0b9-50cfd7194358",
+      "type": "location",
+      "attributes": {
+        "name": "Kutch-Spencer",
+        "location_type": "country"
+      },
+      "relationships": {
+        "parent": {
+          "data": null
+        },
+        "regions": {
+          "data": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "28150e8d-b428-45e7-9a3e-97ddd9eba267",
+      "type": "location",
+      "attributes": {
+        "name": "Bartoletti and Sons",
+        "location_type": "department"
+      },
+      "relationships": {
+        "parent": {
+          "data": {
+            "id": "a74413c8-d1f0-479f-a0b9-50cfd7194358",
+            "type": "location"
+          }
+        },
+        "regions": {
+          "data": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "8868aa8c-2f5d-4e5d-a95a-f9cbde9e6458",
+      "type": "location",
+      "attributes": {
+        "name": "Hane, Lehner and Goyette",
+        "location_type": "municipality"
+      },
+      "relationships": {
+        "parent": {
+          "data": {
+            "id": "28150e8d-b428-45e7-9a3e-97ddd9eba267",
+            "type": "location"
+          }
+        },
+        "regions": {
+          "data": [
+            {
+              "id": "33041b37-2885-4789-863e-1b3065217cb6",
+              "type": "location"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "33041b37-2885-4789-863e-1b3065217cb6",
+      "type": "location",
+      "attributes": {
+        "name": "Hilpert, Waters and Johnston",
+        "location_type": "region"
+      },
+      "relationships": {
+        "parent": {
+          "data": null
+        },
+        "regions": {
+          "data": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "15a5d5ac-66c2-451c-951d-7ed2dfa43f45",
+      "type": "location",
+      "attributes": {
+        "name": "Jacobson, Fritsch and Stanton",
+        "location_type": "municipality"
+      },
+      "relationships": {
+        "parent": {
+          "data": {
+            "id": "28150e8d-b428-45e7-9a3e-97ddd9eba267",
+            "type": "location"
+          }
+        },
+        "regions": {
+          "data": [
+            {
+              "id": "4e9d9bd2-adbb-4e14-b1fe-353191d806d1",
+              "type": "location"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "4e9d9bd2-adbb-4e14-b1fe-353191d806d1",
+      "type": "location",
+      "attributes": {
+        "name": "Keebler, Kub and Zemlak",
+        "location_type": "region"
+      },
+      "relationships": {
+        "parent": {
+          "data": null
+        },
+        "regions": {
+          "data": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "435fa71f-a803-44dd-a9f7-981d37d96f9b",
+      "type": "location",
+      "attributes": {
+        "name": "Becker LLC",
+        "location_type": "municipality"
+      },
+      "relationships": {
+        "parent": {
+          "data": {
+            "id": "28150e8d-b428-45e7-9a3e-97ddd9eba267",
+            "type": "location"
+          }
+        },
+        "regions": {
+          "data": [
+            {
+              "id": "9cff335c-3f37-4c28-bf57-b82df46d3903",
+              "type": "location"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "9cff335c-3f37-4c28-bf57-b82df46d3903",
+      "type": "location",
+      "attributes": {
+        "name": "Runolfsson and Sons",
+        "location_type": "region"
+      },
+      "relationships": {
+        "parent": {
+          "data": null
+        },
+        "regions": {
+          "data": [
+
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/backend/spec/models/location_member_spec.rb
+++ b/backend/spec/models/location_member_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe LocationMember, type: :model do
+  subject { build(:location_member) }
+
+  it { is_expected.to be_valid }
+
+  it "should not be valid without location" do
+    subject.location = nil
+    expect(subject).to have(1).errors_on(:location)
+  end
+
+  it "should not be valid without member" do
+    subject.member = nil
+    expect(subject).to have(1).errors_on(:member)
+  end
+end

--- a/backend/spec/requests/api/v1/locations_spec.rb
+++ b/backend/spec/requests/api/v1/locations_spec.rb
@@ -1,0 +1,106 @@
+require "swagger_helper"
+
+RSpec.describe "API V1 Locations", type: :request do
+  before_all do
+    @country = create :location, :with_municipalities, municipalities_count: 3
+  end
+
+  path "/api/v1/locations" do
+    get "Returns list of the locations" do
+      tags "Locations"
+      produces "application/json"
+      parameter name: :location_type, in: :query, type: :string, enum: LocationType::TYPES, description: "Filter locations based on location type", required: false
+      parameter name: :parent_id, in: :query, type: :string, description: "Filter locations based on its closest parent", required: false
+      parameter name: "fields[location]", in: :query, type: :string, description: "Get only required fields. Use comma to separate multiple fields", required: false
+      parameter name: :includes, in: :query, type: :string, description: "Include relationships. Use comma to separate multiple fields", required: false
+
+      response "200", :success do
+        schema type: :object, properties: {
+          data: {type: :array, items: {"$ref" => "#/components/schemas/location"}}
+        }
+
+        run_test!
+
+        it "matches snapshot", generate_swagger_example: true do
+          expect(response.body).to match_snapshot("api/v1/locations")
+        end
+
+        context "with sparse fieldset" do
+          let("fields[location]") { "name,nonexisting" }
+
+          it "matches snapshot" do
+            expect(response.body).to match_snapshot("api/v1/locations-sparse-fieldset")
+          end
+        end
+
+        context "with relationships" do
+          let("fields[location]") { "name,parent" }
+          let(:includes) { "parent" }
+
+          it "matches snapshot" do
+            expect(response.body).to match_snapshot("api/v1/locations-include-relationships")
+          end
+        end
+
+        context "when filter by location type is used" do
+          let(:location_type) { "country" }
+
+          it "matches snapshot" do
+            expect(response.body).to match_snapshot("api/v1/locations-filter-by-location-type")
+          end
+        end
+
+        context "when filter by parent id is used" do
+          let(:parent_id) { @country.id }
+
+          it "matches snapshot" do
+            expect(response.body).to match_snapshot("api/v1/locations-filter-by-parent-id")
+          end
+        end
+      end
+    end
+  end
+
+  path "/api/v1/locations/{id}" do
+    get "Find location by id" do
+      tags "Locations"
+      produces "application/json"
+      parameter name: :id, in: :path, type: :string, description: "Use location ID"
+      parameter name: "fields[location]", in: :query, type: :string, description: "Get only required fields. Use comma to separate multiple fields", required: false
+      parameter name: :includes, in: :query, type: :string, description: "Include relationships. Use comma to separate multiple fields", required: false
+
+      let(:id) { Location.find_by(location_type: "municipality").id }
+
+      it_behaves_like "with not found error"
+
+      response "200", :success do
+        schema type: :object, properties: {
+          data: {"$ref" => "#/components/schemas/location"}
+        }
+
+        run_test!
+
+        it "matches snapshot", generate_swagger_example: true do
+          expect(response.body).to match_snapshot("api/v1/get-location")
+        end
+
+        context "with sparse fieldset" do
+          let("fields[location]") { "name,nonexisting" }
+
+          it "matches snapshot" do
+            expect(response.body).to match_snapshot("api/v1/get-location-sparse-fieldset")
+          end
+        end
+
+        context "with relationships" do
+          let("fields[location]") { "name,parent" }
+          let(:includes) { "parent" }
+
+          it "matches snapshot" do
+            expect(response.body).to match_snapshot("api/v1/get-location-include-relationships")
+          end
+        end
+      end
+    end
+  end
+end

--- a/backend/spec/services/importers/locations_spec.rb
+++ b/backend/spec/services/importers/locations_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Importers::Locations do
 
     before { subject.call }
 
-    it "inserts correct state" do
-      expect(Location.where(name_en: "Colombia", location_type: "state")).to be_exists
+    it "inserts correct country" do
+      expect(Location.where(name_en: "Colombia", location_type: "country")).to be_exists
     end
 
     it "inserts correct departments" do

--- a/backend/spec/services/importers/locations_spec.rb
+++ b/backend/spec/services/importers/locations_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe Importers::Locations do
   subject do
     described_class.new "Colombia",
       departments_file_path: Rails.root.join("spec/fixtures/files/dummy_colombia_departments.csv"),
-      municipalities_file_path: Rails.root.join("spec/fixtures/files/dummy_colombia_municipalities.csv")
+      municipalities_file_path: Rails.root.join("spec/fixtures/files/dummy_colombia_municipalities.csv"),
+      regions_file_path: Rails.root.join("spec/fixtures/files/dummy_colombia_regions.csv")
   end
 
   describe "#call" do
@@ -12,6 +13,8 @@ RSpec.describe Importers::Locations do
     let(:department_names) { departments.map(&:name) }
     let(:municipalities) { Location.where(location_type: "municipality") }
     let(:municipality_names) { municipalities.map(&:name) }
+    let(:regions) { Location.where(location_type: "region") }
+    let(:region_names) { regions.map(&:name) }
 
     before { subject.call }
 
@@ -44,9 +47,31 @@ RSpec.describe Importers::Locations do
         .to eq(["Antioquia Department"])
     end
 
+    it "inserts correct regions" do
+      expect(regions.count).to eq(3)
+      expect(region_names).to include("Cordillera Oriental")
+      expect(region_names).to include("Piedemonte Amazónico - Macizo")
+      expect(region_names).to include("Transición Pacífico - Caribe")
+    end
+
+    it "assigns correct parent to regions" do
+      expect(regions.map { |r| r.parent.name }.uniq).to eq(["Colombia"])
+    end
+
+    it "assigns regions to municipalities" do
+      expect(municipalities.where(name_en: ["Leticia", "Puerto Nariño"]).map { |r| r.regions.map(&:name) }.flatten)
+        .to eq(["Piedemonte Amazónico - Macizo", "Piedemonte Amazónico - Macizo"])
+      expect(municipalities.where(name_en: ["Abejorral", "Abriaquí"]).map { |r| r.regions.map(&:name) }.flatten)
+        .to eq(["Cordillera Oriental", "Cordillera Oriental"])
+    end
+
     context "when run multiple times" do
-      it "does not corrupt locations" do
+      it "does not duplicate locations" do
         expect { subject.call }.not_to change(Location, :count)
+      end
+
+      it "does not duplicate location members" do
+        expect { subject.call }.not_to change(LocationMember, :count)
       end
     end
   end

--- a/backend/spec/services/importers/locations_spec.rb
+++ b/backend/spec/services/importers/locations_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe Importers::Locations do
 
     it "inserts correct departments" do
       expect(departments.count).to eq(2)
-      expect(department_names).to include("Amazonas Department")
-      expect(department_names).to include("Antioquia Department")
+      expect(department_names).to include("Amazonas")
+      expect(department_names).to include("Antioquia")
     end
 
     it "assigns correct parent to departments" do
@@ -42,9 +42,9 @@ RSpec.describe Importers::Locations do
 
     it "assigns correct parents to municipalities" do
       expect(municipalities.where(name_en: ["Leticia", "Puerto Nariño"]).map { |r| r.parent.name_en }.uniq)
-        .to eq(["Amazonas Department"])
+        .to eq(["Amazonas"])
       expect(municipalities.where(name_en: ["Abejorral", "Abriaquí"]).map { |r| r.parent.name }.uniq)
-        .to eq(["Antioquia Department"])
+        .to eq(["Antioquia"])
     end
 
     it "inserts correct regions" do

--- a/backend/spec/swagger_helper.rb
+++ b/backend/spec/swagger_helper.rb
@@ -55,6 +55,58 @@ RSpec.configure do |config|
             },
             required: %w[id type attributes]
           },
+          location: {
+            type: :object,
+            properties: {
+              id: {type: :string},
+              type: {type: :string},
+              attributes: {
+                type: :object,
+                properties: {
+                  name: {type: :string},
+                  location_type: {type: :string, enum: LocationType::TYPES}
+                }
+              },
+              relationships: {
+                type: :object,
+                properties: {
+                  parent: {
+                    type: :object,
+                    properties: {
+                      data: {
+                        type: :object,
+                        nullable: true,
+                        properties: {
+                          id: {type: :string},
+                          type: {type: :string}
+                        },
+                        required: %w[id type]
+                      },
+                      required: %w[data]
+                    }
+                  },
+                  regions: {
+                    type: :object,
+                    properties: {
+                      data: {
+                        type: :array,
+                        items: {
+                          object: :object,
+                          properties: {
+                            id: {type: :string},
+                            type: {type: :string}
+                          },
+                          required: %w[id type]
+                        }
+                      }
+                    },
+                    required: %w[data]
+                  }
+                }
+              }
+            },
+            required: %w[id type attributes relationships]
+          },
           open_call: {
             type: :object,
             properties: {

--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -177,6 +177,22 @@ paths:
                   type: investor_type
                   attributes:
                     name: HNWI or Celebrity
+                - id: country
+                  type: location_type
+                  attributes:
+                    name: Country
+                - id: department
+                  type: location_type
+                  attributes:
+                    name: Department
+                - id: municipality
+                  type: location_type
+                  attributes:
+                    name: Municipality
+                - id: region
+                  type: location_type
+                  attributes:
+                    name: Region
               schema:
                 type: object
                 properties:
@@ -215,7 +231,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: b5439f9d-0594-4633-98d3-c9e50ec35a0d
+                - id: f4ad0a9e-e5d8-429a-81f2-dfb9210d9863
                   type: investor
                   attributes:
                     name: Kutch-Spencer
@@ -254,7 +270,7 @@ paths:
                     previously_invested_description: Enim repellat pariatur. Earum
                       modi eos. Libero tempora exercitationem. Qui dolorem quo.
                     language: en
-                - id: e3c0029b-145f-4186-b715-3d139393fd46
+                - id: 0c844926-601d-4ca1-8225-a31661c46a07
                   type: investor
                   attributes:
                     name: Bartoletti and Sons
@@ -293,7 +309,7 @@ paths:
                     previously_invested_description: Placeat commodi libero. Quo recusandae
                       repellat. Sunt commodi tempore. Voluptatem et corrupti.
                     language: en
-                - id: e0ecb2a0-5ace-4c58-b661-826eac70ab0a
+                - id: aaa6cef3-d7e1-4dbe-8ba1-4f8756feccc3
                   type: investor
                   attributes:
                     name: Hane, Lehner and Goyette
@@ -332,7 +348,7 @@ paths:
                     previously_invested_description: Et quaerat omnis. Harum voluptas
                       atque. Quo nesciunt voluptas. Suscipit ex cum.
                     language: en
-                - id: 57f44f99-abbd-48eb-a180-49ac3ea0ab5e
+                - id: c5e9ddad-b4f6-463b-9fc4-b5a7fcedc2e9
                   type: investor
                   attributes:
                     name: Hilpert, Waters and Johnston
@@ -371,7 +387,7 @@ paths:
                     previously_invested_description: Dolores fugiat nesciunt. Ut laborum
                       dolores. Sit neque eos. Expedita molestiae quia.
                     language: en
-                - id: 3834b0a0-ef99-4e96-9ef9-4d68e0119de8
+                - id: 5df5f758-5ed2-47a3-aa64-fdf0d511cee6
                   type: investor
                   attributes:
                     name: Jacobson, Fritsch and Stanton
@@ -410,7 +426,7 @@ paths:
                     previously_invested_description: Autem et et. Voluptatem neque
                       quibusdam. Repellat recusandae eum. Eius ex est.
                     language: en
-                - id: 4f7b0bc1-aadd-4231-a135-21f4fc6f2a0e
+                - id: '0283f575-3b7b-4f21-b465-48f72ef9532b'
                   type: investor
                   attributes:
                     name: Keebler, Kub and Zemlak
@@ -449,7 +465,7 @@ paths:
                     previously_invested_description: Porro soluta beatae. Quia ratione
                       facilis. Eligendi sapiente voluptatem. Quas rerum officia.
                     language: en
-                - id: 6c02dff3-effd-4994-92b9-bb8237c376e5
+                - id: da1e5b32-1f12-4177-80e9-d976ceb7f930
                   type: investor
                   attributes:
                     name: Becker LLC
@@ -541,7 +557,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: b5439f9d-0594-4633-98d3-c9e50ec35a0d
+                  id: f4ad0a9e-e5d8-429a-81f2-dfb9210d9863
                   type: investor
                   attributes:
                     name: Kutch-Spencer
@@ -585,6 +601,205 @@ paths:
                 properties:
                   data:
                     "$ref": "#/components/schemas/investor"
+  "/api/v1/locations":
+    get:
+      summary: Returns list of the locations
+      tags:
+      - Locations
+      parameters:
+      - name: location_type
+        in: query
+        enum:
+        - country
+        - department
+        - municipality
+        - region
+        description: Filter locations based on location type
+        required: false
+        schema:
+          type: string
+      - name: parent_id
+        in: query
+        description: Filter locations based on its closest parent
+        required: false
+        schema:
+          type: string
+      - name: fields[location]
+        in: query
+        description: Get only required fields. Use comma to separate multiple fields
+        required: false
+        schema:
+          type: string
+      - name: includes
+        in: query
+        description: Include relationships. Use comma to separate multiple fields
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              example:
+                data:
+                - id: 23a4bd27-33e5-40c0-a442-4ebbf92f8448
+                  type: location
+                  attributes:
+                    name: Kutch-Spencer
+                    location_type: country
+                  relationships:
+                    parent:
+                      data:
+                    regions:
+                      data: []
+                - id: 14929dff-8203-4ab8-8167-ff601490fe64
+                  type: location
+                  attributes:
+                    name: Bartoletti and Sons
+                    location_type: department
+                  relationships:
+                    parent:
+                      data:
+                        id: 23a4bd27-33e5-40c0-a442-4ebbf92f8448
+                        type: location
+                    regions:
+                      data: []
+                - id: f8bfa2f1-ab28-4de3-8591-a16930a25c8f
+                  type: location
+                  attributes:
+                    name: Hane, Lehner and Goyette
+                    location_type: municipality
+                  relationships:
+                    parent:
+                      data:
+                        id: 14929dff-8203-4ab8-8167-ff601490fe64
+                        type: location
+                    regions:
+                      data:
+                      - id: 30a4b8e3-541a-41d9-bf4d-9eb480c7417a
+                        type: location
+                - id: 30a4b8e3-541a-41d9-bf4d-9eb480c7417a
+                  type: location
+                  attributes:
+                    name: Hilpert, Waters and Johnston
+                    location_type: region
+                  relationships:
+                    parent:
+                      data:
+                    regions:
+                      data: []
+                - id: 938479fe-a1fe-40af-a821-39f970b901f5
+                  type: location
+                  attributes:
+                    name: Jacobson, Fritsch and Stanton
+                    location_type: municipality
+                  relationships:
+                    parent:
+                      data:
+                        id: 14929dff-8203-4ab8-8167-ff601490fe64
+                        type: location
+                    regions:
+                      data:
+                      - id: 5daf2df7-5a3e-49ee-bc5f-36fdbf089a29
+                        type: location
+                - id: 5daf2df7-5a3e-49ee-bc5f-36fdbf089a29
+                  type: location
+                  attributes:
+                    name: Keebler, Kub and Zemlak
+                    location_type: region
+                  relationships:
+                    parent:
+                      data:
+                    regions:
+                      data: []
+                - id: 47782f33-7c83-4df5-a5e6-a9faccc98a78
+                  type: location
+                  attributes:
+                    name: Becker LLC
+                    location_type: municipality
+                  relationships:
+                    parent:
+                      data:
+                        id: 14929dff-8203-4ab8-8167-ff601490fe64
+                        type: location
+                    regions:
+                      data:
+                      - id: f2147a62-70bc-4c38-9880-90a4f9ffa256
+                        type: location
+                - id: f2147a62-70bc-4c38-9880-90a4f9ffa256
+                  type: location
+                  attributes:
+                    name: Runolfsson and Sons
+                    location_type: region
+                  relationships:
+                    parent:
+                      data:
+                    regions:
+                      data: []
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/location"
+  "/api/v1/locations/{id}":
+    get:
+      summary: Find location by id
+      tags:
+      - Locations
+      parameters:
+      - name: id
+        in: path
+        description: Use location ID
+        required: true
+        schema:
+          type: string
+      - name: fields[location]
+        in: query
+        description: Get only required fields. Use comma to separate multiple fields
+        required: false
+        schema:
+          type: string
+      - name: includes
+        in: query
+        description: Include relationships. Use comma to separate multiple fields
+        required: false
+        schema:
+          type: string
+      responses:
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/errors"
+        '200':
+          description: success
+          content:
+            application/json:
+              example:
+                data:
+                  id: f8bfa2f1-ab28-4de3-8591-a16930a25c8f
+                  type: location
+                  attributes:
+                    name: Hane, Lehner and Goyette
+                    location_type: municipality
+                  relationships:
+                    parent:
+                      data:
+                        id: 14929dff-8203-4ab8-8167-ff601490fe64
+                        type: location
+                    regions:
+                      data:
+                      - id: 30a4b8e3-541a-41d9-bf4d-9eb480c7417a
+                        type: location
+              schema:
+                type: object
+                properties:
+                  data:
+                    "$ref": "#/components/schemas/location"
   "/api/v1/open_calls":
     get:
       summary: Returns list of the open calls
@@ -616,7 +831,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: 4462ac24-0c74-400e-9509-53027c55089f
+                - id: 4d42b943-f9c0-4225-8491-e7d944ed0d62
                   type: open_call
                   attributes:
                     name: Open call 1
@@ -633,14 +848,14 @@ paths:
                       tempora exercitationem. Qui dolorem quo.
                     impact_description: Enim repellat pariatur. Earum modi eos. Libero
                       tempora exercitationem. Qui dolorem quo.
-                    closing_at: '2023-01-16T09:40:22.145Z'
+                    closing_at: '2023-01-21T10:22:18.695Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: 5c7bcc49-4419-4186-b621-fa21cd46f168
+                        id: 911379b5-f5cc-44ce-9405-46bc06e60059
                         type: investor
-                - id: d69e651e-0f25-4591-a468-e5eb932c567d
+                - id: 18a4f7bb-48a1-41f8-b413-c56af01d9f56
                   type: open_call
                   attributes:
                     name: Open call 2
@@ -657,14 +872,14 @@ paths:
                       Sunt commodi tempore. Voluptatem et corrupti.
                     impact_description: Placeat commodi libero. Quo recusandae repellat.
                       Sunt commodi tempore. Voluptatem et corrupti.
-                    closing_at: '2023-01-16T09:40:22.174Z'
+                    closing_at: '2023-01-21T10:22:18.724Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: 60181d8f-3d60-49aa-98b3-853639b86821
+                        id: 1c70faee-252b-4cfd-a9e3-94c94efbd77f
                         type: investor
-                - id: 95a23f24-01a4-4ead-98be-daa70a5553d4
+                - id: d65d7179-644f-401d-8d78-225d7bb35d56
                   type: open_call
                   attributes:
                     name: Open call 3
@@ -681,14 +896,14 @@ paths:
                       nesciunt voluptas. Suscipit ex cum.
                     impact_description: Et quaerat omnis. Harum voluptas atque. Quo
                       nesciunt voluptas. Suscipit ex cum.
-                    closing_at: '2023-01-16T09:40:22.197Z'
+                    closing_at: '2023-01-21T10:22:18.747Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: 80489957-2b8c-4be7-8765-53299b18ee81
+                        id: 535959d9-330d-4ec0-b590-351dacfa78d6
                         type: investor
-                - id: ea641d05-a24b-4f64-84f5-cf1b42c5569f
+                - id: 0e7844ea-0251-44b6-ab67-a913b4e47c98
                   type: open_call
                   attributes:
                     name: Open call 4
@@ -705,14 +920,14 @@ paths:
                       Sit neque eos. Expedita molestiae quia.
                     impact_description: Dolores fugiat nesciunt. Ut laborum dolores.
                       Sit neque eos. Expedita molestiae quia.
-                    closing_at: '2023-01-16T09:40:22.220Z'
+                    closing_at: '2023-01-21T10:22:18.772Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: 960a6cfa-1545-4b28-adcc-911193f679a1
+                        id: 9b131b4f-f53c-4364-8e79-f443821213d9
                         type: investor
-                - id: 5cd08286-8321-4300-a78d-38faf4eab712
+                - id: 82ab1bac-f11d-47dc-b707-24aaf8fbd355
                   type: open_call
                   attributes:
                     name: Open call 5
@@ -729,14 +944,14 @@ paths:
                       recusandae eum. Eius ex est.
                     impact_description: Autem et et. Voluptatem neque quibusdam. Repellat
                       recusandae eum. Eius ex est.
-                    closing_at: '2023-01-16T09:40:22.242Z'
+                    closing_at: '2023-01-21T10:22:18.794Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: b8561d99-7c9d-426c-acdf-903b3365a4c1
+                        id: 5580b21b-2f54-42b0-9c0e-f949d72eeb55
                         type: investor
-                - id: ef766bfa-da2a-4e6a-8209-ad0312a43c57
+                - id: ef376e02-00f6-44ce-9ece-d96d6ff1ca74
                   type: open_call
                   attributes:
                     name: Open call 6
@@ -753,14 +968,14 @@ paths:
                       Eligendi sapiente voluptatem. Quas rerum officia.
                     impact_description: Porro soluta beatae. Quia ratione facilis.
                       Eligendi sapiente voluptatem. Quas rerum officia.
-                    closing_at: '2023-01-16T09:40:22.264Z'
+                    closing_at: '2023-01-21T10:22:18.816Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: 370179f0-3953-4df9-bd9b-ab6337938914
+                        id: bf4caafb-69d5-473e-8516-108314993f48
                         type: investor
-                - id: c1cd5b53-d364-44ae-81e9-c7ee0e9aaf7d
+                - id: e70bfd91-0f25-4367-8e4a-0867afc5bca6
                   type: open_call
                   attributes:
                     name: Open call 7
@@ -777,12 +992,12 @@ paths:
                       laudantium et. Sed recusandae aut.
                     impact_description: Mollitia aut vel. Qui illum accusantium. Et
                       laudantium et. Sed recusandae aut.
-                    closing_at: '2023-01-16T09:40:22.288Z'
+                    closing_at: '2023-01-21T10:22:18.839Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: c5fc86cb-275b-4d19-a367-3cf46151f9c1
+                        id: e5e31840-b189-401e-bd75-6df5d61383fe
                         type: investor
                 meta:
                   page: 1
@@ -837,7 +1052,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 4462ac24-0c74-400e-9509-53027c55089f
+                  id: 4d42b943-f9c0-4225-8491-e7d944ed0d62
                   type: open_call
                   attributes:
                     name: Open call 1
@@ -854,12 +1069,12 @@ paths:
                       tempora exercitationem. Qui dolorem quo.
                     impact_description: Enim repellat pariatur. Earum modi eos. Libero
                       tempora exercitationem. Qui dolorem quo.
-                    closing_at: '2023-01-16T09:40:22.145Z'
+                    closing_at: '2023-01-21T10:22:18.695Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: 5c7bcc49-4419-4186-b621-fa21cd46f168
+                        id: 911379b5-f5cc-44ce-9405-46bc06e60059
                         type: investor
               schema:
                 type: object
@@ -897,7 +1112,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: 0ff4aeb7-3a05-45dd-a90d-3ba0c731a199
+                - id: f5f14cb0-1747-46d9-9e2f-a8f485db47d1
                   type: project_developer
                   attributes:
                     name: Kutch-Spencer
@@ -919,7 +1134,7 @@ paths:
                     - climate
                     - water
                     language: en
-                - id: 54432fa4-fd9b-4bf6-aa3d-a6c513305299
+                - id: b8e8dd3f-2993-4d2c-8c46-d3264a25c000
                   type: project_developer
                   attributes:
                     name: Bartoletti and Sons
@@ -941,7 +1156,7 @@ paths:
                     - climate
                     - water
                     language: en
-                - id: 6112b210-686d-44eb-8597-6b9f180ddb84
+                - id: 24dd3d82-3d72-4a27-901d-8f39efe45336
                   type: project_developer
                   attributes:
                     name: Hane, Lehner and Goyette
@@ -963,7 +1178,7 @@ paths:
                     - climate
                     - water
                     language: en
-                - id: 690921f3-de10-4be8-9866-2b6b42847353
+                - id: f2d4db32-5ef8-4230-958e-d6841136d793
                   type: project_developer
                   attributes:
                     name: Hilpert, Waters and Johnston
@@ -985,7 +1200,7 @@ paths:
                     - climate
                     - water
                     language: en
-                - id: b2dfb2e1-a144-4f1d-aeea-a6dad3a809b5
+                - id: 52dec9dc-c0dd-4875-a61b-3f4cf1ab1c6a
                   type: project_developer
                   attributes:
                     name: Jacobson, Fritsch and Stanton
@@ -1007,7 +1222,7 @@ paths:
                     - climate
                     - water
                     language: en
-                - id: 070c077c-a711-4240-87e4-9455d5b1c77f
+                - id: 814defb0-a718-47fe-bea1-bfeefe396c69
                   type: project_developer
                   attributes:
                     name: Keebler, Kub and Zemlak
@@ -1029,7 +1244,7 @@ paths:
                     - climate
                     - water
                     language: en
-                - id: f9c1a657-68fa-475a-a7ce-26c7cb16de3a
+                - id: 92ca3e09-772a-4d62-84f0-9e13c9cca828
                   type: project_developer
                   attributes:
                     name: Becker LLC
@@ -1104,7 +1319,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 0ff4aeb7-3a05-45dd-a90d-3ba0c731a199
+                  id: f5f14cb0-1747-46d9-9e2f-a8f485db47d1
                   type: project_developer
                   attributes:
                     name: Kutch-Spencer
@@ -1168,7 +1383,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: 7db0ccb9-ab50-4938-a045-954efd6e90cf
+                - id: 7a5388f2-2d32-4911-8aab-f7f8529dcf9d
                   type: project
                   attributes:
                     name: Project 1
@@ -1210,9 +1425,9 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: eeb92ea8-25ac-417c-a967-25b29d984ebe
+                        id: 942ba021-4fbc-4639-86b6-08a60d69cf15
                         type: project_developer
-                - id: 1adc50fb-17e1-4ce4-b5ad-6b5687c4c683
+                - id: be89dffd-b988-483f-93c3-66966ed9a8e9
                   type: project
                   attributes:
                     name: Project 2
@@ -1254,9 +1469,9 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 660a4f82-0813-49e0-ab31-54de5e7314e6
+                        id: 3dabd7fb-1190-4151-91b8-6121ac2afcec
                         type: project_developer
-                - id: 8b8e1359-276b-47c5-8028-68382ccf97d5
+                - id: ec2968cc-3fc2-4e70-bdaf-483762fd222b
                   type: project
                   attributes:
                     name: Project 3
@@ -1298,9 +1513,9 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: b9082702-fe3a-438b-983e-617cb76df9ea
+                        id: 7587b836-59a6-4688-a79a-2687d8c60b04
                         type: project_developer
-                - id: e602b4f4-2019-447a-b5a5-32f0707bcb2e
+                - id: d80868f3-da80-476a-b854-2616f4354ae4
                   type: project
                   attributes:
                     name: Project 4
@@ -1342,9 +1557,9 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 86b2d092-a470-4b5c-b47b-a364329a472d
+                        id: 8d37822a-6ea6-4105-8ba0-1ccb7467e86a
                         type: project_developer
-                - id: 75dfcad0-ce78-47a4-888a-1875212d9e67
+                - id: b86aeba7-f92a-4128-aa00-bb981ec2cdcc
                   type: project
                   attributes:
                     name: Project 5
@@ -1386,9 +1601,9 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 9d03c7ca-cae2-4a31-ad7d-b89413981957
+                        id: b9f44eab-cfb0-483c-aa98-9822bf693baa
                         type: project_developer
-                - id: efb02fab-ee4b-4b96-8a9e-453ced590235
+                - id: 1f05b4db-ef83-4492-b63f-33ce8543c491
                   type: project
                   attributes:
                     name: Project 6
@@ -1430,9 +1645,9 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: d11dd32a-c834-4db0-b594-e4f409fa9282
+                        id: 42c2a89f-566b-446c-8c2b-94ec6e595991
                         type: project_developer
-                - id: 3309d417-36d5-4d3f-a8fe-eb9b4e7f66e6
+                - id: fc563cdc-49d1-45ce-b9a6-0be43996cdac
                   type: project
                   attributes:
                     name: Project 7
@@ -1474,7 +1689,7 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 35bcab24-7553-4e92-ba32-eb0c279f7e72
+                        id: e0f6c5d0-2bd7-48e1-9515-4f946e83cec6
                         type: project_developer
                 meta:
                   page: 1
@@ -1535,7 +1750,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 7db0ccb9-ab50-4938-a045-954efd6e90cf
+                  id: 7a5388f2-2d32-4911-8aab-f7f8529dcf9d
                   type: project
                   attributes:
                     name: Project 1
@@ -1577,7 +1792,7 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: eeb92ea8-25ac-417c-a967-25b29d984ebe
+                        id: 942ba021-4fbc-4639-86b6-08a60d69cf15
                         type: project_developer
               schema:
                 type: object
@@ -1659,6 +1874,66 @@ components:
       - id
       - type
       - attributes
+    location:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        attributes:
+          type: object
+          properties:
+            name:
+              type: string
+            location_type:
+              type: string
+              enum:
+              - country
+              - department
+              - municipality
+              - region
+        relationships:
+          type: object
+          properties:
+            parent:
+              type: object
+              properties:
+                data:
+                  type: object
+                  nullable: true
+                  properties:
+                    id:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - id
+                  - type
+                required:
+                - data
+            regions:
+              type: object
+              properties:
+                data:
+                  type: array
+                  items:
+                    object: object
+                    properties:
+                      id:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - id
+                    - type
+              required:
+              - data
+      required:
+      - id
+      - type
+      - attributes
+      - relationships
     open_call:
       type: object
       properties:


### PR DESCRIPTION
Second part of feature focused on import of location data. This one is about Colombia regions (mosaics) ;)

I have added new model `LocationMember` which allows to have `have_many` relation between other locations (regions). Reason for this is that administrative location (state, municipality, etc.) can be at multiple geographic locations (regions). Locations importer now supports import of regions and also assigns these regions to correct municipalities.

About regions data -- I have used shapefile provided via Jira ticket to get regions and downloaded coordinates for every municipality from wikipedia. Then I have computed intersections and decided which municipalities are at which regions. Unfortunately, this approach is super inaccurate, because whole municipality is represented just by one point and even though point itself is not at region, part of the municipality still can be. Unfortunately, I don't have exact geometry for every municipality so this is as far as I can go with wikipedia data.
 
![colombia_regions](https://user-images.githubusercontent.com/20660167/159039565-ff1d7756-4ad8-4b16-a56a-8634792cbce9.png)

## Testing instructions

Same as first iteration of location import feature. Run `rake db:seed` and check that LocationMember table contains data ;)

## Tracking

https://vizzuality.atlassian.net/browse/LET-130