### PR TITLE
Fixing Tag/TagGroup validation errors & keyboard focus ring

### DIFF
--- a/frontend/components/forms/tag-group/component.stories.tsx
+++ b/frontend/components/forms/tag-group/component.stories.tsx
@@ -27,6 +27,7 @@ const Template: Story<TagProps<FormValues>> = (args: TagProps<FormValues>) => {
     register,
     setValue,
     clearErrors,
+    watch,
     formState: { errors },
   } = useForm<FormValues>();
 
@@ -34,7 +35,13 @@ const Template: Story<TagProps<FormValues>> = (args: TagProps<FormValues>) => {
     <div className="p-4">
       <fieldset>
         <legend className="mb-2 font-sans font-semibold text-gray-800">Category</legend>
-        <TagGroup name={args.name} setValue={setValue} clearErrors={clearErrors} errors={errors}>
+        <TagGroup
+          name={args.name}
+          setValue={setValue}
+          clearErrors={clearErrors}
+          watch={watch}
+          errors={errors}
+        >
           <Tag
             id="first-category"
             value="first-category"
@@ -88,6 +95,7 @@ const TemplateWithForm: Story<TagProps<FormValues>> = (args: TagProps<FormValues
     setValue,
     handleSubmit,
     clearErrors,
+    watch,
     formState: { errors },
   } = useForm<FormValues>({
     shouldUseNativeValidation: true,
@@ -108,7 +116,13 @@ const TemplateWithForm: Story<TagProps<FormValues>> = (args: TagProps<FormValues
       >
         <fieldset name={args.name}>
           <legend className="mb-2 font-sans font-semibold text-gray-800">Category</legend>
-          <TagGroup name={args.name} setValue={setValue} errors={errors} clearErrors={clearErrors}>
+          <TagGroup
+            name={args.name}
+            setValue={setValue}
+            errors={errors}
+            clearErrors={clearErrors}
+            watch={watch}
+          >
             <Tag
               id="first-category"
               value="first-category"

--- a/frontend/components/forms/tag-group/component.stories.tsx
+++ b/frontend/components/forms/tag-group/component.stories.tsx
@@ -23,13 +23,18 @@ interface FormValues {
 }
 
 const Template: Story<TagProps<FormValues>> = (args: TagProps<FormValues>) => {
-  const { register, setValue } = useForm<FormValues>();
+  const {
+    register,
+    setValue,
+    clearErrors,
+    formState: { errors },
+  } = useForm<FormValues>();
 
   return (
     <div className="p-4">
       <fieldset>
         <legend className="mb-2 font-sans font-semibold text-gray-800">Category</legend>
-        <TagGroup name={args.name} setValue={setValue}>
+        <TagGroup name={args.name} setValue={setValue} clearErrors={clearErrors} errors={errors}>
           <Tag
             id="first-category"
             value="first-category"
@@ -82,13 +87,14 @@ const TemplateWithForm: Story<TagProps<FormValues>> = (args: TagProps<FormValues
     register,
     setValue,
     handleSubmit,
+    clearErrors,
     formState: { errors },
   } = useForm<FormValues>({
-    // We don't want to use the native validation here; the validation is specific to the group
-    // and not each tag individually, so we don't want the inputs to have the `valid` or `invalid`
-    // pseudo classes
-    shouldUseNativeValidation: false,
+    shouldUseNativeValidation: true,
+    shouldFocusError: true,
+    reValidateMode: 'onChange',
   });
+
   const onSubmit: SubmitHandler<FormValues> = (data) => action('onSubmit')(data);
 
   return (
@@ -100,9 +106,9 @@ const TemplateWithForm: Story<TagProps<FormValues>> = (args: TagProps<FormValues
         noValidate
         onSubmit={handleSubmit(onSubmit)}
       >
-        <fieldset>
+        <fieldset name={args.name}>
           <legend className="mb-2 font-sans font-semibold text-gray-800">Category</legend>
-          <TagGroup name={args.name} setValue={setValue}>
+          <TagGroup name={args.name} setValue={setValue} errors={errors} clearErrors={clearErrors}>
             <Tag
               id="first-category"
               value="first-category"
@@ -159,6 +165,17 @@ const TemplateWithForm: Story<TagProps<FormValues>> = (args: TagProps<FormValues
 };
 
 export const ErrorState: Story<TagProps<FormValues>> = TemplateWithForm.bind({});
+
+// Issue: https://github.com/react-hook-form/react-hook-form/issues/4449
+// Workaround: https://github.com/storybookjs/storybook/issues/12747
+ErrorState.parameters = {
+  docs: {
+    source: {
+      type: 'code',
+    },
+  },
+};
+
 ErrorState.args = {
   name: 'categories',
   registerOptions: {

--- a/frontend/components/forms/tag-group/component.tsx
+++ b/frontend/components/forms/tag-group/component.tsx
@@ -1,11 +1,9 @@
 import { ReactElement, Children, useMemo, cloneElement } from 'react';
 
-import { UseFormSetValue, FieldValues, UseFormClearErrors } from 'react-hook-form';
+import { FieldValues } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 
 import cx from 'classnames';
-
-import { noop } from 'lodash-es';
 
 import { TagGroupProps } from './types';
 
@@ -15,8 +13,9 @@ export const TagGroup = <FormValues extends FieldValues>({
   thresholdToShowSelectAll = 4,
   children,
   errors,
-  clearErrors = noop as UseFormClearErrors<any>,
-  setValue = noop as UseFormSetValue<any>,
+  watch,
+  clearErrors,
+  setValue,
   setValueOptions = { shouldDirty: true },
 }: TagGroupProps<FormValues>) => {
   const numChildren = useMemo(() => Children.count(children), [children]);
@@ -35,7 +34,7 @@ export const TagGroup = <FormValues extends FieldValues>({
   };
 
   const tags = Children.map(children, (child: ReactElement) => {
-    return cloneElement(child, { name, invalid: errors && errors[name] });
+    return cloneElement(child, { name, watch, invalid: errors && errors[name] });
   });
 
   const showSelectAllButton = numChildren >= thresholdToShowSelectAll;

--- a/frontend/components/forms/tag-group/types.ts
+++ b/frontend/components/forms/tag-group/types.ts
@@ -1,8 +1,8 @@
 import { PropsWithChildren } from 'react';
 
-import { UseFormSetValue, SetValueConfig } from 'react-hook-form';
+import { UseFormSetValue, UseFormClearErrors, SetValueConfig, FieldErrors } from 'react-hook-form';
 
-export type TagGroupProps = PropsWithChildren<{
+export type TagGroupProps<FormValues> = PropsWithChildren<{
   /** Classes to apply to the container */
   className?: string;
   /** Name of the tag group (will be assigned to each individual `<Tag />`) */
@@ -10,7 +10,11 @@ export type TagGroupProps = PropsWithChildren<{
   /** Number of tags required to show the “Select All” button. Defaults to `4`. */
   thresholdToShowSelectAll?: number;
   /** React Hook Form's `setValue` function */
-  setValue?: UseFormSetValue<any>;
-  /** Options for `setValue` function. Defaults to `{ shouldDirty: true, shouldValidate: true }`. */
+  setValue: UseFormSetValue<any>;
+  /** Options for `setValue` function. Defaults to `{ shouldDirty: true }`. */
   setValueOptions?: SetValueConfig;
+  /** ReactHook Form's `clearErrors` callback */
+  clearErrors: UseFormClearErrors<any>;
+  /** Form validation errors */
+  errors: FieldErrors<FormValues>;
 }>;

--- a/frontend/components/forms/tag-group/types.ts
+++ b/frontend/components/forms/tag-group/types.ts
@@ -1,6 +1,12 @@
 import { PropsWithChildren } from 'react';
 
-import { UseFormSetValue, UseFormClearErrors, SetValueConfig, FieldErrors } from 'react-hook-form';
+import {
+  UseFormSetValue,
+  UseFormClearErrors,
+  UseFormWatch,
+  SetValueConfig,
+  FieldErrors,
+} from 'react-hook-form';
 
 export type TagGroupProps<FormValues> = PropsWithChildren<{
   /** Classes to apply to the container */
@@ -9,6 +15,8 @@ export type TagGroupProps<FormValues> = PropsWithChildren<{
   name: string;
   /** Number of tags required to show the “Select All” button. Defaults to `4`. */
   thresholdToShowSelectAll?: number;
+  /** ReactHook Form's `watch` callback */
+  watch: UseFormWatch<any>;
   /** React Hook Form's `setValue` function */
   setValue: UseFormSetValue<any>;
   /** Options for `setValue` function. Defaults to `{ shouldDirty: true }`. */

--- a/frontend/components/forms/tag/component.tsx
+++ b/frontend/components/forms/tag/component.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { FieldValues } from 'react-hook-form';
 
@@ -14,9 +14,18 @@ export const Tag = <FormValues extends FieldValues>({
   register,
   registerOptions,
   children,
+  invalid: invalidProp = false,
   ...rest
 }: TagProps<FormValues>) => {
-  const [invalid, setInvalid] = useState(false);
+  const [invalid, setInvalid] = useState(invalidProp);
+
+  // This is mainly needed for when the Tag is part of a group of tags wrapped in a TagGroup component.
+  // TagGroup will be checking if the field has errors (by name), and passing `invalid` as either
+  // `true` or `false`. This is because the tag itself may be valid/not having errors, while the group
+  // as a whole may not be valid.
+  useEffect(() => {
+    setInvalid(invalidProp);
+  }, [invalidProp]);
 
   return (
     <div className={className}>
@@ -24,12 +33,10 @@ export const Tag = <FormValues extends FieldValues>({
         id={id}
         type="checkbox"
         className="sr-only peer"
-        {...rest}
-        {...register(name, {
-          ...registerOptions,
-        })}
         value={value}
         onInvalid={() => setInvalid(true)}
+        {...register(name, registerOptions)}
+        {...rest}
       />
       <label
         htmlFor={id}

--- a/frontend/components/forms/tag/component.tsx
+++ b/frontend/components/forms/tag/component.tsx
@@ -4,6 +4,8 @@ import { FieldValues } from 'react-hook-form';
 
 import cx from 'classnames';
 
+import { useFocusRing } from '@react-aria/focus';
+
 import { TagProps } from './types';
 
 export const Tag = <FormValues extends FieldValues>({
@@ -13,11 +15,15 @@ export const Tag = <FormValues extends FieldValues>({
   value,
   register,
   registerOptions,
+  watch,
   children,
   invalid: invalidProp = false,
   ...rest
 }: TagProps<FormValues>) => {
-  const [invalid, setInvalid] = useState(invalidProp);
+  const [invalid, setInvalid] = useState<boolean>(invalidProp);
+  const [selected, setSelected] = useState<boolean>(false);
+  const { isFocusVisible, focusProps } = useFocusRing();
+  const watchFields = watch && watch(name);
 
   // This is mainly needed for when the Tag is part of a group of tags wrapped in a TagGroup component.
   // TagGroup will be checking if the field has errors (by name), and passing `invalid` as either
@@ -27,6 +33,16 @@ export const Tag = <FormValues extends FieldValues>({
     setInvalid(invalidProp);
   }, [invalidProp]);
 
+  // We're displaying a green ring when the Tag is focused, but only when keyboard focused (for accessibility).
+  // We cannot use the `focus:` tailwind selector because it'll cause the ring to appear when the user clicks
+  // on it. In order to solve that, we're using `useFocusRing` from `react-aria`. That means we're keeping
+  // track of the tag's selected state manually. The `useEffect` block below keeps this functionality compatible
+  // with when the tag is part of a group, wrapped by the `TagGroup` component.
+  useEffect(() => {
+    if (!watchFields) return;
+    setSelected(watchFields.includes(value));
+  }, [value, watchFields]);
+
   return (
     <div className={className}>
       <input
@@ -35,14 +51,20 @@ export const Tag = <FormValues extends FieldValues>({
         className="sr-only peer"
         value={value}
         onInvalid={() => setInvalid(true)}
-        {...register(name, registerOptions)}
+        {...register(name, {
+          onChange: (e) => setSelected(!!e.target.checked),
+          ...registerOptions,
+        })}
+        {...focusProps}
         {...rest}
       />
       <label
         htmlFor={id}
         className={cx({
-          'inline-flex items-center px-4 py-2 border rounded-lg transition bg-white peer-focus:ring-2 ring-green-dark ring-offset-2 peer-checked:border-green-dark hover:shadow peer-disabled:shadow-none cursor-pointer peer-disabled:cursor-default peer-disabled:opacity-60':
+          'inline-flex items-center px-4 py-2 border rounded-lg transition bg-white hover:shadow peer-disabled:shadow-none cursor-pointer peer-disabled:cursor-default peer-disabled:opacity-60':
             true,
+          'ring-2 ring-green-dark ring-offset-2': isFocusVisible,
+          'border-green-dark': selected && !invalid,
           'peer-invalid:border-red-700': invalid,
         })}
       >

--- a/frontend/components/forms/tag/types.ts
+++ b/frontend/components/forms/tag/types.ts
@@ -17,6 +17,8 @@ export type TagProps<FormValues> = {
   registerOptions?: RegisterOptions<FormValues, FieldPath<FormValues>>;
   /** Classes to apply to the container */
   className?: string;
+  /** Whether the input is invalid. Defaults to `false`. */
+  invalid?: boolean;
 } & Omit<
   React.InputHTMLAttributes<HTMLInputElement>,
   keyof RegisterOptions<FormValues, FieldPath<FormValues>>

--- a/frontend/components/forms/tag/types.ts
+++ b/frontend/components/forms/tag/types.ts
@@ -1,6 +1,13 @@
 import React from 'react';
 
-import { Path, RegisterOptions, FieldPath, UseFormRegisterReturn } from 'react-hook-form';
+import {
+  Path,
+  RegisterOptions,
+  FieldPath,
+  FieldValues,
+  UseFormRegisterReturn,
+  UseFormWatch,
+} from 'react-hook-form';
 
 export type TagProps<FormValues> = {
   /** ID of the element */
@@ -11,6 +18,8 @@ export type TagProps<FormValues> = {
    * Value of the input. Set this if there are multiple tags with the same name (multiple choices).
    */
   value?: string;
+  /** ReactHook Form's `watch` callback */
+  watch?: UseFormWatch<FieldValues>;
   /** React Hook Form's `register` callback */
   register: (name, RegisterOptions) => UseFormRegisterReturn;
   /** Options for React Hook Form's `register` callback */

--- a/frontend/pages/project-developers/new.tsx
+++ b/frontend/pages/project-developers/new.tsx
@@ -87,6 +87,7 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, NakedPageLayoutProp
     setError,
     setValue,
     clearErrors,
+    watch,
   } = useForm<ProjectDeveloperSetupForm>({
     resolver,
     defaultValues: { categories: [], impacts: [], mosaics: [] },
@@ -528,6 +529,7 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, NakedPageLayoutProp
                   </legend>
                   <TagGroup
                     name={name}
+                    watch={watch}
                     setValue={setValue}
                     errors={errors}
                     clearErrors={clearErrors}

--- a/frontend/pages/project-developers/new.tsx
+++ b/frontend/pages/project-developers/new.tsx
@@ -86,6 +86,7 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, NakedPageLayoutProp
     control,
     setError,
     setValue,
+    clearErrors,
   } = useForm<ProjectDeveloperSetupForm>({
     resolver,
     defaultValues: { categories: [], impacts: [], mosaics: [] },
@@ -525,7 +526,12 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, NakedPageLayoutProp
                     <span className="mr-2.5">{title}</span>
                     <FieldInfo infoText={infoText || getItemsInfoText(items)} />
                   </legend>
-                  <TagGroup name={name} setValue={setValue}>
+                  <TagGroup
+                    name={name}
+                    setValue={setValue}
+                    errors={errors}
+                    clearErrors={clearErrors}
+                  >
                     {items?.map((item: Enum | Locations) => (
                       <Tag
                         key={item.id}


### PR DESCRIPTION
**Description:**  

Fix for [LET-170](https://vizzuality.atlassian.net/browse/LET-170)'s current issues with Tag/TagGroup error display as well as keyboard focus rings. 

## Testing instructions

Verify that the issues described [here](https://vizzuality.atlassian.net/browse/LET-276?focusedCommentId=15782) no longer occur:  

1. Choosing tags works
2. The "Select All" button works
3. Clicking "Select All" on the categories tags section will not trigger validation on the impacts tags section
4. Clicking "Submit" does not trigger a missing email error  

Also:  

1. Rings appear around the tags when navigating via keyboard "Tab"  
2. Rings do not appear around the tags when clicking on them 

## Tracking

[LET-170](https://vizzuality.atlassian.net/browse/LET-170)