### PR TITLE
Correct Colombia region intersections from shapefiles

### DIFF
--- a/backend/app/services/importers/locations.rb
+++ b/backend/app/services/importers/locations.rb
@@ -29,14 +29,14 @@ module Importers
 
     def import_departments!
       data = CSV.parse(File.read(departments_file_path), headers: true, col_sep: ";").map do |row|
-        {name_en: row["name"], parent_id: country.id, location_type: "department"}
+        {name_en: row["name"], parent_id: country.id, code: row["code"], location_type: "department"}
       end
       Location.insert_all data
     end
 
     def import_municipalities!
       data = CSV.parse(File.read(municipalities_file_path), headers: true, col_sep: ";").map do |row|
-        {name_en: row["name"], parent_id: departments[row["department"]].first.id, location_type: "municipality"}
+        {name_en: row["name"], parent_id: departments[row["department"]].first.id, code: row["code"], location_type: "municipality"}
       end
       Location.insert_all data
     end

--- a/backend/db/migrate/20220331104516_add_code_to_locations.rb
+++ b/backend/db/migrate/20220331104516_add_code_to_locations.rb
@@ -1,0 +1,5 @@
+class AddCodeToLocations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :locations, :code, :string
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_28_102306) do
+ActiveRecord::Schema[7.0].define(version: 2022_03_31_104516) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -121,6 +121,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_28_102306) do
     t.text "name_pt"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "code"
     t.index ["location_type", "name_en"], name: "uniq_name_en_without_parent_id", unique: true, where: "(parent_id IS NULL)"
     t.index ["location_type", "name_es"], name: "uniq_name_es_without_parent_id", unique: true, where: "(parent_id IS NULL)"
     t.index ["location_type", "name_pt"], name: "uniq_name_pt_without_parent_id", unique: true, where: "(parent_id IS NULL)"

--- a/backend/db/seeds/files/colombia_departments.csv
+++ b/backend/db/seeds/files/colombia_departments.csv
@@ -1,33 +1,33 @@
-name
-Amazonas
-Antioquia
-Arauca
-Atlántico
-Bolívar
-Boyacá
-Caldas
-Caquetá
-Casanare
-Cauca
-Cesar
-Chocó
-Córdoba
-Cundinamarca
-Guainía
-Guaviare
-Huila
-La Guajira
-Magdalena
-Meta
-Nariño
-Norte De Santander
-Putumayo
-Quindío
-Risaralda
-San Andrés Providencia Y Santa Catalina
-Santander
-Sucre
-Tolima
-Valle Del Cauca
-Vaupés
-Vichada
+name;code
+Nariño;52
+Putumayo;86
+Tolima;73
+Meta;50
+Cundinamarca;25
+Valle Del Cauca;76
+Quindío;63
+Vaupés;97
+Huila;41
+Cauca;19
+Guaviare;95
+Caquetá;18
+Guainía;94
+Antioquia;05
+Boyacá;15
+Caldas;17
+Casanare;85
+Chocó;27
+Risaralda;66
+Amazonas;91
+Vichada;99
+Santander;68
+Norte De Santander;54
+Sucre;70
+Bolívar;13
+Córdoba;23
+Magdalena;47
+Cesar;20
+Arauca;81
+Atlántico;08
+La Guajira;44
+San Andrés Providencia Y Santa Catalina;88

--- a/backend/db/seeds/files/colombia_municipalities.csv
+++ b/backend/db/seeds/files/colombia_municipalities.csv
@@ -1,1124 +1,1043 @@
-name;department
-El Encanto;Amazonas
-La Chorrera;Amazonas
-La Pedrera;Amazonas
-La Victoria (Pacoa);Amazonas
-Leticia;Amazonas
-Mirití-paraná (Campoamor);Amazonas
-Puerto Alegría;Amazonas
-Puerto Arica;Amazonas
-Puerto Nariño;Amazonas
-Santander (Araracuara);Amazonas
-Tarapacá;Amazonas
-Abejorral;Antioquia
-Abriaquí;Antioquia
-Alejandría;Antioquia
-Amagá;Antioquia
-Amalfi;Antioquia
-Andes;Antioquia
-Angelópolis;Antioquia
-Angostura;Antioquia
-Anorí;Antioquia
-Anzá;Antioquia
-Apartadó;Antioquia
-Arboletes;Antioquia
-Argelia;Antioquia
-Armenia;Antioquia
-Barbosa;Antioquia
-Bello;Antioquia
-Belmira;Antioquia
-Betania;Antioquia
-Betulia;Antioquia
-Briceño;Antioquia
-Buriticá;Antioquia
-Cáceres;Antioquia
-Caicedo;Antioquia
-Caldas;Antioquia
-Campamento;Antioquia
-Cañasgordas;Antioquia
-Caracolí;Antioquia
-Caramanta;Antioquia
-Carepa;Antioquia
-Carmen De Viboral;Antioquia
-Carolina;Antioquia
-Caucasia;Antioquia
-Chigorodó;Antioquia
-Cisneros;Antioquia
-Ciudad Bolívar;Antioquia
-Cocorná;Antioquia
-Concepción;Antioquia
-Concordia;Antioquia
-Copacabana;Antioquia
-Dabeiba;Antioquia
-Don Matías;Antioquia
-Ebéjico;Antioquia
-El Bagre;Antioquia
-Entrerrios;Antioquia
-Envigado;Antioquia
-Fredonia;Antioquia
-Frontino;Antioquia
-Giraldo;Antioquia
-Girardota;Antioquia
-Gómez Plata;Antioquia
-Granada;Antioquia
-Guadalupe;Antioquia
-Guarne;Antioquia
-Guatapé;Antioquia
-Heliconia;Antioquia
-Hispania;Antioquia
-Itagüí;Antioquia
-Ituango;Antioquia
-Jardín;Antioquia
-Jericó;Antioquia
-La Ceja;Antioquia
-La Estrella;Antioquia
-La Pintada;Antioquia
-La Unión;Antioquia
-Liborina;Antioquia
-Maceo;Antioquia
-Marinilla;Antioquia
-Medellín;Antioquia
-Montebello;Antioquia
-Murindó;Antioquia
-Mutatá;Antioquia
-Nariño;Antioquia
-Nechí;Antioquia
-Necoclí;Antioquia
-Olaya;Antioquia
-Peñol;Antioquia
-Peque;Antioquia
-Pueblorrico;Antioquia
-Puerto Berrío;Antioquia
-Puerto Nare;Antioquia
-Puerto Triunfo;Antioquia
-Remedios;Antioquia
-Retiro;Antioquia
-Rionegro;Antioquia
-Sabanalarga;Antioquia
-Sabaneta;Antioquia
-Salgar;Antioquia
-San Andrés;Antioquia
-San Carlos;Antioquia
-San Francisco;Antioquia
-San Jerónimo;Antioquia
-San José De La Montaña;Antioquia
-San Juan De Urabá;Antioquia
-San Luis;Antioquia
-San Pedro;Antioquia
-San Pedro De Urabá;Antioquia
-San Rafael;Antioquia
-San Roque;Antioquia
-San Vicente;Antioquia
-Santa Bárbara;Antioquia
-Santa Fe De Antioquia;Antioquia
-Santa Rosa De Osos;Antioquia
-Santo Domingo;Antioquia
-Santuario;Antioquia
-Segovia;Antioquia
-Sonsón;Antioquia
-Sopetrán;Antioquia
-Támesis;Antioquia
-Tarazá;Antioquia
-Tarso;Antioquia
-Titiribí;Antioquia
-Toledo;Antioquia
-Turbo;Antioquia
-Uramita;Antioquia
-Urrao;Antioquia
-Valdivia;Antioquia
-Valparaiso;Antioquia
-Vegachí;Antioquia
-Venecia;Antioquia
-Vigia Del Fuerte;Antioquia
-Yalí;Antioquia
-Yarumal;Antioquia
-Yolombó;Antioquia
-Yondó (Casabe);Antioquia
-Zaragoza;Antioquia
-Arauca;Antioquia
-Arauquita;Arauca
-Cravo Norte;Arauca
-Fortul;Arauca
-Puerto Rondón;Arauca
-Saravena;Arauca
-Tame;Arauca
-Baranoa;Atlántico
-Barranquilla;Atlántico
-Campo De La Cruz;Atlántico
-Candelaria;Atlántico
-Galapa;Atlántico
-Juan De Acosta;Atlántico
-Luruaco;Atlántico
-Malambo;Atlántico
-Manatí;Atlántico
-Palmar De Varela;Atlántico
-Piojó;Atlántico
-Polonuevo;Atlántico
-Ponedera;Atlántico
-Puerto Colombia;Atlántico
-Repelón;Atlántico
-Sabanagrande;Atlántico
-Sabanalarga;Atlántico
-Santa Lucía;Atlántico
-Santo Tomás;Atlántico
-Soledad;Atlántico
-Suan;Atlántico
-Tubará;Atlántico
-Usiacurí;Atlántico
-Achí;Bolívar
-Altos Del Rosario;Bolívar
-Arenal;Bolívar
-Arjona;Bolívar
-Arroyohondo;Bolívar
-Barranco De Loba;Bolívar
-Calamar;Bolívar
-Cantagallo;Bolívar
-Cartagena De Indias;Bolívar
-Cicuco;Bolívar
-Clemencia;Bolívar
-Córdoba;Bolívar
-El Carmen De Bolívar;Bolívar
-El Guamo;Bolívar
-El Peñón;Bolívar
-Hatillo De Loba;Bolívar
-Magangué;Bolívar
-Mahates;Bolívar
-Margarita;Bolívar
-María La Baja;Bolívar
-Mompós;Bolívar
-Montecristo;Bolívar
-Morales;Bolívar
-Norosi;Bolívar
-Pinillos;Bolívar
-Regidor;Bolívar
-Rioviejo;Bolívar
-San Cristobal;Bolívar
-San Estanislao;Bolívar
-San Fernando;Bolívar
-San Jacinto;Bolívar
-San Jacinto Del Cauca;Bolívar
-San Juan Nepomuceno;Bolívar
-San Martin De Loba;Bolívar
-San Pablo;Bolívar
-Santa Catalina;Bolívar
-Santa Rosa;Bolívar
-Santa Rosa Del Sur;Bolívar
-Simití;Bolívar
-Soplaviento;Bolívar
-Talaigua Nuevo;Bolívar
-Tiquisio (Puerto Rico);Bolívar
-Turbaco;Bolívar
-Turbana;Bolívar
-Villanueva;Bolívar
-Zambrano;Bolívar
-Almeida;Boyacá
-Aquitania;Boyacá
-Arcabuco;Boyacá
-Belén;Boyacá
-Berbeo;Boyacá
-Betéitiva;Boyacá
-Boavita;Boyacá
-Boyacá;Boyacá
-Briceño;Boyacá
-Buenavista;Boyacá
-Busbanzá;Boyacá
-Caldas;Boyacá
-Campohermoso;Boyacá
-Cerinza;Boyacá
-Chinavita;Boyacá
-Chiquinquirá;Boyacá
-Chíquiza;Boyacá
-Chiscas;Boyacá
-Chita;Boyacá
-Chitaraque;Boyacá
-Chivatá;Boyacá
-Chivor;Boyacá
-Ciénega;Boyacá
-Cómbita;Boyacá
-Coper;Boyacá
-Corrales;Boyacá
-Covarachía;Boyacá
-Cubará;Boyacá
-Cucaita;Boyacá
-Cuítiva;Boyacá
-Duitama;Boyacá
-El Cocuy;Boyacá
-El Espino;Boyacá
-Firavitoba;Boyacá
-Floresta;Boyacá
-Gachantivá;Boyacá
-Gámeza;Boyacá
-Garagoa;Boyacá
-Guacamayas;Boyacá
-Guateque;Boyacá
-Guayatá;Boyacá
-Guicán;Boyacá
-Iza;Boyacá
-Jenesano;Boyacá
-Jericó;Boyacá
-La Capilla;Boyacá
-La Uvita;Boyacá
-La Victoria;Boyacá
-Labranzagrande;Boyacá
-Macanal;Boyacá
-Maripí;Boyacá
-Miraflores;Boyacá
-Mongua;Boyacá
-Monguí;Boyacá
-Moniquirá;Boyacá
-Motavita;Boyacá
-Muzo;Boyacá
-Nobsa;Boyacá
-Nuevo Colón;Boyacá
-Oicatá;Boyacá
-Otanche;Boyacá
-Pachavita;Boyacá
-Páez;Boyacá
-Paipa;Boyacá
-Pajarito;Boyacá
-Panqueba;Boyacá
-Pauna;Boyacá
-Paya;Boyacá
-Paz De Rio;Boyacá
-Pesca;Boyacá
-Pisva;Boyacá
-Puerto Boyacá;Boyacá
-Quípama;Boyacá
-Ramiriquí;Boyacá
-Ráquira;Boyacá
-Rondón;Boyacá
-Saboyá;Boyacá
-Sáchica;Boyacá
-Samacá;Boyacá
-San Eduardo;Boyacá
-San José De Pare;Boyacá
-San Luis De Gaceno;Boyacá
-San Mateo;Boyacá
-San Miguel De Sema;Boyacá
-San Pablo De Borbur;Boyacá
-Santa María;Boyacá
-Santa Rosa De Viterbo;Boyacá
-Santa Sofía;Boyacá
-Santana;Boyacá
-Sativanorte;Boyacá
-Sativasur;Boyacá
-Siachoque;Boyacá
-Soatá;Boyacá
-Socha;Boyacá
-Socotá;Boyacá
-Sogamoso;Boyacá
-Somondoco;Boyacá
-Sora;Boyacá
-Soracá;Boyacá
-Sotaquirá;Boyacá
-Susacón;Boyacá
-Sutamarchán;Boyacá
-Sutatenza;Boyacá
-Tasco;Boyacá
-Tenza;Boyacá
-Tibaná;Boyacá
-Tibasosa;Boyacá
-Tinjacá;Boyacá
-Tipacoque;Boyacá
-Toca;Boyacá
-Togüí;Boyacá
-Tópaga;Boyacá
-Tota;Boyacá
-Tunja;Boyacá
-Tununguá;Boyacá
-Turmequé;Boyacá
-Tuta;Boyacá
-Tutazá;Boyacá
-Úmbita;Boyacá
-Ventaquemada;Boyacá
-Villa De Leiva;Boyacá
-Viracachá;Boyacá
-Zetaquirá;Boyacá
-Aguadas;Caldas
-Anserma;Caldas
-Aranzazu;Caldas
-Belalcazar;Caldas
-Chinchiná;Caldas
-Filadelfia;Caldas
-La Dorada;Caldas
-La Merced;Caldas
-Manizales;Caldas
-Manzanares;Caldas
-Marmato;Caldas
-Marquetalia;Caldas
-Marulanda;Caldas
-Neira;Caldas
-Norcasia;Caldas
-Pácora;Caldas
-Palestina;Caldas
-Pensilvania;Caldas
-Riosucio;Caldas
-Risaralda;Caldas
-Salamina;Caldas
-Samaná;Caldas
-San José;Caldas
-Supia;Caldas
-Victoria;Caldas
-Villamaria;Caldas
-Viterbo;Caldas
-Albania;Caquetá
-Belén De Los Andaquíes;Caquetá
-Cartagena Del Chairá;Caquetá
-Curillo;Caquetá
-El Doncello;Caquetá
-El Paujil;Caquetá
-Florencia;Caquetá
-Milán;Caquetá
-Montañita;Caquetá
-Morelia;Caquetá
-Puerto Rico;Caquetá
-San José Del Fragua;Caquetá
-San Vicente Del Caguán;Caquetá
-Solano;Caquetá
-Solita;Caquetá
-Valparaíso;Caquetá
-Aguazul;Casanare
-Chámeza;Casanare
-Hato Corozal;Casanare
-La Salina;Casanare
-Maní;Casanare
-Monterrey;Casanare
-Nunchía;Casanare
-Orocué;Casanare
-Paz de Ariporo;Casanare
-Pore;Casanare
-Recetor;Casanare
-Sabanalarga;Casanare
-Sácama;Casanare
-San Luis De Palenque;Casanare
-Támara;Casanare
-Tauramena;Casanare
-Trinidad;Casanare
-Villanueva;Casanare
-Yopal;Casanare
-Almaguer;Cauca
-Argelia;Cauca
-Balboa;Cauca
-Bolívar;Cauca
-Buenos Aires;Cauca
-Cajibío;Cauca
-Caldono;Cauca
-Caloto;Cauca
-Corinto;Cauca
-El Tambo;Cauca
-Florencia;Cauca
-Guachene;Cauca
-Guapi;Cauca
-Inzá;Cauca
-Jambaló;Cauca
-La Sierra;Cauca
-La Vega;Cauca
-López;Cauca
-Mercaderes;Cauca
-Miranda;Cauca
-Morales;Cauca
-Padilla;Cauca
-Páez (Belalcázar);Cauca
-Patía (El Bordo);Cauca
-Piamonte;Cauca
-Piendamó;Cauca
-Popayán;Cauca
-Puerto Tejada;Cauca
-Puracé (Coconuco);Cauca
-Rosas;Cauca
-San Sebastián;Cauca
-Santa Rosa;Cauca
-Santander De Quilichao;Cauca
-Silvia;Cauca
-Sotará (Paispamba);Cauca
-Suárez;Cauca
-Sucre;Cauca
-Timbío;Cauca
-Timbiquí;Cauca
-Toribío;Cauca
-Totoró;Cauca
-Villa Rica;Cauca
-Aguachica;Cesar
-Agustín Codazzi;Cesar
-Astrea;Cesar
-Becerrill;Cesar
-Bosconia;Cesar
-Chimichagua;Cesar
-Chiriguaná;Cesar
-Curumaní;Cesar
-El Copey;Cesar
-El Paso;Cesar
-Gamarra;Cesar
-González;Cesar
-La Gloria;Cesar
-La Jagua De Ibirico;Cesar
-La Paz;Cesar
-Manaure Balcón Del Cesar;Cesar
-Pailitas;Cesar
-Pelaya;Cesar
-Pueblo Bello;Cesar
-Rio De Oro;Cesar
-San Alberto;Cesar
-San Diego;Cesar
-San Martín;Cesar
-Tamalameque;Cesar
-Valledupar;Cesar
-Acandí;Chocó
-Alto Baudó (Pie De Pato);Chocó
-Atrato (Yuto);Chocó
-Bagadó;Chocó
-Bahía Solano (Mutis);Chocó
-Bajo Baudó (Pizarro);Chocó
-Bojayá (Bellavista);Chocó
-Carmen Del Darién (Curbaradó);Chocó
-Cértegui;Chocó
-Condoto;Chocó
-El Cantón Del San Pablo (Managrú);Chocó
-El Carmen;Chocó
-El Litoral Del San Juán (Docordó);Chocó
-Istmina;Chocó
-Juradó;Chocó
-Lloró;Chocó
-Medio Atrato (Beté);Chocó
-Medio Baudó(boca De Pepé);Chocó
-Medio San Juan (Andagoya);Chocó
-Nóvita;Chocó
-Nuquí;Chocó
-Quibdó;Chocó
-Rio Iró (Santa Rita);Chocó
-Rio Quito (Paimadó);Chocó
-Riosucio;Chocó
-San José Del Palmar;Chocó
-Sipí;Chocó
-Tadó;Chocó
-Unguía;Chocó
-Unión Panamericana ( Animas);Chocó
-Ayapel;Córdoba
-Buenavista;Córdoba
-Canalete;Córdoba
-Cereté;Córdoba
-Chima;Córdoba
-Chinú;Córdoba
-Ciénaga De Oro;Córdoba
-Cotorra;Córdoba
-La Apartada;Córdoba
-Lorica;Córdoba
-Los Córdobas;Córdoba
-Momil;Córdoba
-Moñitos;Córdoba
-Montelíbano;Córdoba
-Montería;Córdoba
-Planeta Rica;Córdoba
-Pueblo Nuevo;Córdoba
-Puerto Escondido;Córdoba
-Puerto Libertador;Córdoba
-Purísima;Córdoba
-Sahagún;Córdoba
-San Andrés De Sotavento;Córdoba
-San Antero;Córdoba
-San Bernardo Del Viento;Córdoba
-San Carlos;Córdoba
-San Jose De Ure;Córdoba
-San Pelayo;Córdoba
-Tierralta;Córdoba
-Tuchín;Córdoba
-Valencia;Córdoba
-Agua De Dios;Cundinamarca
-Albán;Cundinamarca
-Anapoima;Cundinamarca
-Anolaima;Cundinamarca
-Apulo;Cundinamarca
-Arbeláez;Cundinamarca
-Beltrán;Cundinamarca
-Bituima;Cundinamarca
-Bogotá, D.c.;Cundinamarca
-Bojacá;Cundinamarca
-Cabrera;Cundinamarca
-Cachipay;Cundinamarca
-Cajicá;Cundinamarca
-Caparrapí;Cundinamarca
-Cáqueza;Cundinamarca
-Carmen De Carupa;Cundinamarca
-Chaguaní;Cundinamarca
-Chía;Cundinamarca
-Chipaque;Cundinamarca
-Choachí;Cundinamarca
-Chocontá;Cundinamarca
-Cogua;Cundinamarca
-Cota;Cundinamarca
-Cucunubá;Cundinamarca
-El Colegio;Cundinamarca
-El Peñón;Cundinamarca
-El Rosal;Cundinamarca
-Facatativá;Cundinamarca
-Fómeque;Cundinamarca
-Fosca;Cundinamarca
-Funza;Cundinamarca
-Fúquene;Cundinamarca
-Fusagasugá;Cundinamarca
-Gachalá;Cundinamarca
-Gachancipá;Cundinamarca
-Gachetá;Cundinamarca
-Gama;Cundinamarca
-Girardot;Cundinamarca
-Granada;Cundinamarca
-Guachetá;Cundinamarca
-Guaduas;Cundinamarca
-Guasca;Cundinamarca
-Guataquí;Cundinamarca
-Guatavita;Cundinamarca
-Guayabal De Síquima;Cundinamarca
-Guayabetal;Cundinamarca
-Gutiérrez;Cundinamarca
-Jerusalén;Cundinamarca
-Junín;Cundinamarca
-La Calera;Cundinamarca
-La Mesa;Cundinamarca
-La Palma;Cundinamarca
-La Peña;Cundinamarca
-La Vega;Cundinamarca
-Lenguazaque;Cundinamarca
-Machetá;Cundinamarca
-Madrid;Cundinamarca
-Manta;Cundinamarca
-Medina;Cundinamarca
-Mosquera;Cundinamarca
-Nariño;Cundinamarca
-Nemocón;Cundinamarca
-Nilo;Cundinamarca
-Nimaima;Cundinamarca
-Nocaima;Cundinamarca
-Pacho;Cundinamarca
-Paime;Cundinamarca
-Pandi;Cundinamarca
-Paratebueno;Cundinamarca
-Pasca;Cundinamarca
-Puerto Salgar;Cundinamarca
-Pulí;Cundinamarca
-Quebradanegra;Cundinamarca
-Quetame;Cundinamarca
-Quipile;Cundinamarca
-Ricaurte;Cundinamarca
-San Antonio De Tequendama;Cundinamarca
-San Bernardo;Cundinamarca
-San Cayetano;Cundinamarca
-San Francisco;Cundinamarca
-San Juan De Rioseco;Cundinamarca
-Sasaima;Cundinamarca
-Sesquilé;Cundinamarca
-Sibaté;Cundinamarca
-Silvania;Cundinamarca
-Simijaca;Cundinamarca
-Soacha;Cundinamarca
-Sopó;Cundinamarca
-Subachoque;Cundinamarca
-Suesca;Cundinamarca
-Supatá;Cundinamarca
-Susa;Cundinamarca
-Sutatausa;Cundinamarca
-Tabio;Cundinamarca
-Tausa;Cundinamarca
-Tena;Cundinamarca
-Tenjo;Cundinamarca
-Tibacuy;Cundinamarca
-Tibirita;Cundinamarca
-Tocaima;Cundinamarca
-Tocancipá;Cundinamarca
-Topaipí;Cundinamarca
-Ubalá;Cundinamarca
-Ubaque;Cundinamarca
-Ubaté;Cundinamarca
-Une;Cundinamarca
-Útica;Cundinamarca
-Venecia;Cundinamarca
-Vergara;Cundinamarca
-Vianí;Cundinamarca
-Villagómez;Cundinamarca
-Villapinzón;Cundinamarca
-Villeta;Cundinamarca
-Viotá;Cundinamarca
-Yacopí;Cundinamarca
-Zipacón;Cundinamarca
-Zipaquirá;Cundinamarca
-Barranco Mina;Guainía
-Cacahual;Guainía
-Inírida;Guainía
-La Guadalupe;Guainía
-Mapiripana;Guainía
-Morichal (Morichal Nuevo);Guainía
-Paná-paná (Campo Alegre);Guainía
-Puerto Colombia;Guainía
-San Felipe;Guainía
-Calamar;Guaviare
-El Retorno;Guaviare
-Miraflores;Guaviare
-San José Del Guaviare;Guaviare
-Acevedo;Huila
-Agrado;Huila
-Aipe;Huila
-Algeciras;Huila
-Altamira;Huila
-Baraya;Huila
-Campoalegre;Huila
-Colombia;Huila
-Elías;Huila
-Garzón;Huila
-Gigante;Huila
-Guadalupe;Huila
-Hobo;Huila
-Íquira;Huila
-Isnos;Huila
-La Argentina;Huila
-La Plata;Huila
-Nátaga;Huila
-Neiva;Huila
-Oporapa;Huila
-Paicol;Huila
-Palermo;Huila
-Palestina;Huila
-Pital;Huila
-Pitalito;Huila
-Rivera;Huila
-Saladoblanco;Huila
-San Agustín;Huila
-Santa María;Huila
-Suaza;Huila
-Tarqui;Huila
-Tello;Huila
-Teruel;Huila
-Tesalia;Huila
-Timaná;Huila
-Villavieja;Huila
-Yaguará;Huila
-Albania;La Guajira
-Barrancas;La Guajira
-Dibulla;La Guajira
-Distracción;La Guajira
-El Molino;La Guajira
-Fonseca;La Guajira
-Hato Nuevo;La Guajira
-La Jagua Del Pilar;La Guajira
-Maicao;La Guajira
-Manaure;La Guajira
-Riohacha;La Guajira
-San Juan Del Cesar;La Guajira
-Uribia;La Guajira
-Urumita;La Guajira
-Villanueva;La Guajira
-Algarrobo;Magdalena
-Aracataca;Magdalena
-Ariguaní (El Dificil);Magdalena
-Cerro De San Antonio;Magdalena
-Chivolo;Magdalena
-Ciénaga;Magdalena
-Concordia;Magdalena
-El Banco;Magdalena
-El Piñón;Magdalena
-El Retén;Magdalena
-Fundación;Magdalena
-Guamal;Magdalena
-Nueva Granada;Magdalena
-Pedraza;Magdalena
-Pijiño Del Carmen;Magdalena
-Pivijay;Magdalena
-Plato;Magdalena
-Puebloviejo;Magdalena
-Remolino;Magdalena
-Sabanas De San Angel;Magdalena
-Salamina;Magdalena
-San Sebastián De Buenavista;Magdalena
-San Zenón;Magdalena
-Santa Ana;Magdalena
-Santa Bárbara De Pinto;Magdalena
-Santa Marta;Magdalena
-Sitionuevo;Magdalena
-Tenerife;Magdalena
-Zapayán;Magdalena
-Zona Bananera;Magdalena
-Acacías;Meta
-Barranca De Upía;Meta
-Cabuyaro;Meta
-Castilla La Nueva;Meta
-Cubarral;Meta
-Cumaral;Meta
-El Calvario;Meta
-El Castillo;Meta
-El Dorado;Meta
-Fuente De Oro;Meta
-Granada;Meta
-Guamal;Meta
-La Macarena;Meta
-Lejanías;Meta
-Mapiripán;Meta
-Mesetas;Meta
-Puerto Concordia;Meta
-Puerto Gaitán;Meta
-Puerto Lleras;Meta
-Puerto López;Meta
-Puerto Rico;Meta
-Restrepo;Meta
-San Carlos De Guaroa;Meta
-San Juan De Arama;Meta
-San Juanito;Meta
-San Martín;Meta
-Uribe;Meta
-Villavicencio;Meta
-Vistahermosa;Meta
-Albán (San José);Nariño
-Aldana;Nariño
-Ancuya;Nariño
-Arboleda (Berruecos);Nariño
-Barbacoas;Nariño
-Belén;Nariño
-Buesaco;Nariño
-Chachaguí;Nariño
-Colón (Génova);Nariño
-Consacá;Nariño
-Contadero;Nariño
-Córdoba;Nariño
-Cuaspud (Carlosama);Nariño
-Cumbal;Nariño
-Cumbitara;Nariño
-El Charco;Nariño
-El Peñol;Nariño
-El Rosario;Nariño
-El Tablón;Nariño
-El Tambo;Nariño
-Francisco Pizarro (Salahonda);Nariño
-Funes;Nariño
-Guachucal;Nariño
-Guaitarilla;Nariño
-Gualmatán;Nariño
-Iles;Nariño
-Imués;Nariño
-Ipiales;Nariño
-La Cruz;Nariño
-La Florida;Nariño
-La Llanada;Nariño
-La Tola;Nariño
-La Unión;Nariño
-Leiva;Nariño
-Linares;Nariño
-Los Andes (Sotomayor);Nariño
-Magüí (Payán);Nariño
-Mallama (Piedrancha);Nariño
-Mosquera;Nariño
-Nariño;Nariño
-Olaya Herrera (Bocas De Satinga);Nariño
-Ospina;Nariño
-Pasto;Nariño
-Policarpa;Nariño
-Potosí;Nariño
-Providencia;Nariño
-Puerres;Nariño
-Pupiales;Nariño
-Ricaurte;Nariño
-Roberto Payán (San José);Nariño
-Samaniego;Nariño
-San Bernardo;Nariño
-San Lorenzo;Nariño
-San Pablo;Nariño
-San Pedro De Cartago (Cartago);Nariño
-Sandoná;Nariño
-Santa Bárbara (Iscuandé);Nariño
-Santa Cruz (Guachavés);Nariño
-Sapuyes;Nariño
-Taminango;Nariño
-Tangua;Nariño
-Tumaco;Nariño
-Tumaco;Nariño
-Túquerres;Nariño
-Yacuanquer;Nariño
-Ábrego;Norte De Santander
-Arboledas;Norte De Santander
-Bochalema;Norte De Santander
-Bucarasica;Norte De Santander
-Cáchira;Norte De Santander
-Cácota;Norte De Santander
-Chinácota;Norte De Santander
-Chitagá;Norte De Santander
-Convención;Norte De Santander
-Cúcuta;Norte De Santander
-Cucutilla;Norte De Santander
-Durania;Norte De Santander
-El Carmen;Norte De Santander
-El Tarra;Norte De Santander
-El Zulia;Norte De Santander
-Gramalote;Norte De Santander
-Hacarí;Norte De Santander
-Herrán;Norte De Santander
-La Esperanza;Norte De Santander
-La Playa;Norte De Santander
-Labateca;Norte De Santander
-Los Patios;Norte De Santander
-Lourdes;Norte De Santander
-Mutiscua;Norte De Santander
-Ocaña;Norte De Santander
-Pamplona;Norte De Santander
-Pamplonita;Norte De Santander
-Puerto Santander;Norte De Santander
-Ragonvalia;Norte De Santander
-Salazar;Norte De Santander
-San Calixto;Norte De Santander
-San Cayetano;Norte De Santander
-Santiago;Norte De Santander
-Sardinata;Norte De Santander
-Silos;Norte De Santander
-Teorama;Norte De Santander
-Tibú;Norte De Santander
-Toledo;Norte De Santander
-Villa Caro;Norte De Santander
-Villa Del Rosario;Norte De Santander
-Colón;Putumayo
-Mocoa;Putumayo
-Orito;Putumayo
-Puerto Asís;Putumayo
-Puerto Caicedo;Putumayo
-Puerto Guzmán;Putumayo
-Puerto Leguízamo;Putumayo
-San Francisco;Putumayo
-San Miguel (La Dorada);Putumayo
-Santiago;Putumayo
-Sibundoy;Putumayo
-Valle Del Guamuez (La Hormiga);Putumayo
-Villagarzón;Putumayo
-Armenia;Quindío
-Buenavista;Quindío
-Calarcá;Quindío
-Circasia;Quindío
-Córdoba;Quindío
-Filandia;Quindío
-Génova;Quindío
-La Tebaida;Quindío
-Montenegro;Quindío
-Pijao;Quindío
-Quimbaya;Quindío
-Salento;Quindío
-Apía;Risaralda
-Balboa;Risaralda
-Belén De Umbría;Risaralda
-Dosquebradas;Risaralda
-Guática;Risaralda
-La Celia;Risaralda
-La Virginia;Risaralda
-Marsella;Risaralda
-Mistrató;Risaralda
-Pereira;Risaralda
-Pueblo Rico;Risaralda
-Quinchía;Risaralda
-Santa Rosa De Cabal;Risaralda
-Santuario;Risaralda
-San Andrés;San Andrés Providencia Y Santa Catalina
-Providencia y Santa Isabel;San Andrés Providencia Y Santa Catalina
-Aguada;Santander
-Albania;Santander
-Aratoca;Santander
-Barbosa;Santander
-Barichara;Santander
-Barrancabermeja;Santander
-Betulia;Santander
-Bolivar;Santander
-Bucaramanga;Santander
-Cabrera;Santander
-California;Santander
-Capitanejo;Santander
-Carcasí;Santander
-Cepitá;Santander
-Cerrito;Santander
-Charalá;Santander
-Charta;Santander
-Chima;Santander
-Chipatá;Santander
-Cimitarra;Santander
-Concepción;Santander
-Confines;Santander
-Contratación;Santander
-Coromoro;Santander
-Curití;Santander
-El Carmen;Santander
-El Guacamayo;Santander
-El Peñón;Santander
-El Playón;Santander
-Encino;Santander
-Enciso;Santander
-Florián;Santander
-Floridablanca;Santander
-Galán;Santander
-Gámbita;Santander
-Girón;Santander
-Guaca;Santander
-Guadalupe;Santander
-Guapotá;Santander
-Guavatá;Santander
-Güepsa;Santander
-Hato;Santander
-Jesús María;Santander
-Jordán;Santander
-La Belleza;Santander
-La Paz;Santander
-Landázuri;Santander
-Lebrija;Santander
-Los Santos;Santander
-Macaravita;Santander
-Málaga;Santander
-Matanza;Santander
-Mogotes;Santander
-Molagavita;Santander
-Ocamonte;Santander
-Oiba;Santander
-Onzaga;Santander
-Palmar;Santander
-Palmas Del Socorro;Santander
-Páramo;Santander
-Piedecuesta;Santander
-Pinchote;Santander
-Puente Nacional;Santander
-Puerto Parra;Santander
-Puerto Wilches;Santander
-Rionegro;Santander
-Sabana De Torres;Santander
-San Andrés;Santander
-San Benito;Santander
-San Gil;Santander
-San Joaquín;Santander
-San José De Miranda;Santander
-San Miguel;Santander
-San Vicente De Chucurí;Santander
-Santa Bárbara;Santander
-Santa Helena Del Opón;Santander
-Simacota;Santander
-Socorro;Santander
-Suaita;Santander
-Sucre;Santander
-Suratá;Santander
-Tona;Santander
-Valle De San José;Santander
-Vélez;Santander
-Vetas;Santander
-Villanueva;Santander
-Zapatoca;Santander
-Buenavista;Sucre
-Caimito;Sucre
-Chalán;Sucre
-Colosó;Sucre
-Corozal;Sucre
-Coveñas;Sucre
-El Roble;Sucre
-Galeras;Sucre
-Guaranda;Sucre
-La Unión;Sucre
-Los Palmitos;Sucre
-Majagual;Sucre
-Morroa;Sucre
-Ovejas;Sucre
-Palmito;Sucre
-Sampués;Sucre
-San Benito Abad;Sucre
-San Juan De Betulia (Betulia);Sucre
-San Marcos;Sucre
-San Onofre;Sucre
-San Pedro;Sucre
-Sincé;Sucre
-Sincelejo;Sucre
-Sucre;Sucre
-Tolú;Sucre
-Toluviejo;Sucre
-Alpujarra;Tolima
-Alvarado;Tolima
-Ambalema;Tolima
-Anzoátegui;Tolima
-Armero (Guayabal);Tolima
-Ataco;Tolima
-Cajamarca;Tolima
-Carmen De Apicalá;Tolima
-Casabianca;Tolima
-Chaparral;Tolima
-Coello;Tolima
-Coyaima;Tolima
-Cunday;Tolima
-Dolores;Tolima
-Espinal;Tolima
-Falan;Tolima
-Flandes;Tolima
-Fresno;Tolima
-Guamo;Tolima
-Herveo;Tolima
-Honda;Tolima
-Ibagué;Tolima
-Icononzo;Tolima
-Lérida;Tolima
-Líbano;Tolima
-Mariquita;Tolima
-Melgar;Tolima
-Murillo;Tolima
-Natagaima;Tolima
-Ortega;Tolima
-Palocabildo;Tolima
-Piedras;Tolima
-Planadas;Tolima
-Prado;Tolima
-Purificación;Tolima
-Rioblanco;Tolima
-Roncesvalles;Tolima
-Rovira;Tolima
-Saldaña;Tolima
-San Antonio;Tolima
-San Luis;Tolima
-Santa Isabel;Tolima
-Suárez;Tolima
-Valle De San Juan;Tolima
-Venadillo;Tolima
-Villahermosa;Tolima
-Villarrica;Tolima
-Alcalá;Valle Del Cauca
-Andalucía;Valle Del Cauca
-Ansermanuevo;Valle Del Cauca
-Argelia;Valle Del Cauca
-Bolívar;Valle Del Cauca
-Buenaventura;Valle Del Cauca
-Buga;Valle Del Cauca
-Bugalagrande;Valle Del Cauca
-Caicedonia;Valle Del Cauca
-Cali;Valle Del Cauca
-Calima (El Darién);Valle Del Cauca
-Candelaria;Valle Del Cauca
-Cartago;Valle Del Cauca
-Dagua;Valle Del Cauca
-El Águila;Valle Del Cauca
-El Cairo;Valle Del Cauca
-El Cerrito;Valle Del Cauca
-El Dovio;Valle Del Cauca
-Florida;Valle Del Cauca
-Ginebra;Valle Del Cauca
-Guacarí;Valle Del Cauca
-Jamundí;Valle Del Cauca
-La Cumbre;Valle Del Cauca
-La Unión;Valle Del Cauca
-La Victoria;Valle Del Cauca
-Obando;Valle Del Cauca
-Palmira;Valle Del Cauca
-Pradera;Valle Del Cauca
-Restrepo;Valle Del Cauca
-Riofrío;Valle Del Cauca
-Roldanillo;Valle Del Cauca
-San Pedro;Valle Del Cauca
-Sevilla;Valle Del Cauca
-Toro;Valle Del Cauca
-Trujillo;Valle Del Cauca
-Tuluá;Valle Del Cauca
-Ulloa;Valle Del Cauca
-Versalles;Valle Del Cauca
-Vijes;Valle Del Cauca
-Yotoco;Valle Del Cauca
-Yumbo;Valle Del Cauca
-Zarzal;Valle Del Cauca
-Carurú;Vaupés
-Mitú;Vaupés
-Pacoa (Cor. Departamental);Vaupés
-Papunaua(cor. Departamental);Vaupés
-Taraira;Vaupés
-Yavaraté (Cor. Departamental);Vaupés
-Cumaribo;Vichada
-La Primavera;Vichada
-Puerto Carreño;Vichada
-Santa Rosalía;Vichada
+name;department;code
+Potosí;Nariño;560
+Puerto Caicedo;Putumayo;569
+Córdoba;Nariño;215
+Puerres;Nariño;573
+Orito;Putumayo;320
+Contadero;Nariño;210
+Carmen De Apicalá;Tolima;148
+Espinal;Tolima;268
+Guamo;Tolima;319
+Suárez;Tolima;770
+Icononzo;Tolima;352
+Melgar;Tolima;449
+Valle De San Juan;Tolima;854
+Roncesvalles;Tolima;622
+Villavicencio;Meta;001
+Arbeláez;Cundinamarca;053
+Flandes;Tolima;275
+Gutiérrez;Cundinamarca;339
+Trujillo;Valle Del Cauca;828
+Génova;Quindío;302
+Bugalagrande;Valle Del Cauca;113
+San Luis;Tolima;678
+Rovira;Tolima;624
+Guayabetal;Cundinamarca;335
+Fosca;Cundinamarca;281
+Nilo;Cundinamarca;488
+Cumaral;Meta;226
+Pijao;Quindío;548
+Ricaurte;Cundinamarca;612
+Tibacuy;Cundinamarca;805
+Pasca;Cundinamarca;535
+Buenavista;Quindío;111
+Quetame;Cundinamarca;594
+Sevilla;Valle Del Cauca;736
+Caicedonia;Valle Del Cauca;122
+Agua De Dios;Cundinamarca;001
+Fusagasugá;Cundinamarca;290
+Une;Cundinamarca;845
+Girardot;Cundinamarca;307
+El Calvario;Meta;245
+Papunaua(Cor. Departamental);Vaupés;777
+Guadalupe;Huila;319
+Bolívar;Cauca;100
+Magüí (Payán);Nariño;427
+Leiva;Nariño;405
+Oporapa;Huila;503
+Sucre;Cauca;785
+La Vega;Cauca;397
+Altamira;Huila;026
+Calamar;Guaviare;015
+San Agustín;Huila;668
+Florencia;Caquetá;001
+Balboa;Cauca;075
+Miranda;Cauca;455
+Baraya;Huila;078
+Planadas;Tolima;555
+Puerto Tejada;Cauca;573
+Florida;Valle Del Cauca;275
+Mapiripana;Guainía;663
+Aipe;Huila;016
+Candelaria;Valle Del Cauca;130
+Mapiripán;Meta;325
+Pradera;Valle Del Cauca;563
+San Juan De Arama;Meta;683
+Alpujarra;Tolima;024
+Cali;Valle Del Cauca;001
+Fuente De Oro;Meta;287
+Mesetas;Meta;330
+Granada;Meta;313
+Ataco;Tolima;067
+Natagaima;Tolima;483
+Yumbo;Valle Del Cauca;892
+Palmira;Valle Del Cauca;520
+Barranco Mina;Guainía;343
+El Castillo;Meta;251
+El Dorado;Meta;270
+El Cerrito;Valle Del Cauca;248
+Cacahual;Guainía;886
+Rioblanco;Tolima;616
+Uribe;Meta;370
+San Martín;Meta;689
+Prado;Tolima;563
+Yarumal;Antioquia;887
+Vijes;Valle Del Cauca;869
+Ginebra;Valle Del Cauca;306
+Dolores;Tolima;236
+Guacarí;Valle Del Cauca;318
+La Cumbre;Valle Del Cauca;377
+Restrepo;Valle Del Cauca;606
+Coyaima;Tolima;217
+Castilla La Nueva;Meta;150
+San Carlos De Guaroa;Meta;680
+Villarrica;Tolima;873
+Buga;Valle Del Cauca;111
+Purificación;Tolima;585
+Cubarral;Meta;223
+Cabrera;Cundinamarca;120
+Chaparral;Tolima;168
+San Pedro;Valle Del Cauca;670
+Yotoco;Valle Del Cauca;890
+Calima (El Darién);Valle Del Cauca;126
+Guamal;Meta;318
+Ortega;Tolima;504
+San Antonio;Tolima;675
+Venecia;Cundinamarca;506
+Machetá;Cundinamarca;426
+Quebradanegra;Cundinamarca;592
+Zipaquirá;Cundinamarca;899
+La Capilla;Boyacá;380
+Nemocón;Cundinamarca;486
+Manizales;Caldas;001
+Herveo;Tolima;347
+Falan;Tolima;270
+Risaralda;Caldas;616
+Tauramena;Casanare;410
+San José Del Palmar;Chocó;660
+Vergara;Cundinamarca;862
+Nimaima;Cundinamarca;489
+Páez;Boyacá;514
+Guasca;Cundinamarca;322
+Angostura;Antioquia;038
+Orocué;Casanare;230
+Suesca;Cundinamarca;772
+Miraflores;Boyacá;455
+Chocontá;Cundinamarca;183
+Útica;Cundinamarca;851
+Tausa;Cundinamarca;793
+Belén De Umbría;Risaralda;088
+Neira;Caldas;486
+Anserma;Caldas;042
+Istmina;Chocó;361
+Tuluá;Valle Del Cauca;834
+Riofrío;Valle Del Cauca;616
+Acacías;Meta;006
+Andalucía;Valle Del Cauca;036
+San Bernardo;Cundinamarca;649
+Pandi;Cundinamarca;524
+Cáqueza;Cundinamarca;151
+Zarzal;Valle Del Cauca;895
+Nariño;Cundinamarca;480
+La Tebaida;Quindío;401
+Chipaque;Cundinamarca;178
+Coello;Tolima;200
+Roldanillo;Valle Del Cauca;622
+Viotá;Cundinamarca;878
+Sibaté;Cundinamarca;740
+San Juanito;Meta;686
+Ubaque;Cundinamarca;841
+La Victoria;Valle Del Cauca;403
+El Litoral Del San Juán (Docordó);Chocó;250
+Montenegro;Quindío;470
+Cajamarca;Tolima;124
+Armenia;Quindío;001
+La Victoria (Pacoa);Amazonas;430
+San Miguel (La Dorada);Putumayo;757
+Guataquí;Cundinamarca;324
+El Dovio;Valle Del Cauca;250
+Tocaima;Cundinamarca;815
+Puerto Lleras;Meta;577
+El Colegio;Cundinamarca;245
+Apulo;Cundinamarca;599
+Piedras;Tolima;547
+Anapoima;Cundinamarca;035
+Choachí;Cundinamarca;181
+San Antonio De  Tequendama;Cundinamarca;645
+Jerusalén;Cundinamarca;368
+Obando;Valle Del Cauca;497
+Circasia;Quindío;190
+La Pedrera;Amazonas;407
+Santander (Araracuara);Amazonas;669
+Mirití-Paraná (Campoamor);Amazonas;460
+Palocabildo;Tolima;520
+Gualmatán;Nariño;323
+Aldana;Nariño;022
+Pupiales;Nariño;585
+Iles;Nariño;352
+Funes;Nariño;287
+Solita;Caquetá;785
+Puerto Guzmán;Putumayo;571
+Ospina;Nariño;506
+Villagarzón;Putumayo;885
+Cumbal;Nariño;227
+Sapuyes;Nariño;720
+Imués;Nariño;354
+Solano;Caquetá;756
+Yacuanquer;Nariño;885
+Santiago;Putumayo;760
+Tangua;Nariño;788
+Guaitarilla;Nariño;320
+Curillo;Caquetá;205
+Consacá;Nariño;207
+San Francisco;Putumayo;755
+Túquerres;Nariño;838
+Colón;Putumayo;219
+Providencia;Nariño;565
+Tarqui;Huila;791
+Roberto Payán (San José);Nariño;621
+La Sierra;Cauca;392
+Saladoblanco;Huila;660
+Isnos;Huila;359
+La Argentina;Huila;378
+El Paujil;Caquetá;256
+Rosas;Cauca;622
+Garzón;Huila;298
+El Doncello;Caquetá;247
+Patía (El Bordo);Cauca;532
+Soracá;Boyacá;764
+San Luis De Palenque;Casanare;325
+Sutatausa;Cundinamarca;781
+Toribío;Cauca;821
+Lejanías;Meta;400
+Colombia;Huila;206
+Dagua;Valle Del Cauca;233
+Saldaña;Tolima;671
+Fresno;Tolima;283
+Pacho;Cundinamarca;513
+Cucunubá;Cundinamarca;224
+Berbeo;Boyacá;090
+Manzanares;Caldas;433
+Pital;Huila;548
+Agrado;Huila;013
+Sotará (Paispamba);Cauca;760
+Puracé (Coconuco);Cauca;585
+Inzá;Cauca;355
+El Retorno;Guaviare;025
+Timbío;Cauca;807
+Paicol;Huila;518
+La Plata;Huila;396
+San Felipe;Guainía;883
+Argelia;Cauca;050
+Gigante;Huila;306
+Popayán;Cauca;001
+Totoró;Cauca;824
+Puerto Rico;Caquetá;592
+Mosquera;Nariño;473
+Olaya Herrera (Bocas De Satinga);Nariño;490
+Santa Bárbara (Iscuandé);Nariño;696
+Tesalia;Huila;797
+La Tola;Nariño;390
+Área En Litigio;Cauca;355
+Nátaga;Huila;483
+El Charco;Nariño;250
+Guapi;Cauca;318
+Cajibío;Cauca;130
+Yaguará;Huila;885
+Campoalegre;Huila;132
+Silvia;Cauca;743
+El Tambo;Cauca;256
+Piendamó;Cauca;548
+Rivera;Huila;615
+Morichal (Morichal Nuevo);Guainía;888
+San José Del Guaviare;Guaviare;001
+Timbiquí;Cauca;809
+San Vicente Del Caguán;Caquetá;753
+Morales;Cauca;473
+Teruel;Huila;801
+Puerto Concordia;Meta;450
+Santa María;Huila;676
+Páez (Belalcázar);Cauca;517
+Palermo;Huila;524
+Buenos Aires;Cauca;110
+Santander De Quilichao;Cauca;698
+Tello;Huila;799
+Caloto;Cauca;142
+Guachene;Cauca;300
+Vistahermosa;Meta;711
+Corinto;Cauca;212
+Padilla;Cauca;513
+López;Cauca;418
+Villa Rica;Cauca;845
+Neiva;Huila;001
+Sutatenza;Boyacá;778
+Guateque;Boyacá;322
+Villahermosa;Tolima;870
+Monterrey;Casanare;162
+Belalcazar;Caldas;088
+Manta;Cundinamarca;436
+Villeta;Cundinamarca;875
+Maní;Casanare;139
+Chinchiná;Caldas;174
+Sesquilé;Cundinamarca;736
+Nocaima;Cundinamarca;491
+Campohermoso;Boyacá;135
+Supatá;Cundinamarca;777
+Casabianca;Tolima;152
+San José;Caldas;665
+Medio San Juan (Andagoya);Chocó;450
+Viterbo;Caldas;877
+Santuario;Risaralda;687
+Palestina;Caldas;524
+Marmato;Caldas;442
+Supia;Caldas;777
+Pensilvania;Caldas;541
+San Eduardo;Boyacá;660
+Mariquita;Tolima;443
+Honda;Tolima;349
+El Peñón;Cundinamarca;258
+Villagómez;Cundinamarca;871
+Aranzazu;Caldas;050
+Marquetalia;Caldas;444
+Jenesano;Boyacá;367
+Ancuya;Nariño;036
+Sibundoy;Putumayo;749
+Pasto;Nariño;001
+Valparaíso;Caquetá;860
+Milán;Caquetá;460
+Albania;Caquetá;029
+Sandoná;Nariño;683
+Mallama (Piedrancha);Nariño;435
+La Florida;Nariño;381
+Buesaco;Nariño;110
+Santa Cruz (Guachavés);Nariño;699
+Mocoa;Putumayo;001
+Linares;Nariño;411
+Albán (San José);Nariño;019
+El Tablón;Nariño;258
+Chachaguí;Nariño;240
+Arboleda (Berruecos);Nariño;051
+Cartagena Del Chairá;Caquetá;150
+Morelia;Caquetá;479
+San José Del Fragua;Caquetá;610
+Piamonte;Cauca;533
+San Pedro De Cartago (Cartago);Nariño;694
+El Peñol;Nariño;254
+Belén;Nariño;083
+La Cruz;Nariño;378
+La Llanada;Nariño;385
+San Lorenzo;Nariño;687
+Colón (Génova);Nariño;203
+Taminango;Nariño;786
+La Unión;Nariño;399
+San Pablo;Nariño;693
+Carurú;Vaupés;161
+Belén De Los Andaquíes;Caquetá;094
+Montañita;Caquetá;410
+Guática;Risaralda;318
+Santa Rosalía;Vichada;624
+Quinchía;Risaralda;594
+Unión Panamericana ( Animas);Chocó;810
+Tadó;Chocó;787
+Oicatá;Boyacá;500
+Bagadó;Chocó;073
+Rio Quito (Paimadó);Chocó;600
+Atrato (Yuto);Chocó;050
+Labranzagrande;Boyacá;377
+Chíquiza;Boyacá;232
+Sipí;Chocó;745
+Quipile;Cundinamarca;596
+Funza;Cundinamarca;286
+Gachalá;Cundinamarca;293
+Zipacón;Cundinamarca;898
+Tena;Cundinamarca;797
+Ibagué;Tolima;001
+Alvarado;Tolima;026
+Versalles;Valle Del Cauca;863
+Salento;Quindío;690
+Anzoátegui;Tolima;043
+La Mesa;Cundinamarca;386
+Villanueva;Casanare;440
+Alcalá;Valle Del Cauca;020
+Caparrapí;Cundinamarca;148
+Samacá;Boyacá;646
+Bajo Baudó (Pizarro);Chocó;077
+Riosucio;Caldas;614
+Cumaribo;Vichada;773
+Cucaita;Boyacá;224
+Mistrató;Risaralda;456
+Trinidad;Casanare;430
+Simijaca;Cundinamarca;745
+Pácora;Caldas;513
+Tunja;Boyacá;001
+Tota;Boyacá;822
+San Miguel De Sema;Boyacá;676
+Victoria;Caldas;867
+Caramanta;Antioquia;145
+Pinchote;Santander;549
+Landázuri;Santander;385
+Chiquinquirá;Boyacá;176
+Firavitoba;Boyacá;272
+Nunchía;Casanare;225
+Aguadas;Caldas;013
+Tuta;Boyacá;837
+Santa Rosa De Osos;Antioquia;686
+Samaná;Caldas;662
+Norcasia;Caldas;495
+Monguí;Boyacá;466
+San Pablo De Borbur;Boyacá;681
+Inírida;Guainía;001
+Valle Del Guamuez (La Hormiga);Putumayo;865
+Cuaspud (Carlosama);Nariño;224
+Medina;Cundinamarca;438
+Fómeque;Cundinamarca;279
+Barbacoas;Nariño;079
+Los Andes (Sotomayor);Nariño;418
+Santa Rosa;Cauca;701
+Policarpa;Nariño;540
+Cumbitara;Nariño;233
+San Sebastián;Cauca;693
+Pitalito;Huila;551
+Almaguer;Cauca;022
+El Rosario;Nariño;256
+Suaza;Huila;770
+Timaná;Huila;807
+Elías;Huila;244
+Marsella;Risaralda;440
+Gachancipá;Cundinamarca;295
+Villamaria;Caldas;873
+Nuevo Colón;Boyacá;494
+Topaipí;Cundinamarca;823
+San Cayetano;Cundinamarca;653
+La Palma;Cundinamarca;394
+Guaduas;Cundinamarca;320
+Pueblo Rico;Risaralda;572
+Ciénega;Boyacá;189
+La Merced;Caldas;388
+Guachetá;Cundinamarca;317
+Chámeza;Casanare;015
+Puerto Boyacá;Boyacá;572
+Villavieja;Huila;872
+Salamina;Caldas;653
+Carmen De Carupa;Cundinamarca;154
+Ventaquemada;Boyacá;861
+Paime;Cundinamarca;518
+Boyacá;Boyacá;104
+Fúquene;Cundinamarca;288
+Pajarito;Boyacá;518
+Cértegui;Chocó;160
+Susa;Cundinamarca;779
+El Cantón Del San Pablo (Managrú);Chocó;135
+Coper;Boyacá;212
+Pachavita;Boyacá;511
+Villapinzón;Cundinamarca;873
+Turmequé;Boyacá;835
+Aguazul;Casanare;010
+Zetaquirá;Boyacá;897
+Ubaté;Cundinamarca;843
+Filadelfia;Caldas;272
+Marulanda;Caldas;446
+Lenguazaque;Cundinamarca;407
+Recetor;Casanare;279
+Medio Baudó(Boca De Pepé);Chocó;430
+Paná-Paná (Campo Alegre);Guainía;887
+Encino;Santander;264
+Heliconia;Antioquia;347
+Susacón;Boyacá;774
+Puerto Carreño;Vichada;001
+Guapotá;Santander;322
+Soatá;Boyacá;753
+Anzá;Antioquia;044
+Copacabana;Antioquia;212
+Concepción;Antioquia;206
+San Mateo;Boyacá;673
+San Jerónimo;Antioquia;656
+Yalí;Antioquia;885
+El Carmen;Santander;235
+Frontino;Antioquia;284
+Mongua;Boyacá;464
+Filandia;Quindío;272
+Toro;Valle Del Cauca;823
+Barranca De Upía;Meta;110
+Ulloa;Valle Del Cauca;845
+Paratebueno;Cundinamarca;530
+Pulí;Cundinamarca;580
+Bojacá;Cundinamarca;099
+Ubalá;Cundinamarca;839
+Cachipay;Cundinamarca;123
+Gama;Cundinamarca;299
+Palmar;Santander;522
+San Joaquín;Santander;682
+Don Matías;Antioquia;237
+Covarachía;Boyacá;218
+San Calixto;Norte De Santander;670
+Francisco Pizarro (Salahonda);Nariño;520
+Sincé;Sucre;742
+San Juan De Betulia (Betulia);Sucre;702
+Palmito;Sucre;523
+Sincelejo;Sucre;001
+Talaigua Nuevo;Bolívar;780
+San Antero;Córdoba;672
+San Bernardo Del Viento;Córdoba;675
+Morroa;Sucre;473
+San Zenón;Magdalena;703
+Chimichagua;Cesar;175
+San Sebastián De Buenavista;Magdalena;692
+Los Palmitos;Sucre;418
+Toluviejo;Sucre;823
+Astrea;Cesar;032
+Colosó;Sucre;204
+Chalán;Sucre;230
+Santa Bárbara De Pinto;Magdalena;720
+Tolú;Sucre;820
+Nóvita;Chocó;491
+Chitaraque;Boyacá;185
+Paz De Rio;Boyacá;537
+Cocorná;Antioquia;197
+Titiribí;Antioquia;809
+Cartago;Valle Del Cauca;147
+Santa Isabel;Tolima;686
+Venadillo;Tolima;861
+La Calera;Cundinamarca;377
+Junín;Cundinamarca;372
+Bogotá, D.C.;Cundinamarca;001
+El Cairo;Valle Del Cauca;246
+Beltrán;Cundinamarca;086
+Cota;Cundinamarca;214
+Anolaima;Cundinamarca;040
+Madrid;Cundinamarca;430
+Ansermanuevo;Valle Del Cauca;041
+Dosquebradas;Risaralda;170
+Puerto Gaitán;Meta;568
+Facatativá;Cundinamarca;269
+Sora;Boyacá;762
+Cuítiva;Boyacá;226
+Tinjacá;Boyacá;808
+Sáchica;Boyacá;638
+Olaya;Antioquia;501
+Entrerrios;Antioquia;264
+Santa Fe De Antioquia;Antioquia;042
+San José De Miranda;Santander;684
+Curití;Santander;229
+Tame;Arauca;794
+Enciso;Santander;266
+Cañasgordas;Antioquia;138
+Vegachí;Antioquia;858
+Uramita;Antioquia;842
+Zapatoca;Santander;895
+San Andrés;Antioquia;647
+Murindó;Antioquia;475
+Valparaiso;Antioquia;856
+Sogamoso;Boyacá;759
+Andes;Antioquia;034
+La Dorada;Caldas;380
+Támesis;Antioquia;789
+Pisva;Boyacá;550
+San Luis De Gaceno;Boyacá;667
+Guayatá;Boyacá;325
+Líbano;Tolima;411
+Sabanalarga;Casanare;300
+Chaguaní;Cundinamarca;168
+Almeida;Boyacá;022
+Somondoco;Boyacá;761
+Sasaima;Cundinamarca;718
+Tocancipá;Cundinamarca;817
+El Águila;Valle Del Cauca;243
+La Celia;Risaralda;383
+Socha;Boyacá;757
+Támara;Casanare;400
+La Ceja;Antioquia;376
+Salgar;Antioquia;642
+Güepsa;Santander;327
+Caldas;Boyacá;131
+Quípama;Boyacá;580
+Aquitania;Boyacá;047
+Pesca;Boyacá;542
+Maripí;Boyacá;442
+Toca;Boyacá;814
+Jardín;Antioquia;364
+Cajicá;Cundinamarca;126
+Chima;Santander;176
+Tipacoque;Boyacá;810
+Valle De San José;Santander;855
+Guacamayas;Boyacá;317
+Panqueba;Boyacá;522
+Páramo;Santander;533
+Caicedo;Antioquia;125
+Barbosa;Antioquia;079
+Santa Helena Del Opón;Santander;720
+Calarcá;Quindío;130
+Soacha;Cundinamarca;754
+Quimbaya;Quindío;594
+La Chorrera;Amazonas;405
+Socorro;Santander;755
+Onzaga;Santander;502
+San Roque;Antioquia;670
+El Espino;Boyacá;248
+Santo Domingo;Antioquia;690
+Vélez;Santander;861
+Cisneros;Antioquia;190
+Macaravita;Santander;425
+Capitanejo;Santander;147
+Urrao;Antioquia;847
+San Miguel;Santander;686
+Puerto Rondón;Arauca;591
+Sopetrán;Antioquia;761
+Hato;Santander;344
+Cravo Norte;Arauca;220
+Mogotes;Santander;464
+San Gil;Santander;679
+Maceo;Antioquia;425
+Palmas Del Socorro;Santander;524
+Girardota;Antioquia;308
+El Cocuy;Boyacá;244
+Boavita;Boyacá;097
+Caracolí;Antioquia;142
+Fredonia;Antioquia;282
+Paipa;Boyacá;516
+Nuquí;Chocó;495
+Cerinza;Boyacá;162
+Santa Bárbara;Antioquia;679
+Duitama;Boyacá;238
+La Belleza;Santander;377
+Alto Baudó (Pie De Pato);Chocó;025
+Puerto Triunfo;Antioquia;591
+La Macarena;Meta;350
+Hobo;Huila;349
+Algeciras;Huila;020
+Íquira;Huila;357
+Caldono;Cauca;137
+Jambaló;Cauca;364
+Cubará;Boyacá;223
+Saravena;Arauca;736
+Guaca;Santander;318
+Toledo;Antioquia;819
+Arauca;Arauca;001
+Piedecuesta;Santander;547
+San Vicente De Chucurí;Santander;689
+Floridablanca;Santander;276
+Betulia;Santander;092
+Dabeiba;Antioquia;234
+Campamento;Antioquia;134
+Girón;Santander;307
+Peque;Antioquia;543
+Briceño;Antioquia;107
+Barrancabermeja;Santander;081
+Tona;Santander;820
+Bucaramanga;Santander;001
+Remedios;Antioquia;604
+Amalfi;Antioquia;031
+Yondó (Casabe);Antioquia;893
+Silos;Norte De Santander;743
+Carmen Del Darién  (Curbaradó);Chocó;150
+Charta;Santander;169
+Saboyá;Boyacá;632
+Puerto Salgar;Cundinamarca;572
+Santa Sofía;Boyacá;696
+Betania;Antioquia;091
+Tópaga;Boyacá;820
+Gachantivá;Boyacá;293
+Cómbita;Boyacá;204
+Nobsa;Boyacá;491
+Amagá;Antioquia;030
+Sativasur;Boyacá;723
+Santana;Boyacá;686
+Socotá;Boyacá;755
+Paz De Ariporo;Casanare;250
+Tenjo;Cundinamarca;799
+Pereira;Risaralda;001
+Chía;Cundinamarca;175
+Murillo;Tolima;461
+Chivor;Boyacá;236
+La Virginia;Risaralda;400
+Bituima;Cundinamarca;095
+El Rosal;Cundinamarca;260
+Ambalema;Tolima;030
+Albán;Cundinamarca;019
+Gachetá;Cundinamarca;297
+Vianí;Cundinamarca;867
+Lérida;Tolima;408
+Santa Rosa De Cabal;Risaralda;682
+San Juan De Rioseco;Cundinamarca;662
+El Guacamayo;Santander;245
+Oiba;Santander;500
+Guatapé;Antioquia;321
+San Carlos;Antioquia;649
+Quibdó;Chocó;001
+La Salina;Casanare;136
+Peñol;Antioquia;541
+Guarne;Antioquia;318
+La Uvita;Boyacá;403
+Contratación;Santander;211
+Coromoro;Santander;217
+La Paz;Santander;397
+Charalá;Santander;167
+San Vicente;Antioquia;674
+Ocamonte;Santander;498
+San Rafael;Antioquia;667
+Confines;Santander;209
+Alejandría;Antioquia;021
+Ebéjico;Antioquia;240
+Bello;Antioquia;088
+Tibasosa;Boyacá;806
+La Pintada;Antioquia;390
+Yacopí;Cundinamarca;885
+Pore;Casanare;263
+Hispania;Antioquia;353
+Arcabuco;Boyacá;051
+Molagavita;Santander;468
+Barichara;Santander;079
+Chipatá;Santander;179
+Sácama;Casanare;315
+Carmen De Viboral;Antioquia;148
+Tutazá;Boyacá;839
+Concordia;Antioquia;209
+Sabaneta;Antioquia;631
+San Benito;Santander;673
+Sativanorte;Boyacá;720
+Envigado;Antioquia;266
+Angelópolis;Antioquia;036
+Retiro;Antioquia;607
+Suaita;Santander;770
+Jericó;Boyacá;368
+Puerto Berrío;Antioquia;579
+Carcasí;Santander;152
+Guicán;Boyacá;332
+Cimitarra;Santander;190
+Galán;Santander;296
+Málaga;Santander;432
+Belmira;Antioquia;086
+Liborina;Antioquia;411
+Bahía Solano (Mutis);Chocó;075
+Cepitá;Santander;160
+Carolina;Antioquia;150
+Aratoca;Santander;051
+Yolombó;Antioquia;890
+Vigia Del Fuerte;Antioquia;873
+Gómez Plata;Antioquia;310
+Chiscas;Boyacá;180
+Bojayá (Bellavista);Chocó;099
+Fortul;Arauca;300
+San José De La Montaña;Antioquia;658
+Puerto Parra;Santander;573
+Los Santos;Santander;418
+Simacota;Santander;745
+Buriticá;Antioquia;113
+Valencia;Córdoba;855
+San Jacinto Del Cauca;Bolívar;655
+Montecristo;Bolívar;458
+González;Cesar;310
+Arenal;Bolívar;042
+Gamarra;Cesar;295
+Ayapel;Córdoba;068
+Aguachica;Cesar;011
+Guaranda;Sucre;265
+Hacarí;Norte De Santander;344
+Cucutilla;Norte De Santander;223
+Planeta Rica;Córdoba;555
+San Pedro De Urabá;Antioquia;665
+Norosi;Bolívar;490
+Pueblo Nuevo;Córdoba;570
+Tiquisio (Puerto Rico);Bolívar;810
+Rioviejo;Bolívar;600
+Necoclí;Antioquia;490
+San Marcos;Sucre;708
+Majagual;Sucre;429
+San Juan De Urabá;Antioquia;659
+La Gloria;Cesar;383
+Canalete;Córdoba;090
+Cunday;Tolima;226
+Silvania;Cundinamarca;743
+Medio Atrato (Beté);Chocó;425
+La Primavera;Vichada;524
+Rionegro;Antioquia;615
+Aguada;Santander;013
+Marinilla;Antioquia;440
+Bolivar;Santander;101
+Puerto Nare;Antioquia;585
+Hato Corozal;Casanare;125
+Chita;Boyacá;183
+Florián;Santander;271
+Gámeza;Boyacá;296
+Sotaquirá;Boyacá;763
+Busbanzá;Boyacá;114
+Corrales;Boyacá;215
+Pueblorrico;Antioquia;576
+Jesús María;Santander;368
+Sonsón;Antioquia;756
+Puente Nacional;Santander;572
+Floresta;Boyacá;276
+Ciudad Bolívar;Antioquia;101
+Abejorral;Antioquia;002
+Moniquirá;Boyacá;469
+Montebello;Antioquia;467
+Betéitiva;Boyacá;092
+Togüí;Boyacá;816
+Giraldo;Antioquia;306
+Jordán;Santander;370
+Abriaquí;Antioquia;004
+Santa Lucía;Atlántico;675
+El Copey;Cesar;238
+Soplaviento;Bolívar;760
+San Cristobal;Bolívar;620
+Turbaco;Bolívar;836
+San Estanislao;Bolívar;647
+El Piñón;Magdalena;258
+Campo De La Cruz;Atlántico;137
+Manatí;Atlántico;436
+Regidor;Bolívar;580
+Achí;Bolívar;006
+Altos Del Rosario;Bolívar;030
+Arboletes;Antioquia;051
+Pelaya;Cesar;550
+Caimito;Sucre;124
+Los Córdobas;Córdoba;419
+Montería;Córdoba;001
+Barranco De Loba;Bolívar;074
+Cereté;Córdoba;162
+Ocaña;Norte De Santander;498
+Gámbita;Santander;298
+San Martin De Loba;Bolívar;667
+Sahagún;Córdoba;660
+Dibulla;La Guajira;090
+Santa Marta;Magdalena;001
+Mahates;Bolívar;433
+Vetas;Santander;867
+California;Santander;132
+Ituango;Antioquia;361
+Lebrija;Santander;406
+Cantagallo;Bolívar;160
+Valdivia;Antioquia;854
+Anorí;Antioquia;040
+Matanza;Santander;444
+Segovia;Antioquia;736
+Mutatá;Antioquia;480
+Herrán;Norte De Santander;347
+Pamplonita;Norte De Santander;520
+El Playón;Santander;255
+Ábrego;Norte De Santander;003
+Salazar;Norte De Santander;660
+Labateca;Norte De Santander;377
+Cerrito;Santander;162
+Chitagá;Norte De Santander;174
+Sabana De Torres;Santander;655
+Zaragoza;Antioquia;895
+Tarazá;Antioquia;790
+Chigorodó;Antioquia;172
+La Esperanza;Norte De Santander;385
+San Jose De Ure;Córdoba;682
+Cáceres;Antioquia;120
+San Alberto;Cesar;710
+El Bagre;Antioquia;250
+Hatillo De Loba;Bolívar;300
+Ciénaga De Oro;Córdoba;189
+Tamalameque;Cesar;787
+Pailitas;Cesar;517
+San Pelayo;Córdoba;686
+Gramalote;Norte De Santander;313
+Durania;Norte De Santander;239
+Cáchira;Norte De Santander;128
+Pamplona;Norte De Santander;518
+Chinácota;Norte De Santander;172
+Mercaderes;Cauca;450
+Macanal;Boyacá;425
+Magangué;Bolívar;430
+Subachoque;Cundinamarca;769
+Tenza;Boyacá;798
+Tibirita;Cundinamarca;807
+Armero (Guayabal);Tolima;055
+Garagoa;Boyacá;299
+Cogua;Cundinamarca;200
+Condoto;Chocó;205
+Apía;Risaralda;045
+Rio Iró (Santa Rita);Chocó;580
+La Peña;Cundinamarca;398
+Yopal;Casanare;001
+Ráquira;Boyacá;600
+Muzo;Boyacá;480
+Chivatá;Boyacá;187
+Iza;Boyacá;362
+Arroyohondo;Bolívar;062
+Arjona;Bolívar;052
+Suan;Atlántico;770
+San Diego;Cesar;750
+Cerro De San Antonio;Magdalena;161
+Algarrobo;Magdalena;030
+Mutiscua;Norte De Santander;480
+Jamundí;Valle Del Cauca;364
+Pinillos;Bolívar;549
+San Benito Abad;Sucre;678
+Puerto Escondido;Córdoba;574
+Cotorra;Córdoba;300
+Chinú;Córdoba;182
+El Roble;Sucre;233
+Margarita;Bolívar;440
+Galeras;Sucre;235
+San Fernando;Bolívar;650
+Sampués;Sucre;670
+San Andrés De Sotavento;Córdoba;670
+Mompós;Bolívar;468
+Tuchín;Córdoba;815
+Cicuco;Bolívar;188
+Moñitos;Córdoba;500
+Corozal;Sucre;215
+Momil;Córdoba;464
+Purísima;Córdoba;586
+El Banco;Magdalena;245
+Convención;Norte De Santander;206
+Teorama;Norte De Santander;800
+Lourdes;Norte De Santander;418
+Puerto Libertador;Córdoba;580
+Apartadó;Antioquia;045
+Caucasia;Antioquia;154
+El Zulia;Norte De Santander;261
+La Apartada;Córdoba;350
+Puerto Wilches;Santander;575
+Montelíbano;Córdoba;466
+Santa Rosa Del Sur;Bolívar;688
+Simití;Bolívar;744
+Nechí;Antioquia;495
+Tierralta;Córdoba;807
+Rio De Oro;Cesar;614
+La Playa;Norte De Santander;398
+Puerto Santander;Norte De Santander;553
+Repelón;Atlántico;606
+El Guamo;Bolívar;248
+Zapayán;Magdalena;960
+Tubará;Atlántico;832
+Sitionuevo;Magdalena;745
+Pijiño  Del Carmen;Magdalena;545
+Santa Ana;Magdalena;707
+Zambrano;Bolívar;894
+El Carmen De Bolívar;Bolívar;244
+Itagüí;Antioquia;360
+El Paso;Cesar;250
+San Jacinto;Bolívar;654
+Nueva Granada;Magdalena;460
+Ariguaní (El Dificil);Magdalena;058
+Tenerife;Magdalena;798
+Plato;Magdalena;555
+Bosconia;Cesar;060
+María La Baja;Bolívar;442
+San Juan Nepomuceno;Bolívar;657
+San Onofre;Sucre;713
+Chivolo;Magdalena;170
+Pedraza;Magdalena;541
+Juan De Acosta;Atlántico;372
+Malambo;Atlántico;433
+Villa Del Rosario;Norte De Santander;874
+Cúcuta;Norte De Santander;001
+El Encanto;Amazonas;263
+Arauquita;Arauca;065
+Taraira;Vaupés;666
+Pacoa (Cor. Departamental);Vaupés;511
+Puerto Leguízamo;Putumayo;573
+Puerto Asís;Putumayo;568
+Puerto Alegría;Amazonas;530
+Clemencia;Bolívar;222
+Pivijay;Magdalena;551
+Ponedera;Atlántico;560
+Pueblo Bello;Cesar;570
+Palmar De Varela;Atlántico;520
+Remolino;Magdalena;605
+Santo Tomás;Atlántico;685
+Piojó;Atlántico;549
+Sabanagrande;Atlántico;634
+Baranoa;Atlántico;078
+Valledupar;Cesar;001
+Aracataca;Magdalena;053
+Usiacurí;Atlántico;849
+Lorica;Córdoba;417
+Manaure;La Guajira;560
+San Andres Y  Providencia (Santa Isabel);San Andrés Providencia Y Santa Catalina;564
+Guachucal;Nariño;317
+Samaniego;Nariño;678
+Acevedo;Huila;006
+Motavita;Boyacá;476
+Sutamarchán;Boyacá;776
+Villa De Leiva;Boyacá;407
+Lloró;Chocó;413
+Paya;Boyacá;533
+Guayabal De Síquima;Cundinamarca;328
+Sopó;Cundinamarca;758
+Guatavita;Cundinamarca;326
+Tabio;Cundinamarca;785
+Otanche;Boyacá;507
+Tarso;Antioquia;792
+Tasco;Boyacá;790
+Guavatá;Santander;324
+Santa Rosa De Viterbo;Boyacá;693
+San José De Pare;Boyacá;664
+Carepa;Antioquia;147
+Ovejas;Sucre;508
+Fundación;Magdalena;288
+El Retén;Magdalena;268
+Polonuevo;Atlántico;558
+Puerto Arica;Amazonas;536
+Soledad;Atlántico;758
+Galapa;Atlántico;296
+Zona Bananera;Magdalena;980
+Puebloviejo;Magdalena;570
+Ciénaga;Magdalena;189
+Barranquilla;Atlántico;001
+Coveñas;Sucre;221
+Turbo;Antioquia;837
+Medellín;Antioquia;001
+Buenaventura;Valle Del Cauca;109
+La Estrella;Antioquia;380
+Mitú;Vaupés;001
+Yavaraté  (Cor. Departamental);Vaupés;889
+Cácota;Norte De Santander;125
+Luruaco;Atlántico;421
+Bucarasica;Norte De Santander;109
+Los Patios;Norte De Santander;405
+Arboledas;Norte De Santander;051
+Bochalema;Norte De Santander;099
+Ragonvalia;Norte De Santander;599
+Suratá;Santander;780
+Sabanas De San Angel;Magdalena;660
+Rondón;Boyacá;621
+El Tarra;Norte De Santander;250
+Villa Caro;Norte De Santander;871
+Sardinata;Norte De Santander;720
+Siachoque;Boyacá;740
+Tibaná;Boyacá;804
+Ramiriquí;Boyacá;599
+Úmbita;Boyacá;842
+Viracachá;Boyacá;879
+Chinavita;Boyacá;172
+Pauna;Boyacá;531
+Tununguá;Boyacá;832
+Cabuyaro;Meta;124
+Puerto López;Meta;573
+Puerto Colombia;Atlántico;573
+Tarapacá;Amazonas;798
+Becerrill;Cesar;045
+Tibú;Norte De Santander;810
+Chiriguaná;Cesar;178
+Hato Nuevo;La Guajira;378
+Fonseca;La Guajira;279
+Agustín Codazzi;Cesar;013
+La Jagua De Ibirico;Cesar;400
+La Jagua Del Pilar;La Guajira;420
+El Molino;La Guajira;110
+Urumita;La Guajira;855
+Manaure Balcón Del Cesar;Cesar;443
+Ipiales;Nariño;356
+Curumaní;Cesar;228
+Puerto Nariño;Amazonas;540
+Uribia;La Guajira;847
+Juradó;Chocó;372
+Acandí;Chocó;006
+Unguía;Chocó;800
+Barrancas;La Guajira;078
+Distracción;La Guajira;098
+San Juan Del Cesar;La Guajira;650
+Riohacha;La Guajira;001
+Maicao;La Guajira;430
+La Guadalupe;Guainía;885
+Cartagena De Indias;Bolívar;001
+Turbana;Bolívar;838
+Santa Catalina;Bolívar;673
+Tumaco;Nariño;835
+Leticia;Amazonas;001

--- a/backend/db/seeds/files/colombia_regions.csv
+++ b/backend/db/seeds/files/colombia_regions.csv
@@ -1,1124 +1,1043 @@
 municipality;Cordillera Oriental;Piedemonte Amazónico - Macizo;Transición Pacífico - Caribe;Transición Orinoquía;Cordillera Central;Pacífico - Marino Costero;Caribe;Orinoquía;Corazón Amazonía
-El Encanto;False;False;False;False;False;False;False;False;False
-La Chorrera;False;False;False;False;False;False;False;False;False
-La Pedrera;False;False;False;False;False;False;False;False;False
-La Victoria (Pacoa);False;False;False;False;False;False;False;False;False
-Leticia;False;False;False;False;False;False;False;False;False
-Mirití-paraná (Campoamor);False;False;False;False;False;False;False;False;False
-Puerto Alegría;False;False;False;False;False;False;False;False;False
-Puerto Arica;False;False;False;False;False;False;False;False;False
-Puerto Nariño;False;False;False;False;False;False;False;False;False
-Santander (Araracuara);False;False;False;False;False;False;False;False;False
-Tarapacá;False;False;False;False;False;False;False;False;False
-Abejorral;False;False;False;False;False;False;False;False;False
-Abriaquí;False;False;False;False;False;False;False;False;False
-Alejandría;False;False;False;False;False;False;False;False;False
-Amagá;False;False;False;False;False;False;False;False;False
-Amalfi;False;False;False;False;False;False;False;False;False
-Andes;False;False;False;False;False;False;False;False;False
-Angelópolis;False;False;False;False;False;False;False;False;False
-Angostura;False;False;False;False;False;False;False;False;False
-Anorí;False;False;False;False;False;False;False;False;False
-Anzá;False;False;False;False;False;False;False;False;False
-Apartadó;False;False;False;False;False;False;False;False;False
-Arboletes;False;False;False;False;False;False;False;False;False
-Argelia;False;False;False;False;False;False;False;False;False
-Armenia;False;False;False;False;False;False;False;False;False
-Barbosa;False;False;False;False;False;False;False;False;False
-Bello;False;False;False;False;False;False;False;False;False
-Belmira;False;False;False;False;False;False;False;False;False
-Betania;False;False;False;False;False;False;False;False;False
-Betulia;False;False;False;False;False;False;False;False;False
-Briceño;False;False;False;False;False;False;False;False;False
-Buriticá;False;False;False;False;False;False;False;False;False
-Cáceres;False;False;False;False;False;False;False;False;False
-Caicedo;False;False;False;False;False;False;False;False;False
-Caldas;False;False;False;False;False;False;False;False;False
-Campamento;False;False;False;False;False;False;False;False;False
-Cañasgordas;False;False;False;False;False;False;False;False;False
-Caracolí;False;False;False;False;False;False;False;False;False
-Caramanta;False;False;False;False;False;False;False;False;False
-Carepa;False;False;False;False;False;False;False;False;False
-Carmen De Viboral;False;False;False;False;False;False;False;False;False
-Carolina;False;False;False;False;False;False;False;False;False
-Caucasia;False;False;False;False;False;False;False;False;False
-Chigorodó;False;False;False;False;False;False;False;False;False
-Cisneros;False;False;False;False;False;False;False;False;False
-Ciudad Bolívar;False;False;False;False;False;False;False;False;False
-Cocorná;False;False;False;False;False;False;False;False;False
-Concepción;False;False;False;False;False;False;False;False;False
-Concordia;False;False;False;False;False;False;False;False;False
-Copacabana;False;False;False;False;False;False;False;False;False
-Dabeiba;False;False;False;False;False;False;False;False;False
-Don Matías;False;False;False;False;False;False;False;False;False
-Ebéjico;False;False;False;False;False;False;False;False;False
-El Bagre;False;False;False;False;False;False;False;False;False
-Entrerrios;False;False;False;False;False;False;False;False;False
-Envigado;False;False;False;False;False;False;False;False;False
-Fredonia;False;False;False;False;False;False;False;False;False
-Frontino;False;False;False;False;False;False;False;False;False
-Giraldo;False;False;False;False;False;False;False;False;False
-Girardota;False;False;False;False;False;False;False;False;False
-Gómez Plata;False;False;False;False;False;False;False;False;False
-Granada;False;False;False;False;False;False;False;False;False
-Guadalupe;False;False;False;False;False;False;False;False;False
-Guarne;False;False;False;False;False;False;False;False;False
-Guatapé;False;False;False;False;False;False;False;False;False
-Heliconia;False;False;False;False;False;False;False;False;False
-Hispania;False;False;False;False;False;False;False;False;False
-Itagüí;False;False;False;False;False;False;False;False;False
-Ituango;False;False;False;False;False;False;False;False;False
-Jardín;False;False;False;False;False;False;False;False;False
-Jericó;False;False;False;False;False;False;False;False;False
-La Ceja;False;False;False;False;False;False;False;False;False
-La Estrella;False;False;False;False;False;False;False;False;False
-La Pintada;False;False;False;False;False;False;False;False;False
-La Unión;False;False;False;False;False;False;False;False;False
-Liborina;False;False;False;False;False;False;False;False;False
-Maceo;False;False;False;False;False;False;False;False;False
-Marinilla;False;False;False;False;False;False;False;False;False
-Medellín;False;False;False;False;False;False;False;False;False
-Montebello;False;False;False;False;False;False;False;False;False
-Murindó;False;False;False;False;False;False;False;False;False
-Mutatá;False;False;False;False;False;False;False;False;False
-Nariño;False;False;False;False;False;False;False;False;False
-Nechí;False;False;False;False;False;False;False;False;False
-Necoclí;False;False;False;False;False;False;False;False;False
-Olaya;False;False;False;False;False;False;False;False;False
-Peñol;False;False;False;False;False;False;False;False;False
-Peque;False;False;False;False;False;False;False;False;False
-Pueblorrico;False;False;False;False;False;False;False;False;False
-Puerto Berrío;False;False;False;False;False;False;False;False;False
-Puerto Nare;False;False;False;False;False;False;False;False;False
-Puerto Triunfo;False;False;False;False;False;False;False;False;False
-Remedios;False;False;False;False;False;False;False;False;False
-Retiro;False;False;False;False;False;False;False;False;False
-Rionegro;False;False;False;False;False;False;False;False;False
-Sabanalarga;False;False;False;False;False;False;False;False;False
-Sabaneta;False;False;False;False;False;False;False;False;False
-Salgar;False;False;False;False;False;False;False;False;False
-San Andrés;False;False;False;False;False;False;False;False;False
-San Carlos;False;False;False;False;False;False;False;False;False
-San Francisco;False;False;False;False;False;False;False;False;False
-San Jerónimo;False;False;False;False;False;False;False;False;False
-San José De La Montaña;False;False;False;False;False;False;False;False;False
-San Juan De Urabá;False;False;False;False;False;False;False;False;False
-San Luis;False;False;False;False;False;False;False;False;False
-San Pedro;False;False;False;False;False;False;False;False;False
-San Pedro De Urabá;False;False;False;False;False;False;False;False;False
-San Rafael;False;False;False;False;False;False;False;False;False
-San Roque;False;False;False;False;False;False;False;False;False
-San Vicente;False;False;False;False;False;False;False;False;False
-Santa Bárbara;False;False;False;False;False;False;False;False;False
-Santa Fe De Antioquia;False;False;False;False;False;False;False;False;False
-Santa Rosa De Osos;False;False;False;False;False;False;False;False;False
-Santo Domingo;False;False;False;False;False;False;False;False;False
-Santuario;False;False;False;False;False;False;False;False;False
-Segovia;False;False;False;False;False;False;False;False;False
-Sonsón;False;False;False;False;False;False;False;False;False
-Sopetrán;False;False;False;False;False;False;False;False;False
-Támesis;False;False;False;False;False;False;False;False;False
-Tarazá;False;False;False;False;False;False;False;False;False
-Tarso;False;False;False;False;False;False;False;False;False
-Titiribí;False;False;False;False;False;False;False;False;False
-Toledo;False;False;False;False;False;False;False;False;False
-Turbo;False;False;False;False;False;False;False;False;False
-Uramita;False;False;False;False;False;False;False;False;False
-Urrao;False;False;False;False;False;False;False;False;False
-Valdivia;False;False;False;False;False;False;False;False;False
-Valparaiso;False;False;False;False;False;False;False;False;False
-Vegachí;False;False;False;False;False;False;False;False;False
-Venecia;False;False;False;False;False;False;False;False;False
-Vigia Del Fuerte;False;False;False;False;False;False;False;False;False
-Yalí;False;False;False;False;False;False;False;False;False
-Yarumal;False;False;False;False;False;False;False;False;False
-Yolombó;False;False;False;False;False;False;False;False;False
-Yondó (Casabe);False;False;False;False;False;False;False;False;False
-Zaragoza;False;False;False;False;False;False;False;False;False
-Arauca;False;False;False;False;False;False;False;False;False
-Arauquita;False;False;False;False;False;False;False;False;False
-Cravo Norte;False;False;False;False;False;False;False;False;False
-Fortul;False;False;False;False;False;False;False;False;False
-Puerto Rondón;False;False;False;False;False;False;False;False;False
-Saravena;False;False;False;False;False;False;False;False;False
-Tame;False;False;False;False;False;False;False;False;False
-Baranoa;False;False;False;False;False;False;False;False;False
-Barranquilla;False;False;False;False;False;False;False;False;False
-Campo De La Cruz;False;False;False;False;False;False;False;False;False
-Candelaria;False;False;False;False;False;False;False;False;False
-Galapa;False;False;False;False;False;False;False;False;False
-Juan De Acosta;False;False;False;False;False;False;False;False;False
-Luruaco;False;False;False;False;False;False;False;False;False
-Malambo;False;False;False;False;False;False;False;False;False
-Manatí;False;False;False;False;False;False;False;False;False
-Palmar De Varela;False;False;False;False;False;False;False;False;False
-Piojó;False;False;False;False;False;False;False;False;False
-Polonuevo;False;False;False;False;False;False;False;False;False
-Ponedera;False;False;False;False;False;False;False;False;False
-Puerto Colombia;False;False;False;False;False;False;False;False;False
-Repelón;False;False;False;False;False;False;False;False;False
-Sabanagrande;False;False;False;False;False;False;False;False;False
-Sabanalarga;False;False;False;False;False;False;False;False;False
-Santa Lucía;False;False;False;False;False;False;False;False;False
-Santo Tomás;False;False;False;False;False;False;False;False;False
-Soledad;False;False;False;False;False;False;False;False;False
-Suan;False;False;False;False;False;False;False;False;False
-Tubará;False;False;False;False;False;False;False;False;False
-Usiacurí;False;False;False;False;False;False;False;False;False
-Achí;False;False;False;False;False;False;False;False;False
-Altos Del Rosario;False;False;False;False;False;False;False;False;False
-Arenal;False;False;False;False;False;False;False;False;False
-Arjona;False;False;False;False;False;False;False;False;False
-Arroyohondo;False;False;False;False;False;False;False;False;False
-Barranco De Loba;False;False;False;False;False;False;False;False;False
-Calamar;False;False;False;False;False;False;False;False;False
-Cantagallo;False;False;False;False;False;False;False;False;False
-Cartagena De Indias;False;False;False;False;False;False;False;False;False
-Cicuco;False;False;False;False;False;False;False;False;False
-Clemencia;False;False;False;False;False;False;False;False;False
-Córdoba;False;False;False;False;False;False;False;False;False
-El Carmen De Bolívar;False;False;False;False;False;False;False;False;False
-El Guamo;False;False;False;False;False;False;False;False;False
-El Peñón;False;False;False;False;False;False;False;False;False
-Hatillo De Loba;False;False;False;False;False;False;False;False;False
-Magangué;False;False;False;False;False;False;False;False;False
-Mahates;False;False;False;False;False;False;False;False;False
-Margarita;False;False;False;False;False;False;False;False;False
-María La Baja;False;False;False;False;False;False;False;False;False
-Mompós;False;False;False;False;False;False;False;False;False
-Montecristo;False;False;False;False;False;False;False;False;False
-Morales;False;False;False;False;False;False;False;False;False
-Norosi;False;False;False;False;False;False;False;False;False
-Pinillos;False;False;False;False;False;False;False;False;False
-Regidor;False;False;False;False;False;False;False;False;False
-Rioviejo;False;False;False;False;False;False;False;False;False
-San Cristobal;False;False;False;False;False;False;False;False;False
-San Estanislao;False;False;False;False;False;False;False;False;False
-San Fernando;False;False;False;False;False;False;False;False;False
-San Jacinto;False;False;False;False;False;False;False;False;False
-San Jacinto Del Cauca;False;False;False;False;False;False;False;False;False
-San Juan Nepomuceno;False;False;False;False;False;False;False;False;False
-San Martin De Loba;False;False;False;False;False;False;False;False;False
-San Pablo;False;False;False;False;False;False;False;False;False
-Santa Catalina;False;False;False;False;False;False;False;False;False
-Santa Rosa;False;False;False;False;False;False;False;False;False
-Santa Rosa Del Sur;False;False;False;False;False;False;False;False;False
-Simití;False;False;False;False;False;False;False;False;False
-Soplaviento;False;False;False;False;False;False;False;False;False
-Talaigua Nuevo;False;False;False;False;False;False;False;False;False
-Tiquisio (Puerto Rico);False;False;False;False;False;False;False;False;False
-Turbaco;False;False;False;False;False;False;False;False;False
-Turbana;False;False;False;False;False;False;False;False;False
-Villanueva;False;False;False;False;False;False;False;False;False
-Zambrano;False;False;False;False;False;False;False;False;False
-Almeida;False;False;False;False;False;False;False;False;False
-Aquitania;False;False;False;False;False;False;False;False;False
-Arcabuco;False;False;False;False;False;False;False;False;False
-Belén;False;False;False;False;False;False;False;False;False
-Berbeo;False;False;False;False;False;False;False;False;False
-Betéitiva;False;False;False;False;False;False;False;False;False
-Boavita;False;False;False;False;False;False;False;False;False
-Boyacá;False;False;False;False;False;False;False;False;False
-Briceño;False;False;False;False;False;False;False;False;False
-Buenavista;False;False;False;False;False;False;False;False;False
-Busbanzá;False;False;False;False;False;False;False;False;False
-Caldas;False;False;False;False;False;False;False;False;False
-Campohermoso;False;False;False;False;False;False;False;False;False
-Cerinza;False;False;False;False;False;False;False;False;False
-Chinavita;False;False;False;False;False;False;False;False;False
-Chiquinquirá;False;False;False;False;False;False;False;False;False
-Chíquiza;False;False;False;False;False;False;False;False;False
-Chiscas;False;False;False;False;False;False;False;False;False
-Chita;False;False;False;False;False;False;False;False;False
-Chitaraque;False;False;False;False;False;False;False;False;False
-Chivatá;False;False;False;False;False;False;False;False;False
-Chivor;False;False;False;False;False;False;False;False;False
-Ciénega;False;False;False;False;False;False;False;False;False
-Cómbita;False;False;False;False;False;False;False;False;False
-Coper;False;False;False;False;False;False;False;False;False
-Corrales;False;False;False;False;False;False;False;False;False
-Covarachía;False;False;False;False;False;False;False;False;False
-Cubará;False;False;False;False;False;False;False;False;False
-Cucaita;False;False;False;False;False;False;False;False;False
-Cuítiva;False;False;False;False;False;False;False;False;False
-Duitama;False;False;False;False;False;False;False;False;False
-El Cocuy;False;False;False;False;False;False;False;False;False
-El Espino;False;False;False;False;False;False;False;False;False
-Firavitoba;False;False;False;False;False;False;False;False;False
-Floresta;False;False;False;False;False;False;False;False;False
-Gachantivá;False;False;False;False;False;False;False;False;False
-Gámeza;False;False;False;False;False;False;False;False;False
-Garagoa;False;False;False;False;False;False;False;False;False
-Guacamayas;False;False;False;False;False;False;False;False;False
-Guateque;False;False;False;False;False;False;False;False;False
-Guayatá;False;False;False;False;False;False;False;False;False
-Guicán;False;False;False;False;False;False;False;False;False
-Iza;False;False;False;False;False;False;False;False;False
-Jenesano;False;False;False;False;False;False;False;False;False
-Jericó;False;False;False;False;False;False;False;False;False
-La Capilla;False;False;False;False;False;False;False;False;False
-La Uvita;False;False;False;False;False;False;False;False;False
-La Victoria;False;False;False;False;False;False;False;False;False
-Labranzagrande;False;False;False;False;False;False;False;False;False
-Macanal;False;False;False;False;False;False;False;False;False
-Maripí;False;False;False;False;False;False;False;False;False
-Miraflores;False;False;False;False;False;False;False;False;False
-Mongua;False;False;False;False;False;False;False;False;False
-Monguí;False;False;False;False;False;False;False;False;False
-Moniquirá;False;False;False;False;False;False;False;False;False
-Motavita;False;False;False;False;False;False;False;False;False
-Muzo;False;False;False;False;False;False;False;False;False
-Nobsa;False;False;False;False;False;False;False;False;False
-Nuevo Colón;False;False;False;False;False;False;False;False;False
-Oicatá;False;False;False;False;False;False;False;False;False
-Otanche;False;False;False;False;False;False;False;False;False
-Pachavita;False;False;False;False;False;False;False;False;False
-Páez;False;False;False;False;False;False;False;False;False
-Paipa;False;False;False;False;False;False;False;False;False
-Pajarito;False;False;False;False;False;False;False;False;False
-Panqueba;False;False;False;False;False;False;False;False;False
-Pauna;False;False;False;False;False;False;False;False;False
-Paya;False;False;False;False;False;False;False;False;False
-Paz De Rio;False;False;False;False;False;False;False;False;False
-Pesca;False;False;False;False;False;False;False;False;False
-Pisva;False;False;False;False;False;False;False;False;False
-Puerto Boyacá;False;False;False;False;False;False;False;False;False
-Quípama;False;False;False;False;False;False;False;False;False
-Ramiriquí;False;False;False;False;False;False;False;False;False
-Ráquira;False;False;False;False;False;False;False;False;False
-Rondón;False;False;False;False;False;False;False;False;False
-Saboyá;False;False;False;False;False;False;False;False;False
-Sáchica;False;False;False;False;False;False;False;False;False
-Samacá;False;False;False;False;False;False;False;False;False
-San Eduardo;False;False;False;False;False;False;False;False;False
-San José De Pare;False;False;False;False;False;False;False;False;False
-San Luis De Gaceno;False;False;False;False;False;False;False;False;False
-San Mateo;False;False;False;False;False;False;False;False;False
-San Miguel De Sema;False;False;False;False;False;False;False;False;False
-San Pablo De Borbur;False;False;False;False;False;False;False;False;False
-Santa María;False;False;False;False;False;False;False;False;False
-Santa Rosa De Viterbo;False;False;False;False;False;False;False;False;False
-Santa Sofía;False;False;False;False;False;False;False;False;False
-Santana;False;False;False;False;False;False;False;False;False
-Sativanorte;False;False;False;False;False;False;False;False;False
-Sativasur;False;False;False;False;False;False;False;False;False
-Siachoque;False;False;False;False;False;False;False;False;False
-Soatá;False;False;False;False;False;False;False;False;False
-Socha;False;False;False;False;False;False;False;False;False
-Socotá;False;False;False;False;False;False;False;False;False
-Sogamoso;False;False;False;False;False;False;False;False;False
-Somondoco;False;False;False;False;False;False;False;False;False
-Sora;False;False;False;False;False;False;False;False;False
-Soracá;False;False;False;False;False;False;False;False;False
-Sotaquirá;False;False;False;False;False;False;False;False;False
-Susacón;False;False;False;False;False;False;False;False;False
-Sutamarchán;False;False;False;False;False;False;False;False;False
-Sutatenza;False;False;False;False;False;False;False;False;False
-Tasco;False;False;False;False;False;False;False;False;False
-Tenza;False;False;False;False;False;False;False;False;False
-Tibaná;False;False;False;False;False;False;False;False;False
-Tibasosa;False;False;False;False;False;False;False;False;False
-Tinjacá;False;False;False;False;False;False;False;False;False
-Tipacoque;False;False;False;False;False;False;False;False;False
-Toca;False;False;False;False;False;False;False;False;False
-Togüí;False;False;False;False;False;False;False;False;False
-Tópaga;False;False;False;False;False;False;False;False;False
-Tota;False;False;False;False;False;False;False;False;False
-Tunja;False;False;False;False;False;False;False;False;False
-Tununguá;False;False;False;False;False;False;False;False;False
-Turmequé;False;False;False;False;False;False;False;False;False
-Tuta;False;False;False;False;False;False;False;False;False
-Tutazá;False;False;False;False;False;False;False;False;False
-Úmbita;False;False;False;False;False;False;False;False;False
-Ventaquemada;False;False;False;False;False;False;False;False;False
-Villa De Leiva;False;False;False;False;False;False;False;False;False
-Viracachá;False;False;False;False;False;False;False;False;False
-Zetaquirá;False;False;False;False;False;False;False;False;False
-Aguadas;False;False;False;False;False;False;False;False;False
-Anserma;False;False;False;False;False;False;False;False;False
-Aranzazu;False;False;False;False;False;False;False;False;False
-Belalcazar;False;False;False;False;False;False;False;False;False
-Chinchiná;False;False;False;False;False;False;False;False;False
-Filadelfia;False;False;False;False;False;False;False;False;False
-La Dorada;False;False;False;False;False;False;False;False;False
-La Merced;False;False;False;False;False;False;False;False;False
-Manizales;False;False;False;False;False;False;False;False;False
-Manzanares;False;False;False;False;False;False;False;False;False
-Marmato;False;False;False;False;False;False;False;False;False
-Marquetalia;False;False;False;False;False;False;False;False;False
-Marulanda;False;False;False;False;False;False;False;False;False
-Neira;False;False;False;False;False;False;False;False;False
-Norcasia;False;False;False;False;False;False;False;False;False
-Pácora;False;False;False;False;False;False;False;False;False
-Palestina;False;False;False;False;False;False;False;False;False
-Pensilvania;False;False;False;False;False;False;False;False;False
-Riosucio;False;False;False;False;False;False;False;False;False
-Risaralda;False;False;False;False;False;False;False;False;False
-Salamina;False;False;False;False;False;False;False;False;False
-Samaná;False;False;False;False;False;False;False;False;False
-San José;False;False;False;False;False;False;False;False;False
-Supia;False;False;False;False;False;False;False;False;False
-Victoria;False;False;False;False;False;False;False;False;False
-Villamaria;False;False;False;False;False;False;False;False;False
-Viterbo;False;False;False;False;False;False;False;False;False
-Albania;False;False;False;False;False;False;False;False;False
-Belén De Los Andaquíes;False;False;False;False;False;False;False;False;False
-Cartagena Del Chairá;False;False;False;False;False;False;False;False;False
-Curillo;False;False;False;False;False;False;False;False;False
-El Doncello;False;False;False;False;False;False;False;False;False
-El Paujil;False;False;False;False;False;False;False;False;False
-Florencia;False;False;False;False;False;False;False;False;False
-Milán;False;False;False;False;False;False;False;False;False
-Montañita;False;False;False;False;False;False;False;False;False
-Morelia;False;False;False;False;False;False;False;False;False
-Puerto Rico;False;False;False;False;False;False;False;False;False
-San José Del Fragua;False;False;False;False;False;False;False;False;False
-San Vicente Del Caguán;False;False;False;False;False;False;False;False;False
-Solano;False;False;False;False;False;False;False;False;False
-Solita;False;False;False;False;False;False;False;False;False
-Valparaíso;False;False;False;False;False;False;False;False;False
-Aguazul;False;False;False;False;False;False;False;False;False
-Chámeza;False;False;False;False;False;False;False;False;False
-Hato Corozal;False;False;False;False;False;False;False;False;False
-La Salina;False;False;False;False;False;False;False;False;False
-Maní;False;False;False;False;False;False;False;False;False
-Monterrey;False;False;False;False;False;False;False;False;False
-Nunchía;False;False;False;False;False;False;False;False;False
-Orocué;False;False;False;False;False;False;False;False;False
-Paz de Ariporo;False;False;False;False;False;False;False;False;False
-Pore;False;False;False;False;False;False;False;False;False
-Recetor;False;False;False;False;False;False;False;False;False
-Sabanalarga;False;False;False;False;False;False;False;False;False
-Sácama;False;False;False;False;False;False;False;False;False
-San Luis De Palenque;False;False;False;False;False;False;False;False;False
-Támara;False;False;False;False;False;False;False;False;False
-Tauramena;False;False;False;False;False;False;False;False;False
-Trinidad;False;False;False;False;False;False;False;False;False
-Villanueva;False;False;False;False;False;False;False;False;False
-Yopal;False;False;False;False;False;False;False;False;False
-Almaguer;False;False;False;False;False;False;False;False;False
-Argelia;False;False;False;False;False;False;False;False;False
-Balboa;False;False;False;False;False;False;False;False;False
-Bolívar;False;False;False;False;False;False;False;False;False
-Buenos Aires;False;False;False;False;False;False;False;False;False
-Cajibío;False;False;False;False;False;False;False;False;False
-Caldono;False;False;False;False;False;False;False;False;False
-Caloto;False;False;False;False;False;False;False;False;False
-Corinto;False;False;False;False;False;False;False;False;False
-El Tambo;False;False;False;False;False;False;False;False;False
-Florencia;False;False;False;False;False;False;False;False;False
-Guachene;False;False;False;False;False;False;False;False;False
-Guapi;False;False;False;False;False;False;False;False;False
-Inzá;False;False;False;False;False;False;False;False;False
-Jambaló;False;False;False;False;False;False;False;False;False
-La Sierra;False;False;False;False;False;False;False;False;False
-La Vega;False;False;False;False;False;False;False;False;False
-López;False;False;False;False;False;False;False;False;False
-Mercaderes;False;False;False;False;False;False;False;False;False
-Miranda;False;False;False;False;False;False;False;False;False
-Morales;False;False;False;False;False;False;False;False;False
-Padilla;False;False;False;False;False;False;False;False;False
-Páez (Belalcázar);False;False;False;False;False;False;False;False;False
-Patía (El Bordo);False;False;False;False;False;False;False;False;False
-Piamonte;False;False;False;False;False;False;False;False;False
-Piendamó;False;False;False;False;False;False;False;False;False
-Popayán;False;False;False;False;False;False;False;False;False
-Puerto Tejada;False;False;False;False;False;False;False;False;False
-Puracé (Coconuco);False;False;False;False;False;False;False;False;False
-Rosas;False;False;False;False;False;False;False;False;False
-San Sebastián;False;False;False;False;False;False;False;False;False
-Santa Rosa;False;False;False;False;False;False;False;False;False
-Santander De Quilichao;False;False;False;False;False;False;False;False;False
-Silvia;False;False;False;False;False;False;False;False;False
-Sotará (Paispamba);False;False;False;False;False;False;False;False;False
+Potosí;False;False;False;False;False;False;False;False;False
+Puerto Caicedo;False;True;False;False;False;False;False;False;False
+Córdoba;False;False;False;False;True;False;False;False;False
+Puerres;False;True;False;False;False;False;False;False;False
+Orito;False;True;False;False;False;False;False;False;False
+Contadero;False;False;False;False;False;False;False;False;False
+Carmen De Apicalá;False;False;False;False;False;False;False;False;False
+Espinal;False;False;False;False;False;False;False;False;False
+Guamo;False;False;False;False;False;False;False;False;False
 Suárez;False;False;False;False;False;False;False;False;False
-Sucre;False;False;False;False;False;False;False;False;False
-Timbío;False;False;False;False;False;False;False;False;False
-Timbiquí;False;False;False;False;False;False;False;False;False
-Toribío;False;False;False;False;False;False;False;False;False
-Totoró;False;False;False;False;False;False;False;False;False
-Villa Rica;False;False;False;False;False;False;False;False;False
-Aguachica;False;False;False;False;False;False;False;False;False
-Agustín Codazzi;False;False;False;False;False;False;False;False;False
-Astrea;False;False;False;False;False;False;False;False;False
-Becerrill;False;False;False;False;False;False;False;False;False
-Bosconia;False;False;False;False;False;False;False;False;False
-Chimichagua;False;False;False;False;False;False;False;False;False
-Chiriguaná;False;False;False;False;False;False;False;False;False
-Curumaní;False;False;False;False;False;False;False;False;False
-El Copey;False;False;False;False;False;False;False;False;False
-El Paso;False;False;False;False;False;False;False;False;False
-Gamarra;False;False;False;False;False;False;False;False;False
-González;False;False;False;False;False;False;False;False;False
-La Gloria;False;False;False;False;False;False;False;False;False
-La Jagua De Ibirico;False;False;False;False;False;False;False;False;False
-La Paz;False;False;False;False;False;False;False;False;False
-Manaure Balcón Del Cesar;False;False;False;False;False;False;False;False;False
-Pailitas;False;False;False;False;False;False;False;False;False
-Pelaya;False;False;False;False;False;False;False;False;False
-Pueblo Bello;False;False;False;False;False;False;False;False;False
-Rio De Oro;False;False;False;False;False;False;False;False;False
-San Alberto;False;False;False;False;False;False;False;False;False
-San Diego;False;False;False;False;False;False;False;False;False
-San Martín;False;False;False;False;False;False;False;False;False
-Tamalameque;False;False;False;False;False;False;False;False;False
-Valledupar;False;False;False;False;False;False;False;False;False
-Acandí;False;False;False;False;False;False;False;False;False
-Alto Baudó (Pie De Pato);False;False;False;False;False;False;False;False;False
-Atrato (Yuto);False;False;False;False;False;False;False;False;False
-Bagadó;False;False;False;False;False;False;False;False;False
-Bahía Solano (Mutis);False;False;False;False;False;False;False;False;False
-Bajo Baudó (Pizarro);False;False;False;False;False;False;False;False;False
-Bojayá (Bellavista);False;False;False;False;False;False;False;False;False
-Carmen Del Darién (Curbaradó);False;False;False;False;False;False;False;False;False
-Cértegui;False;False;False;False;False;False;False;False;False
-Condoto;False;False;False;False;False;False;False;False;False
-El Cantón Del San Pablo (Managrú);False;False;False;False;False;False;False;False;False
-El Carmen;False;False;False;False;False;False;False;False;False
-El Litoral Del San Juán (Docordó);False;False;False;False;False;False;False;False;False
-Istmina;False;False;False;False;False;False;False;False;False
-Juradó;False;False;False;False;False;False;False;False;False
-Lloró;False;False;False;False;False;False;False;False;False
-Medio Atrato (Beté);False;False;False;False;False;False;False;False;False
-Medio Baudó(boca De Pepé);False;False;False;False;False;False;False;False;False
-Medio San Juan (Andagoya);False;False;False;False;False;False;False;False;False
-Nóvita;False;False;False;False;False;False;False;False;False
-Nuquí;False;False;False;False;False;False;False;False;False
-Quibdó;False;False;False;False;False;False;False;False;False
-Rio Iró (Santa Rita);False;False;False;False;False;False;False;False;False
-Rio Quito (Paimadó);False;False;False;False;False;False;False;False;False
-Riosucio;False;False;False;False;False;False;False;False;False
-San José Del Palmar;False;False;False;False;False;False;False;False;False
-Sipí;False;False;False;False;False;False;False;False;False
-Tadó;False;False;False;False;False;False;False;False;False
-Unguía;False;False;False;False;False;False;False;False;False
-Unión Panamericana ( Animas);False;False;False;False;False;False;False;False;False
-Ayapel;False;False;False;False;False;False;False;False;False
+Icononzo;False;False;False;False;False;False;False;False;False
+Melgar;False;False;False;False;False;False;False;False;False
+Valle De San Juan;False;False;False;False;False;False;False;False;False
+Roncesvalles;False;False;False;False;True;False;False;False;False
+Villavicencio;False;False;False;True;False;False;False;False;False
+Arbeláez;False;False;False;True;False;False;False;False;False
+Flandes;False;False;False;False;False;False;False;False;False
+Gutiérrez;False;False;False;True;False;False;False;False;False
+Trujillo;False;False;False;False;True;False;False;False;False
+Génova;False;False;False;False;True;False;False;False;False
+Bugalagrande;False;False;False;False;True;False;False;False;False
+San Luis;False;False;False;False;False;False;False;False;False
+Rovira;False;False;False;False;True;False;False;False;False
+Guayabetal;False;False;False;True;False;False;False;False;False
+Fosca;False;False;False;True;False;False;False;False;False
+Nilo;False;False;False;False;False;False;False;False;False
+Cumaral;False;False;False;True;False;False;False;False;False
+Pijao;False;False;False;False;True;False;False;False;False
+Ricaurte;False;False;False;False;False;False;False;False;False
+Tibacuy;False;False;False;False;False;False;False;False;False
+Pasca;False;False;False;True;False;False;False;False;False
 Buenavista;False;False;False;False;False;False;False;False;False
-Canalete;False;False;False;False;False;False;False;False;False
-Cereté;False;False;False;False;False;False;False;False;False
-Chima;False;False;False;False;False;False;False;False;False
-Chinú;False;False;False;False;False;False;False;False;False
-Ciénaga De Oro;False;False;False;False;False;False;False;False;False
-Cotorra;False;False;False;False;False;False;False;False;False
-La Apartada;False;False;False;False;False;False;False;False;False
-Lorica;False;False;False;False;False;False;False;False;False
-Los Córdobas;False;False;False;False;False;False;False;False;False
-Momil;False;False;False;False;False;False;False;False;False
-Moñitos;False;False;False;False;False;False;False;False;False
-Montelíbano;False;False;False;False;False;False;False;False;False
-Montería;False;False;False;False;False;False;False;False;False
-Planeta Rica;False;False;False;False;False;False;False;False;False
-Pueblo Nuevo;False;False;False;False;False;False;False;False;False
-Puerto Escondido;False;False;False;False;False;False;False;False;False
-Puerto Libertador;False;False;False;False;False;False;False;False;False
-Purísima;False;False;False;False;False;False;False;False;False
-Sahagún;False;False;False;False;False;False;False;False;False
-San Andrés De Sotavento;False;False;False;False;False;False;False;False;False
+Quetame;False;False;False;True;False;False;False;False;False
+Sevilla;False;False;False;False;True;False;False;False;False
+Caicedonia;False;False;False;False;False;False;False;False;False
+Agua De Dios;False;False;False;False;False;False;False;False;False
+Fusagasugá;False;False;False;True;False;False;False;False;False
+Une;False;False;False;True;False;False;False;False;False
+Girardot;False;False;False;False;False;False;False;False;False
+El Calvario;False;False;False;True;False;False;False;False;False
+Papunaua(Cor. Departamental);False;False;False;False;False;False;False;False;False
+Guadalupe;False;False;False;False;False;False;False;False;False
+Bolívar;False;True;False;False;False;False;False;False;False
+Magüí (Payán);False;False;False;False;False;True;False;False;False
+Leiva;False;False;False;False;False;False;False;False;False
+Oporapa;False;True;False;False;True;False;False;False;False
+Sucre;False;False;False;False;False;False;False;False;False
+La Vega;False;False;False;False;True;False;False;False;False
+Altamira;False;True;False;False;False;False;False;False;False
+Calamar;False;False;False;True;False;False;True;False;True
+San Agustín;False;True;False;False;True;False;False;False;False
+Florencia;False;False;False;False;False;False;False;False;False
+Balboa;False;False;False;False;False;False;False;False;False
+Miranda;False;False;False;False;True;False;False;False;False
+Baraya;False;False;False;True;False;False;False;False;False
+Planadas;False;False;False;False;True;False;False;False;False
+Puerto Tejada;False;False;False;False;True;False;False;False;False
+Florida;False;False;False;False;True;False;False;False;False
+Mapiripana;False;False;False;False;False;False;False;False;False
+Aipe;False;False;False;False;False;False;False;False;False
+Candelaria;False;False;False;False;False;False;False;False;False
+Mapiripán;False;False;False;False;False;False;False;False;False
+Pradera;False;False;False;False;True;False;False;False;False
+San Juan De Arama;False;False;False;True;False;False;False;False;False
+Alpujarra;False;False;False;False;False;False;False;False;False
+Cali;False;False;False;False;False;False;False;False;False
+Fuente De Oro;False;False;False;False;False;False;False;False;False
+Mesetas;False;False;False;True;False;False;False;False;False
+Granada;False;False;False;False;False;False;False;False;False
+Ataco;False;False;False;False;True;False;False;False;False
+Natagaima;False;False;False;False;False;False;False;False;False
+Yumbo;False;False;False;False;False;False;False;False;False
+Palmira;False;False;False;False;True;False;False;False;False
+Barranco Mina;False;False;False;False;False;False;False;False;False
+El Castillo;False;False;False;True;False;False;False;False;False
+El Dorado;False;False;False;True;False;False;False;False;False
+El Cerrito;False;False;False;False;True;False;False;False;False
+Cacahual;False;False;False;False;False;False;False;True;False
+Rioblanco;False;False;False;False;True;False;False;False;False
+Uribe;False;False;False;True;False;False;False;False;False
+San Martín;True;False;False;False;False;False;False;False;False
+Prado;False;False;False;True;False;False;False;False;False
+Yarumal;False;False;False;False;False;False;False;False;False
+Vijes;False;False;False;False;False;False;False;False;False
+Ginebra;False;False;False;False;True;False;False;False;False
+Dolores;False;False;False;True;False;False;False;False;False
+Guacarí;False;False;False;False;True;False;False;False;False
+La Cumbre;False;False;False;False;False;False;False;False;False
+Restrepo;False;False;False;True;False;False;False;False;False
+Coyaima;False;False;False;False;False;False;False;False;False
+Castilla La Nueva;False;False;False;False;False;False;False;False;False
+San Carlos De Guaroa;False;False;False;False;False;False;False;False;False
+Villarrica;False;False;False;True;False;False;False;False;False
+Buga;False;False;False;False;True;False;False;False;False
+Purificación;False;False;False;True;False;False;False;False;False
+Cubarral;False;False;False;True;False;False;False;False;False
+Cabrera;False;False;False;True;False;False;False;False;False
+Chaparral;False;False;False;False;True;False;False;False;False
+San Pedro;False;False;False;False;True;False;False;False;False
+Yotoco;False;False;False;False;True;False;False;False;False
+Calima (El Darién);False;False;False;False;False;False;False;False;False
+Guamal;False;False;False;True;False;False;False;False;False
+Ortega;False;False;False;False;False;False;False;False;False
+San Antonio;False;False;False;False;False;False;False;False;False
+Venecia;False;False;False;True;False;False;False;False;False
+Machetá;False;False;False;True;False;False;False;False;False
+Quebradanegra;False;False;False;False;False;False;False;False;False
+Zipaquirá;False;False;False;False;False;False;False;False;False
+La Capilla;False;False;False;False;False;False;False;False;False
+Nemocón;False;False;False;False;False;False;False;False;False
+Manizales;False;False;False;False;True;False;False;False;False
+Herveo;False;False;False;False;True;False;False;False;False
+Falan;False;False;False;False;False;False;False;False;False
+Risaralda;False;False;False;False;True;False;False;False;False
+Tauramena;False;False;False;False;False;False;False;False;False
+San José Del Palmar;False;False;False;False;False;False;False;False;False
+Vergara;False;False;False;False;False;False;False;False;False
+Nimaima;False;False;False;False;False;False;False;False;False
+Páez;False;False;False;False;False;False;False;False;False
+Guasca;False;False;False;True;False;False;False;False;False
+Angostura;False;False;False;False;False;False;False;False;False
+Orocué;False;False;False;False;False;False;False;False;False
+Suesca;False;False;False;False;False;False;False;False;False
+Miraflores;False;False;False;False;False;False;False;False;True
+Chocontá;False;False;False;True;False;False;False;False;False
+Útica;False;False;False;False;False;False;False;False;False
+Tausa;False;False;False;False;False;False;False;False;False
+Belén De Umbría;False;False;False;False;False;False;False;False;False
+Neira;False;False;False;False;True;False;False;False;False
+Anserma;False;False;False;False;True;False;False;False;False
+Istmina;False;False;False;False;False;True;False;False;False
+Tuluá;False;False;False;False;True;False;False;False;False
+Riofrío;False;False;False;False;True;False;False;False;False
+Acacías;False;False;False;True;False;False;False;False;False
+Andalucía;False;False;False;False;True;False;False;False;False
+San Bernardo;False;True;False;True;False;False;False;False;False
+Pandi;False;False;False;False;False;False;False;False;False
+Cáqueza;False;False;False;False;False;False;False;False;False
+Zarzal;False;False;False;False;False;False;False;False;False
+Nariño;False;False;False;False;False;False;False;False;False
+La Tebaida;False;False;False;False;False;False;False;False;False
+Chipaque;False;False;False;True;False;False;False;False;False
+Coello;False;False;False;False;False;False;False;False;False
+Roldanillo;False;False;False;False;False;False;False;False;False
+Viotá;False;False;False;False;False;False;False;False;False
+Sibaté;False;False;False;True;False;False;False;False;False
+San Juanito;False;False;False;True;False;False;False;False;False
+Ubaque;False;False;False;False;False;False;False;False;False
+La Victoria;False;False;False;False;False;False;False;False;False
+El Litoral Del San Juán (Docordó);False;False;False;False;False;True;False;False;False
+Montenegro;False;False;False;False;False;False;False;False;False
+Cajamarca;False;False;False;False;True;False;False;False;False
+Armenia;False;False;False;False;False;False;False;False;False
+La Victoria (Pacoa);False;False;False;False;False;False;False;False;True
+San Miguel (La Dorada);False;False;False;False;False;False;False;False;False
+Guataquí;False;False;False;False;False;False;False;False;False
+El Dovio;False;False;False;False;False;False;False;False;False
+Tocaima;False;False;False;False;False;False;False;False;False
+Puerto Lleras;False;False;False;False;False;False;False;False;False
+El Colegio;False;False;False;False;False;False;False;False;False
+Apulo;False;False;False;False;False;False;False;False;False
+Piedras;False;False;False;False;False;False;False;False;False
+Anapoima;False;False;False;False;False;False;False;False;False
+Choachí;False;False;False;True;False;False;False;False;False
+San Antonio De  Tequendama;False;False;False;False;False;False;False;False;False
+Jerusalén;False;False;False;False;False;False;False;False;False
+Obando;False;False;False;False;False;False;False;False;False
+Circasia;False;False;False;False;True;False;False;False;False
+La Pedrera;False;False;False;False;False;False;False;False;True
+Santander (Araracuara);False;False;False;False;False;False;False;False;True
+Mirití-Paraná (Campoamor);False;False;False;False;False;False;False;False;True
+Palocabildo;False;False;False;False;False;False;False;False;False
+Gualmatán;False;False;False;False;False;False;False;False;False
+Aldana;False;False;False;False;False;False;False;False;False
+Pupiales;False;False;False;False;False;False;False;False;False
+Iles;False;False;False;False;False;False;False;False;False
+Funes;False;True;False;False;False;False;False;False;False
+Solita;False;True;False;False;False;False;False;False;False
+Puerto Guzmán;False;True;False;False;False;False;False;False;True
+Ospina;False;False;False;False;False;False;False;False;False
+Villagarzón;False;True;False;False;False;False;False;False;False
+Cumbal;False;False;False;False;False;False;False;False;False
+Sapuyes;False;False;False;False;False;False;False;False;False
+Imués;False;False;False;False;False;False;False;False;False
+Solano;False;False;False;False;False;False;False;False;True
+Yacuanquer;False;False;False;False;False;False;False;False;False
+Santiago;True;True;False;False;False;False;False;False;False
+Tangua;False;True;False;False;False;False;False;False;False
+Guaitarilla;False;False;False;False;False;False;False;False;False
+Curillo;False;True;False;False;False;False;False;False;False
+Consacá;False;False;False;False;False;False;False;False;False
+San Francisco;False;True;False;False;False;False;False;False;False
+Túquerres;False;False;False;False;False;False;False;False;False
+Colón;False;True;False;False;False;False;False;False;False
+Providencia;False;False;False;False;False;False;False;False;False
+Tarqui;False;True;False;False;False;False;False;False;False
+Roberto Payán (San José);False;False;False;False;False;True;False;False;False
+La Sierra;False;False;False;False;False;False;False;False;False
+Saladoblanco;False;True;False;False;True;False;False;False;False
+Isnos;False;True;False;False;True;False;False;False;False
+La Argentina;False;True;False;False;True;False;False;False;False
+El Paujil;False;False;False;False;False;False;False;False;False
+Rosas;False;False;False;False;False;False;False;False;False
+Garzón;False;False;False;False;False;False;False;False;False
+El Doncello;False;False;False;False;False;False;False;False;False
+Patía (El Bordo);False;False;False;False;False;False;False;False;False
+Soracá;False;False;False;False;False;False;False;False;False
+San Luis De Palenque;False;False;False;False;False;False;False;False;False
+Sutatausa;False;False;False;False;False;False;False;False;False
+Toribío;False;False;False;False;True;False;False;False;False
+Lejanías;False;False;False;True;False;False;False;False;False
+Colombia;False;False;False;True;False;False;False;False;False
+Dagua;False;False;False;False;False;False;False;False;False
+Saldaña;False;False;False;False;False;False;False;False;False
+Fresno;False;False;False;False;False;False;False;False;False
+Pacho;False;False;False;False;False;False;False;False;False
+Cucunubá;False;False;False;False;False;False;False;False;False
+Berbeo;False;False;False;False;False;False;False;False;False
+Manzanares;False;False;False;False;False;False;False;False;False
+Pital;False;True;False;False;False;False;False;False;False
+Agrado;False;False;False;False;False;False;False;False;False
+Sotará (Paispamba);False;False;False;False;True;False;False;False;False
+Puracé (Coconuco);False;False;False;False;True;False;False;False;False
+Inzá;False;False;False;False;True;False;False;False;False
+El Retorno;False;False;False;True;False;False;False;False;True
+Timbío;False;False;False;False;False;False;False;False;False
+Paicol;False;False;False;False;False;False;False;False;False
+La Plata;False;True;False;False;True;False;False;False;False
+San Felipe;False;False;False;False;False;False;False;False;False
+Argelia;False;False;False;False;False;False;False;False;False
+Gigante;False;False;False;False;False;False;False;False;False
+Popayán;False;False;False;False;True;False;False;False;False
+Totoró;False;False;False;False;True;False;False;False;False
+Puerto Rico;False;False;False;True;False;False;False;False;False
+Mosquera;False;False;False;False;False;True;False;False;False
+Olaya Herrera (Bocas De Satinga);False;False;False;False;False;True;False;False;False
+Santa Bárbara (Iscuandé);False;False;False;False;False;True;False;False;False
+Tesalia;False;False;False;False;False;False;False;False;False
+La Tola;False;False;False;False;False;True;False;False;False
+Área En Litigio;False;False;False;False;True;False;False;False;False
+Nátaga;False;False;False;False;False;False;False;False;False
+El Charco;False;False;False;False;False;True;False;False;False
+Guapi;False;False;False;False;False;True;False;False;False
+Cajibío;False;False;False;False;False;False;False;False;False
+Yaguará;False;False;False;False;True;False;False;False;False
+Campoalegre;False;False;False;True;False;False;False;False;False
+Silvia;False;False;False;False;True;False;False;False;False
+El Tambo;False;False;False;False;False;False;False;False;False
+Piendamó;False;False;False;False;False;False;False;False;False
+Rivera;False;False;False;True;False;False;False;False;False
+Morichal (Morichal Nuevo);False;False;False;False;False;False;False;False;False
+San José Del Guaviare;False;False;False;True;False;False;False;False;True
+Timbiquí;False;False;False;False;False;True;False;False;False
+San Vicente Del Caguán;False;False;False;True;False;False;False;False;True
+Morales;False;False;False;False;False;False;False;False;False
+Teruel;False;False;False;False;True;False;False;False;False
+Puerto Concordia;False;False;False;True;False;False;False;False;False
+Santa María;False;False;False;True;True;False;False;False;False
+Páez (Belalcázar);False;False;False;False;True;False;False;False;False
+Palermo;False;False;False;True;True;False;False;False;False
+Buenos Aires;False;False;False;False;False;False;False;False;False
+Santander De Quilichao;False;False;False;False;False;False;False;False;False
+Tello;False;False;False;True;False;False;False;False;False
+Caloto;False;False;False;False;True;False;False;False;False
+Guachene;False;False;False;False;True;False;False;False;False
+Vistahermosa;False;False;False;True;False;False;False;False;False
+Corinto;False;False;False;False;True;False;False;False;False
+Padilla;False;False;False;False;True;False;False;False;False
+López;False;False;False;False;False;True;False;False;False
+Villa Rica;False;False;False;False;False;False;False;False;False
+Neiva;False;False;False;True;False;False;False;False;False
+Sutatenza;False;False;False;False;False;False;False;False;False
+Guateque;False;False;False;False;False;False;False;False;False
+Villahermosa;False;False;False;False;True;False;False;False;False
+Monterrey;False;False;False;False;False;False;False;False;False
+Belalcazar;False;False;False;False;False;False;False;False;False
+Manta;False;False;False;True;False;False;False;False;False
+Villeta;False;False;False;False;False;False;False;False;False
+Maní;False;False;False;False;False;False;False;False;False
+Chinchiná;False;False;False;False;True;False;False;False;False
+Sesquilé;False;False;False;True;False;False;False;False;False
+Nocaima;False;False;False;False;False;False;False;False;False
+Campohermoso;False;False;False;True;False;False;False;False;False
+Supatá;False;False;False;False;False;False;False;False;False
+Casabianca;False;False;False;False;True;False;False;False;False
+San José;False;False;False;False;False;False;False;False;False
+Medio San Juan (Andagoya);False;False;False;False;False;True;False;False;False
+Viterbo;False;False;False;False;False;False;False;False;False
+Santuario;False;False;False;False;False;False;False;False;False
+Palestina;False;True;False;False;True;False;False;False;False
+Marmato;False;False;False;False;False;False;False;False;False
+Supia;False;False;False;False;False;False;False;False;False
+Pensilvania;False;False;False;False;False;False;False;False;False
+San Eduardo;False;False;False;False;False;False;False;False;False
+Mariquita;False;False;False;False;False;False;False;False;False
+Honda;False;False;False;False;False;False;False;False;False
+El Peñón;False;False;False;False;False;False;False;False;False
+Villagómez;False;False;False;False;False;False;False;False;False
+Aranzazu;False;False;False;False;False;False;False;False;False
+Marquetalia;False;False;False;False;False;False;False;False;False
+Jenesano;False;False;False;False;False;False;False;False;False
+Ancuya;False;False;False;False;False;False;False;False;False
+Sibundoy;False;True;False;False;False;False;False;False;False
+Pasto;False;True;False;False;False;False;False;False;False
+Valparaíso;False;True;False;False;False;False;False;False;False
+Milán;False;False;False;False;False;False;False;False;False
+Albania;False;True;False;False;False;False;True;False;False
+Sandoná;False;False;False;False;False;False;False;False;False
+Mallama (Piedrancha);False;False;False;False;False;False;False;False;False
+La Florida;False;False;False;False;False;False;False;False;False
+Buesaco;False;True;False;False;False;False;False;False;False
+Santa Cruz (Guachavés);False;False;False;False;False;False;False;False;False
+Mocoa;False;True;False;False;False;False;False;False;False
+Linares;False;False;False;False;False;False;False;False;False
+Albán (San José);False;False;False;False;False;False;False;False;False
+El Tablón;False;True;False;False;False;False;False;False;False
+Chachaguí;False;False;False;False;False;False;False;False;False
+Arboleda (Berruecos);False;False;False;False;False;False;False;False;False
+Cartagena Del Chairá;False;False;False;False;False;False;False;False;True
+Morelia;False;True;False;False;False;False;False;False;False
+San José Del Fragua;False;True;False;False;False;False;False;False;False
+Piamonte;False;True;False;False;False;False;False;False;False
+San Pedro De Cartago (Cartago);False;False;False;False;False;False;False;False;False
+El Peñol;False;False;False;False;False;False;False;False;False
+Belén;True;False;False;False;False;False;False;False;False
+La Cruz;False;True;False;False;False;False;False;False;False
+La Llanada;False;False;False;False;False;False;False;False;False
+San Lorenzo;False;False;False;False;False;False;False;False;False
+Colón (Génova);False;False;False;False;False;False;False;False;False
+Taminango;False;False;False;False;False;False;False;False;False
+La Unión;False;False;False;False;False;False;False;False;False
+San Pablo;False;False;False;False;False;False;False;False;False
+Carurú;False;False;False;False;False;False;False;False;True
+Belén De Los Andaquíes;False;True;False;False;False;False;False;False;False
+Montañita;False;False;False;False;False;False;False;False;False
+Guática;False;False;False;False;False;False;False;False;False
+Santa Rosalía;False;False;False;False;False;False;False;False;False
+Quinchía;False;False;False;False;False;False;False;False;False
+Unión Panamericana ( Animas);False;False;False;False;False;False;False;False;False
+Tadó;False;False;False;False;False;False;False;False;False
+Oicatá;False;False;False;False;False;False;False;False;False
+Bagadó;False;False;False;False;False;False;False;False;False
+Rio Quito (Paimadó);False;False;False;False;False;False;False;False;False
+Atrato (Yuto);False;False;False;False;False;False;False;False;False
+Labranzagrande;True;False;False;False;False;False;False;False;False
+Chíquiza;True;False;False;False;False;False;False;False;False
+Sipí;False;False;False;False;False;False;False;False;False
+Quipile;False;False;False;False;False;False;False;False;False
+Funza;False;False;False;False;False;False;False;False;False
+Gachalá;False;False;False;True;False;False;False;False;False
+Zipacón;False;False;False;False;False;False;False;False;False
+Tena;False;False;False;False;False;False;False;False;False
+Ibagué;False;False;False;False;True;False;False;False;False
+Alvarado;False;False;False;False;True;False;False;False;False
+Versalles;False;False;False;False;False;False;False;False;False
+Salento;False;False;False;False;True;False;False;False;False
+Anzoátegui;False;False;False;False;True;False;False;False;False
+La Mesa;False;False;False;False;False;False;False;False;False
+Villanueva;False;False;False;False;False;False;True;False;False
+Alcalá;False;False;False;False;False;False;False;False;False
+Caparrapí;False;False;False;False;False;False;False;False;False
+Samacá;False;False;False;False;False;False;False;False;False
+Bajo Baudó (Pizarro);False;False;False;False;False;True;False;False;False
+Riosucio;False;False;True;False;False;True;False;False;False
+Cumaribo;False;False;False;False;False;False;False;True;False
+Cucaita;False;False;False;False;False;False;False;False;False
+Mistrató;False;False;False;False;False;False;False;False;False
+Trinidad;False;False;False;False;False;False;False;False;False
+Simijaca;False;False;False;False;False;False;False;False;False
+Pácora;False;False;False;False;False;False;False;False;False
+Tunja;False;False;False;False;False;False;False;False;False
+Tota;True;False;False;False;False;False;False;False;False
+San Miguel De Sema;False;False;False;False;False;False;False;False;False
+Victoria;False;False;False;False;False;False;False;False;False
+Caramanta;False;False;False;False;False;False;False;False;False
+Pinchote;False;False;False;False;False;False;False;False;False
+Landázuri;False;False;False;False;False;False;False;False;False
+Chiquinquirá;False;False;False;False;False;False;False;False;False
+Firavitoba;True;False;False;False;False;False;False;False;False
+Nunchía;True;False;False;False;False;False;False;False;False
+Aguadas;False;False;False;False;False;False;False;False;False
+Tuta;True;False;False;False;False;False;False;False;False
+Santa Rosa De Osos;False;False;False;False;False;False;False;False;False
+Samaná;False;False;False;False;False;False;False;False;False
+Norcasia;False;False;False;False;False;False;False;False;False
+Monguí;True;False;False;False;False;False;False;False;False
+San Pablo De Borbur;False;False;False;False;False;False;False;False;False
+Inírida;False;False;False;False;False;False;False;True;False
+Valle Del Guamuez (La Hormiga);False;False;False;False;False;False;False;False;False
+Cuaspud (Carlosama);False;False;False;False;False;False;False;False;False
+Medina;False;False;False;True;False;False;False;False;False
+Fómeque;False;False;False;True;False;False;False;False;False
+Barbacoas;False;False;False;False;False;False;False;False;False
+Los Andes (Sotomayor);False;False;False;False;False;False;False;False;False
+Santa Rosa;False;True;False;False;True;False;False;False;False
+Policarpa;False;False;False;False;False;False;False;False;False
+Cumbitara;False;False;False;False;False;False;False;False;False
+San Sebastián;False;True;False;False;True;False;False;False;False
+Pitalito;False;True;False;False;False;False;False;False;False
+Almaguer;False;False;False;False;False;False;False;False;False
+El Rosario;False;False;False;False;False;False;False;False;False
+Suaza;False;False;False;False;False;False;False;False;False
+Timaná;False;True;False;False;False;False;False;False;False
+Elías;False;True;False;False;False;False;False;False;False
+Marsella;False;False;False;False;True;False;False;False;False
+Gachancipá;False;False;False;False;False;False;False;False;False
+Villamaria;False;False;False;False;True;False;False;False;False
+Nuevo Colón;False;False;False;False;False;False;False;False;False
+Topaipí;False;False;False;False;False;False;False;False;False
+San Cayetano;False;False;False;False;False;False;False;False;False
+La Palma;False;False;False;False;False;False;False;False;False
+Guaduas;False;False;False;False;False;False;False;False;False
+Pueblo Rico;False;False;False;False;False;False;False;False;False
+Ciénega;True;False;False;False;False;False;False;False;False
+La Merced;False;False;False;False;False;False;False;False;False
+Guachetá;False;False;False;False;False;False;False;False;False
+Chámeza;False;False;False;False;False;False;False;False;False
+Puerto Boyacá;False;False;False;False;False;False;False;False;False
+Villavieja;False;False;False;False;False;False;False;False;False
+Salamina;False;False;False;False;False;False;True;False;False
+Carmen De Carupa;False;False;False;False;False;False;False;False;False
+Ventaquemada;False;False;False;False;False;False;False;False;False
+Paime;False;False;False;False;False;False;False;False;False
+Boyacá;False;False;False;False;False;False;False;False;False
+Fúquene;False;False;False;False;False;False;False;False;False
+Pajarito;True;False;False;False;False;False;False;False;False
+Cértegui;False;False;False;False;False;False;False;False;False
+Susa;False;False;False;False;False;False;False;False;False
+El Cantón Del San Pablo (Managrú);False;False;False;False;False;False;False;False;False
+Coper;False;False;False;False;False;False;False;False;False
+Pachavita;False;False;False;False;False;False;False;False;False
+Villapinzón;False;False;False;False;False;False;False;False;False
+Turmequé;False;False;False;False;False;False;False;False;False
+Aguazul;False;False;False;False;False;False;False;False;False
+Zetaquirá;False;False;False;False;False;False;False;False;False
+Ubaté;False;False;False;False;False;False;False;False;False
+Filadelfia;False;False;False;False;False;False;False;False;False
+Marulanda;False;False;False;False;True;False;False;False;False
+Lenguazaque;False;False;False;False;False;False;False;False;False
+Recetor;False;False;False;False;False;False;False;False;False
+Medio Baudó(Boca De Pepé);False;False;False;False;False;True;False;False;False
+Paná-Paná (Campo Alegre);False;False;False;False;False;False;False;False;False
+Encino;True;False;False;False;False;False;False;False;False
+Heliconia;False;False;False;False;False;False;False;False;False
+Susacón;True;False;False;False;False;False;False;False;False
+Puerto Carreño;False;False;False;False;False;False;False;True;False
+Guapotá;False;False;False;False;False;False;False;False;False
+Soatá;True;False;False;False;False;False;False;False;False
+Anzá;False;False;False;False;False;False;False;False;False
+Copacabana;False;False;False;False;False;False;False;False;False
+Concepción;True;False;False;False;False;False;False;False;False
+San Mateo;True;False;False;False;False;False;False;False;False
+San Jerónimo;False;False;False;False;False;False;False;False;False
+Yalí;False;False;False;False;False;False;False;False;False
+El Carmen;False;False;False;False;False;False;False;False;False
+Frontino;False;False;False;False;False;False;False;False;False
+Mongua;True;False;False;False;False;False;False;False;False
+Filandia;False;False;False;False;True;False;False;False;False
+Toro;False;False;False;False;False;False;False;False;False
+Barranca De Upía;False;False;False;False;False;False;False;False;False
+Ulloa;False;False;False;False;False;False;False;False;False
+Paratebueno;False;False;False;False;False;False;False;False;False
+Pulí;False;False;False;False;False;False;False;False;False
+Bojacá;False;False;False;False;False;False;False;False;False
+Ubalá;False;False;False;True;False;False;False;False;False
+Cachipay;False;False;False;False;False;False;False;False;False
+Gama;False;False;False;False;False;False;False;False;False
+Palmar;False;False;False;False;False;False;False;False;False
+San Joaquín;True;False;False;False;False;False;False;False;False
+Don Matías;False;False;False;False;False;False;False;False;False
+Covarachía;True;False;False;False;False;False;False;False;False
+San Calixto;False;False;False;False;False;False;False;False;False
+Francisco Pizarro (Salahonda);False;False;False;False;False;True;False;False;False
+Sincé;False;False;False;False;False;False;False;False;False
+San Juan De Betulia (Betulia);False;False;False;False;False;False;False;False;False
+Palmito;False;False;False;False;False;False;False;False;False
+Sincelejo;False;False;False;False;False;False;False;False;False
+Talaigua Nuevo;False;False;False;False;False;False;False;False;False
 San Antero;False;False;False;False;False;False;False;False;False
 San Bernardo Del Viento;False;False;False;False;False;False;False;False;False
-San Carlos;False;False;False;False;False;False;False;False;False
-San Jose De Ure;False;False;False;False;False;False;False;False;False
-San Pelayo;False;False;False;False;False;False;False;False;False
-Tierralta;False;False;False;False;False;False;False;False;False
-Tuchín;False;False;False;False;False;False;False;False;False
-Valencia;False;False;False;False;False;False;False;False;False
-Agua De Dios;False;False;False;False;False;False;False;False;False
-Albán;False;False;False;False;False;False;False;False;False
-Anapoima;False;False;False;False;False;False;False;False;False
-Anolaima;False;False;False;False;False;False;False;False;False
-Apulo;False;False;False;False;False;False;False;False;False
-Arbeláez;False;False;False;False;False;False;False;False;False
-Beltrán;False;False;False;False;False;False;False;False;False
-Bituima;False;False;False;False;False;False;False;False;False
-Bogotá, D.c.;False;False;False;False;False;False;False;False;False
-Bojacá;False;False;False;False;False;False;False;False;False
-Cabrera;False;False;False;False;False;False;False;False;False
-Cachipay;False;False;False;False;False;False;False;False;False
-Cajicá;False;False;False;False;False;False;False;False;False
-Caparrapí;False;False;False;False;False;False;False;False;False
-Cáqueza;False;False;False;False;False;False;False;False;False
-Carmen De Carupa;False;False;False;False;False;False;False;False;False
-Chaguaní;False;False;False;False;False;False;False;False;False
-Chía;False;False;False;False;False;False;False;False;False
-Chipaque;False;False;False;False;False;False;False;False;False
-Choachí;False;False;False;False;False;False;False;False;False
-Chocontá;False;False;False;False;False;False;False;False;False
-Cogua;False;False;False;False;False;False;False;False;False
-Cota;False;False;False;False;False;False;False;False;False
-Cucunubá;False;False;False;False;False;False;False;False;False
-El Colegio;False;False;False;False;False;False;False;False;False
-El Peñón;False;False;False;False;False;False;False;False;False
-El Rosal;False;False;False;False;False;False;False;False;False
-Facatativá;False;False;False;False;False;False;False;False;False
-Fómeque;False;False;False;False;False;False;False;False;False
-Fosca;False;False;False;False;False;False;False;False;False
-Funza;False;False;False;False;False;False;False;False;False
-Fúquene;False;False;False;False;False;False;False;False;False
-Fusagasugá;False;False;False;False;False;False;False;False;False
-Gachalá;False;False;False;False;False;False;False;False;False
-Gachancipá;False;False;False;False;False;False;False;False;False
-Gachetá;False;False;False;False;False;False;False;False;False
-Gama;False;False;False;False;False;False;False;False;False
-Girardot;False;False;False;False;False;False;False;False;False
-Granada;False;False;False;False;False;False;False;False;False
-Guachetá;False;False;False;False;False;False;False;False;False
-Guaduas;False;False;False;False;False;False;False;False;False
-Guasca;False;False;False;False;False;False;False;False;False
-Guataquí;False;False;False;False;False;False;False;False;False
-Guatavita;False;False;False;False;False;False;False;False;False
-Guayabal De Síquima;False;False;False;False;False;False;False;False;False
-Guayabetal;False;False;False;False;False;False;False;False;False
-Gutiérrez;False;False;False;False;False;False;False;False;False
-Jerusalén;False;False;False;False;False;False;False;False;False
-Junín;False;False;False;False;False;False;False;False;False
-La Calera;False;False;False;False;False;False;False;False;False
-La Mesa;False;False;False;False;False;False;False;False;False
-La Palma;False;False;False;False;False;False;False;False;False
-La Peña;False;False;False;False;False;False;False;False;False
-La Vega;False;False;False;False;False;False;False;False;False
-Lenguazaque;False;False;False;False;False;False;False;False;False
-Machetá;False;False;False;False;False;False;False;False;False
-Madrid;False;False;False;False;False;False;False;False;False
-Manta;False;False;False;False;False;False;False;False;False
-Medina;False;False;False;False;False;False;False;False;False
-Mosquera;False;False;False;False;False;False;False;False;False
-Nariño;False;False;False;False;False;False;False;False;False
-Nemocón;False;False;False;False;False;False;False;False;False
-Nilo;False;False;False;False;False;False;False;False;False
-Nimaima;False;False;False;False;False;False;False;False;False
-Nocaima;False;False;False;False;False;False;False;False;False
-Pacho;False;False;False;False;False;False;False;False;False
-Paime;False;False;False;False;False;False;False;False;False
-Pandi;False;False;False;False;False;False;False;False;False
-Paratebueno;False;False;False;False;False;False;False;False;False
-Pasca;False;False;False;False;False;False;False;False;False
-Puerto Salgar;False;False;False;False;False;False;False;False;False
-Pulí;False;False;False;False;False;False;False;False;False
-Quebradanegra;False;False;False;False;False;False;False;False;False
-Quetame;False;False;False;False;False;False;False;False;False
-Quipile;False;False;False;False;False;False;False;False;False
-Ricaurte;False;False;False;False;False;False;False;False;False
-San Antonio De Tequendama;False;False;False;False;False;False;False;False;False
-San Bernardo;False;False;False;False;False;False;False;False;False
-San Cayetano;False;False;False;False;False;False;False;False;False
-San Francisco;False;False;False;False;False;False;False;False;False
-San Juan De Rioseco;False;False;False;False;False;False;False;False;False
-Sasaima;False;False;False;False;False;False;False;False;False
-Sesquilé;False;False;False;False;False;False;False;False;False
-Sibaté;False;False;False;False;False;False;False;False;False
-Silvania;False;False;False;False;False;False;False;False;False
-Simijaca;False;False;False;False;False;False;False;False;False
-Soacha;False;False;False;False;False;False;False;False;False
-Sopó;False;False;False;False;False;False;False;False;False
-Subachoque;False;False;False;False;False;False;False;False;False
-Suesca;False;False;False;False;False;False;False;False;False
-Supatá;False;False;False;False;False;False;False;False;False
-Susa;False;False;False;False;False;False;False;False;False
-Sutatausa;False;False;False;False;False;False;False;False;False
-Tabio;False;False;False;False;False;False;False;False;False
-Tausa;False;False;False;False;False;False;False;False;False
-Tena;False;False;False;False;False;False;False;False;False
-Tenjo;False;False;False;False;False;False;False;False;False
-Tibacuy;False;False;False;False;False;False;False;False;False
-Tibirita;False;False;False;False;False;False;False;False;False
-Tocaima;False;False;False;False;False;False;False;False;False
-Tocancipá;False;False;False;False;False;False;False;False;False
-Topaipí;False;False;False;False;False;False;False;False;False
-Ubalá;False;False;False;False;False;False;False;False;False
-Ubaque;False;False;False;False;False;False;False;False;False
-Ubaté;False;False;False;False;False;False;False;False;False
-Une;False;False;False;False;False;False;False;False;False
-Útica;False;False;False;False;False;False;False;False;False
-Venecia;False;False;False;False;False;False;False;False;False
-Vergara;False;False;False;False;False;False;False;False;False
-Vianí;False;False;False;False;False;False;False;False;False
-Villagómez;False;False;False;False;False;False;False;False;False
-Villapinzón;False;False;False;False;False;False;False;False;False
-Villeta;False;False;False;False;False;False;False;False;False
-Viotá;False;False;False;False;False;False;False;False;False
-Yacopí;False;False;False;False;False;False;False;False;False
-Zipacón;False;False;False;False;False;False;False;False;False
-Zipaquirá;False;False;False;False;False;False;False;False;False
-Barranco Mina;False;False;False;False;False;False;False;False;False
-Cacahual;False;False;False;False;False;False;False;False;False
-Inírida;False;False;False;False;False;False;False;False;False
-La Guadalupe;False;False;False;False;False;False;False;False;False
-Mapiripana;False;False;False;False;False;False;False;False;False
-Morichal (Morichal Nuevo);False;False;False;False;False;False;False;False;False
-Paná-paná (Campo Alegre);False;False;False;False;False;False;False;False;False
-Puerto Colombia;False;False;False;False;False;False;False;False;False
-San Felipe;False;False;False;False;False;False;False;False;False
-Calamar;False;False;False;False;False;False;False;False;False
-El Retorno;False;False;False;False;False;False;False;False;False
-Miraflores;False;False;False;False;False;False;False;False;False
-San José Del Guaviare;False;False;False;False;False;False;False;False;False
-Acevedo;False;False;False;False;False;False;False;False;False
-Agrado;False;False;False;False;False;False;False;False;False
-Aipe;False;False;False;False;False;False;False;False;False
-Algeciras;False;False;False;False;False;False;False;False;False
-Altamira;False;False;False;False;False;False;False;False;False
-Baraya;False;False;False;False;False;False;False;False;False
-Campoalegre;False;False;False;False;False;False;False;False;False
-Colombia;False;False;False;False;False;False;False;False;False
-Elías;False;False;False;False;False;False;False;False;False
-Garzón;False;False;False;False;False;False;False;False;False
-Gigante;False;False;False;False;False;False;False;False;False
-Guadalupe;False;False;False;False;False;False;False;False;False
-Hobo;False;False;False;False;False;False;False;False;False
-Íquira;False;False;False;False;False;False;False;False;False
-Isnos;False;False;False;False;False;False;False;False;False
-La Argentina;False;False;False;False;False;False;False;False;False
-La Plata;False;False;False;False;False;False;False;False;False
-Nátaga;False;False;False;False;False;False;False;False;False
-Neiva;False;False;False;False;False;False;False;False;False
-Oporapa;False;False;False;False;False;False;False;False;False
-Paicol;False;False;False;False;False;False;False;False;False
-Palermo;False;False;False;False;False;False;False;False;False
-Palestina;False;False;False;False;False;False;False;False;False
-Pital;False;False;False;False;False;False;False;False;False
-Pitalito;False;False;False;False;False;False;False;False;False
-Rivera;False;False;False;False;False;False;False;False;False
-Saladoblanco;False;False;False;False;False;False;False;False;False
-San Agustín;False;False;False;False;False;False;False;False;False
-Santa María;False;False;False;False;False;False;False;False;False
-Suaza;False;False;False;False;False;False;False;False;False
-Tarqui;False;False;False;False;False;False;False;False;False
-Tello;False;False;False;False;False;False;False;False;False
-Teruel;False;False;False;False;False;False;False;False;False
-Tesalia;False;False;False;False;False;False;False;False;False
-Timaná;False;False;False;False;False;False;False;False;False
-Villavieja;False;False;False;False;False;False;False;False;False
-Yaguará;False;False;False;False;False;False;False;False;False
-Albania;False;False;False;False;False;False;False;False;False
-Barrancas;False;False;False;False;False;False;False;False;False
-Dibulla;False;False;False;False;False;False;False;False;False
-Distracción;False;False;False;False;False;False;False;False;False
-El Molino;False;False;False;False;False;False;False;False;False
-Fonseca;False;False;False;False;False;False;False;False;False
-Hato Nuevo;False;False;False;False;False;False;False;False;False
-La Jagua Del Pilar;False;False;False;False;False;False;False;False;False
-Maicao;False;False;False;False;False;False;False;False;False
-Manaure;False;False;False;False;False;False;False;False;False
-Riohacha;False;False;False;False;False;False;False;False;False
-San Juan Del Cesar;False;False;False;False;False;False;False;False;False
-Uribia;False;False;False;False;False;False;False;False;False
-Urumita;False;False;False;False;False;False;False;False;False
-Villanueva;False;False;False;False;False;False;False;False;False
-Algarrobo;False;False;False;False;False;False;False;False;False
-Aracataca;False;False;False;False;False;False;False;False;False
-Ariguaní (El Dificil);False;False;False;False;False;False;False;False;False
-Cerro De San Antonio;False;False;False;False;False;False;False;False;False
-Chivolo;False;False;False;False;False;False;False;False;False
-Ciénaga;False;False;False;False;False;False;False;False;False
-Concordia;False;False;False;False;False;False;False;False;False
-El Banco;False;False;False;False;False;False;False;False;False
-El Piñón;False;False;False;False;False;False;False;False;False
-El Retén;False;False;False;False;False;False;False;False;False
-Fundación;False;False;False;False;False;False;False;False;False
-Guamal;False;False;False;False;False;False;False;False;False
-Nueva Granada;False;False;False;False;False;False;False;False;False
-Pedraza;False;False;False;False;False;False;False;False;False
-Pijiño Del Carmen;False;False;False;False;False;False;False;False;False
-Pivijay;False;False;False;False;False;False;False;False;False
-Plato;False;False;False;False;False;False;False;False;False
-Puebloviejo;False;False;False;False;False;False;False;False;False
-Remolino;False;False;False;False;False;False;False;False;False
-Sabanas De San Angel;False;False;False;False;False;False;False;False;False
-Salamina;False;False;False;False;False;False;False;False;False
-San Sebastián De Buenavista;False;False;False;False;False;False;False;False;False
-San Zenón;False;False;False;False;False;False;False;False;False
-Santa Ana;False;False;False;False;False;False;False;False;False
-Santa Bárbara De Pinto;False;False;False;False;False;False;False;False;False
-Santa Marta;False;False;False;False;False;False;False;False;False
-Sitionuevo;False;False;False;False;False;False;False;False;False
-Tenerife;False;False;False;False;False;False;False;False;False
-Zapayán;False;False;False;False;False;False;False;False;False
-Zona Bananera;False;False;False;False;False;False;False;False;False
-Acacías;False;False;False;False;False;False;False;False;False
-Barranca De Upía;False;False;False;False;False;False;False;False;False
-Cabuyaro;False;False;False;False;False;False;False;False;False
-Castilla La Nueva;False;False;False;False;False;False;False;False;False
-Cubarral;False;False;False;False;False;False;False;False;False
-Cumaral;False;False;False;False;False;False;False;False;False
-El Calvario;False;False;False;False;False;False;False;False;False
-El Castillo;False;False;False;False;False;False;False;False;False
-El Dorado;False;False;False;False;False;False;False;False;False
-Fuente De Oro;False;False;False;False;False;False;False;False;False
-Granada;False;False;False;False;False;False;False;False;False
-Guamal;False;False;False;False;False;False;False;False;False
-La Macarena;False;False;False;False;False;False;False;False;False
-Lejanías;False;False;False;False;False;False;False;False;False
-Mapiripán;False;False;False;False;False;False;False;False;False
-Mesetas;False;False;False;False;False;False;False;False;False
-Puerto Concordia;False;False;False;False;False;False;False;False;False
-Puerto Gaitán;False;False;False;False;False;False;False;False;False
-Puerto Lleras;False;False;False;False;False;False;False;False;False
-Puerto López;False;False;False;False;False;False;False;False;False
-Puerto Rico;False;False;False;False;False;False;False;False;False
-Restrepo;False;False;False;False;False;False;False;False;False
-San Carlos De Guaroa;False;False;False;False;False;False;False;False;False
-San Juan De Arama;False;False;False;False;False;False;False;False;False
-San Juanito;False;False;False;False;False;False;False;False;False
-San Martín;False;False;False;False;False;False;False;False;False
-Uribe;False;False;False;False;False;False;False;False;False
-Villavicencio;False;False;False;False;False;False;False;False;False
-Vistahermosa;False;False;False;False;False;False;False;False;False
-Albán (San José);False;False;False;False;False;False;False;False;False
-Aldana;False;False;False;False;False;False;False;False;False
-Ancuya;False;False;False;False;False;False;False;False;False
-Arboleda (Berruecos);False;False;False;False;False;False;False;False;False
-Barbacoas;False;False;False;False;False;False;False;False;False
-Belén;False;False;False;False;False;False;False;False;False
-Buesaco;False;False;False;False;False;False;False;False;False
-Chachaguí;False;False;False;False;False;False;False;False;False
-Colón (Génova);False;False;False;False;False;False;False;False;False
-Consacá;False;False;False;False;False;False;False;False;False
-Contadero;False;False;False;False;False;False;False;False;False
-Córdoba;False;False;False;False;False;False;False;False;False
-Cuaspud (Carlosama);False;False;False;False;False;False;False;False;False
-Cumbal;False;False;False;False;False;False;False;False;False
-Cumbitara;False;False;False;False;False;False;False;False;False
-El Charco;False;False;False;False;False;False;False;False;False
-El Peñol;False;False;False;False;False;False;False;False;False
-El Rosario;False;False;False;False;False;False;False;False;False
-El Tablón;False;False;False;False;False;False;False;False;False
-El Tambo;False;False;False;False;False;False;False;False;False
-Francisco Pizarro (Salahonda);False;False;False;False;False;False;False;False;False
-Funes;False;False;False;False;False;False;False;False;False
-Guachucal;False;False;False;False;False;False;False;False;False
-Guaitarilla;False;False;False;False;False;False;False;False;False
-Gualmatán;False;False;False;False;False;False;False;False;False
-Iles;False;False;False;False;False;False;False;False;False
-Imués;False;False;False;False;False;False;False;False;False
-Ipiales;False;False;False;False;False;False;False;False;False
-La Cruz;False;False;False;False;False;False;False;False;False
-La Florida;False;False;False;False;False;False;False;False;False
-La Llanada;False;False;False;False;False;False;False;False;False
-La Tola;False;False;False;False;False;False;False;False;False
-La Unión;False;False;False;False;False;False;False;False;False
-Leiva;False;False;False;False;False;False;False;False;False
-Linares;False;False;False;False;False;False;False;False;False
-Los Andes (Sotomayor);False;False;False;False;False;False;False;False;False
-Magüí (Payán);False;False;False;False;False;False;False;False;False
-Mallama (Piedrancha);False;False;False;False;False;False;False;False;False
-Mosquera;False;False;False;False;False;False;False;False;False
-Nariño;False;False;False;False;False;False;False;False;False
-Olaya Herrera (Bocas De Satinga);False;False;False;False;False;False;False;False;False
-Ospina;False;False;False;False;False;False;False;False;False
-Pasto;False;False;False;False;False;False;False;False;False
-Policarpa;False;False;False;False;False;False;False;False;False
-Potosí;False;False;False;False;False;False;False;False;False
-Providencia;False;False;False;False;False;False;False;False;False
-Puerres;False;False;False;False;False;False;False;False;False
-Pupiales;False;False;False;False;False;False;False;False;False
-Ricaurte;False;False;False;False;False;False;False;False;False
-Roberto Payán (San José);False;False;False;False;False;False;False;False;False
-Samaniego;False;False;False;False;False;False;False;False;False
-San Bernardo;False;False;False;False;False;False;False;False;False
-San Lorenzo;False;False;False;False;False;False;False;False;False
-San Pablo;False;False;False;False;False;False;False;False;False
-San Pedro De Cartago (Cartago);False;False;False;False;False;False;False;False;False
-Sandoná;False;False;False;False;False;False;False;False;False
-Santa Bárbara (Iscuandé);False;False;False;False;False;False;False;False;False
-Santa Cruz (Guachavés);False;False;False;False;False;False;False;False;False
-Sapuyes;False;False;False;False;False;False;False;False;False
-Taminango;False;False;False;False;False;False;False;False;False
-Tangua;False;False;False;False;False;False;False;False;False
-Tumaco;False;False;False;False;False;False;False;False;False
-Tumaco;False;False;False;False;False;False;False;False;False
-Túquerres;False;False;False;False;False;False;False;False;False
-Yacuanquer;False;False;False;False;False;False;False;False;False
-Ábrego;False;False;False;False;False;False;False;False;False
-Arboledas;False;False;False;False;False;False;False;False;False
-Bochalema;False;False;False;False;False;False;False;False;False
-Bucarasica;False;False;False;False;False;False;False;False;False
-Cáchira;False;False;False;False;False;False;False;False;False
-Cácota;False;False;False;False;False;False;False;False;False
-Chinácota;False;False;False;False;False;False;False;False;False
-Chitagá;False;False;False;False;False;False;False;False;False
-Convención;False;False;False;False;False;False;False;False;False
-Cúcuta;False;False;False;False;False;False;False;False;False
-Cucutilla;False;False;False;False;False;False;False;False;False
-Durania;False;False;False;False;False;False;False;False;False
-El Carmen;False;False;False;False;False;False;False;False;False
-El Tarra;False;False;False;False;False;False;False;False;False
-El Zulia;False;False;False;False;False;False;False;False;False
-Gramalote;False;False;False;False;False;False;False;False;False
-Hacarí;False;False;False;False;False;False;False;False;False
-Herrán;False;False;False;False;False;False;False;False;False
-La Esperanza;False;False;False;False;False;False;False;False;False
-La Playa;False;False;False;False;False;False;False;False;False
-Labateca;False;False;False;False;False;False;False;False;False
-Los Patios;False;False;False;False;False;False;False;False;False
-Lourdes;False;False;False;False;False;False;False;False;False
-Mutiscua;False;False;False;False;False;False;False;False;False
-Ocaña;False;False;False;False;False;False;False;False;False
-Pamplona;False;False;False;False;False;False;False;False;False
-Pamplonita;False;False;False;False;False;False;False;False;False
-Puerto Santander;False;False;False;False;False;False;False;False;False
-Ragonvalia;False;False;False;False;False;False;False;False;False
-Salazar;False;False;False;False;False;False;False;False;False
-San Calixto;False;False;False;False;False;False;False;False;False
-San Cayetano;False;False;False;False;False;False;False;False;False
-Santiago;False;False;False;False;False;False;False;False;False
-Sardinata;False;False;False;False;False;False;False;False;False
-Silos;False;False;False;False;False;False;False;False;False
-Teorama;False;False;False;False;False;False;False;False;False
-Tibú;False;False;False;False;False;False;False;False;False
-Toledo;False;False;False;False;False;False;False;False;False
-Villa Caro;False;False;False;False;False;False;False;False;False
-Villa Del Rosario;False;False;False;False;False;False;False;False;False
-Colón;False;False;False;False;False;False;False;False;False
-Mocoa;False;False;False;False;False;False;False;False;False
-Orito;False;False;False;False;False;False;False;False;False
-Puerto Asís;False;False;False;False;False;False;False;False;False
-Puerto Caicedo;False;False;False;False;False;False;False;False;False
-Puerto Guzmán;False;False;False;False;False;False;False;False;False
-Puerto Leguízamo;False;False;False;False;False;False;False;False;False
-San Francisco;False;False;False;False;False;False;False;False;False
-San Miguel (La Dorada);False;False;False;False;False;False;False;False;False
-Santiago;False;False;False;False;False;False;False;False;False
-Sibundoy;False;False;False;False;False;False;False;False;False
-Valle Del Guamuez (La Hormiga);False;False;False;False;False;False;False;False;False
-Villagarzón;False;False;False;False;False;False;False;False;False
-Armenia;False;False;False;False;False;False;False;False;False
-Buenavista;False;False;False;False;False;False;False;False;False
-Calarcá;False;False;False;False;False;False;False;False;False
-Circasia;False;False;False;False;False;False;False;False;False
-Córdoba;False;False;False;False;False;False;False;False;False
-Filandia;False;False;False;False;False;False;False;False;False
-Génova;False;False;False;False;False;False;False;False;False
-La Tebaida;False;False;False;False;False;False;False;False;False
-Montenegro;False;False;False;False;False;False;False;False;False
-Pijao;False;False;False;False;False;False;False;False;False
-Quimbaya;False;False;False;False;False;False;False;False;False
-Salento;False;False;False;False;False;False;False;False;False
-Apía;False;False;False;False;False;False;False;False;False
-Balboa;False;False;False;False;False;False;False;False;False
-Belén De Umbría;False;False;False;False;False;False;False;False;False
-Dosquebradas;False;False;False;False;False;False;False;False;False
-Guática;False;False;False;False;False;False;False;False;False
-La Celia;False;False;False;False;False;False;False;False;False
-La Virginia;False;False;False;False;False;False;False;False;False
-Marsella;False;False;False;False;False;False;False;False;False
-Mistrató;False;False;False;False;False;False;False;False;False
-Pereira;False;False;False;False;False;False;False;False;False
-Pueblo Rico;False;False;False;False;False;False;False;False;False
-Quinchía;False;False;False;False;False;False;False;False;False
-Santa Rosa De Cabal;False;False;False;False;False;False;False;False;False
-Santuario;False;False;False;False;False;False;False;False;False
-San Andrés;False;False;False;False;False;False;False;False;False
-Providencia y Santa Isabel;False;False;False;False;False;False;False;False;False
-Aguada;False;False;False;False;False;False;False;False;False
-Albania;False;False;False;False;False;False;False;False;False
-Aratoca;False;False;False;False;False;False;False;False;False
-Barbosa;False;False;False;False;False;False;False;False;False
-Barichara;False;False;False;False;False;False;False;False;False
-Barrancabermeja;False;False;False;False;False;False;False;False;False
-Betulia;False;False;False;False;False;False;False;False;False
-Bolivar;False;False;False;False;False;False;False;False;False
-Bucaramanga;False;False;False;False;False;False;False;False;False
-Cabrera;False;False;False;False;False;False;False;False;False
-California;False;False;False;False;False;False;False;False;False
-Capitanejo;False;False;False;False;False;False;False;False;False
-Carcasí;False;False;False;False;False;False;False;False;False
-Cepitá;False;False;False;False;False;False;False;False;False
-Cerrito;False;False;False;False;False;False;False;False;False
-Charalá;False;False;False;False;False;False;False;False;False
-Charta;False;False;False;False;False;False;False;False;False
-Chima;False;False;False;False;False;False;False;False;False
-Chipatá;False;False;False;False;False;False;False;False;False
-Cimitarra;False;False;False;False;False;False;False;False;False
-Concepción;False;False;False;False;False;False;False;False;False
-Confines;False;False;False;False;False;False;False;False;False
-Contratación;False;False;False;False;False;False;False;False;False
-Coromoro;False;False;False;False;False;False;False;False;False
-Curití;False;False;False;False;False;False;False;False;False
-El Carmen;False;False;False;False;False;False;False;False;False
-El Guacamayo;False;False;False;False;False;False;False;False;False
-El Peñón;False;False;False;False;False;False;False;False;False
-El Playón;False;False;False;False;False;False;False;False;False
-Encino;False;False;False;False;False;False;False;False;False
-Enciso;False;False;False;False;False;False;False;False;False
-Florián;False;False;False;False;False;False;False;False;False
-Floridablanca;False;False;False;False;False;False;False;False;False
-Galán;False;False;False;False;False;False;False;False;False
-Gámbita;False;False;False;False;False;False;False;False;False
-Girón;False;False;False;False;False;False;False;False;False
-Guaca;False;False;False;False;False;False;False;False;False
-Guadalupe;False;False;False;False;False;False;False;False;False
-Guapotá;False;False;False;False;False;False;False;False;False
-Guavatá;False;False;False;False;False;False;False;False;False
-Güepsa;False;False;False;False;False;False;False;False;False
-Hato;False;False;False;False;False;False;False;False;False
-Jesús María;False;False;False;False;False;False;False;False;False
-Jordán;False;False;False;False;False;False;False;False;False
-La Belleza;False;False;False;False;False;False;False;False;False
-La Paz;False;False;False;False;False;False;False;False;False
-Landázuri;False;False;False;False;False;False;False;False;False
-Lebrija;False;False;False;False;False;False;False;False;False
-Los Santos;False;False;False;False;False;False;False;False;False
-Macaravita;False;False;False;False;False;False;False;False;False
-Málaga;False;False;False;False;False;False;False;False;False
-Matanza;False;False;False;False;False;False;False;False;False
-Mogotes;False;False;False;False;False;False;False;False;False
-Molagavita;False;False;False;False;False;False;False;False;False
-Ocamonte;False;False;False;False;False;False;False;False;False
-Oiba;False;False;False;False;False;False;False;False;False
-Onzaga;False;False;False;False;False;False;False;False;False
-Palmar;False;False;False;False;False;False;False;False;False
-Palmas Del Socorro;False;False;False;False;False;False;False;False;False
-Páramo;False;False;False;False;False;False;False;False;False
-Piedecuesta;False;False;False;False;False;False;False;False;False
-Pinchote;False;False;False;False;False;False;False;False;False
-Puente Nacional;False;False;False;False;False;False;False;False;False
-Puerto Parra;False;False;False;False;False;False;False;False;False
-Puerto Wilches;False;False;False;False;False;False;False;False;False
-Rionegro;False;False;False;False;False;False;False;False;False
-Sabana De Torres;False;False;False;False;False;False;False;False;False
-San Andrés;False;False;False;False;False;False;False;False;False
-San Benito;False;False;False;False;False;False;False;False;False
-San Gil;False;False;False;False;False;False;False;False;False
-San Joaquín;False;False;False;False;False;False;False;False;False
-San José De Miranda;False;False;False;False;False;False;False;False;False
-San Miguel;False;False;False;False;False;False;False;False;False
-San Vicente De Chucurí;False;False;False;False;False;False;False;False;False
-Santa Bárbara;False;False;False;False;False;False;False;False;False
-Santa Helena Del Opón;False;False;False;False;False;False;False;False;False
-Simacota;False;False;False;False;False;False;False;False;False
-Socorro;False;False;False;False;False;False;False;False;False
-Suaita;False;False;False;False;False;False;False;False;False
-Sucre;False;False;False;False;False;False;False;False;False
-Suratá;False;False;False;False;False;False;False;False;False
-Tona;False;False;False;False;False;False;False;False;False
-Valle De San José;False;False;False;False;False;False;False;False;False
-Vélez;False;False;False;False;False;False;False;False;False
-Vetas;False;False;False;False;False;False;False;False;False
-Villanueva;False;False;False;False;False;False;False;False;False
-Zapatoca;False;False;False;False;False;False;False;False;False
-Buenavista;False;False;False;False;False;False;False;False;False
-Caimito;False;False;False;False;False;False;False;False;False
-Chalán;False;False;False;False;False;False;False;False;False
-Colosó;False;False;False;False;False;False;False;False;False
-Corozal;False;False;False;False;False;False;False;False;False
-Coveñas;False;False;False;False;False;False;False;False;False
-El Roble;False;False;False;False;False;False;False;False;False
-Galeras;False;False;False;False;False;False;False;False;False
-Guaranda;False;False;False;False;False;False;False;False;False
-La Unión;False;False;False;False;False;False;False;False;False
-Los Palmitos;False;False;False;False;False;False;False;False;False
-Majagual;False;False;False;False;False;False;False;False;False
 Morroa;False;False;False;False;False;False;False;False;False
-Ovejas;False;False;False;False;False;False;False;False;False
-Palmito;False;False;False;False;False;False;False;False;False
-Sampués;False;False;False;False;False;False;False;False;False
-San Benito Abad;False;False;False;False;False;False;False;False;False
-San Juan De Betulia (Betulia);False;False;False;False;False;False;False;False;False
-San Marcos;False;False;False;False;False;False;False;False;False
-San Onofre;False;False;False;False;False;False;False;False;False
-San Pedro;False;False;False;False;False;False;False;False;False
-Sincé;False;False;False;False;False;False;False;False;False
-Sincelejo;False;False;False;False;False;False;False;False;False
-Sucre;False;False;False;False;False;False;False;False;False
-Tolú;False;False;False;False;False;False;False;False;False
+San Zenón;False;False;False;False;False;False;False;False;False
+Chimichagua;False;False;False;False;False;False;False;False;False
+San Sebastián De Buenavista;False;False;False;False;False;False;False;False;False
+Los Palmitos;False;False;False;False;False;False;False;False;False
 Toluviejo;False;False;False;False;False;False;False;False;False
-Alpujarra;False;False;False;False;False;False;False;False;False
-Alvarado;False;False;False;False;False;False;False;False;False
-Ambalema;False;False;False;False;False;False;False;False;False
-Anzoátegui;False;False;False;False;False;False;False;False;False
-Armero (Guayabal);False;False;False;False;False;False;False;False;False
-Ataco;False;False;False;False;False;False;False;False;False
-Cajamarca;False;False;False;False;False;False;False;False;False
-Carmen De Apicalá;False;False;False;False;False;False;False;False;False
-Casabianca;False;False;False;False;False;False;False;False;False
-Chaparral;False;False;False;False;False;False;False;False;False
-Coello;False;False;False;False;False;False;False;False;False
-Coyaima;False;False;False;False;False;False;False;False;False
-Cunday;False;False;False;False;False;False;False;False;False
-Dolores;False;False;False;False;False;False;False;False;False
-Espinal;False;False;False;False;False;False;False;False;False
-Falan;False;False;False;False;False;False;False;False;False
-Flandes;False;False;False;False;False;False;False;False;False
-Fresno;False;False;False;False;False;False;False;False;False
-Guamo;False;False;False;False;False;False;False;False;False
-Herveo;False;False;False;False;False;False;False;False;False
-Honda;False;False;False;False;False;False;False;False;False
-Ibagué;False;False;False;False;False;False;False;False;False
-Icononzo;False;False;False;False;False;False;False;False;False
-Lérida;False;False;False;False;False;False;False;False;False
-Líbano;False;False;False;False;False;False;False;False;False
-Mariquita;False;False;False;False;False;False;False;False;False
-Melgar;False;False;False;False;False;False;False;False;False
-Murillo;False;False;False;False;False;False;False;False;False
-Natagaima;False;False;False;False;False;False;False;False;False
-Ortega;False;False;False;False;False;False;False;False;False
-Palocabildo;False;False;False;False;False;False;False;False;False
-Piedras;False;False;False;False;False;False;False;False;False
-Planadas;False;False;False;False;False;False;False;False;False
-Prado;False;False;False;False;False;False;False;False;False
-Purificación;False;False;False;False;False;False;False;False;False
-Rioblanco;False;False;False;False;False;False;False;False;False
-Roncesvalles;False;False;False;False;False;False;False;False;False
-Rovira;False;False;False;False;False;False;False;False;False
-Saldaña;False;False;False;False;False;False;False;False;False
-San Antonio;False;False;False;False;False;False;False;False;False
-San Luis;False;False;False;False;False;False;False;False;False
-Santa Isabel;False;False;False;False;False;False;False;False;False
-Suárez;False;False;False;False;False;False;False;False;False
-Valle De San Juan;False;False;False;False;False;False;False;False;False
-Venadillo;False;False;False;False;False;False;False;False;False
-Villahermosa;False;False;False;False;False;False;False;False;False
-Villarrica;False;False;False;False;False;False;False;False;False
-Alcalá;False;False;False;False;False;False;False;False;False
-Andalucía;False;False;False;False;False;False;False;False;False
-Ansermanuevo;False;False;False;False;False;False;False;False;False
-Argelia;False;False;False;False;False;False;False;False;False
-Bolívar;False;False;False;False;False;False;False;False;False
-Buenaventura;False;False;False;False;False;False;False;False;False
-Buga;False;False;False;False;False;False;False;False;False
-Bugalagrande;False;False;False;False;False;False;False;False;False
-Caicedonia;False;False;False;False;False;False;False;False;False
-Cali;False;False;False;False;False;False;False;False;False
-Calima (El Darién);False;False;False;False;False;False;False;False;False
-Candelaria;False;False;False;False;False;False;False;False;False
+Astrea;False;False;False;False;False;False;False;False;False
+Colosó;False;False;False;False;False;False;False;False;False
+Chalán;False;False;False;False;False;False;False;False;False
+Santa Bárbara De Pinto;False;False;False;False;False;False;False;False;False
+Tolú;False;False;False;False;False;False;False;False;False
+Nóvita;False;False;False;False;False;False;False;False;False
+Chitaraque;False;False;False;False;False;False;False;False;False
+Paz De Rio;True;False;False;False;False;False;False;False;False
+Cocorná;False;False;False;False;False;False;False;False;False
+Titiribí;False;False;False;False;False;False;False;False;False
 Cartago;False;False;False;False;False;False;False;False;False
-Dagua;False;False;False;False;False;False;False;False;False
-El Águila;False;False;False;False;False;False;False;False;False
+Santa Isabel;False;False;False;False;True;False;False;False;False
+Venadillo;False;False;False;False;True;False;False;False;False
+La Calera;False;False;False;True;False;False;False;False;False
+Junín;False;False;False;True;False;False;False;False;False
+Bogotá, D.C.;False;False;False;True;False;False;False;False;False
 El Cairo;False;False;False;False;False;False;False;False;False
-El Cerrito;False;False;False;False;False;False;False;False;False
-El Dovio;False;False;False;False;False;False;False;False;False
-Florida;False;False;False;False;False;False;False;False;False
-Ginebra;False;False;False;False;False;False;False;False;False
-Guacarí;False;False;False;False;False;False;False;False;False
+Beltrán;False;False;False;False;True;False;False;False;False
+Cota;False;False;False;False;False;False;False;False;False
+Anolaima;False;False;False;False;False;False;False;False;False
+Madrid;False;False;False;False;False;False;False;False;False
+Ansermanuevo;False;False;False;False;False;False;False;False;False
+Dosquebradas;False;False;False;False;True;False;False;False;False
+Puerto Gaitán;False;False;False;False;False;False;False;False;False
+Facatativá;False;False;False;False;False;False;False;False;False
+Sora;False;False;False;False;False;False;False;False;False
+Cuítiva;True;False;False;False;False;False;False;False;False
+Tinjacá;False;False;False;False;False;False;False;False;False
+Sáchica;False;False;False;False;False;False;False;False;False
+Olaya;False;False;False;False;False;False;False;False;False
+Entrerrios;False;False;False;False;False;False;False;False;False
+Santa Fe De Antioquia;False;False;False;False;False;False;False;False;False
+San José De Miranda;True;False;False;False;False;False;False;False;False
+Curití;True;False;False;False;False;False;False;False;False
+Tame;True;False;False;False;False;False;False;False;False
+Enciso;False;False;False;False;False;False;False;False;False
+Cañasgordas;False;False;False;False;False;False;False;False;False
+Vegachí;False;False;False;False;False;False;False;False;False
+Uramita;False;False;False;False;False;False;False;False;False
+Zapatoca;False;False;False;False;False;False;False;False;False
+San Andrés;True;False;False;False;False;False;False;False;False
+Murindó;False;False;False;False;False;False;False;False;False
+Valparaiso;False;False;False;False;False;False;False;False;False
+Sogamoso;True;False;False;False;False;False;False;False;False
+Andes;False;False;False;False;False;False;False;False;False
+La Dorada;False;False;False;False;False;False;False;False;False
+Támesis;False;False;False;False;False;False;False;False;False
+Pisva;True;False;False;False;False;False;False;False;False
+San Luis De Gaceno;False;False;False;False;False;False;False;False;False
+Guayatá;False;False;False;False;False;False;False;False;False
+Líbano;False;False;False;False;True;False;False;False;False
+Sabanalarga;False;False;False;False;False;False;False;False;False
+Chaguaní;False;False;False;False;False;False;False;False;False
+Almeida;False;False;False;False;False;False;False;False;False
+Somondoco;False;False;False;False;False;False;False;False;False
+Sasaima;False;False;False;False;False;False;False;False;False
+Tocancipá;False;False;False;False;False;False;False;False;False
+El Águila;False;False;False;False;False;False;False;False;False
+La Celia;False;False;False;False;False;False;False;False;False
+Socha;True;False;False;False;False;False;False;False;False
+Támara;True;False;False;False;False;False;False;False;False
+La Ceja;False;False;False;False;False;False;False;False;False
+Salgar;False;False;False;False;False;False;False;False;False
+Güepsa;False;False;False;False;False;False;False;False;False
+Caldas;False;False;False;False;False;False;False;False;False
+Quípama;False;False;False;False;False;False;False;False;False
+Aquitania;True;False;False;False;False;False;False;False;False
+Pesca;True;False;False;False;False;False;False;False;False
+Maripí;False;False;False;False;False;False;False;False;False
+Toca;True;False;False;False;False;False;False;False;False
+Jardín;False;False;False;False;False;False;False;False;False
+Cajicá;False;False;False;False;False;False;False;False;False
+Chima;False;False;False;False;False;False;False;False;False
+Tipacoque;True;False;False;False;False;False;False;False;False
+Valle De San José;True;False;False;False;False;False;False;False;False
+Guacamayas;True;False;False;False;False;False;False;False;False
+Panqueba;True;False;False;False;False;False;False;False;False
+Páramo;True;False;False;False;False;False;False;False;False
+Caicedo;False;False;False;False;False;False;False;False;False
+Barbosa;False;False;False;False;False;False;False;False;False
+Santa Helena Del Opón;False;False;False;False;False;False;False;False;False
+Calarcá;False;False;False;False;True;False;False;False;False
+Soacha;False;False;False;True;False;False;False;False;False
+Quimbaya;False;False;False;False;False;False;False;False;False
+La Chorrera;False;False;False;False;False;False;False;False;True
+Socorro;False;False;False;False;False;False;False;False;False
+Onzaga;True;False;False;False;False;False;False;False;False
+San Roque;False;False;False;False;False;False;False;False;False
+El Espino;True;False;False;False;False;False;False;False;False
+Santo Domingo;False;False;False;False;False;False;False;False;False
+Vélez;False;False;False;False;False;False;False;False;False
+Cisneros;False;False;False;False;False;False;False;False;False
+Macaravita;True;False;False;False;False;False;False;False;False
+Capitanejo;False;False;False;False;False;False;False;False;False
+Urrao;False;False;False;False;False;False;False;False;False
+San Miguel;True;False;False;False;False;False;False;False;False
+Puerto Rondón;False;False;False;False;False;False;False;False;False
+Sopetrán;False;False;False;False;False;False;False;False;False
+Hato;False;False;False;False;False;False;False;False;False
+Cravo Norte;False;False;False;False;False;False;False;False;False
+Mogotes;True;False;False;False;False;False;False;False;False
+San Gil;True;False;False;False;False;False;False;False;False
+Maceo;False;False;False;False;False;False;False;False;False
+Palmas Del Socorro;False;False;False;False;False;False;False;False;False
+Girardota;False;False;False;False;False;False;False;False;False
+El Cocuy;True;False;False;False;False;False;False;False;False
+Boavita;True;False;False;False;False;False;False;False;False
+Caracolí;False;False;False;False;False;False;False;False;False
+Fredonia;False;False;False;False;False;False;False;False;False
+Paipa;True;False;False;False;False;False;False;False;False
+Nuquí;False;False;False;False;False;True;False;False;False
+Cerinza;True;False;False;False;False;False;False;False;False
+Santa Bárbara;True;False;False;False;False;False;False;False;False
+Duitama;True;False;False;False;False;False;False;False;False
+La Belleza;False;False;False;False;False;False;False;False;False
+Alto Baudó (Pie De Pato);False;False;False;False;False;True;False;False;False
+Puerto Triunfo;False;False;False;False;False;False;False;False;False
+La Macarena;False;False;False;True;False;False;False;False;True
+Hobo;False;False;False;False;False;False;False;False;False
+Algeciras;False;False;False;True;False;False;False;False;False
+Íquira;False;False;False;False;True;False;False;False;False
+Caldono;False;False;False;False;False;False;False;False;False
+Jambaló;False;False;False;False;True;False;False;False;False
+Cubará;True;False;False;False;False;False;False;False;False
+Saravena;True;False;False;False;False;False;False;False;False
+Guaca;True;False;False;False;False;False;False;False;False
+Toledo;True;False;False;False;False;False;False;False;False
+Arauca;False;False;False;False;False;False;False;False;False
+Piedecuesta;True;False;False;False;False;False;False;False;False
+San Vicente De Chucurí;False;False;False;False;False;False;False;False;False
+Floridablanca;True;False;False;False;False;False;False;False;False
+Betulia;False;False;False;False;False;False;False;False;False
+Dabeiba;False;False;True;False;False;False;False;False;False
+Campamento;False;False;False;False;False;False;False;False;False
+Girón;False;False;False;False;False;False;False;False;False
+Peque;False;False;True;False;False;False;False;False;False
+Briceño;False;False;False;False;False;False;False;False;False
+Barrancabermeja;False;False;False;False;False;False;False;False;False
+Tona;True;False;False;False;False;False;False;False;False
+Bucaramanga;False;False;False;False;False;False;False;False;False
+Remedios;False;False;False;False;False;False;False;False;False
+Amalfi;False;False;False;False;False;False;False;False;False
+Yondó (Casabe);False;False;False;False;False;False;False;False;False
+Silos;True;False;False;False;False;False;False;False;False
+Carmen Del Darién  (Curbaradó);False;False;False;False;False;True;False;False;False
+Charta;True;False;False;False;False;False;False;False;False
+Saboyá;False;False;False;False;False;False;False;False;False
+Puerto Salgar;False;False;False;False;False;False;False;False;False
+Santa Sofía;False;False;False;False;False;False;False;False;False
+Betania;False;False;False;False;False;False;False;False;False
+Tópaga;True;False;False;False;False;False;False;False;False
+Gachantivá;False;False;False;False;False;False;False;False;False
+Cómbita;True;False;False;False;False;False;False;False;False
+Nobsa;False;False;False;False;False;False;False;False;False
+Amagá;False;False;False;False;False;False;False;False;False
+Sativasur;True;False;False;False;False;False;False;False;False
+Santana;False;False;False;False;False;False;False;False;False
+Socotá;True;False;False;False;False;False;False;False;False
+Paz De Ariporo;True;False;False;False;False;False;False;False;False
+Tenjo;False;False;False;False;False;False;False;False;False
+Pereira;False;False;False;False;True;False;False;False;False
+Chía;False;False;False;False;False;False;False;False;False
+Murillo;False;False;False;False;True;False;False;False;False
+Chivor;False;False;False;True;False;False;False;False;False
+La Virginia;False;False;False;False;False;False;False;False;False
+Bituima;False;False;False;False;False;False;False;False;False
+El Rosal;False;False;False;False;False;False;False;False;False
+Ambalema;False;False;False;False;True;False;False;False;False
+Albán;False;False;False;False;False;False;False;False;False
+Gachetá;False;False;False;True;False;False;False;False;False
+Vianí;False;False;False;False;False;False;False;False;False
+Lérida;False;False;False;False;True;False;False;False;False
+Santa Rosa De Cabal;False;False;False;False;True;False;False;False;False
+San Juan De Rioseco;False;False;False;False;False;False;False;False;False
+El Guacamayo;False;False;False;False;False;False;False;False;False
+Oiba;False;False;False;False;False;False;False;False;False
+Guatapé;False;False;False;False;False;False;False;False;False
+San Carlos;False;False;False;False;False;False;False;False;False
+Quibdó;False;False;False;False;False;True;False;False;False
+La Salina;True;False;False;False;False;False;False;False;False
+Peñol;False;False;False;False;False;False;False;False;False
+Guarne;False;False;False;False;False;False;False;False;False
+La Uvita;True;False;False;False;False;False;False;False;False
+Contratación;False;False;False;False;False;False;False;False;False
+Coromoro;True;False;False;False;False;False;False;False;False
+La Paz;False;False;False;False;False;False;True;False;False
+Charalá;True;False;False;False;False;False;False;False;False
+San Vicente;False;False;False;False;False;False;False;False;False
+Ocamonte;True;False;False;False;False;False;False;False;False
+San Rafael;False;False;False;False;False;False;False;False;False
+Confines;False;False;False;False;False;False;False;False;False
+Alejandría;False;False;False;False;False;False;False;False;False
+Ebéjico;False;False;False;False;False;False;False;False;False
+Bello;False;False;False;False;False;False;False;False;False
+Tibasosa;True;False;False;False;False;False;False;False;False
+La Pintada;False;False;False;False;False;False;False;False;False
+Yacopí;False;False;False;False;False;False;False;False;False
+Pore;True;False;False;False;False;False;False;False;False
+Hispania;False;False;False;False;False;False;False;False;False
+Arcabuco;True;False;False;False;False;False;False;False;False
+Molagavita;True;False;False;False;False;False;False;False;False
+Barichara;False;False;False;False;False;False;False;False;False
+Chipatá;False;False;False;False;False;False;False;False;False
+Sácama;True;False;False;False;False;False;False;False;False
+Carmen De Viboral;False;False;False;False;False;False;False;False;False
+Tutazá;True;False;False;False;False;False;False;False;False
+Concordia;False;False;False;False;False;False;True;False;False
+Sabaneta;False;False;False;False;False;False;False;False;False
+San Benito;False;False;False;False;False;False;False;False;False
+Sativanorte;True;False;False;False;False;False;False;False;False
+Envigado;False;False;False;False;False;False;False;False;False
+Angelópolis;False;False;False;False;False;False;False;False;False
+Retiro;False;False;False;False;False;False;False;False;False
+Suaita;True;False;False;False;False;False;False;False;False
+Jericó;True;False;False;False;False;False;False;False;False
+Puerto Berrío;False;False;False;False;False;False;False;False;False
+Carcasí;True;False;False;False;False;False;False;False;False
+Guicán;True;False;False;False;False;False;False;False;False
+Cimitarra;False;False;False;False;False;False;False;False;False
+Galán;False;False;False;False;False;False;False;False;False
+Málaga;False;False;False;False;False;False;False;False;False
+Belmira;False;False;False;False;False;False;False;False;False
+Liborina;False;False;False;False;False;False;False;False;False
+Bahía Solano (Mutis);False;False;False;False;False;True;False;False;False
+Cepitá;False;False;False;False;False;False;False;False;False
+Carolina;False;False;False;False;False;False;False;False;False
+Aratoca;False;False;False;False;False;False;False;False;False
+Yolombó;False;False;False;False;False;False;False;False;False
+Vigia Del Fuerte;False;False;False;False;False;False;False;False;False
+Gómez Plata;False;False;False;False;False;False;False;False;False
+Chiscas;True;False;False;False;False;False;False;False;False
+Bojayá (Bellavista);False;False;False;False;False;True;False;False;False
+Fortul;True;False;False;False;False;False;False;False;False
+San José De La Montaña;False;False;False;False;False;False;False;False;False
+Puerto Parra;False;False;False;False;False;False;False;False;False
+Los Santos;False;False;False;False;False;False;False;False;False
+Simacota;False;False;False;False;False;False;False;False;False
+Buriticá;False;False;False;False;False;False;False;False;False
+Valencia;False;False;True;False;False;False;False;False;False
+San Jacinto Del Cauca;False;False;False;False;False;False;False;False;False
+Montecristo;False;False;False;False;False;False;False;False;False
+González;False;False;False;False;False;False;False;False;False
+Arenal;False;False;False;False;False;False;False;False;False
+Gamarra;False;False;False;False;False;False;False;False;False
+Ayapel;False;False;False;False;False;False;False;False;False
+Aguachica;False;False;False;False;False;False;False;False;False
+Guaranda;False;False;False;False;False;False;False;False;False
+Hacarí;False;False;False;False;False;False;False;False;False
+Cucutilla;True;False;False;False;False;False;False;False;False
+Planeta Rica;False;False;False;False;False;False;False;False;False
+San Pedro De Urabá;False;False;False;False;False;False;False;False;False
+Norosi;False;False;False;False;False;False;False;False;False
+Pueblo Nuevo;False;False;False;False;False;False;False;False;False
+Tiquisio (Puerto Rico);False;False;False;False;False;False;False;False;False
+Rioviejo;False;False;False;False;False;False;False;False;False
+Necoclí;False;False;True;False;False;False;False;False;False
+San Marcos;False;False;False;False;False;False;False;False;False
+Majagual;False;False;False;False;False;False;False;False;False
+San Juan De Urabá;False;False;True;False;False;False;False;False;False
+La Gloria;False;False;False;False;False;False;False;False;False
+Canalete;False;False;False;False;False;False;False;False;False
+Cunday;False;False;False;True;False;False;False;False;False
+Silvania;False;False;False;False;False;False;False;False;False
+Medio Atrato (Beté);False;False;False;False;False;False;False;False;False
+La Primavera;False;False;False;False;False;False;False;True;False
+Rionegro;False;False;False;False;False;False;False;False;False
+Aguada;False;False;False;False;False;False;False;False;False
+Marinilla;False;False;False;False;False;False;False;False;False
+Bolivar;False;False;False;False;False;False;False;False;False
+Puerto Nare;False;False;False;False;False;False;False;False;False
+Hato Corozal;True;False;False;False;False;False;False;False;False
+Chita;True;False;False;False;False;False;False;False;False
+Florián;False;False;False;False;False;False;False;False;False
+Gámeza;True;False;False;False;False;False;False;False;False
+Sotaquirá;True;False;False;False;False;False;False;False;False
+Busbanzá;True;False;False;False;False;False;False;False;False
+Corrales;True;False;False;False;False;False;False;False;False
+Pueblorrico;False;False;False;False;False;False;False;False;False
+Jesús María;False;False;False;False;False;False;False;False;False
+Sonsón;False;False;False;False;False;False;False;False;False
+Puente Nacional;False;False;False;False;False;False;False;False;False
+Floresta;True;False;False;False;False;False;False;False;False
+Ciudad Bolívar;False;False;False;False;False;False;False;False;False
+Abejorral;False;False;False;False;False;False;False;False;False
+Moniquirá;False;False;False;False;False;False;False;False;False
+Montebello;False;False;False;False;False;False;False;False;False
+Betéitiva;True;False;False;False;False;False;False;False;False
+Togüí;False;False;False;False;False;False;False;False;False
+Giraldo;False;False;False;False;False;False;False;False;False
+Jordán;False;False;False;False;False;False;False;False;False
+Abriaquí;False;False;False;False;False;False;False;False;False
+Santa Lucía;False;False;False;False;False;False;False;False;False
+El Copey;False;False;False;False;False;False;True;False;False
+Soplaviento;False;False;False;False;False;False;False;False;False
+San Cristobal;False;False;False;False;False;False;False;False;False
+Turbaco;False;False;False;False;False;False;False;False;False
+San Estanislao;False;False;False;False;False;False;False;False;False
+El Piñón;False;False;False;False;False;False;True;False;False
+Campo De La Cruz;False;False;False;False;False;False;True;False;False
+Manatí;False;False;False;False;False;False;False;False;False
+Regidor;False;False;False;False;False;False;False;False;False
+Achí;False;False;False;False;False;False;False;False;False
+Altos Del Rosario;False;False;False;False;False;False;False;False;False
+Arboletes;False;False;True;False;False;False;False;False;False
+Pelaya;False;False;False;False;False;False;False;False;False
+Caimito;False;False;False;False;False;False;False;False;False
+Los Córdobas;False;False;True;False;False;False;False;False;False
+Montería;False;False;True;False;False;False;False;False;False
+Barranco De Loba;False;False;False;False;False;False;False;False;False
+Cereté;False;False;False;False;False;False;False;False;False
+Ocaña;True;False;False;False;False;False;False;False;False
+Gámbita;True;False;False;False;False;False;False;False;False
+San Martin De Loba;False;False;False;False;False;False;False;False;False
+Sahagún;False;False;False;False;False;False;False;False;False
+Dibulla;False;False;False;False;False;False;True;False;False
+Santa Marta;False;False;False;False;False;False;True;False;False
+Mahates;False;False;False;False;False;False;False;False;False
+Vetas;True;False;False;False;False;False;False;False;False
+California;True;False;False;False;False;False;False;False;False
+Ituango;False;False;True;False;False;False;False;False;False
+Lebrija;False;False;False;False;False;False;False;False;False
+Cantagallo;False;False;False;False;False;False;False;False;False
+Valdivia;False;False;False;False;False;False;False;False;False
+Anorí;False;False;False;False;False;False;False;False;False
+Matanza;False;False;False;False;False;False;False;False;False
+Segovia;False;False;False;False;False;False;False;False;False
+Mutatá;False;False;True;False;False;False;False;False;False
+Herrán;True;False;False;False;False;False;False;False;False
+Pamplonita;True;False;False;False;False;False;False;False;False
+El Playón;False;False;False;False;False;False;False;False;False
+Ábrego;True;False;False;False;False;False;False;False;False
+Salazar;True;False;False;False;False;False;False;False;False
+Labateca;True;False;False;False;False;False;False;False;False
+Cerrito;True;False;False;False;False;False;False;False;False
+Chitagá;True;False;False;False;False;False;False;False;False
+Sabana De Torres;False;False;False;False;False;False;False;False;False
+Zaragoza;False;False;False;False;False;False;False;False;False
+Tarazá;False;False;True;False;False;False;False;False;False
+Chigorodó;False;False;True;False;False;False;False;False;False
+La Esperanza;True;False;False;False;False;False;False;False;False
+San Jose De Ure;False;False;True;False;False;False;False;False;False
+Cáceres;False;False;False;False;False;False;False;False;False
+San Alberto;True;False;False;False;False;False;False;False;False
+El Bagre;False;False;False;False;False;False;False;False;False
+Hatillo De Loba;False;False;False;False;False;False;False;False;False
+Ciénaga De Oro;False;False;False;False;False;False;False;False;False
+Tamalameque;False;False;False;False;False;False;False;False;False
+Pailitas;False;False;False;False;False;False;False;False;False
+San Pelayo;False;False;False;False;False;False;False;False;False
+Gramalote;True;False;False;False;False;False;False;False;False
+Durania;False;False;False;False;False;False;False;False;False
+Cáchira;True;False;False;False;False;False;False;False;False
+Pamplona;True;False;False;False;False;False;False;False;False
+Chinácota;True;False;False;False;False;False;False;False;False
+Mercaderes;False;False;False;False;False;False;False;False;False
+Macanal;False;False;False;True;False;False;False;False;False
+Magangué;False;False;False;False;False;False;False;False;False
+Subachoque;False;False;False;False;False;False;False;False;False
+Tenza;False;False;False;False;False;False;False;False;False
+Tibirita;False;False;False;False;False;False;False;False;False
+Armero (Guayabal);False;False;False;False;False;False;False;False;False
+Garagoa;False;False;False;False;False;False;False;False;False
+Cogua;False;False;False;False;False;False;False;False;False
+Condoto;False;False;False;False;False;False;False;False;False
+Apía;False;False;False;False;False;False;False;False;False
+Rio Iró (Santa Rita);False;False;False;False;False;False;False;False;False
+La Peña;False;False;False;False;False;False;False;False;False
+Yopal;False;False;False;False;False;False;False;False;False
+Ráquira;False;False;False;False;False;False;False;False;False
+Muzo;False;False;False;False;False;False;False;False;False
+Chivatá;False;False;False;False;False;False;False;False;False
+Iza;True;False;False;False;False;False;False;False;False
+Arroyohondo;False;False;False;False;False;False;False;False;False
+Arjona;False;False;False;False;False;False;False;False;False
+Suan;False;False;False;False;False;False;True;False;False
+San Diego;False;False;False;False;False;False;True;False;False
+Cerro De San Antonio;False;False;False;False;False;False;True;False;False
+Algarrobo;False;False;False;False;False;False;True;False;False
+Mutiscua;True;False;False;False;False;False;False;False;False
 Jamundí;False;False;False;False;False;False;False;False;False
-La Cumbre;False;False;False;False;False;False;False;False;False
-La Unión;False;False;False;False;False;False;False;False;False
-La Victoria;False;False;False;False;False;False;False;False;False
-Obando;False;False;False;False;False;False;False;False;False
-Palmira;False;False;False;False;False;False;False;False;False
-Pradera;False;False;False;False;False;False;False;False;False
-Restrepo;False;False;False;False;False;False;False;False;False
-Riofrío;False;False;False;False;False;False;False;False;False
-Roldanillo;False;False;False;False;False;False;False;False;False
-San Pedro;False;False;False;False;False;False;False;False;False
-Sevilla;False;False;False;False;False;False;False;False;False
-Toro;False;False;False;False;False;False;False;False;False
-Trujillo;False;False;False;False;False;False;False;False;False
-Tuluá;False;False;False;False;False;False;False;False;False
-Ulloa;False;False;False;False;False;False;False;False;False
-Versalles;False;False;False;False;False;False;False;False;False
-Vijes;False;False;False;False;False;False;False;False;False
-Yotoco;False;False;False;False;False;False;False;False;False
-Yumbo;False;False;False;False;False;False;False;False;False
-Zarzal;False;False;False;False;False;False;False;False;False
-Carurú;False;False;False;False;False;False;False;False;False
+Pinillos;False;False;False;False;False;False;False;False;False
+San Benito Abad;False;False;False;False;False;False;False;False;False
+Puerto Escondido;False;False;False;False;False;False;False;False;False
+Cotorra;False;False;False;False;False;False;False;False;False
+Chinú;False;False;False;False;False;False;False;False;False
+El Roble;False;False;False;False;False;False;False;False;False
+Margarita;False;False;False;False;False;False;False;False;False
+Galeras;False;False;False;False;False;False;False;False;False
+San Fernando;False;False;False;False;False;False;False;False;False
+Sampués;False;False;False;False;False;False;False;False;False
+San Andrés De Sotavento;False;False;False;False;False;False;False;False;False
+Mompós;False;False;False;False;False;False;False;False;False
+Tuchín;False;False;False;False;False;False;False;False;False
+Cicuco;False;False;False;False;False;False;False;False;False
+Moñitos;False;False;False;False;False;False;False;False;False
+Corozal;False;False;False;False;False;False;False;False;False
+Momil;False;False;False;False;False;False;False;False;False
+Purísima;False;False;False;False;False;False;False;False;False
+El Banco;False;False;False;False;False;False;False;False;False
+Convención;False;False;False;False;False;False;False;False;False
+Teorama;False;False;False;False;False;False;False;False;False
+Lourdes;True;False;False;False;False;False;False;False;False
+Puerto Libertador;False;False;True;False;False;False;False;False;False
+Apartadó;False;False;True;False;False;False;False;False;False
+Caucasia;False;False;False;False;False;False;False;False;False
+El Zulia;False;False;False;False;False;False;False;False;False
+La Apartada;False;False;False;False;False;False;False;False;False
+Puerto Wilches;False;False;False;False;False;False;False;False;False
+Montelíbano;False;False;True;False;False;False;False;False;False
+Santa Rosa Del Sur;False;False;False;False;False;False;False;False;False
+Simití;False;False;False;False;False;False;False;False;False
+Nechí;False;False;False;False;False;False;False;False;False
+Tierralta;False;False;True;False;False;False;False;False;False
+Rio De Oro;False;False;False;False;False;False;False;False;False
+La Playa;True;False;False;False;False;False;False;False;False
+Puerto Santander;False;False;False;False;False;False;False;False;False
+Repelón;False;False;False;False;False;False;False;False;False
+El Guamo;False;False;False;False;False;False;True;False;False
+Zapayán;False;False;False;False;False;False;True;False;False
+Tubará;False;False;False;False;False;False;True;False;False
+Sitionuevo;False;False;False;False;False;False;True;False;False
+Pijiño  Del Carmen;False;False;False;False;False;False;False;False;False
+Santa Ana;False;False;False;False;False;False;False;False;False
+Zambrano;False;False;False;False;False;False;False;False;False
+El Carmen De Bolívar;False;False;False;False;False;False;False;False;False
+Itagüí;False;False;False;False;False;False;False;False;False
+El Paso;False;False;False;False;False;False;False;False;False
+San Jacinto;False;False;False;False;False;False;False;False;False
+Nueva Granada;False;False;False;False;False;False;False;False;False
+Ariguaní (El Dificil);False;False;False;False;False;False;False;False;False
+Tenerife;False;False;False;False;False;False;False;False;False
+Plato;False;False;False;False;False;False;False;False;False
+Bosconia;False;False;False;False;False;False;True;False;False
+María La Baja;False;False;False;False;False;False;False;False;False
+San Juan Nepomuceno;False;False;False;False;False;False;False;False;False
+San Onofre;False;False;False;False;False;False;False;False;False
+Chivolo;False;False;False;False;False;False;False;False;False
+Pedraza;False;False;False;False;False;False;True;False;False
+Juan De Acosta;False;False;False;False;False;False;False;False;False
+Malambo;False;False;False;False;False;False;True;False;False
+Villa Del Rosario;False;False;False;False;False;False;False;False;False
+Cúcuta;False;False;False;False;False;False;False;False;False
+El Encanto;False;False;False;False;False;False;False;False;False
+Arauquita;False;False;False;False;False;False;False;False;False
+Taraira;False;False;False;False;False;False;False;False;True
+Pacoa (Cor. Departamental);False;False;False;False;False;False;False;False;True
+Puerto Leguízamo;False;True;False;False;False;False;False;False;True
+Puerto Asís;False;True;False;False;False;False;False;False;False
+Puerto Alegría;False;False;False;False;False;False;False;False;False
+Clemencia;False;False;False;False;False;False;False;False;False
+Pivijay;False;False;False;False;False;False;True;False;False
+Ponedera;False;False;False;False;False;False;True;False;False
+Pueblo Bello;False;False;False;False;False;False;True;False;False
+Palmar De Varela;False;False;False;False;False;False;True;False;False
+Remolino;False;False;False;False;False;False;True;False;False
+Santo Tomás;False;False;False;False;False;False;True;False;False
+Piojó;False;False;False;False;False;False;False;False;False
+Sabanagrande;False;False;False;False;False;False;True;False;False
+Baranoa;False;False;False;False;False;False;True;False;False
+Valledupar;False;False;False;False;False;False;True;False;False
+Aracataca;False;False;False;False;False;False;True;False;False
+Usiacurí;False;False;False;False;False;False;False;False;False
+Lorica;False;False;False;False;False;False;False;False;False
+Manaure;False;False;False;False;False;False;True;False;False
+San Andres Y  Providencia (Santa Isabel);False;False;False;False;False;False;False;False;False
+Guachucal;False;False;False;False;False;False;False;False;False
+Samaniego;False;False;False;False;False;False;False;False;False
+Acevedo;False;True;False;False;False;False;False;False;False
+Motavita;False;False;False;False;False;False;False;False;False
+Sutamarchán;False;False;False;False;False;False;False;False;False
+Villa De Leiva;True;False;False;False;False;False;False;False;False
+Lloró;False;False;False;False;False;False;False;False;False
+Paya;True;False;False;False;False;False;False;False;False
+Guayabal De Síquima;False;False;False;False;False;False;False;False;False
+Sopó;False;False;False;False;False;False;False;False;False
+Guatavita;False;False;False;True;False;False;False;False;False
+Tabio;False;False;False;False;False;False;False;False;False
+Otanche;False;False;False;False;False;False;False;False;False
+Tarso;False;False;False;False;False;False;False;False;False
+Tasco;True;False;False;False;False;False;False;False;False
+Guavatá;False;False;False;False;False;False;False;False;False
+Santa Rosa De Viterbo;True;False;False;False;False;False;False;False;False
+San José De Pare;False;False;False;False;False;False;False;False;False
+Carepa;False;False;True;False;False;False;False;False;False
+Ovejas;False;False;False;False;False;False;False;False;False
+Fundación;False;False;False;False;False;False;True;False;False
+El Retén;False;False;False;False;False;False;True;False;False
+Polonuevo;False;False;False;False;False;False;False;False;False
+Puerto Arica;False;False;False;False;False;False;False;False;True
+Soledad;False;False;False;False;False;False;True;False;False
+Galapa;False;False;False;False;False;False;True;False;False
+Zona Bananera;False;False;False;False;False;False;True;False;False
+Puebloviejo;False;False;False;False;False;False;True;False;False
+Ciénaga;False;False;False;False;False;False;True;False;False
+Barranquilla;False;False;False;False;False;False;True;False;False
+Coveñas;False;False;False;False;False;False;False;False;False
+Turbo;False;False;True;False;False;False;False;False;False
+Medellín;False;False;False;False;False;False;False;False;False
+Buenaventura;False;False;False;False;False;True;False;False;False
+La Estrella;False;False;False;False;False;False;False;False;False
 Mitú;False;False;False;False;False;False;False;False;False
-Pacoa (Cor. Departamental);False;False;False;False;False;False;False;False;False
-Papunaua(cor. Departamental);False;False;False;False;False;False;False;False;False
-Taraira;False;False;False;False;False;False;False;False;False
-Yavaraté (Cor. Departamental);False;False;False;False;False;False;False;False;False
-Cumaribo;False;False;False;False;False;False;False;False;False
-La Primavera;False;False;False;False;False;False;False;False;False
-Puerto Carreño;False;False;False;False;False;False;False;False;False
-Santa Rosalía;False;False;False;False;False;False;False;False;False
+Yavaraté  (Cor. Departamental);False;False;False;False;False;False;False;False;False
+Cácota;True;False;False;False;False;False;False;False;False
+Luruaco;False;False;False;False;False;False;False;False;False
+Bucarasica;True;False;False;False;False;False;False;False;False
+Los Patios;False;False;False;False;False;False;False;False;False
+Arboledas;True;False;False;False;False;False;False;False;False
+Bochalema;False;False;False;False;False;False;False;False;False
+Ragonvalia;False;False;False;False;False;False;False;False;False
+Suratá;True;False;False;False;False;False;False;False;False
+Sabanas De San Angel;False;False;False;False;False;False;False;False;False
+Rondón;True;False;False;False;False;False;False;False;False
+El Tarra;False;False;False;False;False;False;False;False;False
+Villa Caro;True;False;False;False;False;False;False;False;False
+Sardinata;False;False;False;False;False;False;False;False;False
+Siachoque;True;False;False;False;False;False;False;False;False
+Tibaná;False;False;False;False;False;False;False;False;False
+Ramiriquí;False;False;False;False;False;False;False;False;False
+Úmbita;False;False;False;False;False;False;False;False;False
+Viracachá;True;False;False;False;False;False;False;False;False
+Chinavita;False;False;False;False;False;False;False;False;False
+Pauna;False;False;False;False;False;False;False;False;False
+Tununguá;False;False;False;False;False;False;False;False;False
+Cabuyaro;False;False;False;False;False;False;False;False;False
+Puerto López;False;False;False;False;False;False;False;False;False
+Puerto Colombia;False;False;False;False;False;False;True;False;False
+Tarapacá;False;False;False;False;False;False;False;False;True
+Becerrill;False;False;False;False;False;False;True;False;False
+Tibú;False;False;False;False;False;False;False;False;False
+Chiriguaná;False;False;False;False;False;False;False;False;False
+Hato Nuevo;False;False;False;False;False;False;True;False;False
+Fonseca;False;False;False;False;False;False;True;False;False
+Agustín Codazzi;False;False;False;False;False;False;True;False;False
+La Jagua De Ibirico;False;False;False;False;False;False;False;False;False
+La Jagua Del Pilar;False;False;False;False;False;False;True;False;False
+El Molino;False;False;False;False;False;False;True;False;False
+Urumita;False;False;False;False;False;False;True;False;False
+Manaure Balcón Del Cesar;False;False;False;False;False;False;True;False;False
+Ipiales;False;False;False;False;False;False;False;False;False
+Curumaní;False;False;False;False;False;False;False;False;False
+Puerto Nariño;False;False;False;False;False;False;False;False;True
+Uribia;False;False;False;False;False;False;False;False;False
+Juradó;False;False;False;False;False;True;False;False;False
+Acandí;False;False;True;False;False;False;False;False;False
+Unguía;False;False;True;False;False;False;False;False;False
+Barrancas;False;False;False;False;False;False;True;False;False
+Distracción;False;False;False;False;False;False;True;False;False
+San Juan Del Cesar;False;False;False;False;False;False;True;False;False
+Riohacha;False;False;False;False;False;False;True;False;False
+Maicao;False;False;False;False;False;False;True;False;False
+La Guadalupe;False;False;False;False;False;False;False;False;False
+Cartagena De Indias;False;False;False;False;False;False;False;False;False
+Turbana;False;False;False;False;False;False;False;False;False
+Santa Catalina;False;False;False;False;False;False;False;False;False
+Tumaco;False;False;False;False;False;True;False;False;False
+Leticia;False;False;False;False;False;False;False;False;True

--- a/backend/spec/fixtures/files/dummy_colombia_departments.csv
+++ b/backend/spec/fixtures/files/dummy_colombia_departments.csv
@@ -1,3 +1,3 @@
-name
-Amazonas
-Antioquia
+name;code
+Amazonas;1
+Antioquia;2

--- a/backend/spec/fixtures/files/dummy_colombia_municipalities.csv
+++ b/backend/spec/fixtures/files/dummy_colombia_municipalities.csv
@@ -1,5 +1,5 @@
-name;department
-Leticia;Amazonas
-Puerto Nariño;Amazonas
-Abejorral;Antioquia
-Abriaquí;Antioquia
+name;department;code
+Leticia;Amazonas;100
+Puerto Nariño;Amazonas;200
+Abejorral;Antioquia;300
+Abriaquí;Antioquia;400


### PR DESCRIPTION
I got my hands on correct geometries of all Colombia municipalities so I am updating `backend/db/seeds/files/colombia_regions.csv` with correct intersections between municipalities and regions (mosaics).

Shapefiles also contained codes for every department and municipality, so I have added them to csv as well.

## Testing instructions

Re-seed database and check that Locations (departments, municipalities and regions) and LocationMembers (intersections between regions and municipalities) were imported.

## Tracking

https://vizzuality.atlassian.net/browse/LET-205
