### PR TITLE
Change PD texts

### DIFF
--- a/frontend/hooks/useInterests.ts
+++ b/frontend/hooks/useInterests.ts
@@ -23,8 +23,8 @@ const useInterests = ({ category, impact, mosaics }: InterestItems) => {
     () => [
       {
         title: formatMessage({
-          defaultMessage: 'Select the categories that interests you',
-          id: 'k5KxPA',
+          defaultMessage: 'Select the topics/sector categories that you work on',
+          id: 'LmHPHR',
         }),
         name: InterestNames.Categories,
         items: category,

--- a/frontend/pages/project-developers/new.tsx
+++ b/frontend/pages/project-developers/new.tsx
@@ -415,8 +415,8 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, NakedPageLayoutProp
                   register={register}
                   aria-required
                   placeholder={formatMessage({
-                    defaultMessage: 'insert your answer (max 500 characters)',
-                    id: 'rBoq14',
+                    defaultMessage: 'insert your answer (max 600 characters)',
+                    id: 'hPsrc0',
                   })}
                   aria-describedby="about-error"
                 />

--- a/frontend/pages/project-developers/new.tsx
+++ b/frontend/pages/project-developers/new.tsx
@@ -273,12 +273,12 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, NakedPageLayoutProp
           <form className="flex flex-col justify-between" noValidate>
             <div className="mb-10">
               <h1 className="mb-2 font-serif text-3xl font-semibold">
-                <FormattedMessage defaultMessage="Project developer information" id="n2WWAj" />
+                <FormattedMessage defaultMessage="Project developer profile" id="twK/jv" />
               </h1>
               <p className="font-sans text-base text-gray-600">
                 <FormattedMessage
-                  defaultMessage="General information about the account profile."
-                  id="aplkMy"
+                  defaultMessage="General information about the the project developer."
+                  id="CiBvks"
                 />
               </p>
             </div>
@@ -324,7 +324,7 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, NakedPageLayoutProp
             <div className="md:flex gap-x-6 mb-6.5">
               <div className="md:w-1/2 mb-6.5 md:m-0">
                 <Label htmlFor="profile">
-                  <FormattedMessage defaultMessage="Profile name" id="s+n2ku" />
+                  <FormattedMessage defaultMessage="Project developer name" id="Sv/Mtz" />
                   <Input
                     name="name"
                     className="mt-2.5"
@@ -333,8 +333,8 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, NakedPageLayoutProp
                     type="text"
                     register={register}
                     placeholder={formatMessage({
-                      defaultMessage: 'insert the profile name',
-                      id: '0WHWA/',
+                      defaultMessage: 'insert the name',
+                      id: 'WAr33U',
                     })}
                     aria-describedby="profile-error"
                   />
@@ -343,7 +343,7 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, NakedPageLayoutProp
               </div>
               <div className="md:w-1/2">
                 <Label htmlFor="project-developer-type" id="project-developer-type-label">
-                  <FormattedMessage defaultMessage="Type" id="+U6ozc" />
+                  <FormattedMessage defaultMessage="Project developer type" id="3tWxy0" />
                   <Combobox
                     control={control}
                     controlOptions={{ disabled: false }}
@@ -518,7 +518,10 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, NakedPageLayoutProp
                 <FormattedMessage defaultMessage="About your work" id="kEXoaQ" />
               </h1>
               <p className="font-sans text-base text-gray-600">
-                <FormattedMessage defaultMessage="Tell us about your work." id="Y6xIpg" />
+                <FormattedMessage
+                  defaultMessage="Tell us about your work and impact priorities."
+                  id="ViF88C"
+                />
               </p>
             </div>
             {interests.map(({ name, title, items, infoText }) => (


### PR DESCRIPTION
This PR changes some texts on the PD form to the updated one

## Testing instructions

The texts of the Project developer account creation form  will be changed as defined in [[SHARED] HeCo Platform - Phase 02](https://www.figma.com/proto/kEDAYIlBkRTVaPVc20oeyI/%5BSHARED%5D-HeCo-Platform---Phase-02?node-id=4%3A2337&viewport=396%2C48%2C0.04&scaling=min-zoom&starting-point-node-id=4%3A2319&show-proto-sidebar=1)
## Tracking

[LET-340](https://vizzuality.atlassian.net/browse/LET-340)