### PR TITLE
Add missing i18n that hasn't been extracted

### DIFF
--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -68,6 +68,9 @@
   "3l2y4U": {
     "string": "Person of contact"
   },
+  "47FYwb": {
+    "string": "Cancel"
+  },
   "4CrCbD": {
     "string": "Community"
   },
@@ -339,6 +342,9 @@
   "QDj3j7": {
     "string": "Inter-American Development Bank Lab"
   },
+  "Qmlx+T": {
+    "string": "Insert the email to receive the contact messages."
+  },
   "RXoqkD": {
     "string": "Mission"
   },
@@ -387,6 +393,9 @@
   "Vge+RX": {
     "string": "Footer"
   },
+  "VkljLs": {
+    "string": "Insert the phone number in case you would like to be contacted by phone."
+  },
   "Vxcu91": {
     "string": "{name} account"
   },
@@ -398,6 +407,9 @@
   },
   "WkrNSk": {
     "string": "English"
+  },
+  "Wo0Pmr": {
+    "string": "Already a member? Log in"
   },
   "X0E3iC": {
     "string": "I agree with the Terms and Privacy Policy."
@@ -519,6 +531,9 @@
   "hLG9bm": {
     "string": "Project financial instrument"
   },
+  "hPsrc0": {
+    "string": "insert your answer (max 600 characters)"
+  },
   "hiQOgT": {
     "string": "<span>Biodiversity:</span> endemism, conservation/restoration potential, landscape connectivity;"
   },
@@ -533,6 +548,9 @@
   },
   "in26xr": {
     "string": "{organization} logo"
+  },
+  "jQfYef": {
+    "string": "Leave create project develop"
   },
   "jWOeHy": {
     "string": "<a>Call on our community</a> of project developers to identify opportunities in your preferred sectors and geographies."
@@ -554,6 +572,9 @@
   },
   "lPkzC0": {
     "string": "This makes a difference to them"
+  },
+  "lfvUqs": {
+    "string": "Do you want to leave?"
   },
   "m3Dnav": {
     "string": "Investment info"
@@ -578,6 +599,9 @@
   },
   "oMC3r1": {
     "string": "Choose your account type"
+  },
+  "oYPIc/": {
+    "string": "By leaving you will lose your current progress"
   },
   "oiQKNY": {
     "string": "Search and find"


### PR DESCRIPTION
I've noticed that on `develop`, not all `i18n` strings have been extracted.  
These tend to try to sneak into unrelated PRs, so this is an attempt to make `develop` proper and avoid issues in the future. 