### PR TITLE
Remove the native validation from the forms

### DIFF
--- a/frontend/components/forms/checkbox/component.stories.tsx
+++ b/frontend/components/forms/checkbox/component.stories.tsx
@@ -16,6 +16,7 @@ export default {
   title: 'Components/Forms/Checkbox',
   argTypes: {
     register: { control: { disable: true } },
+    invalid: { control: { disable: true } },
   },
 } as Meta;
 
@@ -73,27 +74,18 @@ const TemplateWithForm: Story<CheckboxProps<FormValues>> = (args: CheckboxProps<
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm<FormValues>({
-    // Using the native validation, we're able to style the inputs using the `valid` and `invalid`
-    // pseudo class
-    shouldUseNativeValidation: true,
-  });
+  } = useForm<FormValues>();
   const onSubmit: SubmitHandler<FormValues> = (data) => action('onSubmit')(data);
 
   return (
     <div className="p-4">
-      <form
-        // `noValidate` here prevents the browser from not submitting the form if there's a validation
-        // error. We absolutely want the form to be submitted so that React Hook Form is made aware of
-        // the validation errors and we can display errors below inputs.
-        noValidate
-        onSubmit={handleSubmit(onSubmit)}
-      >
+      <form onSubmit={handleSubmit(onSubmit)}>
         <label htmlFor="story-check">
           <Checkbox
             id="story-check"
             name="accept"
             register={register}
+            invalid={!!errors.accept}
             aria-describedby="form-error"
             {...args}
           />
@@ -130,11 +122,7 @@ const TemplateDisabled: Story<CheckboxProps<FormValues>> = (args: CheckboxProps<
   const {
     register,
     formState: { errors },
-  } = useForm<FormValues>({
-    // Using the native validation, we're able to style the inputs using the `valid` and `invalid`
-    // pseudo class
-    shouldUseNativeValidation: true,
-  });
+  } = useForm<FormValues>();
 
   return (
     <div className="p-4">
@@ -143,6 +131,7 @@ const TemplateDisabled: Story<CheckboxProps<FormValues>> = (args: CheckboxProps<
           id="story-check"
           name="accept"
           register={register}
+          invalid={!!errors.accept}
           aria-describedby="form-error"
           {...args}
         />

--- a/frontend/components/forms/checkbox/component.tsx
+++ b/frontend/components/forms/checkbox/component.tsx
@@ -7,10 +7,8 @@ import cx from 'classnames';
 import { CheckboxProps } from './types';
 
 export const Checkbox = <FormValues extends FieldValues>(props: CheckboxProps<FormValues>) => {
-  const { register, registerOptions, ...rest } = props;
+  const { register, registerOptions, invalid = false, ...rest } = props;
   const { name, id, 'aria-label': ariaLabel, className } = rest;
-
-  const [invalid, setInvalid] = useState(false);
 
   return (
     <input
@@ -18,7 +16,7 @@ export const Checkbox = <FormValues extends FieldValues>(props: CheckboxProps<Fo
       className={cx(
         'appearance-none inline-block w-4 h-4 mr-2 mt-0.5 px-0.5 py-[3px] border border-beige rounded hover:border hover:border-green-dark outline-none focus-visible:ring-green-dark focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white  checked:border-green-dark checked:bg-green-dark checked:bg-[url("/images/checkbox-checked.svg")] bg-no-repeat bg-center disabled:opacity-60 disabled:hover:border-beige transition',
         {
-          'invalid:border-red-700': invalid,
+          'border-red-700': invalid,
           [className]: !!className,
         }
       )}
@@ -28,7 +26,6 @@ export const Checkbox = <FormValues extends FieldValues>(props: CheckboxProps<Fo
       {...register(name, {
         ...registerOptions,
       })}
-      onInvalid={() => setInvalid(true)}
     />
   );
 };

--- a/frontend/components/forms/checkbox/types.ts
+++ b/frontend/components/forms/checkbox/types.ts
@@ -13,6 +13,8 @@ export type CheckboxProps<FormValues> = {
   register: UseFormRegister<FormValues>;
   /** Options for React Hook Form's `register` function */
   registerOptions?: RegisterOptions<FormValues, FieldPath<FormValues>>;
+  /** Whether the input has an invalid state. Defaults to `false`. */
+  invalid?: boolean;
   /** class to change checkbox element style */
   className?: string;
 } & Omit<

--- a/frontend/components/forms/combobox/component.stories.tsx
+++ b/frontend/components/forms/combobox/component.stories.tsx
@@ -145,21 +145,11 @@ const TemplateWithForm: Story<ComboboxProps<FormValues, {}>> = (
     control,
     handleSubmit,
     formState: { errors },
-  } = useForm<FormValues>({
-    // Using the native validation, we're able to style the inputs using the `valid` and `invalid`
-    // pseudo class
-    shouldUseNativeValidation: true,
-  });
+  } = useForm<FormValues>();
   const onSubmit: SubmitHandler<FormValues> = (data) => action('onSubmit')(data);
 
   return (
-    <form
-      // `noValidate` here prevents the browser from not submitting the form if there's a validation
-      // error. We absolutely want the form to be submitted so that React Hook Form is made aware of
-      // the validation errors and we can display errors below inputs.
-      noValidate
-      onSubmit={handleSubmit(onSubmit)}
-    >
+    <form onSubmit={handleSubmit(onSubmit)}>
       <label htmlFor={args.id} className="mb-2">
         Sustainable Development Goal
       </label>

--- a/frontend/components/forms/input/component.stories.tsx
+++ b/frontend/components/forms/input/component.stories.tsx
@@ -14,6 +14,7 @@ export default {
   title: 'Components/Forms/Input',
   argTypes: {
     register: { control: { disable: true } },
+    invalid: { control: { disable: true } },
   },
 } as Meta;
 
@@ -75,25 +76,15 @@ const TemplateWithForm: Story<InputProps<FormValues>> = (args: InputProps<FormVa
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm<FormValues>({
-    // Using the native validation, we're able to style the inputs using the `valid` and `invalid`
-    // pseudo class
-    shouldUseNativeValidation: true,
-  });
+  } = useForm<FormValues>();
   const onSubmit: SubmitHandler<FormValues> = (data) => action('onSubmit')(data);
 
   return (
-    <form
-      // `noValidate` here prevents the browser from not submitting the form if there's a validation
-      // error. We absolutely want the form to be submitted so that React Hook Form is made aware of
-      // the validation errors and we can display errors below inputs.
-      noValidate
-      onSubmit={handleSubmit(onSubmit)}
-    >
+    <form onSubmit={handleSubmit(onSubmit)}>
       <label htmlFor={args.id} className="mb-2">
         Name
       </label>
-      <Input register={register} aria-describedby="form-error" {...args} />
+      <Input register={register} invalid={!!errors.name} aria-describedby="form-error" {...args} />
       {errors.name?.message && (
         <p id="form-error" className="pl-2 mt-1 text-xs text-red-700">
           {errors.name?.message}

--- a/frontend/components/forms/input/component.tsx
+++ b/frontend/components/forms/input/component.tsx
@@ -13,35 +13,23 @@ export const Input = <FormValues extends FieldValues>({
   name,
   register,
   registerOptions,
+  invalid = false,
   className,
   ...rest
-}: InputProps<FormValues>) => {
-  // We want the input to have some specific styles when it is invalid (most likely required and
-  // empty). Unfortunately the `:invalid` pseudo-class is always matched, even if the form has not
-  // been submitted yet. In order to only display the error styles when relevant, we listen to the
-  // `invalid` event which is triggered when the input is validated and invalid. If not manually
-  // triggered, the validation only happens when the form is submitted, hence we can dynamically
-  // add the `:invalid` styles at that point.
-  // Note that we don't care about setting this variable back to `false` because what only matters
-  // is to not display the `:invalid` styles too soon.
-  const [invalid, setInvalid] = useState(false);
-
-  return (
-    <input
-      id={id}
-      aria-label={ariaLabel}
-      type={type}
-      className={cx({
-        'block w-full px-4 py-2 text-base text-gray-900 placeholder-gray-400 placeholder-opacity-100 border border-solid border-beige hover:shadow-sm focus:shadow-sm focus:border-green-dark outline-none bg-white rounded-lg disabled:opacity-60 transition':
-          true,
-        [className]: !!className,
-        'invalid:border-red-700': invalid,
-      })}
-      {...register(name, registerOptions)}
-      onInvalid={() => setInvalid(true)}
-      {...rest}
-    />
-  );
-};
+}: InputProps<FormValues>) => (
+  <input
+    id={id}
+    aria-label={ariaLabel}
+    type={type}
+    className={cx({
+      'block w-full px-4 py-2 text-base text-gray-900 placeholder-gray-400 placeholder-opacity-100 border border-solid border-beige hover:shadow-sm focus:shadow-sm focus:border-green-dark outline-none bg-white rounded-lg disabled:opacity-60 transition':
+        true,
+      [className]: !!className,
+      'border-red-700': invalid,
+    })}
+    {...register(name, registerOptions)}
+    {...rest}
+  />
+);
 
 export default Input;

--- a/frontend/components/forms/input/types.ts
+++ b/frontend/components/forms/input/types.ts
@@ -15,6 +15,8 @@ export type InputProps<FormValues> = {
   register: UseFormRegister<FormValues>;
   /** Options for React Hook Form's `register` function */
   registerOptions?: RegisterOptions<FormValues, FieldPath<FormValues>>;
+  /** Whether the input has an invalid state. Defaults to `false`. */
+  invalid?: boolean;
 } & Omit<
   React.InputHTMLAttributes<HTMLInputElement>,
   keyof RegisterOptions<FormValues, FieldPath<FormValues>>

--- a/frontend/components/forms/select/component.stories.tsx
+++ b/frontend/components/forms/select/component.stories.tsx
@@ -145,21 +145,11 @@ const TemplateWithForm: Story<SelectProps<FormValues, {}>> = (
     control,
     handleSubmit,
     formState: { errors },
-  } = useForm<FormValues>({
-    // Using the native validation, we're able to style the inputs using the `valid` and `invalid`
-    // pseudo class
-    shouldUseNativeValidation: true,
-  });
+  } = useForm<FormValues>();
   const onSubmit: SubmitHandler<FormValues> = (data) => action('onSubmit')(data);
 
   return (
-    <form
-      // `noValidate` here prevents the browser from not submitting the form if there's a validation
-      // error. We absolutely want the form to be submitted so that React Hook Form is made aware of
-      // the validation errors and we can display errors below inputs.
-      noValidate
-      onSubmit={handleSubmit(onSubmit)}
-    >
+    <form onSubmit={handleSubmit(onSubmit)}>
       <label htmlFor={args.id} className="mb-2">
         Sustainable Development Goal
       </label>

--- a/frontend/components/forms/tag-group/component.stories.tsx
+++ b/frontend/components/forms/tag-group/component.stories.tsx
@@ -83,23 +83,12 @@ const TemplateWithForm: Story<TagProps<FormValues>> = (args: TagProps<FormValues
     setValue,
     handleSubmit,
     formState: { errors },
-  } = useForm<FormValues>({
-    // We don't want to use the native validation here; the validation is specific to the group
-    // and not each tag individually, so we don't want the inputs to have the `valid` or `invalid`
-    // pseudo classes
-    shouldUseNativeValidation: false,
-  });
+  } = useForm<FormValues>();
   const onSubmit: SubmitHandler<FormValues> = (data) => action('onSubmit')(data);
 
   return (
     <div className="p-4">
-      <form
-        // `noValidate` here prevents the browser from not submitting the form if there's a validation
-        // error. We absolutely want the form to be submitted so that React Hook Form is made aware of
-        // the validation errors and we can display errors below inputs.
-        noValidate
-        onSubmit={handleSubmit(onSubmit)}
-      >
+      <form onSubmit={handleSubmit(onSubmit)}>
         <fieldset>
           <legend className="mb-2 font-sans font-semibold text-gray-800">Category</legend>
           <TagGroup name={args.name} setValue={setValue}>
@@ -108,6 +97,7 @@ const TemplateWithForm: Story<TagProps<FormValues>> = (args: TagProps<FormValues
               value="first-category"
               aria-describedby="form-error"
               register={register}
+              invalid={!!errors.categories}
               {...args}
             >
               First category
@@ -117,6 +107,7 @@ const TemplateWithForm: Story<TagProps<FormValues>> = (args: TagProps<FormValues
               value="second-category"
               aria-describedby="form-error"
               register={register}
+              invalid={!!errors.categories}
               {...args}
             >
               Second category
@@ -126,6 +117,7 @@ const TemplateWithForm: Story<TagProps<FormValues>> = (args: TagProps<FormValues
               value="third-category"
               aria-describedby="form-error"
               register={register}
+              invalid={!!errors.categories}
               {...args}
             >
               Third category
@@ -135,6 +127,7 @@ const TemplateWithForm: Story<TagProps<FormValues>> = (args: TagProps<FormValues
               value="fourth-category"
               aria-describedby="form-error"
               register={register}
+              invalid={!!errors.categories}
               {...args}
             >
               Four category

--- a/frontend/components/forms/tag/component.stories.tsx
+++ b/frontend/components/forms/tag/component.stories.tsx
@@ -76,28 +76,19 @@ const TemplateWithForm: Story<TagProps<FormValues>> = (args: TagProps<FormValues
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm<FormValues>({
-    // Using the native validation, we're able to style the inputs using the `valid` and `invalid`
-    // pseudo class
-    shouldUseNativeValidation: true,
-  });
+  } = useForm<FormValues>();
   const onSubmit: SubmitHandler<FormValues> = (data) => action('onSubmit')(data);
 
   return (
     <div className="p-4">
-      <form
-        // `noValidate` here prevents the browser from not submitting the form if there's a validation
-        // error. We absolutely want the form to be submitted so that React Hook Form is made aware of
-        // the validation errors and we can display errors below inputs.
-        noValidate
-        onSubmit={handleSubmit(onSubmit)}
-      >
+      <form onSubmit={handleSubmit(onSubmit)}>
         <fieldset>
           <legend className="mb-2 font-sans font-semibold text-gray-800">Category</legend>
           <Tag
             id="story-check"
             name="category"
             register={register}
+            invalid={!!errors.category}
             aria-describedby="form-error"
             {...args}
           >
@@ -135,11 +126,7 @@ const TemplateDisabled: Story<TagProps<FormValues>> = (args: TagProps<FormValues
   const {
     register,
     formState: { errors },
-  } = useForm<FormValues>({
-    // Using the native validation, we're able to style the inputs using the `valid` and `invalid`
-    // pseudo class
-    shouldUseNativeValidation: true,
-  });
+  } = useForm<FormValues>();
 
   return (
     <div className="p-4">

--- a/frontend/components/forms/tag/component.tsx
+++ b/frontend/components/forms/tag/component.tsx
@@ -13,36 +13,32 @@ export const Tag = <FormValues extends FieldValues>({
   value,
   register,
   registerOptions,
+  invalid = false,
   children,
   ...rest
-}: TagProps<FormValues>) => {
-  const [invalid, setInvalid] = useState(false);
-
-  return (
-    <div className={className}>
-      <input
-        id={id}
-        type="checkbox"
-        className="sr-only peer"
-        {...rest}
-        {...register(name, {
-          ...registerOptions,
-        })}
-        value={value}
-        onInvalid={() => setInvalid(true)}
-      />
-      <label
-        htmlFor={id}
-        className={cx({
-          'inline-flex items-center px-4 py-2 border rounded-lg transition bg-white peer-focus:ring-2 ring-green-dark ring-offset-2 peer-checked:border-green-dark hover:shadow peer-disabled:shadow-none cursor-pointer peer-disabled:cursor-default peer-disabled:opacity-60':
-            true,
-          'peer-invalid:border-red-700': invalid,
-        })}
-      >
-        {children}
-      </label>
-    </div>
-  );
-};
+}: TagProps<FormValues>) => (
+  <div className={className}>
+    <input
+      id={id}
+      type="checkbox"
+      className="sr-only peer"
+      {...rest}
+      {...register(name, {
+        ...registerOptions,
+      })}
+      value={value}
+    />
+    <label
+      htmlFor={id}
+      className={cx({
+        'inline-flex items-center px-4 py-2 border rounded-lg transition bg-white peer-focus:ring-2 ring-green-dark ring-offset-2 peer-checked:border-green-dark hover:shadow peer-disabled:shadow-none cursor-pointer peer-disabled:cursor-default peer-disabled:opacity-60':
+          true,
+        'border-red-700': invalid,
+      })}
+    >
+      {children}
+    </label>
+  </div>
+);
 
 export default Tag;

--- a/frontend/components/forms/tag/types.ts
+++ b/frontend/components/forms/tag/types.ts
@@ -15,6 +15,8 @@ export type TagProps<FormValues> = {
   register: (name, RegisterOptions) => UseFormRegisterReturn;
   /** Options for React Hook Form's `register` callback */
   registerOptions?: RegisterOptions<FormValues, FieldPath<FormValues>>;
+  /** Whether the input has an invalid state. Defaults to `false`. */
+  invalid?: boolean;
   /** Classes to apply to the container */
   className?: string;
 } & Omit<

--- a/frontend/components/forms/textarea/component.stories.tsx
+++ b/frontend/components/forms/textarea/component.stories.tsx
@@ -14,6 +14,7 @@ export default {
   title: 'Components/Forms/Textarea',
   argTypes: {
     register: { control: { disable: true } },
+    invalid: { control: { disable: true } },
   },
 } as Meta;
 
@@ -74,25 +75,20 @@ const TemplateWithForm: Story<TextareaProps<FormValues>> = (args: TextareaProps<
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm<FormValues>({
-    // Using the native validation, we're able to style the inputs using the `valid` and `invalid`
-    // pseudo class
-    shouldUseNativeValidation: true,
-  });
+  } = useForm<FormValues>();
   const onSubmit: SubmitHandler<FormValues> = (data) => action('onSubmit')(data);
 
   return (
-    <form
-      // `noValidate` here prevents the browser from not submitting the form if there's a validation
-      // error. We absolutely want the form to be submitted so that React Hook Form is made aware of
-      // the validation errors and we can display errors below inputs.
-      noValidate
-      onSubmit={handleSubmit(onSubmit)}
-    >
+    <form onSubmit={handleSubmit(onSubmit)}>
       <label htmlFor={args.id} className="mb-2">
         Details
       </label>
-      <Textarea register={register} aria-describedby="form-error" {...args} />
+      <Textarea
+        register={register}
+        invalid={!!errors.details}
+        aria-describedby="form-error"
+        {...args}
+      />
       {errors.details?.message && (
         <p id="form-error" className="pl-2 mt-1 text-xs text-red-700">
           {errors.details?.message}

--- a/frontend/components/forms/textarea/component.tsx
+++ b/frontend/components/forms/textarea/component.tsx
@@ -14,36 +14,24 @@ export const Textarea = <FormValues extends FieldValues>({
   name,
   register,
   registerOptions,
+  invalid = false,
   className,
   ...rest
-}: TextareaProps<FormValues>) => {
-  // We want the input to have some specific styles when it is invalid (most likely required and
-  // empty). Unfortunately the `:invalid` pseudo-class is always matched, even if the form has not
-  // been submitted yet. In order to only display the error styles when relevant, we listen to the
-  // `invalid` event which is triggered when the input is validated and invalid. If not manually
-  // triggered, the validation only happens when the form is submitted, hence we can dynamically
-  // add the `:invalid` styles at that point.
-  // Note that we don't care about setting this variable back to `false` because what only matters
-  // is to not display the `:invalid` styles too soon.
-  const [invalid, setInvalid] = useState(false);
-
-  return (
-    <textarea
-      id={id}
-      aria-label={ariaLabel}
-      className={cx({
-        'block w-full px-4 py-2 text-base text-gray-900 placeholder-gray-400 placeholder-opacity-100 border border-solid border-beige hover:shadow-sm focus:shadow-sm focus:border-green-dark outline-none bg-white rounded-lg disabled:opacity-60 transition':
-          true,
-        [resize]: true,
-        [className]: !!className,
-        'invalid:border-red-700': invalid,
-      })}
-      rows={rows}
-      {...register(name, registerOptions)}
-      onInvalid={() => setInvalid(true)}
-      {...rest}
-    />
-  );
-};
+}: TextareaProps<FormValues>) => (
+  <textarea
+    id={id}
+    aria-label={ariaLabel}
+    className={cx({
+      'block w-full px-4 py-2 text-base text-gray-900 placeholder-gray-400 placeholder-opacity-100 border border-solid border-beige hover:shadow-sm focus:shadow-sm focus:border-green-dark outline-none bg-white rounded-lg disabled:opacity-60 transition':
+        true,
+      [resize]: true,
+      [className]: !!className,
+      'border-red-700': invalid,
+    })}
+    rows={rows}
+    {...register(name, registerOptions)}
+    {...rest}
+  />
+);
 
 export default Textarea;

--- a/frontend/components/forms/textarea/types.ts
+++ b/frontend/components/forms/textarea/types.ts
@@ -24,6 +24,8 @@ export type TextareaProps<FormValues> = {
   register: UseFormRegister<FormValues>;
   /** Options for React Hook Form's `register` function */
   registerOptions?: RegisterOptions<FormValues, FieldPath<FormValues>>;
+  /** Whether the input has an invalid state. Defaults to `false`. */
+  invalid?: boolean;
 } & Omit<
   React.TextareaHTMLAttributes<HTMLTextAreaElement>,
   keyof RegisterOptions<FormValues, FieldPath<FormValues>>

--- a/frontend/containers/social-contact/inputs-social-contact/component.stories.tsx
+++ b/frontend/containers/social-contact/inputs-social-contact/component.stories.tsx
@@ -12,24 +12,30 @@ import InputsSocialContact from '.';
 export default {
   component: InputsSocialContact,
   title: 'Containers/InputsSocialContact',
-  argTypes: {},
+  argTypes: {
+    register: { control: { disable: true } },
+    errors: { control: { disable: true } },
+  },
 } as Meta;
 
-const Template: Story<InputSocialContactProps<SocialContactInputs>> = ({ ...rest }) => {
+const Template: Story<InputSocialContactProps<SocialContactInputs>> = (props) => {
   const {
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm<SocialContactInputs>({ shouldUseNativeValidation: true });
-  const onSubmit: SubmitHandler<any> = (data) => action('onSubmit')(data);
+  } = useForm<SocialContactInputs>();
+  const onSubmit: SubmitHandler<SocialContactInputs> = (data) => action('onSubmit')(data);
   return (
-    <div>
-      <form onSubmit={handleSubmit(onSubmit)} noValidate>
-        <InputsSocialContact {...rest} register={register} />
-        <Button type="submit">submit</Button>
-        {Object.keys(errors).length > 0 && 'Something went wrong'}
-      </form>
-    </div>
+    <form onSubmit={handleSubmit(onSubmit)}>
+      {Object.keys(errors).length > 0 && <p className="mb-3 text-red-700">Something went wrong</p>}
+      <InputsSocialContact {...props} register={register} errors={errors} />
+      <Button type="submit" className="mt-2">
+        Submit
+      </Button>
+      <p className="mt-2 text-xs text-gray-50">
+        Submit the form to see the {"inputs'"} error state (the inputs are required).
+      </p>
+    </form>
   );
 };
 
@@ -41,4 +47,13 @@ Default.args = {
 export const Required: Story<InputSocialContactProps<SocialContactInputs>> = Template.bind({});
 Required.args = {
   registerOptions: { required: 'This field is required' },
+};
+Required.parameters = {
+  docs: {
+    source: {
+      // NOTE: Needed to prevent Storybook from freezing the browser. More information there:
+      // https://github.com/storybookjs/storybook/issues/17098
+      type: 'code',
+    },
+  },
 };

--- a/frontend/containers/social-contact/inputs-social-contact/component.tsx
+++ b/frontend/containers/social-contact/inputs-social-contact/component.tsx
@@ -4,9 +4,9 @@ import { FieldValues, Path } from 'react-hook-form';
 import { useIntl } from 'react-intl';
 
 import ErrorMessage from 'components/forms/error-message';
+import Input from 'components/forms/input';
+import Label from 'components/forms/label';
 
-import Input from '../../../components/forms/input';
-import Label from '../../../components/forms/label';
 import { SOCIAL_DATA } from '../constants';
 
 import { InputSocialContactProps } from './types';
@@ -33,15 +33,15 @@ export const InputsSocialContact = <FormValues extends FieldValues>({
               type="text"
               register={register}
               registerOptions={registerOptions}
+              invalid={!!errors?.[id]}
               placeholder={formatMessage({
                 defaultMessage: 'insert URL',
                 id: 'et2m37',
               })}
+              aria-describedby={`${id}-error`}
             />
           </Label>
-          {errors && errors[id] && (
-            <ErrorMessage id={`${id}-error`} errorText={errors[id].message} />
-          )}
+          {errors?.[id] && <ErrorMessage id={`${id}-error`} errorText={errors[id].message} />}
         </div>
       ))}
     </div>

--- a/frontend/containers/social-contact/inputs-social-contact/types.ts
+++ b/frontend/containers/social-contact/inputs-social-contact/types.ts
@@ -1,4 +1,4 @@
-import { UseFormRegister, RegisterOptions, FieldPath, FormState } from 'react-hook-form';
+import { UseFormRegister, RegisterOptions, FieldPath, FieldErrors } from 'react-hook-form';
 
 export type SocialContactInputs = {
   website: string;
@@ -14,5 +14,5 @@ export interface InputSocialContactProps<FormValues> {
   /** Options for React Hook Form's `register` function */
   registerOptions?: RegisterOptions<FormValues, FieldPath<FormValues>>;
   /** Form validation errors */
-  errors?: FormState<FormValues>['errors'];
+  errors?: FieldErrors<FormValues>;
 }

--- a/frontend/pages/project-developers/new.tsx
+++ b/frontend/pages/project-developers/new.tsx
@@ -17,7 +17,7 @@ import { loadI18nMessages } from 'helpers/i18n';
 
 import { CategoryTagDot } from 'containers/category-tag';
 import MultiPageLayout, { Page } from 'containers/multi-page-layout';
-import SocialMediaImputs from 'containers/social-contact/inputs-social-contact/component';
+import SocialMediaInputs from 'containers/social-contact/inputs-social-contact';
 
 import Combobox, { Option } from 'components/forms/combobox';
 import ErrorMessage from 'components/forms/error-message';
@@ -89,7 +89,6 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, NakedPageLayoutProp
   } = useForm<ProjectDeveloperSetupForm>({
     resolver,
     defaultValues: { categories: [], impacts: [], mosaics: [] },
-    shouldUseNativeValidation: true,
     shouldFocusError: true,
     reValidateMode: 'onChange',
   });
@@ -213,7 +212,7 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, NakedPageLayoutProp
         onSubmitClick={handleSubmit(onSubmit)}
       >
         <Page hasErrors={!!errors?.language}>
-          <form className="flex flex-col justify-between" noValidate>
+          <form className="flex flex-col justify-between">
             <h1 className="mb-6 font-serif text-3xl font-semibold text-green-dark">
               <FormattedMessage defaultMessage="I want to write my content in" id="APjPYs" />
             </h1>
@@ -267,7 +266,7 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, NakedPageLayoutProp
           </form>
         </Page>
         <Page hasErrors={getPageErrors(1)}>
-          <form className="flex flex-col justify-between" noValidate>
+          <form className="flex flex-col justify-between">
             <div className="mb-10">
               <h1 className="mb-2 font-serif text-3xl font-semibold">
                 <FormattedMessage defaultMessage="Project developer information" id="n2WWAj" />
@@ -329,6 +328,7 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, NakedPageLayoutProp
                     id="profile"
                     type="text"
                     register={register}
+                    invalid={!!errors.name}
                     placeholder={formatMessage({
                       defaultMessage: 'insert the profile name',
                       id: '0WHWA/',
@@ -388,6 +388,7 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, NakedPageLayoutProp
                   id="entity-legal-registration"
                   className="mt-2.5"
                   register={register}
+                  invalid={!!errors.entity_legal_registration_number}
                   aria-required
                   name="entity_legal_registration_number"
                   placeholder={formatMessage({
@@ -410,6 +411,7 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, NakedPageLayoutProp
                   className="mt-2.5"
                   id="about"
                   register={register}
+                  invalid={!!errors.about}
                   aria-required
                   placeholder={formatMessage({
                     defaultMessage: 'insert your answer (max 500 characters)',
@@ -429,6 +431,7 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, NakedPageLayoutProp
                   id="mission"
                   aria-required
                   register={register}
+                  invalid={!!errors.mission}
                   placeholder={formatMessage({
                     defaultMessage: 'insert your answer (max 500 characters)',
                     id: 'rBoq14',
@@ -443,11 +446,11 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, NakedPageLayoutProp
                 <FormattedMessage defaultMessage="Online presence" id="NjKSap" />
               </p>
             </div>
-            <SocialMediaImputs errors={errors} register={register} />
+            <SocialMediaInputs errors={errors} register={register} />
           </form>
         </Page>
         <Page hasErrors={getPageErrors(2)}>
-          <form className="flex flex-col justify-between" noValidate>
+          <form className="flex flex-col justify-between">
             <div className="mb-6">
               <h1 className="font-serif text-3xl font-semibold">
                 <FormattedMessage defaultMessage="About your work" id="kEXoaQ" />
@@ -472,6 +475,7 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, NakedPageLayoutProp
                         value={item.id}
                         aria-describedby={`${name}-error`}
                         register={register}
+                        invalid={!!errors?.[name]}
                       >
                         {item.type === 'category' && (
                           <CategoryTagDot category={item.id as CategoryType} />

--- a/frontend/pages/sign-in/forgot-password.tsx
+++ b/frontend/pages/sign-in/forgot-password.tsx
@@ -40,7 +40,7 @@ const ForgotPassword: PageComponent<ForgotPasswordPageProps, AuthPageLayoutProps
     register,
     formState: { errors },
     handleSubmit,
-  } = useForm<ResetPassword>({ resolver, shouldUseNativeValidation: true });
+  } = useForm<ResetPassword>({ resolver });
   const { push } = useRouter();
 
   const handleResetPassword = useCallback(
@@ -66,7 +66,7 @@ const ForgotPassword: PageComponent<ForgotPasswordPageProps, AuthPageLayoutProps
           id="P+9ug1"
         />
       </p>
-      <form onSubmit={handleSubmit(onSubmit)} noValidate>
+      <form onSubmit={handleSubmit(onSubmit)}>
         {resetPassword.isError && (
           <Alert className="mb-4.5" withLayoutContainer>
             {Array.isArray(resetPassword.error.message)
@@ -87,6 +87,7 @@ const ForgotPassword: PageComponent<ForgotPasswordPageProps, AuthPageLayoutProps
               })}
               aria-describedby="email-error"
               register={register}
+              invalid={!!errors.email}
               className="mt-2.5 mb-4.5"
             />
           </Label>

--- a/frontend/pages/sign-in/index.tsx
+++ b/frontend/pages/sign-in/index.tsx
@@ -46,7 +46,7 @@ const SignIn: PageComponent<SignInPageProps, AuthPageLayoutProps> = () => {
     register,
     formState: { errors },
     handleSubmit,
-  } = useForm<SignIn>({ resolver, shouldUseNativeValidation: true });
+  } = useForm<SignIn>({ resolver });
   const { user } = useMe();
 
   const handleSignIn = useCallback(
@@ -76,7 +76,7 @@ const SignIn: PageComponent<SignInPageProps, AuthPageLayoutProps> = () => {
           id="ZjA6uH"
         />
       </p>
-      <form onSubmit={handleSubmit(onSubmit)} noValidate>
+      <form onSubmit={handleSubmit(onSubmit)}>
         {signIn.error?.message && (
           <Alert className="mb-4.5" withLayoutContainer>
             {Array.isArray(signIn.error.message)
@@ -97,6 +97,7 @@ const SignIn: PageComponent<SignInPageProps, AuthPageLayoutProps> = () => {
               })}
               aria-describedby="email-error"
               register={register}
+              invalid={!!errors.email}
               className="mt-2.5"
             />
           </Label>
@@ -127,6 +128,7 @@ const SignIn: PageComponent<SignInPageProps, AuthPageLayoutProps> = () => {
               id="password"
               aria-describedby="password-description password-error"
               register={register}
+              invalid={!!errors.password}
             />
             <ErrorMessage id="password-error" errorText={errors.password?.message} />
           </div>

--- a/frontend/pages/sign-up/index.tsx
+++ b/frontend/pages/sign-up/index.tsx
@@ -45,7 +45,7 @@ const SignUp: PageComponent<SIgnUpPageProps, AuthPageLayoutProps> = () => {
     register,
     formState: { errors },
     handleSubmit,
-  } = useForm<SignupFormI>({ resolver, shouldUseNativeValidation: true });
+  } = useForm<SignupFormI>({ resolver });
 
   const handleSignUp = useCallback(
     (data: SignupDto) =>
@@ -75,7 +75,7 @@ const SignUp: PageComponent<SIgnUpPageProps, AuthPageLayoutProps> = () => {
       <p className="mb-1.5 font-sans text-base text-gray-600">
         <FormattedMessage defaultMessage="Please enter your details below." id="rfVDxL" />
       </p>
-      <form onSubmit={handleSubmit(onSubmit)} noValidate>
+      <form onSubmit={handleSubmit(onSubmit)}>
         {signUp.isError && signUp.error.message ? (
           Array.isArray(signUp.error.message) ? (
             <ul>
@@ -107,6 +107,7 @@ const SignUp: PageComponent<SIgnUpPageProps, AuthPageLayoutProps> = () => {
                 })}
                 aria-describedby="first-name-error"
                 register={register}
+                invalid={!!errors.first_name}
               />
             </label>
             <ErrorMessage id="first-name-error" errorText={errors.first_name?.message} />
@@ -126,6 +127,7 @@ const SignUp: PageComponent<SIgnUpPageProps, AuthPageLayoutProps> = () => {
                 })}
                 aria-describedby="last-name-error"
                 register={register}
+                invalid={!!errors.last_name}
               />
             </label>
             <ErrorMessage id="last-name-error" errorText={errors.last_name?.message} />
@@ -146,6 +148,7 @@ const SignUp: PageComponent<SIgnUpPageProps, AuthPageLayoutProps> = () => {
               })}
               aria-describedby="email-error"
               register={register}
+              invalid={!!errors.email}
             />
           </label>
           <ErrorMessage id="email-error" errorText={errors.email?.message} />
@@ -166,6 +169,7 @@ const SignUp: PageComponent<SIgnUpPageProps, AuthPageLayoutProps> = () => {
                 id="password"
                 aria-describedby="password-description password-error"
                 register={register}
+                invalid={!!errors.password}
               />
             </label>
             <p
@@ -194,6 +198,7 @@ const SignUp: PageComponent<SIgnUpPageProps, AuthPageLayoutProps> = () => {
                 })}
                 aria-describedby="confirm-password-error"
                 register={register}
+                invalid={!!errors.confirm_password}
               />
             </label>
             <ErrorMessage
@@ -209,6 +214,7 @@ const SignUp: PageComponent<SIgnUpPageProps, AuthPageLayoutProps> = () => {
               id="accept-terms"
               aria-describedby="accept-terms-error"
               register={register}
+              invalid={!!errors.accept_terms}
             />
             <span className="ml-2 font-sans text-sm text-gray-800 font-regular">
               <FormattedMessage


### PR DESCRIPTION
React Hook Form is used with a resolver (Yup) to validate the form. Unfortunately, RHF is not able to validate individual fields when using one. The whole schema needs to be validated to check the validity of just one field.

As long as the user is the initiator of the change to a field's value, validation will be triggered on this field only. Nevertheless, if a field's value is updated programmatically and it needs to be validated, then the whole form will be validated and display errors.

This is the case of the `<TagGroup />` component: the “Select All” button needs to update the field's value and we also need to trigger validation on that field to remove the red ring (border). The problem is that if the user clicks the “Select All” button, then the whole form will be validated and errors will be displayed next to fields the user hasn't even had a look at yet. You can see this in action when replicating [Susana's steps](https://vizzuality.atlassian.net/browse/LET-276?focusedCommentId=15782).

The solution proposed by this PR is imperfect but I believe it is the simplest to fix the issue and to keep the fields' validation updated (add/remove the red ring): remove the native validation.

A better solution would be to pass `control` and `controlOptions` props to each of the inputs (like for the `<Select />` component) so that we would have a standardised way to deal with inputs and they could read their validation status by themselves instead of relying on the parent to pass it.

## Testing instructions

1. Go to the PD form
2. On the 3rd step, click the “Select All” button of the first field

Make sure errors are not triggered elsewhere in the form.

## Tracking

Based on an issue reported on the user story [LET-276](https://vizzuality.atlassian.net/browse/LET-276). This PR blocks the acceptance of the story.
