### PR TITLE
refactoring: minor tweaking of email confirmation tests

### DIFF
--- a/backend/spec/requests/api/v1/email_confirmation_spec.rb
+++ b/backend/spec/requests/api/v1/email_confirmation_spec.rb
@@ -80,37 +80,43 @@ RSpec.describe "API V1 Email Confirmation", type: :request do
       end
 
       response "422", "Invalid Token" do
-        let(:confirmation_token) { "invalid_token" }
+        context "when confirmation token is invalid" do
+          let(:confirmation_token) { "invalid_token" }
 
-        run_test!
+          run_test!
 
-        it "returns correct error", generate_swagger_example: true do
-          expect(response_json["errors"][0]["title"]).to eq("Confirmation token is invalid")
-          expect(session["warden.user.user.key"]).to be_nil
-          expect(unconfirmed_user.reload.confirmed?).to eq(false)
+          it "returns correct error", generate_swagger_example: true do
+            expect(response_json["errors"][0]["title"]).to eq("Confirmation token is invalid")
+            expect(session["warden.user.user.key"]).to be_nil
+            expect(unconfirmed_user.reload.confirmed?).to eq(false)
+          end
         end
 
         context "already confirmed" do
-          let(:confirmation_token) do
-            unconfirmed_user.confirm # not sure why it does not work in before block
-            unconfirmed_user.confirmation_token
-          end
+          let(:confirmation_token) { unconfirmed_user.confirmation_token }
 
-          it "returns correct error", generate_swagger_example: true do
+          before { unconfirmed_user.confirm }
+
+          run_test!
+
+          it "returns correct error" do
             expect(response_json["errors"][0]["title"]).to eq("Email was already confirmed, please try signing in")
             expect(session["warden.user.user.key"]).to be_nil
           end
         end
 
         context "expired token" do
-          let(:confirmation_token) do
+          let(:confirmation_token) { unconfirmed_user.confirmation_token }
+
+          before do
             travel_to 11.days.ago do
               unconfirmed_user.send_confirmation_instructions
             end
-            unconfirmed_user.confirmation_token
           end
 
-          it "returns correct error", generate_swagger_example: true do
+          run_test!
+
+          it "returns correct error" do
             expect(response_json["errors"][0]["title"]).to eq("Email needs to be confirmed within 10 days, please request a new one")
           end
         end


### PR DESCRIPTION
I have just removed logic from `let` variables inside email confirmation tests
