### PR TITLE
Add a `Combobox` component

### DIFF
--- a/frontend/components/forms/combobox/component.stories.tsx
+++ b/frontend/components/forms/combobox/component.stories.tsx
@@ -1,0 +1,195 @@
+import React from 'react';
+
+import { SubmitHandler, useForm } from 'react-hook-form';
+
+import { action } from '@storybook/addon-actions';
+import { Story, Meta } from '@storybook/react/types-6-0';
+
+import Button from 'components/button';
+
+import Combobox, { ComboboxProps, Option } from '.';
+
+export default {
+  component: Combobox,
+  title: 'Components/Forms/Combobox',
+  argTypes: {
+    register: { control: { disable: true } },
+  },
+} as Meta;
+
+interface FormValues {
+  sdg: string;
+}
+
+const OPTIONS = [
+  { key: 'no-poverty', label: 'No poverty' },
+  { key: 'zero-hunger', label: 'Zero hunger' },
+  { key: 'good-health-and-well-being', label: 'Good health and well-being' },
+  { key: 'quality-education', label: 'Quality education' },
+  { key: 'gender-equality', label: 'Gender equality' },
+  { key: 'clean-water-and-sanitation', label: 'Clean water and sanitation' },
+  { key: 'affordable-and-clean-energy', label: 'Affordable and clean energy' },
+  { key: 'decent-work-and-economic-growth', label: 'Decent work and economic growth' },
+  {
+    key: 'industry-innovation-and-infrastructure',
+    label: 'Industry, innovation and infrastructure',
+  },
+  { key: 'reduced-inequalities', label: 'Reduced inequalities' },
+  { key: 'sustainable-cities-and-communities', label: 'Sustainable cities and communities' },
+  {
+    key: 'responsible-consumption-and-production',
+    label: 'Responsible consumption and production',
+  },
+  { key: 'climate-action', label: 'Climate action' },
+  { key: 'life-below-water', label: 'Life below water' },
+  { key: 'life-on-land', label: 'Life on land' },
+  { key: 'peace-justice-and-strong-institutions', label: 'Peace, justice and strong institutions' },
+  { key: 'partnerships-for-the-goals', label: 'Partnerships for the goals' },
+];
+
+const Template: Story<ComboboxProps<FormValues, {}>> = (args: ComboboxProps<FormValues, {}>) => {
+  const { control } = useForm<FormValues>();
+
+  return (
+    <>
+      <Combobox control={control} {...args}>
+        {OPTIONS.map(({ key, label }) => (
+          <Option key={key}>{label}</Option>
+        ))}
+      </Combobox>
+      <p className="mt-2 text-xs text-gray-50">
+        This select is not accessible. Either define <code>aria-label</code> or associate a label
+        (see the “With Label” story).
+      </p>
+    </>
+  );
+};
+
+export const Default: Story<ComboboxProps<FormValues, {}>> = Template.bind({});
+Default.args = {
+  id: 'form-sdg',
+  name: 'sdg',
+  placeholder: 'Sustainable tourism',
+  controlOptions: {
+    disabled: false,
+  },
+};
+
+export const DefaultValue: Story<ComboboxProps<FormValues, {}>> = Template.bind({});
+DefaultValue.args = {
+  id: 'form-sdg',
+  name: 'sdg',
+  placeholder: 'Sustainable tourism',
+  controlOptions: {
+    value: 'clean-water-and-sanitation',
+    disabled: false,
+  },
+};
+
+export const DisabledOptions: Story<ComboboxProps<FormValues, {}>> = Template.bind({});
+DisabledOptions.args = {
+  id: 'form-sdg',
+  name: 'sdg',
+  placeholder: 'Sustainable tourism',
+  disabledKeys: ['industry-innovation-and-infrastructure', 'climate-action', 'life-on-land'],
+  controlOptions: {
+    disabled: false,
+  },
+};
+
+export const OpenOnTop: Story<ComboboxProps<FormValues, {}>> = Template.bind({});
+OpenOnTop.args = {
+  id: 'form-sdg',
+  name: 'sdg',
+  placeholder: 'Sustainable tourism',
+  className: 'mt-80',
+  direction: 'top',
+  controlOptions: {
+    disabled: false,
+  },
+};
+
+const TemplateWithLabel: Story<ComboboxProps<FormValues, {}>> = (
+  args: ComboboxProps<FormValues, {}>
+) => {
+  const { control } = useForm<FormValues>();
+
+  return (
+    <>
+      <label htmlFor={args.id} className="mb-2">
+        Sustainable Development Goal
+      </label>
+      <Combobox control={control} {...args}>
+        {OPTIONS.map(({ key, label }) => (
+          <Option key={key}>{label}</Option>
+        ))}
+      </Combobox>
+    </>
+  );
+};
+
+export const WithLabel: Story<ComboboxProps<FormValues, {}>> = TemplateWithLabel.bind({});
+WithLabel.args = {
+  id: 'form-sdg',
+  name: 'sdg',
+  placeholder: 'Sustainable tourism',
+  controlOptions: {
+    disabled: false,
+  },
+};
+
+const TemplateWithForm: Story<ComboboxProps<FormValues, {}>> = (
+  args: ComboboxProps<FormValues, {}>
+) => {
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>({
+    // Using the native validation, we're able to style the inputs using the `valid` and `invalid`
+    // pseudo class
+    shouldUseNativeValidation: true,
+  });
+  const onSubmit: SubmitHandler<FormValues> = (data) => action('onSubmit')(data);
+
+  return (
+    <form
+      // `noValidate` here prevents the browser from not submitting the form if there's a validation
+      // error. We absolutely want the form to be submitted so that React Hook Form is made aware of
+      // the validation errors and we can display errors below inputs.
+      noValidate
+      onSubmit={handleSubmit(onSubmit)}
+    >
+      <label htmlFor={args.id} className="mb-2">
+        Sustainable Development Goal
+      </label>
+      <Combobox control={control} aria-describedby="form-error" {...args}>
+        {OPTIONS.map(({ key, label }) => (
+          <Option key={key}>{label}</Option>
+        ))}
+      </Combobox>
+      {errors.sdg?.message && (
+        <p id="form-error" className="pl-2 mt-1 text-xs text-red">
+          {errors.sdg?.message}
+        </p>
+      )}
+      <Button type="submit" className="mt-2">
+        Submit
+      </Button>
+      <p className="mt-2 text-xs text-gray-50">
+        Submit the form to see the {"select's"} error state (the select is required).
+      </p>
+    </form>
+  );
+};
+
+export const ErrorState: Story<ComboboxProps<FormValues, {}>> = TemplateWithForm.bind({});
+ErrorState.args = {
+  id: 'form-sdg',
+  name: 'sdg',
+  placeholder: 'Sustainable tourism',
+  controlOptions: {
+    disabled: false,
+    required: 'A SDG is required.',
+  },
+};

--- a/frontend/components/forms/combobox/component.tsx
+++ b/frontend/components/forms/combobox/component.tsx
@@ -1,0 +1,119 @@
+import React, { useRef } from 'react';
+
+import { useComboBox, useFilter, useButton } from 'react-aria';
+import { ChevronDown as ChevronDownIcon } from 'react-feather';
+import { FieldValues, Path, PathValue, UnpackNestedValue, useController } from 'react-hook-form';
+import { useComboBoxState } from 'react-stately';
+
+import cx from 'classnames';
+
+import type { ComboBoxProps } from '@react-types/combobox';
+
+import { mergeRefs } from 'helpers/refs';
+
+import Icon from 'components/icon';
+
+import Listbox from '../select/listbox';
+import Popover from '../select/popover';
+
+import { ComboboxProps } from './types';
+
+export const Combobox = <FormValues extends FieldValues, T extends object>({
+  name,
+  placeholder,
+  className,
+  direction = 'bottom',
+  control,
+  controlOptions,
+  ...rest
+}: ComboboxProps<FormValues, T>) => {
+  const {
+    field: { ref, value, onChange, onBlur },
+    fieldState: { invalid },
+  } = useController({
+    name,
+    control,
+    rules: controlOptions,
+    defaultValue: controlOptions.value as UnpackNestedValue<
+      PathValue<FormValues, Path<FormValues>>
+    >,
+  });
+
+  const ariaComboboxProps: ComboBoxProps<T> = {
+    ...rest,
+    selectedKey: value,
+    isDisabled: controlOptions.disabled,
+    isRequired: controlOptions.required === 'true' || typeof controlOptions.required === 'string',
+    onSelectionChange: (key) => onChange({ type: 'change', target: { name: name, value: key } }),
+    onBlur,
+    placeholder,
+  };
+
+  const { contains } = useFilter({ sensitivity: 'base' });
+
+  const state = useComboBoxState({ ...ariaComboboxProps, defaultFilter: contains });
+
+  const triggerRef = useRef(null);
+  const inputRef = React.useRef(null);
+  const listboxRef = React.useRef(null);
+  const popoverRef = React.useRef(null);
+  const {
+    buttonProps: triggerProps,
+    inputProps,
+    listBoxProps: listboxProps,
+  } = useComboBox(
+    { ...ariaComboboxProps, inputRef, buttonRef: triggerRef, listBoxRef: listboxRef, popoverRef },
+    state
+  );
+
+  const { buttonProps } = useButton(
+    { ...triggerProps, isDisabled: controlOptions.disabled },
+    triggerRef
+  );
+
+  return (
+    <div
+      className={cx({
+        'relative text-base text-gray-900 px-4 py-2 flex justify-between items-center w-full border border-solid hover:shadow-sm bg-white rounded-lg transition':
+          true,
+        'border-beige': !state.isOpen && !state.isFocused,
+        'shadow-sm': state.isOpen || state.isFocused,
+        'text-gray-900': state.selectedItem,
+        'text-gray-400': !state.selectedItem,
+        'border-green-dark': (!invalid && state.isOpen) || state.isFocused,
+        'border-red-600': invalid && !state.isFocused,
+        'opacity-60': controlOptions.disabled,
+        [className]: !!className,
+      })}
+    >
+      <input
+        {...inputProps}
+        ref={mergeRefs([ref, inputRef])}
+        name={name}
+        className="outline-none grow"
+      />
+      <button {...buttonProps} ref={triggerRef} className="shrink-0">
+        <Icon
+          aria-hidden={true}
+          icon={ChevronDownIcon}
+          className={cx({
+            'inline-block w-5 h-5 ml-2 text-gray-600 shrink-0 transition': true,
+            'rotate-180': state.isOpen,
+          })}
+        />
+      </button>
+      {state.isOpen && (
+        <Popover
+          popoverRef={popoverRef}
+          isOpen={state.isOpen}
+          onClose={state.close}
+          direction={direction}
+        >
+          <Listbox {...listboxProps} listBoxRef={listboxRef} state={state} />
+        </Popover>
+      )}
+    </div>
+  );
+};
+
+export default Combobox;

--- a/frontend/components/forms/combobox/index.ts
+++ b/frontend/components/forms/combobox/index.ts
@@ -1,0 +1,3 @@
+export { Item as Option } from 'react-stately';
+export type { ComboboxProps } from './types';
+export { default } from './component';

--- a/frontend/components/forms/combobox/types.ts
+++ b/frontend/components/forms/combobox/types.ts
@@ -1,0 +1,32 @@
+import { Path, Control, RegisterOptions, FieldPath, UseControllerProps } from 'react-hook-form';
+
+import type { ComboBoxProps } from '@react-types/combobox';
+
+export type ComboboxProps<FormValues, T extends object> = {
+  /** ID of the input */
+  id: string;
+  /** Name of the input */
+  name: Path<FormValues>;
+  /** Placeholder of the input */
+  placeholder?: string;
+  /** Vertical alignment of the dropdown relative to the trigger. Default to `'bottom'`. */
+  direction?: 'bottom' | 'top';
+  /** String to attach to the input */
+  className?: string;
+  /** React Hook Form's `control` function */
+  control: Control<FormValues, FieldPath<FormValues>>;
+  /** Options for React Hook Form's `control` function */
+  controlOptions: UseControllerProps<FormValues, FieldPath<FormValues>>['rules'] & {
+    /** Whether the input is disabled */
+    disabled?: boolean;
+  };
+} & Omit<
+  ComboBoxProps<T>,
+  | keyof RegisterOptions<FormValues, FieldPath<FormValues>>
+  | 'name'
+  | 'isDisabled'
+  | 'isRequired'
+  | 'inputValue'
+  | 'defaultInputValue'
+  | 'onInputChange'
+>;


### PR DESCRIPTION
This PR adds a `<Combobox />` component to be used in forms with [React Hook Form](https://react-hook-form.com/).

## Testing instructions

- Respects the [visual design](https://www.figma.com/file/3epSYh4KQZBCyh4Y5OzmHw/HeCo---Design-System?node-id=2313%3A39262) (of the select)
- Has visual error state when input validation fails ([see text input error example](https://www.figma.com/file/3epSYh4KQZBCyh4Y5OzmHw/HeCo---Design-System?node-id=2377%3A3138))
- Compatible with React Hook Form (see [example of integration](https://react-hook-form.com/get-started/#Integratinganexistingform))
- Accessible by [WCAG 2.1 standards](https://www.w3.org/TR/WCAG21/)
- Focused state for keyboard users
- Requires an 'id' prop to link to a label externally
- Available in Storybook

## Tracking

[LET-208](https://vizzuality.atlassian.net/browse/LET-208).
