### PR TITLE
Fix rswag empty params that not set content type

### DIFF
--- a/backend/spec/requests/api/v1/session_spec.rb
+++ b/backend/spec/requests/api/v1/session_spec.rb
@@ -85,6 +85,7 @@ RSpec.describe "API V1 Session", type: :request do
       security [cookie_auth: [], csrf: []]
       consumes "application/json"
       produces "application/json"
+      parameter name: :empty, in: :body, schema: {type: :object}, required: false
 
       it_behaves_like "with not authorized error", csrf: true
 

--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -231,7 +231,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: 7ee91890-fabe-4227-a58b-d04670a9d17f
+                - id: 1ed3e1f9-69d2-4ecd-a58f-55be28164e12
                   type: investor
                   attributes:
                     name: Kutch-Spencer
@@ -270,7 +270,7 @@ paths:
                     previously_invested_description: Enim repellat pariatur. Earum
                       modi eos. Libero tempora exercitationem. Qui dolorem quo.
                     language: en
-                - id: 497cd918-5d20-492a-aae7-6029a2e22455
+                - id: b82f576d-b3d0-4dcf-ad1d-c04467513ce6
                   type: investor
                   attributes:
                     name: Bartoletti and Sons
@@ -309,7 +309,7 @@ paths:
                     previously_invested_description: Placeat commodi libero. Quo recusandae
                       repellat. Sunt commodi tempore. Voluptatem et corrupti.
                     language: en
-                - id: 8848c0b6-468c-443c-8a66-21373d6e2a5c
+                - id: d2073623-521b-4699-a9de-984dfe9e5452
                   type: investor
                   attributes:
                     name: Hane, Lehner and Goyette
@@ -348,7 +348,7 @@ paths:
                     previously_invested_description: Et quaerat omnis. Harum voluptas
                       atque. Quo nesciunt voluptas. Suscipit ex cum.
                     language: en
-                - id: 398931e8-6c87-4c54-94a2-03ab41e08271
+                - id: 15c7044e-9c54-4e4f-a40c-2b1dd0022708
                   type: investor
                   attributes:
                     name: Hilpert, Waters and Johnston
@@ -387,7 +387,7 @@ paths:
                     previously_invested_description: Dolores fugiat nesciunt. Ut laborum
                       dolores. Sit neque eos. Expedita molestiae quia.
                     language: en
-                - id: e8b8ee90-e310-447e-ba73-5618eba6b551
+                - id: 8076cef8-09a5-480c-8c8d-2e9f20fdbac6
                   type: investor
                   attributes:
                     name: Jacobson, Fritsch and Stanton
@@ -426,7 +426,7 @@ paths:
                     previously_invested_description: Autem et et. Voluptatem neque
                       quibusdam. Repellat recusandae eum. Eius ex est.
                     language: en
-                - id: 7097972e-70b4-45f0-a49f-05c08ab8a943
+                - id: a0e1fffc-8e78-40e0-a214-39ce1f996522
                   type: investor
                   attributes:
                     name: Keebler, Kub and Zemlak
@@ -465,7 +465,7 @@ paths:
                     previously_invested_description: Porro soluta beatae. Quia ratione
                       facilis. Eligendi sapiente voluptatem. Quas rerum officia.
                     language: en
-                - id: 0331ab11-e7c9-4aa6-8787-d1b46c1befc6
+                - id: 48baa4f3-58dd-4acb-aed1-d82902659a2f
                   type: investor
                   attributes:
                     name: Becker LLC
@@ -557,7 +557,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 7ee91890-fabe-4227-a58b-d04670a9d17f
+                  id: 1ed3e1f9-69d2-4ecd-a58f-55be28164e12
                   type: investor
                   attributes:
                     name: Kutch-Spencer
@@ -643,7 +643,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: fda56d20-ae55-4164-bccb-9a2610b98b44
+                - id: dde62c3c-005d-4309-8074-25d7fc2feba4
                   type: location
                   attributes:
                     name: Kutch-Spencer
@@ -653,7 +653,7 @@ paths:
                       data:
                     regions:
                       data: []
-                - id: 6446833d-a79c-459a-b7d4-0498b9cf1b37
+                - id: 80dcdd10-5068-4713-a3b5-7a345f699eeb
                   type: location
                   attributes:
                     name: Bartoletti and Sons
@@ -661,11 +661,11 @@ paths:
                   relationships:
                     parent:
                       data:
-                        id: fda56d20-ae55-4164-bccb-9a2610b98b44
+                        id: dde62c3c-005d-4309-8074-25d7fc2feba4
                         type: location
                     regions:
                       data: []
-                - id: db9cf02c-14db-497e-9d09-4d1467fb99b1
+                - id: c3a2b8e7-fad1-4db6-8369-344446f1ca9b
                   type: location
                   attributes:
                     name: Hane, Lehner and Goyette
@@ -673,13 +673,13 @@ paths:
                   relationships:
                     parent:
                       data:
-                        id: 6446833d-a79c-459a-b7d4-0498b9cf1b37
+                        id: 80dcdd10-5068-4713-a3b5-7a345f699eeb
                         type: location
                     regions:
                       data:
-                      - id: d1e86b89-7797-4ac3-b5cf-d91c76d45918
+                      - id: 753c07df-20d8-4e8d-803f-4eb210ffb277
                         type: location
-                - id: d1e86b89-7797-4ac3-b5cf-d91c76d45918
+                - id: 753c07df-20d8-4e8d-803f-4eb210ffb277
                   type: location
                   attributes:
                     name: Hilpert, Waters and Johnston
@@ -689,7 +689,7 @@ paths:
                       data:
                     regions:
                       data: []
-                - id: 410e9a09-4ba6-49a6-a190-ed5e4f10c7da
+                - id: d343fda0-4c0b-4db7-964d-53d832e45b00
                   type: location
                   attributes:
                     name: Jacobson, Fritsch and Stanton
@@ -697,13 +697,13 @@ paths:
                   relationships:
                     parent:
                       data:
-                        id: 6446833d-a79c-459a-b7d4-0498b9cf1b37
+                        id: 80dcdd10-5068-4713-a3b5-7a345f699eeb
                         type: location
                     regions:
                       data:
-                      - id: a4397f44-42dd-420a-a716-d19e2a72fb8b
+                      - id: 073bf22c-674e-4218-b698-7ceac0c5b03e
                         type: location
-                - id: a4397f44-42dd-420a-a716-d19e2a72fb8b
+                - id: 073bf22c-674e-4218-b698-7ceac0c5b03e
                   type: location
                   attributes:
                     name: Keebler, Kub and Zemlak
@@ -713,7 +713,7 @@ paths:
                       data:
                     regions:
                       data: []
-                - id: 006edccf-c12f-483e-8cf5-20ec53205420
+                - id: 118b865e-8902-4657-bd6b-08121d3f91e9
                   type: location
                   attributes:
                     name: Becker LLC
@@ -721,13 +721,13 @@ paths:
                   relationships:
                     parent:
                       data:
-                        id: 6446833d-a79c-459a-b7d4-0498b9cf1b37
+                        id: 80dcdd10-5068-4713-a3b5-7a345f699eeb
                         type: location
                     regions:
                       data:
-                      - id: da53637a-cbf5-4342-9258-e258dcb54f6c
+                      - id: c7e3b74b-05b3-4ae9-96f4-4d93d84fb402
                         type: location
-                - id: da53637a-cbf5-4342-9258-e258dcb54f6c
+                - id: c7e3b74b-05b3-4ae9-96f4-4d93d84fb402
                   type: location
                   attributes:
                     name: Runolfsson and Sons
@@ -781,7 +781,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: db9cf02c-14db-497e-9d09-4d1467fb99b1
+                  id: c3a2b8e7-fad1-4db6-8369-344446f1ca9b
                   type: location
                   attributes:
                     name: Hane, Lehner and Goyette
@@ -789,11 +789,11 @@ paths:
                   relationships:
                     parent:
                       data:
-                        id: 6446833d-a79c-459a-b7d4-0498b9cf1b37
+                        id: 80dcdd10-5068-4713-a3b5-7a345f699eeb
                         type: location
                     regions:
                       data:
-                      - id: d1e86b89-7797-4ac3-b5cf-d91c76d45918
+                      - id: 753c07df-20d8-4e8d-803f-4eb210ffb277
                         type: location
               schema:
                 type: object
@@ -831,7 +831,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: 9f4f910f-dfdf-4849-8d40-46b038b2af5e
+                - id: b0389f6c-b35b-4c83-b751-408fd0c01fb0
                   type: open_call
                   attributes:
                     name: Open call 1
@@ -848,14 +848,14 @@ paths:
                       tempora exercitationem. Qui dolorem quo.
                     impact_description: Enim repellat pariatur. Earum modi eos. Libero
                       tempora exercitationem. Qui dolorem quo.
-                    closing_at: '2023-01-22T18:52:27.728Z'
+                    closing_at: '2023-01-23T16:32:52.588Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: c7682b04-ef14-46f9-b345-4d2b295d9abd
+                        id: 5dfd2c15-ed95-4728-9259-2c410cea8f2f
                         type: investor
-                - id: e08f2a33-79da-4850-b747-62428398c05f
+                - id: eb40be44-e5eb-476b-8362-579e472d793c
                   type: open_call
                   attributes:
                     name: Open call 2
@@ -872,14 +872,14 @@ paths:
                       Sunt commodi tempore. Voluptatem et corrupti.
                     impact_description: Placeat commodi libero. Quo recusandae repellat.
                       Sunt commodi tempore. Voluptatem et corrupti.
-                    closing_at: '2023-01-22T18:52:27.749Z'
+                    closing_at: '2023-01-23T16:32:52.608Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: a3fc7662-e2ae-41d3-9081-b6e81ef512ad
+                        id: fcc590f7-43bd-4d78-8083-b7d4bb8516b9
                         type: investor
-                - id: bc8429ff-2578-4b6a-9d62-f0cf3d26843a
+                - id: 47f6de83-1056-46a8-abc0-f7aed5987f4f
                   type: open_call
                   attributes:
                     name: Open call 3
@@ -896,14 +896,14 @@ paths:
                       nesciunt voluptas. Suscipit ex cum.
                     impact_description: Et quaerat omnis. Harum voluptas atque. Quo
                       nesciunt voluptas. Suscipit ex cum.
-                    closing_at: '2023-01-22T18:52:27.768Z'
+                    closing_at: '2023-01-23T16:32:52.627Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: 25ba924c-e55e-49a0-8c0f-f33632ec144e
+                        id: c5d73488-6105-4536-8d78-20b272b99f52
                         type: investor
-                - id: a3d4dad4-deb1-451e-a71f-586912f0fe1d
+                - id: f6bb7a66-5dcf-46d0-bcc8-56a643ae115e
                   type: open_call
                   attributes:
                     name: Open call 4
@@ -920,14 +920,14 @@ paths:
                       Sit neque eos. Expedita molestiae quia.
                     impact_description: Dolores fugiat nesciunt. Ut laborum dolores.
                       Sit neque eos. Expedita molestiae quia.
-                    closing_at: '2023-01-22T18:52:27.787Z'
+                    closing_at: '2023-01-23T16:32:52.645Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: c2274ef9-b31d-40ad-9d37-509ba027a8a6
+                        id: db7a822b-9103-4e47-8e1f-a1b987531ddd
                         type: investor
-                - id: ee41d0a0-2d09-4a70-8845-4aa835e16043
+                - id: 45d5b933-6740-4a44-ae7f-da290307f025
                   type: open_call
                   attributes:
                     name: Open call 5
@@ -944,14 +944,14 @@ paths:
                       recusandae eum. Eius ex est.
                     impact_description: Autem et et. Voluptatem neque quibusdam. Repellat
                       recusandae eum. Eius ex est.
-                    closing_at: '2023-01-22T18:52:27.806Z'
+                    closing_at: '2023-01-23T16:32:52.665Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: ebbb90c5-8f28-4390-b7b3-73cd4e8d4619
+                        id: dc9c13cb-f024-4c56-913e-e92b3022b83a
                         type: investor
-                - id: da31eabc-0f2e-4514-bdae-a872e00e48e5
+                - id: cd3e500a-ebba-4bdb-b125-3433ffa5fa2f
                   type: open_call
                   attributes:
                     name: Open call 6
@@ -968,14 +968,14 @@ paths:
                       Eligendi sapiente voluptatem. Quas rerum officia.
                     impact_description: Porro soluta beatae. Quia ratione facilis.
                       Eligendi sapiente voluptatem. Quas rerum officia.
-                    closing_at: '2023-01-22T18:52:27.827Z'
+                    closing_at: '2023-01-23T16:32:52.684Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: dc65fa37-d950-4d9b-844d-42be941329b8
+                        id: 3f3c7404-64bd-45b7-97ec-04c187884ca3
                         type: investor
-                - id: 99a23235-bd2f-499b-9fd4-8c7a905b84fc
+                - id: c21bbc01-e68e-4b28-a58a-fed0519510b9
                   type: open_call
                   attributes:
                     name: Open call 7
@@ -992,12 +992,12 @@ paths:
                       laudantium et. Sed recusandae aut.
                     impact_description: Mollitia aut vel. Qui illum accusantium. Et
                       laudantium et. Sed recusandae aut.
-                    closing_at: '2023-01-22T18:52:27.846Z'
+                    closing_at: '2023-01-23T16:32:52.706Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: e21298ec-0e58-4be0-ab6b-f44306b81da1
+                        id: 5ebcc33c-c00d-4b56-baa1-802c15d7c26f
                         type: investor
                 meta:
                   page: 1
@@ -1052,7 +1052,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 9f4f910f-dfdf-4849-8d40-46b038b2af5e
+                  id: b0389f6c-b35b-4c83-b751-408fd0c01fb0
                   type: open_call
                   attributes:
                     name: Open call 1
@@ -1069,12 +1069,12 @@ paths:
                       tempora exercitationem. Qui dolorem quo.
                     impact_description: Enim repellat pariatur. Earum modi eos. Libero
                       tempora exercitationem. Qui dolorem quo.
-                    closing_at: '2023-01-22T18:52:27.728Z'
+                    closing_at: '2023-01-23T16:32:52.588Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: c7682b04-ef14-46f9-b345-4d2b295d9abd
+                        id: 5dfd2c15-ed95-4728-9259-2c410cea8f2f
                         type: investor
               schema:
                 type: object
@@ -1112,7 +1112,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: a644a253-5aad-4ee6-b8bc-d17e54b5ccc2
+                - id: 1b3db8b3-7af9-499e-89ba-706111696a43
                   type: project_developer
                   attributes:
                     name: Kutch-Spencer
@@ -1134,7 +1134,7 @@ paths:
                     - climate
                     - water
                     language: en
-                - id: 125865e9-a1f3-4137-b9d8-38fb7dd0d0dc
+                - id: a953b7c7-8c79-42d6-b063-cb3e69c1e8ca
                   type: project_developer
                   attributes:
                     name: Bartoletti and Sons
@@ -1156,7 +1156,7 @@ paths:
                     - climate
                     - water
                     language: en
-                - id: f242ae4f-6ffc-4625-9f53-aaa3383e29c9
+                - id: 9649fec2-7523-46cd-aa0c-061f9fdcf44d
                   type: project_developer
                   attributes:
                     name: Hane, Lehner and Goyette
@@ -1178,7 +1178,7 @@ paths:
                     - climate
                     - water
                     language: en
-                - id: 59f829fd-e8c9-48c5-9b6a-3c577dcd92f0
+                - id: 3224cecf-f9fe-43a6-bec1-fc70f2957b84
                   type: project_developer
                   attributes:
                     name: Hilpert, Waters and Johnston
@@ -1200,7 +1200,7 @@ paths:
                     - climate
                     - water
                     language: en
-                - id: 9a3aada7-85b5-4d0e-abf2-e63f69b37fbf
+                - id: f0ee4f55-6af9-44c7-94eb-5bb71947b1be
                   type: project_developer
                   attributes:
                     name: Jacobson, Fritsch and Stanton
@@ -1222,7 +1222,7 @@ paths:
                     - climate
                     - water
                     language: en
-                - id: 2aeac68c-3cfc-405c-935e-d56262b789ca
+                - id: 197b715d-3574-4260-af4a-d518a50d0711
                   type: project_developer
                   attributes:
                     name: Keebler, Kub and Zemlak
@@ -1244,7 +1244,7 @@ paths:
                     - climate
                     - water
                     language: en
-                - id: c3444f7a-791a-4141-900b-5e49cf905558
+                - id: 3b67007c-88f2-4baf-9802-608c4b84eb31
                   type: project_developer
                   attributes:
                     name: Becker LLC
@@ -1319,7 +1319,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: a644a253-5aad-4ee6-b8bc-d17e54b5ccc2
+                  id: 1b3db8b3-7af9-499e-89ba-706111696a43
                   type: project_developer
                   attributes:
                     name: Kutch-Spencer
@@ -1383,7 +1383,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: 1428d959-ea6b-4f3c-b0e1-da88d4fad355
+                - id: 9e508611-e949-4fe4-a6cc-983daf9d4c81
                   type: project
                   attributes:
                     name: Project 1
@@ -1425,9 +1425,9 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 2a8ae28f-9d2b-45e9-85aa-36a0cbac3921
+                        id: 2ebc66cd-cee9-4476-8a75-63a9b70f6adf
                         type: project_developer
-                - id: d2379823-5a15-45b3-99f4-296f998b9dcf
+                - id: 4e073a46-cf00-4874-a42a-511e4d2c7a9c
                   type: project
                   attributes:
                     name: Project 2
@@ -1469,9 +1469,9 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: dadaf0da-b4b1-4ce9-8166-f0a169a8928b
+                        id: fa8d899b-a91b-4d3f-876c-35a67b4795dd
                         type: project_developer
-                - id: 6b2c6f87-eca2-4f45-9e8e-3a8ba83e0798
+                - id: 6b1879ba-26b8-4605-b158-b7845282ff66
                   type: project
                   attributes:
                     name: Project 3
@@ -1513,9 +1513,9 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: d71d4a2e-47b0-4e84-98b5-e97478ad932e
+                        id: 9e6b9dc3-788b-4e8a-9f22-412e426bb30f
                         type: project_developer
-                - id: 0f5045ed-f39d-47ee-8eca-3cb5d261595f
+                - id: 74bb9d9d-454a-48af-b1d6-86e4d8db8da6
                   type: project
                   attributes:
                     name: Project 4
@@ -1557,9 +1557,9 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: aa63b5a2-f965-4e5e-8348-36ed3875cd27
+                        id: 2ffb9cf2-1ede-46bd-a6ec-d56ce60a9dbf
                         type: project_developer
-                - id: 8e065402-e6cd-4a7b-9fa7-bb8157c19738
+                - id: fad86bca-b6bf-4a34-a90f-3ef6d946b77c
                   type: project
                   attributes:
                     name: Project 5
@@ -1601,9 +1601,9 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: c7af6966-442e-4571-9442-580a6d49293c
+                        id: 269a9549-bb34-4a5e-b920-80a09af90cdf
                         type: project_developer
-                - id: 2ec8bcc9-b0f7-4327-8c6c-22ee0540d769
+                - id: 78f400c1-6324-47a6-b5ba-63b86304f017
                   type: project
                   attributes:
                     name: Project 6
@@ -1645,9 +1645,9 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: cb4a9038-d372-45ff-b00f-3402aa486b79
+                        id: 8aa5bdc9-51b0-443b-9486-bd4fd92821e3
                         type: project_developer
-                - id: d4e8a4e5-104f-4d4a-962d-b08c0306b7af
+                - id: d083f670-2ab9-439e-815f-b7af31c767c4
                   type: project
                   attributes:
                     name: Project 7
@@ -1689,7 +1689,7 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 5b74cd1a-26f5-4baf-b968-d7df250b4131
+                        id: 00f02ad2-86bc-4a53-83d2-247a1ab46665
                         type: project_developer
                 meta:
                   page: 1
@@ -1750,7 +1750,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 1428d959-ea6b-4f3c-b0e1-da88d4fad355
+                  id: 9e508611-e949-4fe4-a6cc-983daf9d4c81
                   type: project
                   attributes:
                     name: Project 1
@@ -1792,7 +1792,7 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 2a8ae28f-9d2b-45e9-85aa-36a0cbac3921
+                        id: 2ebc66cd-cee9-4476-8a75-63a9b70f6adf
                         type: project_developer
               schema:
                 type: object
@@ -1814,7 +1814,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: dbe196e8-4719-4ec0-bcb3-f6b7062de59a
+                  id: 5d474b26-448c-4bdf-9993-a8854baf9fbc
                   type: user
                   attributes:
                     first_name: Dawna
@@ -1867,6 +1867,7 @@ paths:
       security:
       - cookie_auth: []
         csrf: []
+      parameters: []
       responses:
         '401':
           description: Authentication failed
@@ -1878,6 +1879,11 @@ paths:
                   code:
         '200':
           description: success
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
   "/api/v1/user":
     post:
       summary: Creates/Registers user
@@ -1893,7 +1899,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 717ca32a-e319-4f68-9a79-4b60b0cb100d
+                  id: ac05cd5f-999f-4104-baec-c925f7870913
                   type: user
                   attributes:
                     first_name: Jan
@@ -1964,7 +1970,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: ed10649c-61fe-4633-baf4-773367f7e2bd
+                  id: 6cb01fcd-0b2a-41d2-9520-ea17bc086930
                   type: user
                   attributes:
                     first_name: Dawna


### PR DESCRIPTION
I realized that in api-docs trying out session destroy endpoint does not work. Content type was not set, and API requires `application/json` for non-GET requests. Looks like I have to set some dummy parameter in rswag to set content type.

@martintomas any idea if that could be done better?

## Testing instructions

Clicking on session destroy in api-docs should work

## Tracking

No tracking