### PR TITLE
fix: adding missing variables to docker-compose-test.yml

### DIFF
--- a/backend/docker-compose-test.yml
+++ b/backend/docker-compose-test.yml
@@ -8,6 +8,8 @@ services:
       - DATABASE_USER=heco-test
       - DATABASE_PASSWORD=heco-test
       - DATABASE_HOST=db
+      - IS_API_INSTANCE=true
+      - IS_JOBS_INSTANCE=true
     depends_on:
       - db
   db:


### PR DESCRIPTION
Forget to add two new variables to `backend/docker-compose-test.yml` so adding it now ;)