### PR TITLE
feat: create confirm modal to leave form

### DIFF
--- a/frontend/containers/leave-form-modal/component.tsx
+++ b/frontend/containers/leave-form-modal/component.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+import { FormattedMessage } from 'react-intl';
+
+import Link from 'next/link';
+
+import Button from 'components/button';
+import Modal from 'components/modal';
+import { Paths } from 'enums';
+
+import { LeaveFormModalProps } from './types';
+
+export const LeaveFormModal = ({
+  title,
+  isOpen,
+  close,
+  handleLeave,
+  showSignupLink,
+}: LeaveFormModalProps) => {
+  return (
+    <Modal open={isOpen} title={title} onDismiss={close}>
+      <div className="text-center">
+        <h1 className="mb-8 font-serif text-3xl font-semibold">
+          <FormattedMessage defaultMessage="Do you want to leave?" id="lfvUqs" />
+        </h1>
+        <p>
+          <FormattedMessage
+            defaultMessage="By leaving you will lose your current progress"
+            id="oYPIc/"
+          />
+        </p>
+        <div className="flex justify-center gap-6 mt-12">
+          <Button theme="secondary-green" onClick={close}>
+            <FormattedMessage defaultMessage="Cancel" id="47FYwb" />
+          </Button>
+          <Button onClick={handleLeave}>
+            <FormattedMessage defaultMessage="Leave" id="fnihsY" />
+          </Button>
+        </div>
+        {showSignupLink && (
+          <div className="mt-6">
+            <Link href={Paths.SIGNUP} passHref>
+              <a className="underline text-green-dark">
+                <FormattedMessage defaultMessage="Already a member? Log in" id="Wo0Pmr" />
+              </a>
+            </Link>
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+};
+
+export default LeaveFormModal;

--- a/frontend/containers/leave-form-modal/components.stories.tsx
+++ b/frontend/containers/leave-form-modal/components.stories.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+
+import { ArrowLeft } from 'react-feather';
+
+import { Story, Meta } from '@storybook/react/types-6-0';
+
+import Button from 'components/button';
+
+import LeaveFormModal, { LeaveFormModalProps } from '.';
+
+export default {
+  component: LeaveFormModal,
+  title: 'Containers/LeaveFormModal',
+  argTypes: {},
+} as Meta;
+
+const Template: Story<LeaveFormModalProps> = (props: LeaveFormModalProps) => {
+  const [open, setOpen] = useState(false);
+  const [leave, setLeave] = useState(false);
+
+  return (
+    <div>
+      {!leave && (
+        <div>
+          <p>Form</p>
+          <Button onClick={() => setOpen(true)}>Leave Form</Button>
+          <LeaveFormModal
+            isOpen={open}
+            close={() => setOpen(false)}
+            handleLeave={() => {
+              setLeave(true);
+              setOpen(false);
+            }}
+            {...props}
+          />
+        </div>
+      )}
+      {leave && (
+        <div>
+          <Button theme="secondary-green" icon={ArrowLeft} onClick={() => setLeave(false)}>
+            Back to Form
+          </Button>
+          <p>Leaving the form...</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const Default: Story<LeaveFormModalProps> = Template.bind({});

--- a/frontend/containers/leave-form-modal/index.ts
+++ b/frontend/containers/leave-form-modal/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { LeaveFormModalProps } from './types';

--- a/frontend/containers/leave-form-modal/types.ts
+++ b/frontend/containers/leave-form-modal/types.ts
@@ -1,0 +1,7 @@
+export type LeaveFormModalProps = {
+  title: string;
+  isOpen: boolean;
+  showSignupLink?: boolean;
+  close: () => void;
+  handleLeave: () => void;
+};

--- a/frontend/pages/project-developers/new.tsx
+++ b/frontend/pages/project-developers/new.tsx
@@ -16,9 +16,11 @@ import useInterests, { InterestNames } from 'hooks/useInterests';
 import { loadI18nMessages } from 'helpers/i18n';
 
 import { CategoryTagDot } from 'containers/category-tag';
+import LeaveFormModal from 'containers/leave-form-modal';
 import MultiPageLayout, { Page } from 'containers/multi-page-layout';
 import SocialMediaImputs from 'containers/social-contact/inputs-social-contact/component';
 
+import Button from 'components/button';
 import Combobox, { Option } from 'components/forms/combobox';
 import ErrorMessage from 'components/forms/error-message';
 import FieldInfo from 'components/forms/field-info';
@@ -28,6 +30,7 @@ import Tag from 'components/forms/tag';
 import TagGroup from 'components/forms/tag-group';
 import TextArea from 'components/forms/textarea';
 import Head from 'components/head';
+import Modal from 'components/modal';
 import NakedPageLayout, { NakedPageLayoutProps } from 'layouts/naked-page';
 import languages from 'locales.config.json';
 import { PageComponent } from 'types';
@@ -71,6 +74,7 @@ const getItemsInfoText = (items: Enum[]) => {
 const ProjectDeveloper: PageComponent<ProjectDeveloperProps, NakedPageLayoutProps> = () => {
   const [currentPage, setCurrentPage] = useState(0);
   const [imagePreview, setImagePreview] = useState('');
+  const [showLeave, setShowLeave] = useState(false);
   const { formatMessage } = useIntl();
   const resolver = useProjectDeveloperValidation(currentPage);
   const { push } = useRouter();
@@ -209,7 +213,7 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, NakedPageLayoutProp
         onNextClick={handleNextClick}
         onPreviousClick={() => setCurrentPage(currentPage - 1)}
         showProgressBar
-        onCloseClick={() => push('/')}
+        onCloseClick={() => setShowLeave(true)}
         onSubmitClick={handleSubmit(onSubmit)}
       >
         <Page hasErrors={!!errors?.language}>
@@ -549,6 +553,12 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, NakedPageLayoutProp
           </form>
         </Page>
       </MultiPageLayout>
+      <LeaveFormModal
+        title={formatMessage({ defaultMessage: 'Leave create project develop', id: 'jQfYef' })}
+        isOpen={showLeave}
+        handleLeave={() => push('/')}
+        close={() => setShowLeave(false)}
+      />
     </>
   );
 };


### PR DESCRIPTION
This PR creates a reusable modal to handle the leave button on forms 
AND
adds the modal to the PD form

## Testing instructions

### Acceptance criteria

Respects the [visual design](https://www.figma.com/file/KC49uMR9t1YARmFR0Sr6aN/HeCo---Work-in-progress?node-id=2%3A4434)

The user is able to leave the PD creation form at any point

The user is warned the progress will be lost

Accessible by [WCAG 2.1 standards](https://www.w3.org/TR/WCAG21/)

Available for translation in Spanish, Portuguese and English

Page works well on desktop devices

### Technical notes:

On mobiles, the page is scaled down to fit the device's width. It doesn’t need to be responsive. See this [documentation about the viewport meta tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag) for more information.

Can potentially be reused for the other creation forms

## Tracking

[LET-224](https://vizzuality.atlassian.net/browse/LET-224)