### PR TITLE
feat: Adding /backend url to Swagger doc

### DIFF
--- a/backend/spec/swagger_helper.rb
+++ b/backend/spec/swagger_helper.rb
@@ -342,6 +342,9 @@ RSpec.configure do |config|
       },
       servers: [
         {
+          url: "/backend"
+        },
+        {
           url: "{scheme}://{host}",
           variables: {
             scheme: {

--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -28,7 +28,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: dcea1fc8-6fe0-44d9-9648-24932cd1d97e
+                  id: b190c5a4-3d02-4170-b73d-b21eb6402026
                   type: project_developer
                   attributes:
                     name: Name
@@ -57,11 +57,11 @@ paths:
                   relationships:
                     owner:
                       data:
-                        id: 68f0d996-0cce-4e82-ae12-cfff902206d6
+                        id: a3360463-bc86-42f0-a506-2087a42cee77
                         type: user
                     locations:
                       data:
-                      - id: fc39bffd-f99b-47d4-a247-e14c04e2d335
+                      - id: 4d6df6fa-292c-4fb1-a580-fd82873e25da
                         type: location
               schema:
                 type: object
@@ -174,7 +174,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: f47bb5b7-4e2c-4fb2-9caa-5541687df1be
+                  id: 2c6a62a2-2dbd-4110-8d4d-042126e420a2
                   type: project_developer
                   attributes:
                     name: Name
@@ -203,11 +203,11 @@ paths:
                   relationships:
                     owner:
                       data:
-                        id: 66fe459f-9066-4c82-839d-97d5f93a1415
+                        id: 686c34e3-f11b-4665-b45e-7ed90b487642
                         type: user
                     locations:
                       data:
-                      - id: 8e1c5dd9-8017-402d-8bea-75441ae953da
+                      - id: 70bba262-4ab9-4c74-90cc-44d8e5aa36c3
                         type: location
               schema:
                 type: object
@@ -319,7 +319,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: c92525aa-debb-45ba-8b67-2dab2d85ff48
+                  id: 2992c635-deda-4e4a-a6a4-219e9327cc01
                   type: user
                   attributes:
                     first_name: Dawna
@@ -566,7 +566,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: d901e54e-d045-4968-a927-3eacfea75466
+                - id: d7186ebb-6fe9-4121-829d-d2b8db9e18e1
                   type: investor
                   attributes:
                     name: Kutch-Spencer
@@ -613,9 +613,9 @@ paths:
                   relationships:
                     owner:
                       data:
-                        id: '093542fb-2809-42fe-bcc7-1321bc290626'
+                        id: 2664dd3e-9b3b-4867-9825-5c96f39b109c
                         type: user
-                - id: 34271af5-d61a-4235-a6f6-0dd02856ba91
+                - id: 196cec75-6ef8-434c-8b68-48433bb526ac
                   type: investor
                   attributes:
                     name: Bartoletti and Sons
@@ -662,9 +662,9 @@ paths:
                   relationships:
                     owner:
                       data:
-                        id: db68bec1-c40b-4593-9993-07f0074c1262
+                        id: 5db1b2e2-433a-414a-85f4-deea2b3631d9
                         type: user
-                - id: ed959b4a-1790-4b5b-896a-8d78db75833b
+                - id: 1dc14756-3519-4cc4-9586-8691b66189a0
                   type: investor
                   attributes:
                     name: Hane, Lehner and Goyette
@@ -711,9 +711,9 @@ paths:
                   relationships:
                     owner:
                       data:
-                        id: 205b7ea6-79a2-445c-b466-a2dafdc3c3d7
+                        id: 44245f7a-3fbf-4bb0-999c-910fe701db15
                         type: user
-                - id: cfa3fd18-89b0-41a7-8ab6-7c1b9e6bc7b6
+                - id: 48dd29d7-0978-4cb4-be1c-9d243320f27c
                   type: investor
                   attributes:
                     name: Hilpert, Waters and Johnston
@@ -760,9 +760,9 @@ paths:
                   relationships:
                     owner:
                       data:
-                        id: 0ea05353-818b-4369-b7d0-dcd89110eeb1
+                        id: 3d60acfb-84d6-4a5b-995b-869efbe4032b
                         type: user
-                - id: b557d385-dd12-4602-ac1f-b4f2dc18735a
+                - id: e3fffe02-8801-4fd4-9f5d-887b067dbf68
                   type: investor
                   attributes:
                     name: Jacobson, Fritsch and Stanton
@@ -809,9 +809,9 @@ paths:
                   relationships:
                     owner:
                       data:
-                        id: 5a9ead35-7023-4e9a-a1d8-d1250ef35d77
+                        id: e5abdbf8-66cf-4417-a63f-4a32d917e79d
                         type: user
-                - id: a6120999-02d4-47ca-aa39-cc2e08099649
+                - id: 9bc8ea1a-0d6e-4394-80f7-e1d3c5342d79
                   type: investor
                   attributes:
                     name: Keebler, Kub and Zemlak
@@ -858,9 +858,9 @@ paths:
                   relationships:
                     owner:
                       data:
-                        id: d4f48aea-f895-4e93-b8c8-846043b40c5e
+                        id: f3afb89e-6c54-4114-9390-aab5e81aa357
                         type: user
-                - id: 9b286426-cd41-49c2-abba-0e7b3d96b67e
+                - id: 0bbbbb6a-455c-4beb-9dda-9c2187f6c012
                   type: investor
                   attributes:
                     name: Becker LLC
@@ -907,7 +907,7 @@ paths:
                   relationships:
                     owner:
                       data:
-                        id: 5ab0f27b-9b82-46a1-9c26-10ccf87dd7d8
+                        id: 9eb5a078-5a59-43f8-a2d2-d599386b6179
                         type: user
                 meta:
                   page: 1
@@ -962,7 +962,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: d901e54e-d045-4968-a927-3eacfea75466
+                  id: d7186ebb-6fe9-4121-829d-d2b8db9e18e1
                   type: investor
                   attributes:
                     name: Kutch-Spencer
@@ -1009,7 +1009,7 @@ paths:
                   relationships:
                     owner:
                       data:
-                        id: '093542fb-2809-42fe-bcc7-1321bc290626'
+                        id: 2664dd3e-9b3b-4867-9825-5c96f39b109c
                         type: user
               schema:
                 type: object
@@ -1058,7 +1058,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: 20351bbe-7ae0-4741-8ce1-b417b3da173a
+                - id: 37132f65-a66d-4e96-9584-0c4da8146886
                   type: location
                   attributes:
                     name: Kutch-Spencer
@@ -1068,7 +1068,7 @@ paths:
                       data:
                     regions:
                       data: []
-                - id: c579c170-1f8d-4c3a-ae30-fba140c06e23
+                - id: aa877f5c-af41-4a4a-9d3a-1db3bcb90b2d
                   type: location
                   attributes:
                     name: Bartoletti and Sons
@@ -1076,11 +1076,11 @@ paths:
                   relationships:
                     parent:
                       data:
-                        id: 20351bbe-7ae0-4741-8ce1-b417b3da173a
+                        id: 37132f65-a66d-4e96-9584-0c4da8146886
                         type: location
                     regions:
                       data: []
-                - id: fb724ffc-e770-4968-a7f1-bd46db1e292d
+                - id: 304bca48-9cfc-4f39-a035-011049789af1
                   type: location
                   attributes:
                     name: Hane, Lehner and Goyette
@@ -1088,13 +1088,13 @@ paths:
                   relationships:
                     parent:
                       data:
-                        id: c579c170-1f8d-4c3a-ae30-fba140c06e23
+                        id: aa877f5c-af41-4a4a-9d3a-1db3bcb90b2d
                         type: location
                     regions:
                       data:
-                      - id: 4c5c9fd8-f9cb-4a87-91b9-d929983e088e
+                      - id: 14d159ae-c51b-40b0-8348-8aec243a44f0
                         type: location
-                - id: 4c5c9fd8-f9cb-4a87-91b9-d929983e088e
+                - id: 14d159ae-c51b-40b0-8348-8aec243a44f0
                   type: location
                   attributes:
                     name: Hilpert, Waters and Johnston
@@ -1104,7 +1104,7 @@ paths:
                       data:
                     regions:
                       data: []
-                - id: 2e311a01-b4d4-4e61-a09d-5432c5a4569a
+                - id: c6493df6-75ed-478e-896b-8c8383f473bf
                   type: location
                   attributes:
                     name: Jacobson, Fritsch and Stanton
@@ -1112,13 +1112,13 @@ paths:
                   relationships:
                     parent:
                       data:
-                        id: c579c170-1f8d-4c3a-ae30-fba140c06e23
+                        id: aa877f5c-af41-4a4a-9d3a-1db3bcb90b2d
                         type: location
                     regions:
                       data:
-                      - id: d612d490-e573-4d2b-8ac1-87ffd106d8bb
+                      - id: 704a9b93-802c-4e7d-9160-65a340d8e8ae
                         type: location
-                - id: d612d490-e573-4d2b-8ac1-87ffd106d8bb
+                - id: 704a9b93-802c-4e7d-9160-65a340d8e8ae
                   type: location
                   attributes:
                     name: Keebler, Kub and Zemlak
@@ -1128,7 +1128,7 @@ paths:
                       data:
                     regions:
                       data: []
-                - id: f8fe6d1b-312d-4f27-bb8b-c129d02cbb6a
+                - id: 78162014-0a52-49e8-9437-d1566e6587a0
                   type: location
                   attributes:
                     name: Becker LLC
@@ -1136,13 +1136,13 @@ paths:
                   relationships:
                     parent:
                       data:
-                        id: c579c170-1f8d-4c3a-ae30-fba140c06e23
+                        id: aa877f5c-af41-4a4a-9d3a-1db3bcb90b2d
                         type: location
                     regions:
                       data:
-                      - id: 14b93c54-f8ef-42b2-abef-439a7830027f
+                      - id: 7a7ac414-df8c-43be-9f6a-4c7e97b34050
                         type: location
-                - id: 14b93c54-f8ef-42b2-abef-439a7830027f
+                - id: 7a7ac414-df8c-43be-9f6a-4c7e97b34050
                   type: location
                   attributes:
                     name: Runolfsson and Sons
@@ -1196,7 +1196,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: fb724ffc-e770-4968-a7f1-bd46db1e292d
+                  id: 304bca48-9cfc-4f39-a035-011049789af1
                   type: location
                   attributes:
                     name: Hane, Lehner and Goyette
@@ -1204,11 +1204,11 @@ paths:
                   relationships:
                     parent:
                       data:
-                        id: c579c170-1f8d-4c3a-ae30-fba140c06e23
+                        id: aa877f5c-af41-4a4a-9d3a-1db3bcb90b2d
                         type: location
                     regions:
                       data:
-                      - id: 4c5c9fd8-f9cb-4a87-91b9-d929983e088e
+                      - id: 14d159ae-c51b-40b0-8348-8aec243a44f0
                         type: location
               schema:
                 type: object
@@ -1246,7 +1246,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: 333e155c-bc09-427b-8fb8-fa2e125330a2
+                - id: 29663a23-88bd-4300-abd1-29c5264a3fa1
                   type: open_call
                   attributes:
                     name: Open call 1
@@ -1263,14 +1263,14 @@ paths:
                       tempora exercitationem. Qui dolorem quo.
                     impact_description: Enim repellat pariatur. Earum modi eos. Libero
                       tempora exercitationem. Qui dolorem quo.
-                    closing_at: '2023-01-30T10:27:18.153Z'
+                    closing_at: '2023-01-30T12:44:29.810Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: 8941908e-51a5-4100-b4c2-7144cd818544
+                        id: 967d7d7f-67fd-4ba4-943c-920c04a946bd
                         type: investor
-                - id: c546ae6c-c11e-474a-b50b-cafe04cdfa11
+                - id: 9f46cf3d-9bd3-41fd-995a-616f8b9481f9
                   type: open_call
                   attributes:
                     name: Open call 2
@@ -1287,14 +1287,14 @@ paths:
                       Sunt commodi tempore. Voluptatem et corrupti.
                     impact_description: Placeat commodi libero. Quo recusandae repellat.
                       Sunt commodi tempore. Voluptatem et corrupti.
-                    closing_at: '2023-01-30T10:27:18.292Z'
+                    closing_at: '2023-01-30T12:44:29.868Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: 5b6b8bd0-24c8-4786-aa0c-11a45b49e2ad
+                        id: 59fc756c-d6d2-4f28-956a-7eb519d9e236
                         type: investor
-                - id: c5bb62b7-f75e-475e-b149-a6a948def529
+                - id: d92079f2-7e59-44bc-98de-7f8b0d82bf08
                   type: open_call
                   attributes:
                     name: Open call 3
@@ -1311,14 +1311,14 @@ paths:
                       nesciunt voluptas. Suscipit ex cum.
                     impact_description: Et quaerat omnis. Harum voluptas atque. Quo
                       nesciunt voluptas. Suscipit ex cum.
-                    closing_at: '2023-01-30T10:27:18.413Z'
+                    closing_at: '2023-01-30T12:44:29.918Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: 1025f4fa-85b7-4613-b9b1-897615929dbf
+                        id: 02aa72a2-62f8-48ce-b09c-c35f75851d0c
                         type: investor
-                - id: 863030d9-25e5-4500-9e7e-a1039a88d9f5
+                - id: fb9727bc-08e0-4b57-8b3a-712202c6d642
                   type: open_call
                   attributes:
                     name: Open call 4
@@ -1335,14 +1335,14 @@ paths:
                       Sit neque eos. Expedita molestiae quia.
                     impact_description: Dolores fugiat nesciunt. Ut laborum dolores.
                       Sit neque eos. Expedita molestiae quia.
-                    closing_at: '2023-01-30T10:27:18.543Z'
+                    closing_at: '2023-01-30T12:44:29.971Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: d9a3e645-d0e5-4927-8bc5-5d5359adb0f7
+                        id: acd0f26b-b058-4150-8abf-b0307bf95b99
                         type: investor
-                - id: 2ac02585-1490-440b-99eb-041452d30b50
+                - id: b70174d0-5074-409d-8979-b1d2746db335
                   type: open_call
                   attributes:
                     name: Open call 5
@@ -1359,14 +1359,14 @@ paths:
                       recusandae eum. Eius ex est.
                     impact_description: Autem et et. Voluptatem neque quibusdam. Repellat
                       recusandae eum. Eius ex est.
-                    closing_at: '2023-01-30T10:27:18.705Z'
+                    closing_at: '2023-01-30T12:44:30.022Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: 40321018-5a18-4466-b07c-46a678ceb0d5
+                        id: 6b8d654f-9d1d-4e9e-ac32-1c531e6d2d8a
                         type: investor
-                - id: 4c0df43d-5f62-427c-9e16-3a7125894410
+                - id: de453f60-51e6-4610-a25e-7d8a368b7cfa
                   type: open_call
                   attributes:
                     name: Open call 6
@@ -1383,14 +1383,14 @@ paths:
                       Eligendi sapiente voluptatem. Quas rerum officia.
                     impact_description: Porro soluta beatae. Quia ratione facilis.
                       Eligendi sapiente voluptatem. Quas rerum officia.
-                    closing_at: '2023-01-30T10:27:18.820Z'
+                    closing_at: '2023-01-30T12:44:30.070Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: 45c5c936-940a-41b8-9370-222126555aea
+                        id: 2a97e7f9-bf21-47c7-9360-47d4296db13b
                         type: investor
-                - id: 47a0de79-18e7-4750-8dc7-d87348cbd452
+                - id: d40e9692-3519-4b30-934a-86ee9d7201c7
                   type: open_call
                   attributes:
                     name: Open call 7
@@ -1407,12 +1407,12 @@ paths:
                       laudantium et. Sed recusandae aut.
                     impact_description: Mollitia aut vel. Qui illum accusantium. Et
                       laudantium et. Sed recusandae aut.
-                    closing_at: '2023-01-30T10:27:18.947Z'
+                    closing_at: '2023-01-30T12:44:30.119Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: 938760af-190c-4d3e-8179-bb8a27a39600
+                        id: 718d5d7d-b08a-47ce-9411-c3c89a90f893
                         type: investor
                 meta:
                   page: 1
@@ -1467,7 +1467,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 333e155c-bc09-427b-8fb8-fa2e125330a2
+                  id: 29663a23-88bd-4300-abd1-29c5264a3fa1
                   type: open_call
                   attributes:
                     name: Open call 1
@@ -1484,12 +1484,12 @@ paths:
                       tempora exercitationem. Qui dolorem quo.
                     impact_description: Enim repellat pariatur. Earum modi eos. Libero
                       tempora exercitationem. Qui dolorem quo.
-                    closing_at: '2023-01-30T10:27:18.153Z'
+                    closing_at: '2023-01-30T12:44:29.810Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: 8941908e-51a5-4100-b4c2-7144cd818544
+                        id: 967d7d7f-67fd-4ba4-943c-920c04a946bd
                         type: investor
               schema:
                 type: object
@@ -1527,7 +1527,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: 4fbab703-e6b1-43b2-8510-1a305a8834ee
+                - id: 6508f0fb-169d-4257-8c9e-0a3b6c4f69f9
                   type: project_developer
                   attributes:
                     name: Kutch-Spencer
@@ -1558,15 +1558,15 @@ paths:
                   relationships:
                     owner:
                       data:
-                        id: 4256b2d6-d51c-4e52-b51f-ebe78f443c77
+                        id: b29df9c0-7e58-4fe2-8cca-95716706168c
                         type: user
                     locations:
                       data:
-                      - id: 9f1dcba3-3cf1-4b38-81bd-0e88fb1741cc
+                      - id: bad529de-8763-49b5-b38d-6628cf958a93
                         type: location
-                      - id: c19f7e75-352f-412a-bef2-bd91e1a56439
+                      - id: be72ae78-1797-4d50-a309-4d4656b67e3b
                         type: location
-                - id: 1464dd5b-1ddc-4269-9d9d-0b08cadc7c64
+                - id: 3cdf4ba7-66cc-4df8-965c-24b20d764122
                   type: project_developer
                   attributes:
                     name: Bartoletti and Sons
@@ -1597,11 +1597,11 @@ paths:
                   relationships:
                     owner:
                       data:
-                        id: 0a9f4b94-929e-4cd9-850a-3c3218f22268
+                        id: 9069bd90-4105-4d92-9263-2c200436542e
                         type: user
                     locations:
                       data: []
-                - id: e839d3b3-88be-42ae-acff-c835048623d6
+                - id: 5deb1217-4eb0-4a0e-bc8b-5fbc504319da
                   type: project_developer
                   attributes:
                     name: Hane, Lehner and Goyette
@@ -1632,11 +1632,11 @@ paths:
                   relationships:
                     owner:
                       data:
-                        id: 01c026f8-db0a-44c1-b41c-3d2c5f308515
+                        id: acfdd38d-7909-4c36-b43c-9866985c08ca
                         type: user
                     locations:
                       data: []
-                - id: 420d3cdb-7a1a-40a5-a712-54973d02f18e
+                - id: a86486d4-9b0e-4404-88e6-a24c3a4c0d09
                   type: project_developer
                   attributes:
                     name: Hilpert, Waters and Johnston
@@ -1667,11 +1667,11 @@ paths:
                   relationships:
                     owner:
                       data:
-                        id: 4b22225b-be05-4c7a-aae3-e4f9d56e06cb
+                        id: 0ad5a90d-56a9-4d60-bc2d-7264641aa640
                         type: user
                     locations:
                       data: []
-                - id: 3d90677c-b583-4a28-88ea-2af072e8e6e8
+                - id: 26f3bafc-dae9-4b8e-83b4-dcb207b90e4c
                   type: project_developer
                   attributes:
                     name: Jacobson, Fritsch and Stanton
@@ -1702,11 +1702,11 @@ paths:
                   relationships:
                     owner:
                       data:
-                        id: 3b554ff8-87e2-43fd-bd5e-ec7503f2b5a5
+                        id: 2c6058e9-fba1-4d82-8183-cb47434194a9
                         type: user
                     locations:
                       data: []
-                - id: 2a003651-a3d7-494c-ac5e-eae7aea7cfe8
+                - id: 2896f079-f280-4f3e-9155-d463fb822f9f
                   type: project_developer
                   attributes:
                     name: Keebler, Kub and Zemlak
@@ -1737,11 +1737,11 @@ paths:
                   relationships:
                     owner:
                       data:
-                        id: 24518834-4b55-4811-b37c-5640d9daa11e
+                        id: d56f4de8-26d5-40f2-8404-acc28c603544
                         type: user
                     locations:
                       data: []
-                - id: e130665f-014b-4bf0-94f5-57e84100cfb1
+                - id: b1a0e8fb-4349-4e01-ad22-2c9d4f2e8868
                   type: project_developer
                   attributes:
                     name: Becker LLC
@@ -1772,7 +1772,7 @@ paths:
                   relationships:
                     owner:
                       data:
-                        id: 5e680228-2dea-4d61-b2e9-1d452104e4f5
+                        id: 0e844877-52fd-40df-b363-60beaaaccc4d
                         type: user
                     locations:
                       data: []
@@ -1829,7 +1829,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 4fbab703-e6b1-43b2-8510-1a305a8834ee
+                  id: 6508f0fb-169d-4257-8c9e-0a3b6c4f69f9
                   type: project_developer
                   attributes:
                     name: Kutch-Spencer
@@ -1860,13 +1860,13 @@ paths:
                   relationships:
                     owner:
                       data:
-                        id: 4256b2d6-d51c-4e52-b51f-ebe78f443c77
+                        id: b29df9c0-7e58-4fe2-8cca-95716706168c
                         type: user
                     locations:
                       data:
-                      - id: 9f1dcba3-3cf1-4b38-81bd-0e88fb1741cc
+                      - id: bad529de-8763-49b5-b38d-6628cf958a93
                         type: location
-                      - id: c19f7e75-352f-412a-bef2-bd91e1a56439
+                      - id: be72ae78-1797-4d50-a309-4d4656b67e3b
                         type: location
               schema:
                 type: object
@@ -1910,7 +1910,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: 2be9e7ad-4a7c-4512-9119-5445134aed5b
+                - id: 46c6da85-c7a1-481c-84a7-66f633848c38
                   type: project
                   attributes:
                     name: Project 1
@@ -1952,9 +1952,9 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 6f359089-773b-4cc7-8320-30098fb5f3e9
+                        id: e8bac027-d1c9-49e6-9b40-6faa53fb60d8
                         type: project_developer
-                - id: d9ad2ec4-549e-400f-85da-5709ada2bd24
+                - id: 412a81e5-3d05-4f0a-a9fe-36d06ec80854
                   type: project
                   attributes:
                     name: Project 2
@@ -1996,9 +1996,9 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: b4d9d571-986c-402e-9587-0ce09fba11a9
+                        id: 9dc36d5b-ef68-418a-a98c-3fdae5da6d11
                         type: project_developer
-                - id: 776707b3-0d8e-44bd-91d3-68f9abe8a831
+                - id: 519c4aa8-2b92-4e00-862c-ff6f2d3e6469
                   type: project
                   attributes:
                     name: Project 3
@@ -2040,9 +2040,9 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 17ee9b8a-a7b8-4afa-8397-9b79edcda4f0
+                        id: eec7d367-bef9-4599-988c-ee95da0ab982
                         type: project_developer
-                - id: d8be25a3-b6cf-4b0a-8a97-a9793e1dd254
+                - id: 3275a693-ca24-4336-8480-1696ebd03d8f
                   type: project
                   attributes:
                     name: Project 4
@@ -2084,9 +2084,9 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 9d760dea-de9d-44be-9d82-bc2e51a3a3e5
+                        id: e746fa48-15a7-43a6-be29-ea55c62270ab
                         type: project_developer
-                - id: 7b02b533-cab0-4dc5-b3c6-d1c9e7833d91
+                - id: 074dcf21-a0a3-4056-924c-ab0e802dbb8e
                   type: project
                   attributes:
                     name: Project 5
@@ -2128,9 +2128,9 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 65d45816-84c9-47bd-adeb-a5d885dd5e26
+                        id: cbcbb56c-1498-49a1-824f-fdc5550e8678
                         type: project_developer
-                - id: 556ae5fc-1796-43cb-8279-ce916691d01a
+                - id: 31b1bffc-11e2-41d5-baad-ac99da8d82d1
                   type: project
                   attributes:
                     name: Project 6
@@ -2172,9 +2172,9 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 394be82f-6312-45e4-b724-7998676095e2
+                        id: e50d930f-4b4a-497d-8374-d5b034917b20
                         type: project_developer
-                - id: 99229193-4640-47a3-ba48-1fc1915f6e44
+                - id: 235a18fb-2338-4f8d-8021-bebb2497f7b1
                   type: project
                   attributes:
                     name: Project 7
@@ -2216,7 +2216,7 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 757d701b-14fc-429e-832b-e5f39f12f735
+                        id: c24ef278-baa6-4e62-9545-9ee30efb45af
                         type: project_developer
                 meta:
                   page: 1
@@ -2277,7 +2277,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 2be9e7ad-4a7c-4512-9119-5445134aed5b
+                  id: 46c6da85-c7a1-481c-84a7-66f633848c38
                   type: project
                   attributes:
                     name: Project 1
@@ -2319,7 +2319,7 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 6f359089-773b-4cc7-8320-30098fb5f3e9
+                        id: e8bac027-d1c9-49e6-9b40-6faa53fb60d8
                         type: project_developer
               schema:
                 type: object
@@ -2361,7 +2361,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: faefa5d8-a5bf-41ce-9235-66ac8708f296
+                  id: 427a849c-8e68-409d-a2b5-678b7f25f85e
                   type: user
                   attributes:
                     first_name: Dawna
@@ -2409,7 +2409,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 7b238266-edf8-4d5c-8946-8aaee8114662
+                  id: 28f203ec-5704-4240-9c00-11b6ed3436ad
                   type: user
                   attributes:
                     first_name: Dawna
@@ -2494,7 +2494,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 6e98b540-ce29-4890-ac4d-312e2e548b15
+                  id: 921233cd-5283-4274-b05b-5a87c16df42a
                   type: user
                   attributes:
                     first_name: Jan
@@ -2565,7 +2565,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 88cdb623-56a6-465d-9965-cc05171be954
+                  id: a6c6fba1-4084-4eae-84ce-b36f285f4748
                   type: user
                   attributes:
                     first_name: Dawna
@@ -2592,19 +2592,19 @@ paths:
           content:
             application/json:
               example:
-                id: 451bc7d9-f186-4be2-896c-57a3adee2ada
-                key: cvh8igvo8d65w5jywamsv3q0wlz3
+                id: c3e85408-ce71-42f8-b395-d3bec9516dcc
+                key: t8zc7nqlypwlypws96qbljcydki7
                 filename: test.jpg
                 content_type: image/jpeg
                 metadata: {}
                 service_name: test
                 byte_size: 32326
                 checksum: QYeLAwqIj9HrwITqtTYaEw==
-                created_at: '2022-03-30T10:27:24.617Z'
-                signed_id: eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswTlRGaVl6ZGtPUzFtTVRnMkxUUmlaVEl0T0RrMll5MDFOMkV6WVdSbFpUSmhaR0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0b876cb63c883e57d665c53b36c81dac68f9eec6
-                attachable_sgid: BAh7CEkiCGdpZAY6BkVUSSJWZ2lkOi8vYmFja2VuZC9BY3RpdmVTdG9yYWdlOjpCbG9iLzQ1MWJjN2Q5LWYxODYtNGJlMi04OTZjLTU3YTNhZGVlMmFkYT9leHBpcmVzX2luBjsAVEkiDHB1cnBvc2UGOwBUSSIPYXR0YWNoYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--53bec302d0d0ebe803bd471ab24a11e3276a879a
+                created_at: '2022-03-30T12:44:33.119Z'
+                signed_id: eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTTJVNE5UUXdPQzFqWlRjeExUUXlaamd0WWpNNU5TMWtNMkpsWXprMU1UWmtZMk1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--bccf1c9fe39c1717eb192b0d01c3918e5363b8d3
+                attachable_sgid: BAh7CEkiCGdpZAY6BkVUSSJWZ2lkOi8vYmFja2VuZC9BY3RpdmVTdG9yYWdlOjpCbG9iL2MzZTg1NDA4LWNlNzEtNDJmOC1iMzk1LWQzYmVjOTUxNmRjYz9leHBpcmVzX2luBjsAVEkiDHB1cnBvc2UGOwBUSSIPYXR0YWNoYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--d9dbf99e7fba50ec76f2a3fbda10a4ca897fdf5f
                 direct_upload:
-                  url: http://www.example.com/backend/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDam9JYTJWNVNTSWhZM1pvT0dsbmRtODRaRFkxZHpWcWVYZGhiWE4yTTNFd2QyeDZNd1k2QmtWVU9oRmpiMjUwWlc1MFgzUjVjR1ZKSWc5cGJXRm5aUzlxY0dWbkJqc0dWRG9UWTI5dWRHVnVkRjlzWlc1bmRHaHBBa1orT2cxamFHVmphM04xYlVraUhWRlpaVXhCZDNGSmFqbEljbmRKVkhGMFZGbGhSWGM5UFFZN0JsUTZFWE5sY25acFkyVmZibUZ0WlRvSmRHVnpkQT09IiwiZXhwIjoiMjAyMi0wMy0zMFQxMDozMjoyNC42MjBaIiwicHVyIjoiYmxvYl90b2tlbiJ9fQ==--34556c2283681caf54b5f962e139ae6b16c50ff1
+                  url: http://www.example.com/backend/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDam9JYTJWNVNTSWhkRGg2WXpkdWNXeDVjSGRzZVhCM2N6azJjV0pzYW1ONVpHdHBOd1k2QmtWVU9oRmpiMjUwWlc1MFgzUjVjR1ZKSWc5cGJXRm5aUzlxY0dWbkJqc0dWRG9UWTI5dWRHVnVkRjlzWlc1bmRHaHBBa1orT2cxamFHVmphM04xYlVraUhWRlpaVXhCZDNGSmFqbEljbmRKVkhGMFZGbGhSWGM5UFFZN0JsUTZFWE5sY25acFkyVmZibUZ0WlRvSmRHVnpkQT09IiwiZXhwIjoiMjAyMi0wMy0zMFQxMjo0OTozMy4xMjJaIiwicHVyIjoiYmxvYl90b2tlbiJ9fQ==--db87f735e80628444439b0c217c933295f18676b
                   headers:
                     Content-Type: image/jpeg
               schema:
@@ -3105,6 +3105,7 @@ components:
       required:
       - errors
 servers:
+- url: "/backend"
 - url: "{scheme}://{host}"
   variables:
     scheme:


### PR DESCRIPTION
Just simple tweak which ensures that `/backend` url endpoint is first at list of available servers at rswag doc so you don't need to manually specify url yourself.

On local machine, you will need to switch to localhost on your own or start your rails server with `RAILS_RELATIVE_URL_ROOT=/backend`

![Screenshot 2022-03-30 at 14 45 39](https://user-images.githubusercontent.com/20660167/160842142-4c23dd09-76b7-445a-9ce5-fdd6cb3138bd.png)

