### PR TITLE
LET-183 SMTP config

### DIFF
--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -1,4 +1,21 @@
 SECRET_KEY_BASE=
+
+BACKEND_URL=localhost:4000/backend
 RAILS_RELATIVE_URL_ROOT=/backend
-DATABASE_URL=
+
+DATABASE_NAME=
+DATABASE_USER=
+DATABASE_PASSWORD=
+DATABASE_HOST=
+
 TX_TOKEN=
+
+# email settings, for which we’ll use sendgrid smtp relay
+SMTP_USERNAME=
+SMTP_PASSWORD=here the sendgrid api key
+SMTP_HOST=
+SMTP_PORT=
+
+# some more mailer settings:
+MAILER_DEFAULT_FROM=
+MAILER_DEFAULT_HOST=localhost:4000

--- a/backend/ENV_VARS.md
+++ b/backend/ENV_VARS.md
@@ -1,9 +1,12 @@
 For starters, we’ll need these:
 RAILS_ENV (I prefer to separate staging / production, but maybe that’s just an old habit no longer needed)
-RAILS_RELATIVE_URL_ROOT (if running backend application in sub url, like /backend)
 RACK_ENV
 RAILS_MAX_THREADS (say 10)
 SECRET_KEY_BASE (generated with rake secret)
+
+BACKEND_URL (without protocol)
+RAILS_RELATIVE_URL_ROOT (if running backend application in sub url, like /backend)
+
 DATABASE_NAME
 DATABASE_USER
 DATABASE_PASSWORD

--- a/backend/app/mailers/application_mailer.rb
+++ b/backend/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
+  default from: ENV.fetch("MAILER_DEFAULT_FROM", "please-change-me@example.com")
   layout "mailer"
 end

--- a/backend/config/environments/development.rb
+++ b/backend/config/environments/development.rb
@@ -38,10 +38,9 @@ Rails.application.configure do
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
-
   config.action_mailer.perform_caching = false
   config.action_mailer.delivery_method = :letter_opener
-  config.action_mailer.default_url_options = {host: "localhost", port: 4000}
+  config.action_mailer.default_url_options = {host: ENV["MAILER_DEFAULT_HOST"], protocol: "http"}
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -63,6 +63,16 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "backend_production"
 
   config.action_mailer.perform_caching = false
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    user_name: ENV["SMTP_USERNAME"],
+    password: ENV["SMTP_PASSWORD"],
+    address: ENV["SMTP_HOST"],
+    port: ENV["SMTP_PORT"],
+    authentication: :plain,
+    enable_starttls_auto: true
+  }
+  config.action_mailer.default_url_options = {host: ENV["MAILER_DEFAULT_HOST"], protocol: "https"}
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/backend/config/initializers/devise.rb
+++ b/backend/config/initializers/devise.rb
@@ -32,13 +32,13 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
+  # config.mailer_sender = ENV.fetch("MAILER_DEFAULT_FROM", "please-change-me-at-config-initializers-devise@example.com")
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
 
   # Configure the parent class responsible to send e-mails.
-  # config.parent_mailer = 'ActionMailer::Base'
+  config.parent_mailer = "ApplicationMailer"
 
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and

--- a/infrastructure/base/modules/env/main.tf
+++ b/infrastructure/base/modules/env/main.tf
@@ -41,6 +41,14 @@ module "transifex_api_key" {
   use_random_value = false
 }
 
+module "sendgrid_api_key" {
+  source           = "../secret_value"
+  region           = var.gcp_region
+  key              = "${var.project_name}_sendgrid_api_key"
+  value            = var.sendgrid_api_key
+  use_random_value = false
+}
+
 locals {
   frontend_docker_build_args = {
     TRANSIFEX_TOKEN = var.transifex_token
@@ -127,6 +135,9 @@ module "backend_cloudrun" {
     }, {
       name        = "TX_TOKEN"
       secret_name = module.transifex_api_key.secret_name
+    }, {
+      name        = "SMTP_PASSWORD"
+      secret_name = module.sendgrid_api_key.secret_name
     }
   ]
   env_vars = [
@@ -161,6 +172,26 @@ module "backend_cloudrun" {
     {
       name  = "TEST_PUBSUB_SUBSCRIPTION"
       value = module.test_pubsub.subscription_name
+    },
+    {
+      name  = "SMTP_USERNAME"
+      value = "apikey"
+    },
+    {
+      name  = "SMTP_HOST"
+      value = "smtp.sendgrid.net"
+    },
+    {
+      name  = "SMTP_PORT"
+      value = 587
+    },
+    {
+      name  = "MAILER_DEFAULT_HOST"
+      value = var.domain
+    },
+    {
+      name  = "MAILER_DEFAULT_FROM"
+      value = "agnieszka.figiel@vizzuality.com"
     }
   ]
 }

--- a/infrastructure/base/modules/env/variables.tf
+++ b/infrastructure/base/modules/env/variables.tf
@@ -41,6 +41,11 @@ variable "transifex_token" {
   description = "Transifex API access token"
 }
 
+variable "sendgrid_api_key" {
+  type = string
+  description = "SendGrid API key"
+}
+
 variable "google_analytics_key" {
   type = string
   description = "Google Analytics key"


### PR DESCRIPTION
Adds smtp config to the Rails app and to the tf sorcery

## Testing instructions

In development I left the letter_opener as mail delivery method, but I did test with the sendgrid account. It is a temporary account which sends emails from my address. Hopefully at some point next week we'll just need to update the password to use the target one.

## Tracking

https://vizzuality.atlassian.net/browse/LET-183?atlOrigin=eyJpIjoiYmFiN2ZmMTFlYWQ3NGJkMmE3YjZiZmE2NmUzYWIwZTkiLCJwIjoiaiJ9