### PR TITLE
Tag checkbox component

### DIFF
--- a/frontend/components/forms/tag-group/component.stories.tsx
+++ b/frontend/components/forms/tag-group/component.stories.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+
+import { SubmitHandler, useForm, NestedValue } from 'react-hook-form';
+
+import { action } from '@storybook/addon-actions';
+import { Story, Meta } from '@storybook/react/types-6-0';
+
+import Button from 'components/button';
+import Tag, { TagProps } from 'components/forms/tag';
+
+import TagGroup from '.';
+
+export default {
+  component: TagGroup,
+  title: 'Components/Forms/TagGroup',
+  argTypes: {
+    register: { control: { disable: true } },
+  },
+} as Meta;
+
+interface FormValues {
+  categories: NestedValue<string[]>;
+}
+
+const Template: Story<TagProps<FormValues>> = (args: TagProps<FormValues>) => {
+  const { register, setValue, watch } = useForm<FormValues>();
+
+  return (
+    <div className="p-4">
+      <TagGroup name={args.name} setValue={setValue} watch={watch}>
+        <Tag
+          id="first-category"
+          value="first-category"
+          aria-describedby="categories-error"
+          register={register}
+          {...args}
+        >
+          First category
+        </Tag>
+        <Tag
+          id="second-category"
+          value="second-category"
+          aria-describedby="categories-error"
+          register={register}
+          {...args}
+        >
+          Second category
+        </Tag>
+        <Tag
+          id="third-category"
+          value="third-category"
+          aria-describedby="categories-error"
+          register={register}
+          {...args}
+        >
+          Third category
+        </Tag>
+        <Tag
+          id="fourth-category"
+          value="fourth-category"
+          aria-describedby="categories-error"
+          register={register}
+          {...args}
+        >
+          Four category
+        </Tag>
+      </TagGroup>
+    </div>
+  );
+};
+
+export const Default: Story<TagProps<FormValues>> = Template.bind({});
+Default.args = {
+  name: 'categories',
+};
+
+const TemplateWithForm: Story<TagProps<FormValues>> = (args: TagProps<FormValues>) => {
+  const {
+    register,
+    setValue,
+    watch,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>({
+    // We don't want to use the native validation here; the validation is specific to the group
+    // and not each tag individually, so we don't want the inputs to have the `valid` or `invalid`
+    // pseudo classes
+    shouldUseNativeValidation: false,
+  });
+  const onSubmit: SubmitHandler<FormValues> = (data) => action('onSubmit')(data);
+
+  return (
+    <div className="p-4">
+      <form
+        // `noValidate` here prevents the browser from not submitting the form if there's a validation
+        // error. We absolutely want the form to be submitted so that React Hook Form is made aware of
+        // the validation errors and we can display errors below inputs.
+        noValidate
+        onSubmit={handleSubmit(onSubmit)}
+      >
+        <TagGroup name={args.name} setValue={setValue} watch={watch}>
+          <Tag
+            id="first-category"
+            value="first-category"
+            aria-describedby="categories-error"
+            register={register}
+            {...args}
+          >
+            First category
+          </Tag>
+          <Tag
+            id="second-category"
+            value="second-category"
+            aria-describedby="categories-error"
+            register={register}
+            {...args}
+          >
+            Second category
+          </Tag>
+          <Tag
+            id="third-category"
+            value="third-category"
+            aria-describedby="categories-error"
+            register={register}
+            {...args}
+          >
+            Third category
+          </Tag>
+          <Tag
+            id="fourth-category"
+            value="fourth-category"
+            aria-describedby="categories-error"
+            register={register}
+            {...args}
+          >
+            Four category
+          </Tag>
+        </TagGroup>
+        {errors.categories?.message && (
+          <p id="form-error" className="pl-2 mt-1 text-xs text-red-700">
+            {errors.categories?.message}
+          </p>
+        )}
+
+        <Button type="submit" className="mt-2">
+          Submit
+        </Button>
+        <p className="mt-2 text-xs text-gray-50">
+          Submit the form to see the {"tags'"} error state (selecting tags is required).
+        </p>
+      </form>
+    </div>
+  );
+};
+
+export const ErrorState: Story<TagProps<FormValues>> = TemplateWithForm.bind({});
+ErrorState.args = {
+  name: 'categories',
+  registerOptions: {
+    required: 'Selecting categories is required.',
+  },
+};

--- a/frontend/components/forms/tag-group/component.stories.tsx
+++ b/frontend/components/forms/tag-group/component.stories.tsx
@@ -23,82 +23,13 @@ interface FormValues {
 }
 
 const Template: Story<TagProps<FormValues>> = (args: TagProps<FormValues>) => {
-  const { register, setValue, watch } = useForm<FormValues>();
+  const { register, setValue } = useForm<FormValues>();
 
   return (
     <div className="p-4">
-      <TagGroup name={args.name} setValue={setValue} watch={watch}>
-        <Tag
-          id="first-category"
-          value="first-category"
-          aria-describedby="categories-error"
-          register={register}
-          {...args}
-        >
-          First category
-        </Tag>
-        <Tag
-          id="second-category"
-          value="second-category"
-          aria-describedby="categories-error"
-          register={register}
-          {...args}
-        >
-          Second category
-        </Tag>
-        <Tag
-          id="third-category"
-          value="third-category"
-          aria-describedby="categories-error"
-          register={register}
-          {...args}
-        >
-          Third category
-        </Tag>
-        <Tag
-          id="fourth-category"
-          value="fourth-category"
-          aria-describedby="categories-error"
-          register={register}
-          {...args}
-        >
-          Four category
-        </Tag>
-      </TagGroup>
-    </div>
-  );
-};
-
-export const Default: Story<TagProps<FormValues>> = Template.bind({});
-Default.args = {
-  name: 'categories',
-};
-
-const TemplateWithForm: Story<TagProps<FormValues>> = (args: TagProps<FormValues>) => {
-  const {
-    register,
-    setValue,
-    watch,
-    handleSubmit,
-    formState: { errors },
-  } = useForm<FormValues>({
-    // We don't want to use the native validation here; the validation is specific to the group
-    // and not each tag individually, so we don't want the inputs to have the `valid` or `invalid`
-    // pseudo classes
-    shouldUseNativeValidation: false,
-  });
-  const onSubmit: SubmitHandler<FormValues> = (data) => action('onSubmit')(data);
-
-  return (
-    <div className="p-4">
-      <form
-        // `noValidate` here prevents the browser from not submitting the form if there's a validation
-        // error. We absolutely want the form to be submitted so that React Hook Form is made aware of
-        // the validation errors and we can display errors below inputs.
-        noValidate
-        onSubmit={handleSubmit(onSubmit)}
-      >
-        <TagGroup name={args.name} setValue={setValue} watch={watch}>
+      <fieldset>
+        <legend className="mb-2 font-sans font-semibold text-gray-800">Category</legend>
+        <TagGroup name={args.name} setValue={setValue}>
           <Tag
             id="first-category"
             value="first-category"
@@ -136,11 +67,85 @@ const TemplateWithForm: Story<TagProps<FormValues>> = (args: TagProps<FormValues
             Four category
           </Tag>
         </TagGroup>
-        {errors.categories?.message && (
-          <p id="form-error" className="pl-2 mt-1 text-xs text-red-700">
-            {errors.categories?.message}
-          </p>
-        )}
+      </fieldset>
+    </div>
+  );
+};
+
+export const Default: Story<TagProps<FormValues>> = Template.bind({});
+Default.args = {
+  name: 'categories',
+};
+
+const TemplateWithForm: Story<TagProps<FormValues>> = (args: TagProps<FormValues>) => {
+  const {
+    register,
+    setValue,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>({
+    // We don't want to use the native validation here; the validation is specific to the group
+    // and not each tag individually, so we don't want the inputs to have the `valid` or `invalid`
+    // pseudo classes
+    shouldUseNativeValidation: false,
+  });
+  const onSubmit: SubmitHandler<FormValues> = (data) => action('onSubmit')(data);
+
+  return (
+    <div className="p-4">
+      <form
+        // `noValidate` here prevents the browser from not submitting the form if there's a validation
+        // error. We absolutely want the form to be submitted so that React Hook Form is made aware of
+        // the validation errors and we can display errors below inputs.
+        noValidate
+        onSubmit={handleSubmit(onSubmit)}
+      >
+        <fieldset>
+          <legend className="mb-2 font-sans font-semibold text-gray-800">Category</legend>
+          <TagGroup name={args.name} setValue={setValue}>
+            <Tag
+              id="first-category"
+              value="first-category"
+              aria-describedby="form-error"
+              register={register}
+              {...args}
+            >
+              First category
+            </Tag>
+            <Tag
+              id="second-category"
+              value="second-category"
+              aria-describedby="form-error"
+              register={register}
+              {...args}
+            >
+              Second category
+            </Tag>
+            <Tag
+              id="third-category"
+              value="third-category"
+              aria-describedby="form-error"
+              register={register}
+              {...args}
+            >
+              Third category
+            </Tag>
+            <Tag
+              id="fourth-category"
+              value="fourth-category"
+              aria-describedby="form-error"
+              register={register}
+              {...args}
+            >
+              Four category
+            </Tag>
+          </TagGroup>
+          {errors.categories?.message && (
+            <p id="form-error" className="pl-2 mt-1 text-xs text-red-700">
+              {errors.categories?.message}
+            </p>
+          )}
+        </fieldset>
 
         <Button type="submit" className="mt-2">
           Submit

--- a/frontend/components/forms/tag-group/component.tsx
+++ b/frontend/components/forms/tag-group/component.tsx
@@ -49,7 +49,7 @@ export const TagGroup = ({
 
       {showSelectAllButton && (
         <button
-          className="mt-4 text-sm font-light underline cursor-pointer text-green-dark"
+          className="mt-6 text-sm font-light underline cursor-pointer text-green-dark"
           type="button"
           onClick={handleSelectAllClick}
         >

--- a/frontend/components/forms/tag-group/component.tsx
+++ b/frontend/components/forms/tag-group/component.tsx
@@ -1,6 +1,6 @@
 import { ReactElement, Children, useMemo, cloneElement } from 'react';
 
-import { UseFormSetValue, UseFormWatch, UseFormClearErrors } from 'react-hook-form';
+import { UseFormSetValue } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 
 import cx from 'classnames';
@@ -14,10 +14,8 @@ export const TagGroup = ({
   name,
   thresholdToShowSelectAll = 4,
   children,
-  watch = noop as UseFormWatch<any>,
-  clearErrors = noop as UseFormClearErrors<any>,
   setValue = noop as UseFormSetValue<any>,
-  setValueOptions = { shouldDirty: true },
+  setValueOptions = { shouldDirty: true, shouldValidate: true },
 }: TagGroupProps) => {
   const numChildren = useMemo(() => Children.count(children), [children]);
 
@@ -28,11 +26,10 @@ export const TagGroup = ({
 
   const handleSelectAllClick = () => {
     setValue(name, allValues, setValueOptions);
-    clearErrors(name);
   };
 
   const tags = Children.map(children, (child: ReactElement) => {
-    return cloneElement(child, { watch, name });
+    return cloneElement(child, { name });
   });
 
   const showSelectAllButton = numChildren >= thresholdToShowSelectAll;

--- a/frontend/components/forms/tag-group/component.tsx
+++ b/frontend/components/forms/tag-group/component.tsx
@@ -1,0 +1,63 @@
+import { ReactElement, Children, useMemo, cloneElement } from 'react';
+
+import { UseFormSetValue, UseFormWatch, UseFormClearErrors } from 'react-hook-form';
+import { FormattedMessage } from 'react-intl';
+
+import cx from 'classnames';
+
+import { noop } from 'lodash-es';
+
+import { TagGroupProps } from './types';
+
+export const TagGroup = ({
+  className,
+  name,
+  thresholdToShowSelectAll = 4,
+  children,
+  watch = noop as UseFormWatch<any>,
+  clearErrors = noop as UseFormClearErrors<any>,
+  setValue = noop as UseFormSetValue<any>,
+  setValueOptions = { shouldDirty: true },
+}: TagGroupProps) => {
+  const numChildren = useMemo(() => Children.count(children), [children]);
+
+  const allValues = useMemo(
+    () => Children.map(children, (child: ReactElement) => child.props.value),
+    [children]
+  );
+
+  const handleSelectAllClick = () => {
+    setValue(name, allValues, setValueOptions);
+    clearErrors(name);
+  };
+
+  const tags = Children.map(children, (child: ReactElement) => {
+    return cloneElement(child, { watch, name });
+  });
+
+  const showSelectAllButton = numChildren >= thresholdToShowSelectAll;
+
+  return (
+    <div
+      className={cx({
+        [className]: !!className,
+      })}
+    >
+      <div role="group">
+        <div className="flex flex-wrap gap-4">{tags}</div>
+      </div>
+
+      {showSelectAllButton && (
+        <button
+          className="mt-4 text-sm font-light underline cursor-pointer text-green-dark"
+          type="button"
+          onClick={handleSelectAllClick}
+        >
+          <FormattedMessage defaultMessage="Select all" id="94Fg25" />
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default TagGroup;

--- a/frontend/components/forms/tag-group/index.ts
+++ b/frontend/components/forms/tag-group/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { TagGroupProps } from './types';

--- a/frontend/components/forms/tag-group/types.ts
+++ b/frontend/components/forms/tag-group/types.ts
@@ -1,20 +1,16 @@
 import { PropsWithChildren } from 'react';
 
-import { UseFormSetValue, UseFormWatch, UseFormClearErrors, SetValueConfig } from 'react-hook-form';
+import { UseFormSetValue, SetValueConfig } from 'react-hook-form';
 
 export type TagGroupProps = PropsWithChildren<{
-  /** classNames to apply to the container */
+  /** Classes to apply to the container */
   className?: string;
-  /** `name` of the tag group. Should match the `name` used in the respective Tags*/
+  /** Name of the tag group (will be assigned to each individual `<Tag />`) */
   name: string;
-  /** Number of children Elements required to show Select All button. Defaults to `4` */
+  /** Number of tags required to show the “Select All” button. Defaults to `4`. */
   thresholdToShowSelectAll?: number;
-  /** Configuration for setValue. Defaults to: { shouldDirty: true } */
-  setValueOptions?: SetValueConfig;
-  /** ReactHook Form's `watch` callback */
-  watch?: UseFormWatch<any>;
-  /** ReactHook Form's `trigger` callback */
-  clearErrors?: UseFormClearErrors<any>;
-  /** dynamically sets the values of a registered field (react-hook-form) */
+  /** React Hook Form's `setValue` function */
   setValue?: UseFormSetValue<any>;
+  /** Options for `setValue` function. Defaults to `{ shouldDirty: true, shouldValidate: true }`. */
+  setValueOptions?: SetValueConfig;
 }>;

--- a/frontend/components/forms/tag-group/types.ts
+++ b/frontend/components/forms/tag-group/types.ts
@@ -1,0 +1,20 @@
+import { PropsWithChildren } from 'react';
+
+import { UseFormSetValue, UseFormWatch, UseFormClearErrors, SetValueConfig } from 'react-hook-form';
+
+export type TagGroupProps = PropsWithChildren<{
+  /** classNames to apply to the container */
+  className?: string;
+  /** `name` of the tag group. Should match the `name` used in the respective Tags*/
+  name: string;
+  /** Number of children Elements required to show Select All button. Defaults to `4` */
+  thresholdToShowSelectAll?: number;
+  /** Configuration for setValue. Defaults to: { shouldDirty: true } */
+  setValueOptions?: SetValueConfig;
+  /** ReactHook Form's `watch` callback */
+  watch?: UseFormWatch<any>;
+  /** ReactHook Form's `trigger` callback */
+  clearErrors?: UseFormClearErrors<any>;
+  /** dynamically sets the values of a registered field (react-hook-form) */
+  setValue?: UseFormSetValue<any>;
+}>;

--- a/frontend/components/forms/tag/component.stories.tsx
+++ b/frontend/components/forms/tag/component.stories.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+
+import { SubmitHandler, useForm } from 'react-hook-form';
+
+import { action } from '@storybook/addon-actions';
+import { Story, Meta } from '@storybook/react/types-6-0';
+
+import Button from 'components/button';
+
+import { TagProps } from './types';
+
+import Tag from '.';
+
+export default {
+  component: Tag,
+  title: 'Components/Forms/Tag',
+  argTypes: {
+    register: { control: { disable: true } },
+  },
+} as Meta;
+
+interface FormValues {
+  category: boolean;
+}
+
+const Template: Story<TagProps<FormValues>> = (args: TagProps<FormValues>) => {
+  const { register } = useForm<FormValues>();
+
+  return (
+    <div className="p-4">
+      <Tag register={register} {...args}>
+        Category
+      </Tag>
+      <p className="mt-2 text-xs text-gray-50">
+        This input is not accessible. Define <code>aria-label</code>.
+      </p>
+    </div>
+  );
+};
+
+export const Default: Story<TagProps<FormValues>> = Template.bind({});
+Default.args = {
+  id: 'form-tag',
+  name: 'category',
+  registerOptions: {
+    disabled: false,
+  },
+};
+
+const TemplateWithForm: Story<TagProps<FormValues>> = (args: TagProps<FormValues>) => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>({
+    // Using the native validation, we're able to style the inputs using the `valid` and `invalid`
+    // pseudo class
+    shouldUseNativeValidation: true,
+  });
+  const onSubmit: SubmitHandler<FormValues> = (data) => action('onSubmit')(data);
+
+  return (
+    <div className="p-4">
+      <form
+        // `noValidate` here prevents the browser from not submitting the form if there's a validation
+        // error. We absolutely want the form to be submitted so that React Hook Form is made aware of
+        // the validation errors and we can display errors below inputs.
+        noValidate
+        onSubmit={handleSubmit(onSubmit)}
+      >
+        <Tag
+          id="story-check"
+          name="category"
+          register={register}
+          aria-describedby="form-error"
+          {...args}
+        >
+          Category
+        </Tag>
+        {errors.category?.message && (
+          <p id="form-error" className="pl-2 mt-1 text-xs text-red-700">
+            {errors.category?.message}
+          </p>
+        )}
+
+        <Button type="submit" className="mt-2">
+          Submit
+        </Button>
+        <p className="mt-2 text-xs text-gray-50">
+          Submit the form to see the {"tag's"} error state (selecting the tag is required).
+        </p>
+      </form>
+    </div>
+  );
+};
+
+export const ErrorState: Story<TagProps<FormValues>> = TemplateWithForm.bind({});
+ErrorState.args = {
+  id: 'story-tag',
+  name: 'category',
+  registerOptions: {
+    disabled: false,
+    required: 'Selecting the category is required.',
+  },
+};
+
+const TemplateDisabled: Story<TagProps<FormValues>> = (args: TagProps<FormValues>) => {
+  const {
+    register,
+    formState: { errors },
+  } = useForm<FormValues>({
+    // Using the native validation, we're able to style the inputs using the `valid` and `invalid`
+    // pseudo class
+    shouldUseNativeValidation: true,
+  });
+
+  return (
+    <div className="p-4">
+      <Tag
+        id="story-tag"
+        name="category"
+        register={register}
+        aria-describedby="form-error"
+        {...args}
+      >
+        Category
+      </Tag>
+      {errors.category?.message && (
+        <p id="form-error" className="pl-2 mt-1 text-xs text-red-700">
+          {errors.category?.message}
+        </p>
+      )}
+    </div>
+  );
+};
+
+export const Disabled: Story<TagProps<FormValues>> = TemplateDisabled.bind({});
+Disabled.args = {
+  id: 'story-tag',
+  name: 'category',
+  registerOptions: {
+    disabled: true,
+    required: false,
+  },
+};

--- a/frontend/components/forms/tag/component.stories.tsx
+++ b/frontend/components/forms/tag/component.stories.tsx
@@ -29,10 +29,10 @@ const Template: Story<TagProps<FormValues>> = (args: TagProps<FormValues>) => {
   return (
     <div className="p-4">
       <Tag register={register} {...args}>
-        Category
+        Tourism & Recreation
       </Tag>
       <p className="mt-2 text-xs text-gray-50">
-        This input is not accessible. Define <code>aria-label</code>.
+        This input is not fully accessible. Wrap it in a <code>fieldset</code> tag.
       </p>
     </div>
   );
@@ -40,6 +40,30 @@ const Template: Story<TagProps<FormValues>> = (args: TagProps<FormValues>) => {
 
 export const Default: Story<TagProps<FormValues>> = Template.bind({});
 Default.args = {
+  id: 'form-tag',
+  name: 'category',
+  registerOptions: {
+    disabled: false,
+  },
+};
+
+const TemplateWithFieldset: Story<TagProps<FormValues>> = (args: TagProps<FormValues>) => {
+  const { register } = useForm<FormValues>();
+
+  return (
+    <div className="p-4">
+      <fieldset>
+        <legend className="mb-2 font-sans font-semibold text-gray-800">Category</legend>
+        <Tag register={register} {...args}>
+          Tourism & Recreation
+        </Tag>
+      </fieldset>
+    </div>
+  );
+};
+
+export const WithFieldset: Story<TagProps<FormValues>> = TemplateWithFieldset.bind({});
+WithFieldset.args = {
   id: 'form-tag',
   name: 'category',
   registerOptions: {
@@ -68,20 +92,23 @@ const TemplateWithForm: Story<TagProps<FormValues>> = (args: TagProps<FormValues
         noValidate
         onSubmit={handleSubmit(onSubmit)}
       >
-        <Tag
-          id="story-check"
-          name="category"
-          register={register}
-          aria-describedby="form-error"
-          {...args}
-        >
-          Category
-        </Tag>
-        {errors.category?.message && (
-          <p id="form-error" className="pl-2 mt-1 text-xs text-red-700">
-            {errors.category?.message}
-          </p>
-        )}
+        <fieldset>
+          <legend className="mb-2 font-sans font-semibold text-gray-800">Category</legend>
+          <Tag
+            id="story-check"
+            name="category"
+            register={register}
+            aria-describedby="form-error"
+            {...args}
+          >
+            Tourism & Recreation
+          </Tag>
+          {errors.category?.message && (
+            <p id="form-error" className="pl-2 mt-1 text-xs text-red-700">
+              {errors.category?.message}
+            </p>
+          )}
+        </fieldset>
 
         <Button type="submit" className="mt-2">
           Submit
@@ -116,20 +143,23 @@ const TemplateDisabled: Story<TagProps<FormValues>> = (args: TagProps<FormValues
 
   return (
     <div className="p-4">
-      <Tag
-        id="story-tag"
-        name="category"
-        register={register}
-        aria-describedby="form-error"
-        {...args}
-      >
-        Category
-      </Tag>
-      {errors.category?.message && (
-        <p id="form-error" className="pl-2 mt-1 text-xs text-red-700">
-          {errors.category?.message}
-        </p>
-      )}
+      <fieldset>
+        <legend className="mb-2 font-sans font-semibold text-gray-800">Category</legend>
+        <Tag
+          id="story-tag"
+          name="category"
+          register={register}
+          aria-describedby="form-error"
+          {...args}
+        >
+          Tourism & Recreation
+        </Tag>
+        {errors.category?.message && (
+          <p id="form-error" className="pl-2 mt-1 text-xs text-red-700">
+            {errors.category?.message}
+          </p>
+        )}
+      </fieldset>
     </div>
   );
 };

--- a/frontend/components/forms/tag/component.tsx
+++ b/frontend/components/forms/tag/component.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from 'react';
+
+import { FieldValues } from 'react-hook-form';
+
+import cx from 'classnames';
+
+import { useFocusRing } from '@react-aria/focus';
+import { VisuallyHidden } from '@react-aria/visually-hidden';
+
+import { TagProps } from './types';
+
+export const Tag = <FormValues extends FieldValues>(props: TagProps<FormValues>) => {
+  const {
+    className,
+    id,
+    'aria-label': ariaLabel,
+    name,
+    register,
+    watch,
+    value,
+    registerOptions,
+    children,
+    ...rest
+  } = props;
+
+  const [isSelected, setIsSelected] = useState<boolean>(false);
+  const [isInvalid, setIsInvalid] = useState<boolean>(false);
+  const { isFocusVisible, focusProps } = useFocusRing();
+
+  const watchFields = watch && watch(name);
+
+  useEffect(() => {
+    if (!watchFields) return;
+    setIsInvalid(false);
+    setIsSelected(watchFields?.includes(value));
+  }, [value, watchFields]);
+
+  return (
+    <label htmlFor={id}>
+      <VisuallyHidden>
+        <input
+          id={id}
+          aria-hidden={true}
+          type="checkbox"
+          value={value}
+          disabled={registerOptions?.disabled}
+          onInvalid={() => setIsInvalid(true)}
+          {...register(name, {
+            onChange: (e) => {
+              const isChecked = !!e.target.checked;
+              setIsSelected(isChecked);
+            },
+            ...registerOptions,
+          })}
+          {...focusProps}
+          {...rest}
+        />
+      </VisuallyHidden>
+      <div
+        role="checkbox"
+        aria-label={ariaLabel}
+        aria-checked={isSelected}
+        className={cx({
+          'inline-flex items-center border rounded-lg transition-all bg-white': true,
+          'hover:shadow cursor-pointer': !registerOptions?.disabled,
+          'cursor-default opacity-60': registerOptions?.disabled,
+          'border-green-dark': isSelected && !isInvalid,
+          'ring-2 ring-green-dark ring-offset-2': isFocusVisible,
+          [className]: !!className,
+          'px-4 py-2': !className,
+          'border-red-700': isInvalid,
+          'outline:focus-none': true,
+        })}
+      >
+        {children}
+      </div>
+    </label>
+  );
+};
+
+export default Tag;

--- a/frontend/components/forms/tag/component.tsx
+++ b/frontend/components/forms/tag/component.tsx
@@ -1,80 +1,47 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 
 import { FieldValues } from 'react-hook-form';
 
 import cx from 'classnames';
 
-import { useFocusRing } from '@react-aria/focus';
-import { VisuallyHidden } from '@react-aria/visually-hidden';
-
 import { TagProps } from './types';
 
-export const Tag = <FormValues extends FieldValues>(props: TagProps<FormValues>) => {
-  const {
-    className,
-    id,
-    'aria-label': ariaLabel,
-    name,
-    register,
-    watch,
-    value,
-    registerOptions,
-    children,
-    ...rest
-  } = props;
-
-  const [isSelected, setIsSelected] = useState<boolean>(false);
-  const [isInvalid, setIsInvalid] = useState<boolean>(false);
-  const { isFocusVisible, focusProps } = useFocusRing();
-
-  const watchFields = watch && watch(name);
-
-  useEffect(() => {
-    if (!watchFields) return;
-    setIsInvalid(false);
-    setIsSelected(watchFields?.includes(value));
-  }, [value, watchFields]);
+export const Tag = <FormValues extends FieldValues>({
+  className,
+  id,
+  name,
+  value,
+  register,
+  registerOptions,
+  children,
+  ...rest
+}: TagProps<FormValues>) => {
+  const [invalid, setInvalid] = useState(false);
 
   return (
-    <label htmlFor={id}>
-      <VisuallyHidden>
-        <input
-          id={id}
-          aria-hidden={true}
-          type="checkbox"
-          value={value}
-          disabled={registerOptions?.disabled}
-          onInvalid={() => setIsInvalid(true)}
-          {...register(name, {
-            onChange: (e) => {
-              const isChecked = !!e.target.checked;
-              setIsSelected(isChecked);
-            },
-            ...registerOptions,
-          })}
-          {...focusProps}
-          {...rest}
-        />
-      </VisuallyHidden>
-      <div
-        role="checkbox"
-        aria-label={ariaLabel}
-        aria-checked={isSelected}
+    <div className={className}>
+      <input
+        id={id}
+        type="checkbox"
+        className="sr-only peer"
+        {...rest}
+        {...register(name, {
+          ...registerOptions,
+        })}
+        value={value}
+        onInvalid={() => setInvalid(true)}
+      />
+      <label
+        htmlFor={id}
         className={cx({
-          'inline-flex items-center border rounded-lg transition-all bg-white': true,
-          'hover:shadow cursor-pointer': !registerOptions?.disabled,
-          'cursor-default opacity-60': registerOptions?.disabled,
-          'border-green-dark': isSelected && !isInvalid,
-          'ring-2 ring-green-dark ring-offset-2': isFocusVisible,
-          [className]: !!className,
-          'px-4 py-2': !className,
-          'border-red-700': isInvalid,
-          'outline:focus-none': true,
+          'inline-flex items-center px-4 py-2 border rounded-lg transition bg-white peer-focus:ring-2 ring-green-dark ring-offset-2 peer-checked:border-green-dark hover:shadow peer-disabled:shadow-none cursor-pointer peer-disabled:cursor-default peer-disabled:opacity-60':
+            true,
+          'peer-invalid:border-red-700': invalid,
         })}
       >
         {children}
-      </div>
-    </label>
+      </label>
+    </div>
   );
 };
 

--- a/frontend/components/forms/tag/index.ts
+++ b/frontend/components/forms/tag/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { TagProps } from './types';

--- a/frontend/components/forms/tag/types.ts
+++ b/frontend/components/forms/tag/types.ts
@@ -1,30 +1,21 @@
 import React from 'react';
 
-import {
-  Path,
-  RegisterOptions,
-  FieldPath,
-  UseFormWatch,
-  UseFormRegisterReturn,
-  FieldValues,
-} from 'react-hook-form';
+import { Path, RegisterOptions, FieldPath, UseFormRegisterReturn } from 'react-hook-form';
 
 export type TagProps<FormValues> = {
-  /** ID of the element. Required if `aria-label` is not provided. */
-  id?: string;
-  /** Label of the element. Required `id` is not provided. */
-  'aria-label'?: string;
+  /** ID of the element */
+  id: string;
   /** Name of the tag input */
   name: Path<FormValues>;
-  /** Value of the element */
-  value?: any;
-  /** ReactHook Form's `watch` callback */
-  watch?: UseFormWatch<FieldValues>;
+  /**
+   * Value of the input. Set this if there are multiple tags with the same name (multiple choices).
+   */
+  value?: string;
   /** React Hook Form's `register` callback */
   register: (name, RegisterOptions) => UseFormRegisterReturn;
   /** Options for React Hook Form's `register` callback */
   registerOptions?: RegisterOptions<FormValues, FieldPath<FormValues>>;
-  /** class to change tag element style */
+  /** Classes to apply to the container */
   className?: string;
 } & Omit<
   React.InputHTMLAttributes<HTMLInputElement>,

--- a/frontend/components/forms/tag/types.ts
+++ b/frontend/components/forms/tag/types.ts
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import {
+  Path,
+  RegisterOptions,
+  FieldPath,
+  UseFormWatch,
+  UseFormRegisterReturn,
+  FieldValues,
+} from 'react-hook-form';
+
+export type TagProps<FormValues> = {
+  /** ID of the element. Required if `aria-label` is not provided. */
+  id?: string;
+  /** Label of the element. Required `id` is not provided. */
+  'aria-label'?: string;
+  /** Name of the tag input */
+  name: Path<FormValues>;
+  /** Value of the element */
+  value?: any;
+  /** ReactHook Form's `watch` callback */
+  watch?: UseFormWatch<FieldValues>;
+  /** React Hook Form's `register` callback */
+  register: (name, RegisterOptions) => UseFormRegisterReturn;
+  /** Options for React Hook Form's `register` callback */
+  registerOptions?: RegisterOptions<FormValues, FieldPath<FormValues>>;
+  /** class to change tag element style */
+  className?: string;
+} & Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  keyof RegisterOptions<FormValues, FieldPath<FormValues>>
+>;

--- a/frontend/containers/category-tag/category-tag-dot/component.tsx
+++ b/frontend/containers/category-tag/category-tag-dot/component.tsx
@@ -1,0 +1,19 @@
+import { FC } from 'react';
+
+import cx from 'classnames';
+
+import type { CategoryTagDotProps } from './types';
+
+export const CategoryTagDot: FC<CategoryTagDotProps> = ({ category }: CategoryTagDotProps) => (
+  <span
+    className={cx({
+      'inline-block w-4 h-4 mr-4 rounded-full': true,
+      'bg-category-tourism': category === 'tourism',
+      'bg-category-production': category === 'production',
+      'bg-category-agrosystems': category === 'agrosystems',
+      'bg-category-forestry': category === 'forestry',
+    })}
+  />
+);
+
+export default CategoryTagDot;

--- a/frontend/containers/category-tag/category-tag-dot/component.tsx
+++ b/frontend/containers/category-tag/category-tag-dot/component.tsx
@@ -2,6 +2,8 @@ import { FC } from 'react';
 
 import cx from 'classnames';
 
+import { CategoryType } from 'types/category';
+
 import type { CategoryTagDotProps } from './types';
 
 export const CategoryTagDot: FC<CategoryTagDotProps> = ({ category }: CategoryTagDotProps) => (

--- a/frontend/containers/category-tag/category-tag-dot/component.tsx
+++ b/frontend/containers/category-tag/category-tag-dot/component.tsx
@@ -8,10 +8,11 @@ export const CategoryTagDot: FC<CategoryTagDotProps> = ({ category }: CategoryTa
   <span
     className={cx({
       'inline-block w-4 h-4 mr-4 rounded-full': true,
-      'bg-category-tourism': category === 'tourism',
-      'bg-category-production': category === 'production',
-      'bg-category-agrosystems': category === 'agrosystems',
-      'bg-category-forestry': category === 'forestry',
+      'bg-category-tourism': category === 'tourism-and-recreation',
+      'bg-category-production': category === 'non-timber-forest-production',
+      'bg-category-agrosystems': category === 'sustainable-agrosystems',
+      'bg-category-forestry': category === 'forestry-and-agroforestry',
+      'bg-category-human': category === 'human-capital-and-inclusion',
     })}
   />
 );

--- a/frontend/containers/category-tag/category-tag-dot/index.ts
+++ b/frontend/containers/category-tag/category-tag-dot/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { CategoryTagDotProps } from './types';

--- a/frontend/containers/category-tag/category-tag-dot/types.ts
+++ b/frontend/containers/category-tag/category-tag-dot/types.ts
@@ -1,4 +1,4 @@
-import { CategoryType } from '../types';
+import { CategoryType } from 'types/category';
 
 export type CategoryTagDotProps = {
   /** Identifier of the investment type so that the corresponding colored dot is displayed */

--- a/frontend/containers/category-tag/category-tag-dot/types.ts
+++ b/frontend/containers/category-tag/category-tag-dot/types.ts
@@ -1,0 +1,6 @@
+import { CategoryType } from '../types';
+
+export type CategoryTagDotProps = {
+  /** Identifier of the investment type so that the corresponding colored dot is displayed */
+  category: CategoryType;
+};

--- a/frontend/containers/category-tag/component.stories.tsx
+++ b/frontend/containers/category-tag/component.stories.tsx
@@ -14,6 +14,6 @@ const Template: Story<CategoryTagProps> = ({ children, ...rest }: CategoryTagPro
 
 export const Default: Story<CategoryTagProps> = Template.bind({});
 Default.args = {
-  category: 'tourism',
+  category: 'tourism-and-recreation',
   children: 'Tourism & Recreation',
 };

--- a/frontend/containers/category-tag/component.tsx
+++ b/frontend/containers/category-tag/component.tsx
@@ -1,22 +1,13 @@
 import { FC } from 'react';
 
-import cx from 'classnames';
-
 import Tag from 'components/tag';
 
+import CategoryTagDot from './category-tag-dot';
 import type { CategoryTagProps } from './types';
 
 export const CategoryTag: FC<CategoryTagProps> = ({ category, children }: CategoryTagProps) => (
   <Tag>
-    <span
-      className={cx({
-        'inline-block w-4 h-4 mr-4 rounded-full': true,
-        'bg-category-tourism': category === 'tourism',
-        'bg-category-production': category === 'production',
-        'bg-category-agrosystems': category === 'agrosystems',
-        'bg-category-forestry': category === 'forestry',
-      })}
-    />
+    <CategoryTagDot category={category} />
     {children}
   </Tag>
 );

--- a/frontend/containers/category-tag/index.ts
+++ b/frontend/containers/category-tag/index.ts
@@ -1,3 +1,3 @@
 export { default } from './component';
 export { default as CategoryTagDot } from './category-tag-dot';
-export type { CategoryTagProps, CategoryType } from './types';
+export type { CategoryTagProps } from './types';

--- a/frontend/containers/category-tag/index.ts
+++ b/frontend/containers/category-tag/index.ts
@@ -1,2 +1,3 @@
 export { default } from './component';
+export { default as CategoryTagDot } from './category-tag-dot';
 export type { CategoryTagProps, CategoryType } from './types';

--- a/frontend/containers/category-tag/types.ts
+++ b/frontend/containers/category-tag/types.ts
@@ -1,4 +1,3 @@
 import { CategoryTagDotProps } from './category-tag-dot';
 
-export type CategoryType = 'tourism' | 'production' | 'agrosystems' | 'forestry';
 export type CategoryTagProps = React.PropsWithChildren<CategoryTagDotProps>;

--- a/frontend/containers/category-tag/types.ts
+++ b/frontend/containers/category-tag/types.ts
@@ -1,6 +1,4 @@
-export type CategoryType = 'tourism' | 'production' | 'agrosystems' | 'forestry';
+import { CategoryTagDotProps } from './category-tag-dot';
 
-export type CategoryTagProps = React.PropsWithChildren<{
-  /** Identifier of the investment type so that the corresponding colored dot is displayed */
-  category: CategoryType;
-}>;
+export type CategoryType = 'tourism' | 'production' | 'agrosystems' | 'forestry';
+export type CategoryTagProps = React.PropsWithChildren<CategoryTagDotProps>;

--- a/frontend/containers/multi-page-layout/page/component.tsx
+++ b/frontend/containers/multi-page-layout/page/component.tsx
@@ -33,7 +33,11 @@ export const MultiPageLayoutPage: FC<MultiPageLayoutPageProps> = ({
         })}
       >
         <main
-          tabIndex={-1}
+          // TODO: tabIndex was meant to make it so that when changing pages, focus would go
+          // directly to the form. However, using it causes react-aria's `useFocusRing` in the
+          // form tags components to misbehave. A possible alternative may pass through setting
+          // focus on the first child automatically.
+          // tabIndex={-1}
           ref={mainRef}
           className={cx({
             'outline-none': true,

--- a/frontend/containers/tags-grid/component.stories.tsx
+++ b/frontend/containers/tags-grid/component.stories.tsx
@@ -17,10 +17,10 @@ Default.args = {
       title: 'Invests in',
       type: 'category',
       tags: [
-        { id: 'tourism', title: 'Tourism & Recreation' },
-        { id: 'production', title: 'Non-timber forest production' },
-        { id: 'agrosystems', title: 'Sustainable agrosystems' },
-        { id: 'forestry', title: 'Forestry & agroforestry' },
+        { id: 'tourism-and-recreation', title: 'Tourism & Recreation' },
+        { id: 'non-timber-forest-production', title: 'Non-timber forest production' },
+        { id: 'sustainable-agrosystems', title: 'Sustainable agrosystems' },
+        { id: 'forestry-and-agroforestry', title: 'Forestry & agroforestry' },
       ],
     },
     {

--- a/frontend/containers/tags-grid/types.ts
+++ b/frontend/containers/tags-grid/types.ts
@@ -1,4 +1,4 @@
-import type { CategoryType } from 'containers/category-tag';
+import type { CategoryType } from 'types/category';
 
 export type TagsGridRowType = {
   /** Label for the tags list */

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -137,6 +137,9 @@
   "9+Ddtu": {
     "string": "Next"
   },
+  "94Fg25": {
+    "string": "Select all"
+  },
   "9Er2U2": {
     "string": "Investments in HeCo will contribute to climate change mitigation and adaptation. Investments will conserve the natural capital and associated environmental services of some of the most biodiverse landscapes on the planet."
   },

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -312,6 +312,9 @@
   "Ow9MS8": {
     "string": "I want to find the right investment for my projects"
   },
+  "P+9ug1": {
+    "string": "We’ll help you reset it and get back on track."
+  },
   "P4T4Ib": {
     "string": "Discover projects that have impact in the Amazon region and get connected with investors and project developers."
   },
@@ -353,6 +356,9 @@
   },
   "UxTJRa": {
     "string": "Projects"
+  },
+  "V/JHlm": {
+    "string": "Forgot password?"
   },
   "V4KNjk": {
     "string": "optional"
@@ -420,6 +426,9 @@
   "ZiErTG": {
     "string": "Be part of the biggest change in the Colombian Amazon"
   },
+  "ZjA6uH": {
+    "string": "Welcome to HeCo Invest. Please enter your details below."
+  },
   "aDn1WM": {
     "string": "Curated database"
   },
@@ -467,6 +476,9 @@
   },
   "cyR7Kh": {
     "string": "Back"
+  },
+  "cyRU1N": {
+    "string": "Forgot your password?"
   },
   "dPuc1g": {
     "string": "Slide {slideNumber}"
@@ -591,6 +603,9 @@
   "sMWFoV": {
     "string": "As an Investor / Funder"
   },
+  "sZIoMy": {
+    "string": "Send email"
+  },
   "sy+pv5": {
     "string": "Email"
   },
@@ -671,5 +686,8 @@
   },
   "zkonnO": {
     "string": "World Wildlife Fund (WWF) is the largest international conservation organization in the world, with more than 50 offices implementing conservation projects across more than 100 countries and has a membership of almost five million people. WWF has extensive experience working in the Amazon region, with offices in all seven signatory countries of the Leticia Pact. In Colombia, WWF has been working in partnership with the government and a consortium of civil society organizations on Heritage Colombia since 2015."
+  },
+  "zniaka": {
+    "string": "Unable to load the data"
   }
 }

--- a/frontend/pages/investor/[id]/index.tsx
+++ b/frontend/pages/investor/[id]/index.tsx
@@ -5,8 +5,8 @@ import { loadI18nMessages } from 'helpers/i18n';
 
 import ProfileHeader from 'containers/profile-header';
 import SDGs, { SDGType } from 'containers/sdgs';
-import TagsGrid, { TagsGridRowType } from 'containers/tags-grid';
 import { SocialType } from 'containers/social-contact/website-social-contact';
+import TagsGrid, { TagsGridRowType } from 'containers/tags-grid';
 
 import Head from 'components/head';
 import LayoutContainer from 'components/layout-container';
@@ -54,10 +54,10 @@ const InvestorPage: PageComponent<{}, StaticPageLayoutProps> = (props) => {
       title: 'Invests in',
       type: 'category',
       tags: [
-        { id: 'tourism', title: 'Tourism & Recreation' },
-        { id: 'production', title: 'Non-timber forest production' },
-        { id: 'agrosystems', title: 'Sustainable agrosystems' },
-        { id: 'forestry', title: 'Forestry & agroforestry' },
+        { id: 'tourism-and-recreation', title: 'Tourism & Recreation' },
+        { id: 'non-timber-forest-production', title: 'Non-timber forest production' },
+        { id: 'sustainable-agrosystems', title: 'Sustainable agrosystems' },
+        { id: 'forestry-and-agroforestry', title: 'Forestry & agroforestry' },
       ],
     },
     {

--- a/frontend/pages/project-developer/[id]/index.tsx
+++ b/frontend/pages/project-developer/[id]/index.tsx
@@ -65,8 +65,8 @@ const InvestorPage: PageComponent<{}, StaticPageLayoutProps> = (props) => {
       title: 'Categories of interest',
       type: 'category',
       tags: [
-        { id: 'tourism', title: 'Tourism & Recreation' },
-        { id: 'production', title: 'Non-timber forest production' },
+        { id: 'tourism-and-recreation', title: 'Tourism & Recreation' },
+        { id: 'non-timber-forest-production', title: 'Non-timber forest production' },
       ],
     },
     {

--- a/frontend/pages/project-developers/new.tsx
+++ b/frontend/pages/project-developers/new.tsx
@@ -15,6 +15,7 @@ import useInterests, { InterestNames } from 'hooks/useInterests';
 
 import { loadI18nMessages } from 'helpers/i18n';
 
+import { CategoryTagDot } from 'containers/category-tag';
 import MultiPageLayout, { Page } from 'containers/multi-page-layout';
 import SocialMediaImputs from 'containers/social-contact/inputs-social-contact/component';
 
@@ -23,6 +24,8 @@ import ErrorMessage from 'components/forms/error-message';
 import FieldInfo from 'components/forms/field-info';
 import Input from 'components/forms/input';
 import Label from 'components/forms/label';
+import Tag from 'components/forms/tag';
+import TagGroup from 'components/forms/tag-group';
 import TextArea from 'components/forms/textarea';
 import Head from 'components/head';
 import NakedPageLayout, { NakedPageLayoutProps } from 'layouts/naked-page';
@@ -81,6 +84,9 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, NakedPageLayoutProp
     formState: { errors },
     control,
     setError,
+    setValue,
+    clearErrors,
+    watch,
   } = useForm<ProjectDeveloperSetupForm>({
     resolver,
     defaultValues: { categories: [], impacts: [], mosaics: [] },
@@ -458,26 +464,21 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, NakedPageLayoutProp
                     <span className="mr-2.5">{title}</span>
                     <FieldInfo infoText={infoText || getItemsInfoText(items)} />
                   </legend>
-                  <div className="mb-4">
+                  <TagGroup name={name} setValue={setValue} watch={watch} clearErrors={clearErrors}>
                     {items?.map((item: Enum | Locations) => (
-                      <div
+                      <Tag
                         key={item.id}
-                        className="inline-block px-4 py-2 mb-4 mr-4 border rounded-lg border-beige"
+                        id={item.id}
+                        name={name}
+                        value={item.id}
+                        aria-describedby={`${name}-error`}
+                        register={register}
                       >
-                        <Label htmlFor={item.id} className="flex items-center">
-                          <input
-                            {...register(name as keyof ProjectDeveloperSetupForm)}
-                            id={item.id}
-                            name={name}
-                            type="checkbox"
-                            value={item.id}
-                            aria-describedby={`${name}-error`}
-                          />
-                          <span className="ml-1">{item.attributes.name}</span>
-                        </Label>
-                      </div>
+                        {item.type === 'category' && <CategoryTagDot category={item.id} />}
+                        {item.attributes.name}
+                      </Tag>
                     ))}
-                  </div>
+                  </TagGroup>
                 </fieldset>
                 <ErrorMessage id={`${name}-error`} errorText={getInterestsErrorText(name)} />
               </div>

--- a/frontend/pages/project-developers/new.tsx
+++ b/frontend/pages/project-developers/new.tsx
@@ -31,6 +31,7 @@ import Head from 'components/head';
 import NakedPageLayout, { NakedPageLayoutProps } from 'layouts/naked-page';
 import languages from 'locales.config.json';
 import { PageComponent } from 'types';
+import { CategoryType } from 'types/category';
 import { Enum } from 'types/enums';
 import { Locations } from 'types/locations';
 import { ProjectDeveloperSetupForm } from 'types/projectDeveloper';
@@ -474,7 +475,9 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, NakedPageLayoutProp
                         aria-describedby={`${name}-error`}
                         register={register}
                       >
-                        {item.type === 'category' && <CategoryTagDot category={item.id} />}
+                        {item.type === 'category' && (
+                          <CategoryTagDot category={item.id as CategoryType} />
+                        )}
                         {item.attributes.name}
                       </Tag>
                     ))}

--- a/frontend/pages/project-developers/new.tsx
+++ b/frontend/pages/project-developers/new.tsx
@@ -86,8 +86,6 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, NakedPageLayoutProp
     control,
     setError,
     setValue,
-    clearErrors,
-    watch,
   } = useForm<ProjectDeveloperSetupForm>({
     resolver,
     defaultValues: { categories: [], impacts: [], mosaics: [] },
@@ -465,7 +463,7 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, NakedPageLayoutProp
                     <span className="mr-2.5">{title}</span>
                     <FieldInfo infoText={infoText || getItemsInfoText(items)} />
                   </legend>
-                  <TagGroup name={name} setValue={setValue} watch={watch} clearErrors={clearErrors}>
+                  <TagGroup name={name} setValue={setValue}>
                     {items?.map((item: Enum | Locations) => (
                       <Tag
                         key={item.id}

--- a/frontend/types/category.ts
+++ b/frontend/types/category.ts
@@ -1,7 +1,6 @@
-export enum CategoryType {
-  'sustainable-agrosystems',
-  'tourism-and-recreation',
-  'forestry-and-agroforestry',
-  'non-timber-forest-production',
-  'human-capital-and-inclusion',
-}
+export type CategoryType =
+  | 'sustainable-agrosystems'
+  | 'tourism-and-recreation'
+  | 'forestry-and-agroforestry'
+  | 'non-timber-forest-production'
+  | 'human-capital-and-inclusion';

--- a/frontend/types/category.ts
+++ b/frontend/types/category.ts
@@ -1,0 +1,7 @@
+export enum CategoryType {
+  'sustainable-agrosystems',
+  'tourism-and-recreation',
+  'forestry-and-agroforestry',
+  'non-timber-forest-production',
+  'human-capital-and-inclusion',
+}

--- a/frontend/types/projectDeveloper.ts
+++ b/frontend/types/projectDeveloper.ts
@@ -1,5 +1,6 @@
 import { SocialContactInputs } from 'containers/social-contact/inputs-social-contact/types';
 
+import { CategoryType } from './category';
 import { Enum } from './enums';
 
 export type ProjectDeveloperSetupForm = SocialContactInputs & {
@@ -10,7 +11,7 @@ export type ProjectDeveloperSetupForm = SocialContactInputs & {
   entity_legal_registration_number: string;
   about: string;
   mission: string;
-  categories: Category[];
+  categories: CategoryType[];
   impacts: Impact[];
   mosaics?: Mosaic[];
 };
@@ -19,14 +20,6 @@ export enum Language {
   'en',
   'es',
   'pt',
-}
-
-export enum Category {
-  'sustainable-agrosystems',
-  'tourism-and-recreation',
-  'forestry-and-agroforestry',
-  'non-timber-forest-production',
-  'human-capital-and-inclusion',
 }
 
 export enum Impact {


### PR DESCRIPTION
**In this PR** 

Added a `Forms/Tag` component
_Used as a regular uncontrolled checkbox_  
- Styling is achieved by means of using a `label`  
- Supports invalid states  
- Uses `useFocusRing` for keyboard navigation  

Added a `Forms/TagGroup` component  
_Responsible for standardising the visual styling of a group of tags_  
- Automatically displays a `Select All` button to select all tags  
- Can automatically set `react-hook-form`'s values and clear errors  

`project-developers/new` page  
  - Added the new `Tag` and `TagGroup` components  

&nbsp;

**Other relevant changes:**  
- Updated components that use category ids (eg: regular `Tag` and `TagsGrid` components) to use the correct ones the API will return, as well as a fifth category
  _Note: still hardcoded, not using enums. It was mostly to keep ids consistent on the frontend, and validate types_  
- Fixed an issue with the `MultiPageLayout` component which caused `useFocusRing`'s `isFocusVisible` to erroneously be set to `true` when clicking on tags. 

&nbsp;

**NOTE:** There's a small deviation from the acceptance criteria. Although Tags do take an `id` prop, it shouldn't be used to link to an external label. The reason for that is that was that to keep the tags behaving as an uncontrolled checkbox, and ensuring max compatibility with `react-hook-form` and `invalid` states, the label was embedded into the component. 

## Testing instructions

Respects the [visual design](https://www.figma.com/file/3epSYh4KQZBCyh4Y5OzmHw/HeCo---Design-System?node-id=2345%3A4757)

Has visual error state when input validation fails ([see error state example](https://www.figma.com/file/3epSYh4KQZBCyh4Y5OzmHw/HeCo---Design-System?node-id=2377%3A3138))

Compatible with React Hook Form (see [example of integration](https://react-hook-form.com/get-started/#Integratinganexistingform))

Accessible by [WCAG 2.1 standards](https://www.w3.org/TR/WCAG21/)

Focused state for keyboard users

Presented as a checkbox list to assisted technologies (AT)

Requires an 'id' prop to link to a label externally and a 'name' prop to link the checkboxes between themselves

Available in Storybook

## Tracking

[LET-170](https://vizzuality.atlassian.net/browse/LET-170)

## Screenshots
<img width="1040" alt="Screenshot 2022-04-12 at 12 56 09" src="https://user-images.githubusercontent.com/6273795/162957440-9760d2ff-06e6-46dc-9d4c-54bea75e4a60.png">
<img width="852" alt="Screenshot 2022-04-12 at 12 56 24" src="https://user-images.githubusercontent.com/6273795/162957448-ec831bed-8656-4615-8a95-cf487daee6b0.png">

