### PR TITLE
Let 285 add contact info to pd form

### DIFF
--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -185,6 +185,9 @@
   "DQoGRx": {
     "string": "About the impact"
   },
+  "DkjIbR": {
+    "string": "insert email"
+  },
   "ErIkUS": {
     "string": "Insert your email"
   },
@@ -234,6 +237,9 @@
   "IMe8OV": {
     "string": "Nature based solutions are estimated to compensate up to 30% of global emissions."
   },
+  "ITdmlJ": {
+    "string": "Contact information"
+  },
   "IbrSk1": {
     "string": "Learn"
   },
@@ -245,6 +251,9 @@
   },
   "JIehAU": {
     "string": "This is why ARIES is developing a 'Wikipedia-like' platform, that is collaborative, open-source and enables interoperable models and data. For the first time, this generates new knowledge through integrating the existing platform with the ultimate scope of building a more sustainable and resilient future for all."
+  },
+  "JNTB42": {
+    "string": "Phone number (optional)"
   },
   "JRfERD": {
     "string": "Paulson Institute"
@@ -518,6 +527,9 @@
   },
   "i50XU3": {
     "string": "Features for investors"
+  },
+  "iiVhlC": {
+    "string": "insert phone number"
   },
   "in26xr": {
     "string": "{organization} logo"

--- a/frontend/pages/project-developers/new.tsx
+++ b/frontend/pages/project-developers/new.tsx
@@ -438,6 +438,51 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, NakedPageLayoutProp
               </Label>
               <ErrorMessage errorText={errors?.mission?.message} id="mission-error" />
             </div>
+            <div className="mb-10">
+              <p className="font-sans font-medium text-base text-gray-600 mb-4.5">
+                <FormattedMessage defaultMessage="Contact information" id="ITdmlJ" />
+              </p>
+              <div className="md:flex gap-x-6">
+                <div className="md:w-1/2">
+                  <Label>
+                    <FormattedMessage defaultMessage="Email" id="sy+pv5" />
+                    <Input
+                      name="contact_email"
+                      type="email"
+                      id="email"
+                      register={register}
+                      aria-required
+                      placeholder={formatMessage({
+                        defaultMessage: 'insert email',
+                        id: 'DkjIbR',
+                      })}
+                      className="mt-2.5"
+                      aria-describedby="email-error"
+                    />
+                  </Label>
+                  <ErrorMessage id="email-error" errorText={errors.contact_email?.message} />
+                </div>
+                <div className="md:w-1/2">
+                  <Label>
+                    <FormattedMessage defaultMessage="Phone number (optional)" id="JNTB42" />
+                    <Input
+                      name="contact_phone"
+                      type="tel"
+                      id="phone-number"
+                      register={register}
+                      aria-required
+                      placeholder={formatMessage({
+                        defaultMessage: 'insert phone number',
+                        id: 'iiVhlC',
+                      })}
+                      className="mt-2.5"
+                      aria-describedby="phone-number-error"
+                    />
+                  </Label>
+                  <ErrorMessage id="phone-number-error" errorText={errors.contact_phone?.message} />
+                </div>
+              </div>
+            </div>
             <div>
               <p className="font-sans font-medium text-base text-gray-600 mb-4.5">
                 <FormattedMessage defaultMessage="Online presence" id="NjKSap" />

--- a/frontend/schemas/projectDeveloper.ts
+++ b/frontend/schemas/projectDeveloper.ts
@@ -30,6 +30,17 @@ export default (page: number) => {
     },
     about: formatMessage({ defaultMessage: 'You need enter a "about" text', id: 'tzSubd' }),
     mission: formatMessage({ defaultMessage: 'You need to enter a "mission" text', id: 'laO/jL' }),
+    contactEmail: {
+      required: formatMessage({
+        defaultMessage: 'You need to enter an email',
+        id: 'GkDTfx',
+      }),
+      isValid: formatMessage({
+        defaultMessage: 'Invalid email format.',
+        id: '05q+7T',
+      }),
+    },
+    contactPhone: formatMessage({ defaultMessage: 'Invalid phone number', id: 'HhjmvS' }),
     categories: formatMessage({
       defaultMessage: 'You need to select one or more categories',
       id: 'ora/x9',
@@ -69,7 +80,14 @@ export default (page: number) => {
       .required(messages.entityLegalRegistrationNumber.required),
     about: string().max(500, messages.maxTextLength).required(messages.about),
     mission: string().max(500, messages.maxTextLength).required(messages.mission),
-    website: string().url(messages.website),
+    contact_email: string()
+      .email(messages.contactEmail.isValid)
+      .required(messages.contactEmail.required),
+    contact_phone: string().test(
+      'isValid',
+      messages.contactPhone,
+      (value) => !value || !!value.match(/^[+]*[(]{0,1}[0-9]{1,4}[)]{0,1}[-\s\./0-9]*$/)
+    ),
     facebook: string().test(
       'isSocialMediaLink',
       messages.social_medias,

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -1,6 +1,8 @@
 import axios from 'axios';
 import Jsona from 'jsona';
 
+import { ApiError } from 'types/api';
+
 const dataFormatter = new Jsona();
 
 const baseUrl =
@@ -31,7 +33,7 @@ const onResponseSuccess = (response) => {
 
 const onResponseError = (error) => {
   if (error.response.data?.errors?.length > 0) {
-    return Promise.reject<{ message: { title: string }[] }>({
+    return Promise.reject<ApiError>({
       message: error.response.data.errors,
     });
   }

--- a/frontend/services/users/userService.ts
+++ b/frontend/services/users/userService.ts
@@ -2,6 +2,7 @@ import { useMutation, UseMutationResult } from 'react-query';
 
 import { AxiosResponse, AxiosError } from 'axios';
 
+import { ApiError } from 'types/api';
 import { ResetPassword } from 'types/sign-in';
 import { SignupDto } from 'types/user';
 
@@ -9,7 +10,7 @@ import API from '../api';
 
 export function useSignup(): UseMutationResult<
   AxiosResponse<SignupDto>,
-  AxiosError,
+  AxiosError<ApiError>,
   SignupDto,
   unknown
 > {

--- a/frontend/types/api.ts
+++ b/frontend/types/api.ts
@@ -1,4 +1,3 @@
 export type ApiError = {
-  message: { title: string }[];
-  code?: number;
+  message: { title: string; code?: number }[];
 };

--- a/frontend/types/projectDeveloper.ts
+++ b/frontend/types/projectDeveloper.ts
@@ -1,19 +1,25 @@
 import { SocialContactInputs } from 'containers/social-contact/inputs-social-contact/types';
 
-import { CategoryType } from './category';
+import { Languages } from 'enums';
+
 import { Enum } from './enums';
 
-export type ProjectDeveloperSetupForm = SocialContactInputs & {
-  language: Language;
-  picture: File;
+type ProjectDeveloperBase = SocialContactInputs & {
   name: string;
-  project_developer_type: string;
-  entity_legal_registration_number: string;
   about: string;
   mission: string;
-  categories: CategoryType[];
-  impacts: Impact[];
-  mosaics?: Mosaic[];
+  project_developer_type: string;
+  contact_email: string;
+  contact_phone?: string;
+  categories: string[];
+  impacts: string[];
+  language: Languages;
+  entity_legal_registration_number: string;
+};
+
+export type ProjectDeveloperSetupForm = ProjectDeveloperBase & {
+  picture: File;
+  mosaics?: string[];
 };
 
 export enum Language {
@@ -29,10 +35,33 @@ export enum Impact {
   'community',
 }
 
-export type Mosaic =
-  | 'Piedemonte Amazónico Macizo'
-  | 'Heart of Amazonia'
-  | 'Andean Amazonian Piedmont';
+export type ProjectDeveloper = {
+  id: string;
+  type: 'project_developer';
+  attributes: ProjectDeveloperBase & {
+    slug: string;
+    review_status: 'approved';
+    picture: {
+      small: string;
+      medium: string;
+      original: string;
+    };
+  };
+  relationships: {
+    owner: {
+      data: {
+        id: string;
+        type: 'user';
+      };
+    };
+    locations: {
+      data: {
+        id: string;
+        type: 'location';
+      }[];
+    };
+  };
+};
 
 export type InterestItem = { name: string; id: string; color?: string; infoText?: string };
 


### PR DESCRIPTION
ℹ️ This PR is https://github.com/Vizzuality/heco-invest/pull/90 without the code from https://github.com/Vizzuality/heco-invest/pull/89. @barbara-chaves is the author of this code.

---

This PR adds the contact information to the Project Developer form

## Testing instructions

Contains the following fields in a contact section:

* Email (mandatory)

* Phone number (optional)

Respects the [visual design](https://www.figma.com/file/KC49uMR9t1YARmFR0Sr6aN/HeCo---Work-in-progress?node-id=1983%3A27584)

Available for translation in Spanish, Portuguese and English

Page works well on desktop devices

## Tracking

[LET-285](https://vizzuality.atlassian.net/browse/LET-285)