### PR TITLE
Add a `MultiCombobox` component

### DIFF
--- a/frontend/components/forms/multi-combobox/component.stories.tsx
+++ b/frontend/components/forms/multi-combobox/component.stories.tsx
@@ -1,0 +1,200 @@
+import React from 'react';
+
+import { NestedValue, SubmitHandler, useForm } from 'react-hook-form';
+
+import { action } from '@storybook/addon-actions';
+import { Story, Meta } from '@storybook/react/types-6-0';
+
+import Button from 'components/button';
+
+import MultiCombobox, { MultiComboboxProps, Option } from '.';
+
+export default {
+  component: MultiCombobox,
+  title: 'Components/Forms/MultiCombobox',
+  argTypes: {
+    control: { control: { disable: true } },
+  },
+} as Meta;
+
+interface FormValues {
+  // `NestedValue` is needed for arrays: https://react-hook-form.com/ts/#NestedValue
+  sdgs: NestedValue<string[]>;
+}
+
+const OPTIONS = [
+  { key: 'no-poverty', label: 'No poverty' },
+  { key: 'zero-hunger', label: 'Zero hunger' },
+  { key: 'good-health-and-well-being', label: 'Good health and well-being' },
+  { key: 'quality-education', label: 'Quality education' },
+  { key: 'gender-equality', label: 'Gender equality' },
+  { key: 'clean-water-and-sanitation', label: 'Clean water and sanitation' },
+  { key: 'affordable-and-clean-energy', label: 'Affordable and clean energy' },
+  { key: 'decent-work-and-economic-growth', label: 'Decent work and economic growth' },
+  {
+    key: 'industry-innovation-and-infrastructure',
+    label: 'Industry, innovation and infrastructure',
+  },
+  { key: 'reduced-inequalities', label: 'Reduced inequalities' },
+  { key: 'sustainable-cities-and-communities', label: 'Sustainable cities and communities' },
+  {
+    key: 'responsible-consumption-and-production',
+    label: 'Responsible consumption and production',
+  },
+  { key: 'climate-action', label: 'Climate action' },
+  { key: 'life-below-water', label: 'Life below water' },
+  { key: 'life-on-land', label: 'Life on land' },
+  { key: 'peace-justice-and-strong-institutions', label: 'Peace, justice and strong institutions' },
+  { key: 'partnerships-for-the-goals', label: 'Partnerships for the goals' },
+];
+
+const Template: Story<MultiComboboxProps<FormValues>> = (args: MultiComboboxProps<FormValues>) => {
+  const { control } = useForm<FormValues>();
+
+  return (
+    <>
+      <MultiCombobox control={control} {...args}>
+        {OPTIONS.map(({ key, label }) => (
+          <Option key={key}>{label}</Option>
+        ))}
+      </MultiCombobox>
+      <p className="mt-2 text-xs text-gray-50">
+        This input is not accessible. Either define <code>aria-label</code> or associate a label
+        (see the “With Label” story).
+      </p>
+    </>
+  );
+};
+
+export const Default: Story<MultiComboboxProps<FormValues>> = Template.bind({});
+Default.args = {
+  id: 'form-sdgs',
+  name: 'sdgs',
+  placeholder: 'Sustainable tourism',
+  controlOptions: {
+    disabled: false,
+  },
+  clearable: true,
+};
+
+export const DefaultValue: Story<MultiComboboxProps<FormValues>> = Template.bind({});
+DefaultValue.args = {
+  id: 'form-sdgs',
+  name: 'sdgs',
+  placeholder: 'Sustainable tourism',
+  controlOptions: {
+    // NOTE: couldn't find a way around casting here
+    value: ['no-poverty', 'clean-water-and-sanitation'] as FormValues['sdgs'],
+    disabled: false,
+  },
+};
+
+export const DisabledOptions: Story<MultiComboboxProps<FormValues>> = Template.bind({});
+DisabledOptions.args = {
+  id: 'form-sdgs',
+  name: 'sdgs',
+  placeholder: 'Sustainable tourism',
+  disabledKeys: ['industry-innovation-and-infrastructure', 'climate-action', 'life-on-land'],
+  controlOptions: {
+    disabled: false,
+  },
+};
+
+export const OpenOnTop: Story<MultiComboboxProps<FormValues>> = Template.bind({});
+OpenOnTop.args = {
+  id: 'form-sdgs',
+  name: 'sdgs',
+  placeholder: 'Sustainable tourism',
+  className: 'mt-80',
+  direction: 'top',
+  controlOptions: {
+    disabled: false,
+  },
+};
+
+const TemplateWithLabel: Story<MultiComboboxProps<FormValues>> = (
+  args: MultiComboboxProps<FormValues>
+) => {
+  const { control } = useForm<FormValues>();
+
+  return (
+    <>
+      <label htmlFor={args.id} className="mb-2">
+        Sustainable Development Goals
+      </label>
+      <MultiCombobox control={control} {...args}>
+        {OPTIONS.map(({ key, label }) => (
+          <Option key={key}>{label}</Option>
+        ))}
+      </MultiCombobox>
+    </>
+  );
+};
+
+export const WithLabel: Story<MultiComboboxProps<FormValues>> = TemplateWithLabel.bind({});
+WithLabel.args = {
+  id: 'form-sdgs',
+  name: 'sdgs',
+  placeholder: 'Sustainable tourism',
+  controlOptions: {
+    disabled: false,
+  },
+};
+
+const TemplateWithForm: Story<MultiComboboxProps<FormValues>> = (
+  args: MultiComboboxProps<FormValues>
+) => {
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>({
+    // Using the native validation, we're able to style the inputs using the `valid` and `invalid`
+    // pseudo class
+    shouldUseNativeValidation: true,
+  });
+  const onSubmit: SubmitHandler<FormValues> = (data) => action('onSubmit')(data);
+
+  console.log(errors);
+
+  return (
+    <form
+      // `noValidate` here prevents the browser from not submitting the form if there's a validation
+      // error. We absolutely want the form to be submitted so that React Hook Form is made aware of
+      // the validation errors and we can display errors below inputs.
+      noValidate
+      onSubmit={handleSubmit(onSubmit)}
+    >
+      <label htmlFor={args.id} className="mb-2">
+        Sustainable Development Goals
+      </label>
+      <MultiCombobox control={control} aria-describedby="form-error" {...args}>
+        {OPTIONS.map(({ key, label }) => (
+          <Option key={key}>{label}</Option>
+        ))}
+      </MultiCombobox>
+      {errors.sdgs?.message && (
+        <p id="form-error" className="pl-2 mt-1 text-xs text-red">
+          {errors.sdgs?.message}
+        </p>
+      )}
+      <Button type="submit" className="mt-2">
+        Submit
+      </Button>
+      <p className="mt-2 text-xs text-gray-50">
+        Submit the form to see the {"combobox's"} error state (the combobox is required).
+      </p>
+    </form>
+  );
+};
+
+export const ErrorState: Story<MultiComboboxProps<FormValues>> = TemplateWithForm.bind({});
+ErrorState.args = {
+  id: 'form-sdgs',
+  name: 'sdgs',
+  placeholder: 'Sustainable tourism',
+  controlOptions: {
+    disabled: false,
+    required: 'At least a SDG is required.',
+  },
+};

--- a/frontend/components/forms/multi-combobox/component.tsx
+++ b/frontend/components/forms/multi-combobox/component.tsx
@@ -1,0 +1,96 @@
+import React, { Children, ReactElement, useMemo } from 'react';
+
+import { FieldValues, Path, PathValue, UnpackNestedValue, useController } from 'react-hook-form';
+import { useIntl } from 'react-intl';
+import ReactSelect from 'react-select';
+
+import cx from 'classnames';
+
+import DropdownIndicator from './dropdown-indicator';
+import { getAriaLiveMessages } from './helpers';
+import MenuOption from './menu-option';
+import MultiValueRemove from './multi-value-remove';
+import { OptionProps } from './option';
+import { MultiComboboxProps } from './types';
+
+export const Select = <FormValues extends FieldValues>({
+  id,
+  name,
+  'aria-label': ariaLabel,
+  placeholder,
+  direction = 'bottom',
+  className,
+  control,
+  controlOptions,
+  disabledKeys = [],
+  overflow = false,
+  clearable = false,
+  children,
+}: MultiComboboxProps<FormValues>) => {
+  const intl = useIntl();
+
+  const {
+    field: { value, onChange, onBlur },
+    fieldState: { invalid },
+  } = useController({
+    name,
+    control,
+    rules: controlOptions,
+    defaultValue: controlOptions.value as UnpackNestedValue<
+      PathValue<FormValues, Path<FormValues>>
+    >,
+  });
+
+  const options = useMemo(
+    () =>
+      Children.map(children, (child: ReactElement<OptionProps<{}>>) => ({
+        label: child.props.children,
+        value: child.key as string,
+        isDisabled: disabledKeys.includes(child.key as string),
+      })),
+    [children, disabledKeys]
+  );
+
+  const selectedOptions = useMemo(() => {
+    if (!value) return [];
+
+    return options.filter((option) => (value as string[]).includes(option.value));
+  }, [options, value]);
+
+  return (
+    <div className={cx('relative w-full', className)}>
+      <ReactSelect
+        inputId={id}
+        aria-label={ariaLabel}
+        options={options}
+        value={selectedOptions}
+        onChange={(options) =>
+          onChange({
+            type: 'change',
+            target: { name: name, value: options.map((option) => option.value) },
+          })
+        }
+        onBlur={onBlur}
+        className={cx({ 'c-select': true, invalid })}
+        classNamePrefix="c-select-menu"
+        isDisabled={controlOptions.disabled}
+        isSearchable
+        menuPosition={overflow ? 'fixed' : 'absolute'}
+        placeholder={placeholder}
+        isClearable={clearable}
+        isMulti
+        menuPlacement={direction}
+        hideSelectedOptions={false}
+        components={{
+          DropdownIndicator,
+          MultiValueRemove,
+          ClearIndicator: null,
+          Option: MenuOption,
+        }}
+        ariaLiveMessages={getAriaLiveMessages(intl)}
+      />
+    </div>
+  );
+};
+
+export default Select;

--- a/frontend/components/forms/multi-combobox/dropdown-indicator/component.tsx
+++ b/frontend/components/forms/multi-combobox/dropdown-indicator/component.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { ChevronDown as ChevronDownIcon } from 'react-feather';
+
+import cx from 'classnames';
+
+import Icon from 'components/icon';
+
+import { DropdownIndicatorProps } from './types';
+
+export const DropdownIndicator: React.FC<DropdownIndicatorProps> = ({
+  innerProps: { ref, ...restInnerProps },
+  selectProps: { menuIsOpen },
+}: DropdownIndicatorProps) => (
+  <div ref={ref} {...restInnerProps}>
+    <Icon
+      aria-hidden={true}
+      icon={ChevronDownIcon}
+      className={cx({
+        'inline-block w-5 h-5 ml-2 text-gray-600 shrink-0 transition': true,
+        'rotate-180': menuIsOpen,
+      })}
+    />
+  </div>
+);
+
+export default DropdownIndicator;

--- a/frontend/components/forms/multi-combobox/dropdown-indicator/index.ts
+++ b/frontend/components/forms/multi-combobox/dropdown-indicator/index.ts
@@ -1,0 +1,2 @@
+export type { DropdownIndicatorProps } from './types';
+export { default } from './component';

--- a/frontend/components/forms/multi-combobox/dropdown-indicator/types.ts
+++ b/frontend/components/forms/multi-combobox/dropdown-indicator/types.ts
@@ -1,0 +1,9 @@
+export interface DropdownIndicatorProps {
+  innerProps: {
+    ref: React.MutableRefObject<HTMLDivElement>;
+    [key: string]: unknown;
+  };
+  selectProps: {
+    menuIsOpen: boolean;
+  };
+}

--- a/frontend/components/forms/multi-combobox/helpers.ts
+++ b/frontend/components/forms/multi-combobox/helpers.ts
@@ -1,0 +1,170 @@
+import { IntlShape } from 'react-intl';
+
+// The orginal version of this code comes from:
+// https://github.com/JedWatson/react-select/blob/54f9538e350bae4e11aa11311731cb95eb56d669/packages/react-select/src/accessibility/index.ts#L99
+export const getAriaLiveMessages = (intl: IntlShape) => ({
+  guidance: (props: any) => {
+    const { isDisabled, context } = props;
+    switch (context) {
+      case 'menu':
+        if (isDisabled) {
+          return intl.formatMessage({
+            defaultMessage:
+              'Use up and down to choose options, press escape to exit the menu, press tab to select the option and exit the menu.',
+            id: '/PlWea',
+          });
+        }
+
+        return intl.formatMessage({
+          defaultMessage:
+            'Use up and down to choose options, press Enter to select the currently focused option, press escape to exit the menu, press tab to select the option and exit the menu.',
+          id: 'QncmS+',
+        });
+      case 'input':
+        return intl.formatMessage(
+          {
+            defaultMessage:
+              '{inputName} is focused, type to refine list, press down to open the menu, press left to focus selected values',
+            id: '4vn+6A',
+          },
+          {
+            inputName:
+              props['aria-label'] ||
+              intl.formatMessage({ defaultMessage: 'Combobox', id: 'IXFPYD' }),
+          }
+        );
+      case 'value':
+        return intl.formatMessage({
+          defaultMessage:
+            'Use left and right to toggle between focused values, press backspace to remove the currently focused value',
+          id: 'DWQSFT',
+        });
+      default:
+        return '';
+    }
+  },
+
+  onChange: (props: any) => {
+    const { action, label = '', labels, isDisabled } = props;
+    switch (action) {
+      case 'deselect-option':
+      case 'pop-value':
+      case 'remove-value':
+        return intl.formatMessage(
+          {
+            defaultMessage: 'option {optionName}, deselected.',
+            id: 'rhAEk6',
+          },
+          { optionName: label }
+        );
+      case 'clear':
+        return intl.formatMessage({
+          defaultMessage: 'All selected options have been cleared.',
+          id: 'x6wKw3',
+        });
+      case 'initial-input-focus':
+        return intl.formatMessage(
+          { defaultMessage: 'options {options}, selected.', id: 'U1OBY8' },
+          { options: labels.join(', ') }
+        );
+      case 'select-option':
+        return isDisabled
+          ? intl.formatMessage(
+              {
+                defaultMessage: 'option {optionName} is disabled. Select another option.',
+                id: 'KlHNih',
+              },
+              { optionName: label }
+            )
+          : intl.formatMessage(
+              {
+                defaultMessage: 'option {optionName}, selected.',
+                id: 'ZaT/7W',
+              },
+              { optionName: label }
+            );
+      default:
+        return '';
+    }
+  },
+
+  onFocus: (props: any) => {
+    const { context, focused, options, label = '', selectValue, isDisabled, isSelected } = props;
+
+    const getArrayIndex = (arr, item) =>
+      arr && arr.length
+        ? intl.formatMessage(
+            {
+              defaultMessage: '{start} of {end}',
+              id: '3dEg+E',
+            },
+            {
+              start: arr.indexOf(item) + 1,
+              end: arr.length,
+            }
+          )
+        : '';
+
+    if (context === 'value' && selectValue) {
+      return intl.formatMessage(
+        {
+          defaultMessage: 'value {optionName} focused, {pagination}.',
+          id: 'RDCAd6',
+        },
+        { optionName: label, pagination: getArrayIndex(selectValue, focused) }
+      );
+    }
+
+    if (context === 'menu') {
+      const disabled = isDisabled
+        ? intl.formatMessage({
+            defaultMessage: 'disabled',
+            id: 'hkIfkj',
+          })
+        : '';
+      const selected = isSelected
+        ? intl.formatMessage({
+            defaultMessage: 'selected',
+            id: 'LtTjKV',
+          })
+        : '';
+      const focused = !isSelected
+        ? intl.formatMessage({
+            defaultMessage: 'focused',
+            id: 'Jwjqn/',
+          })
+        : '';
+      return intl.formatMessage(
+        {
+          defaultMessage: 'option {optionName} {status}, {pagination}.',
+          id: '1MTH/x',
+        },
+        {
+          optionName: label,
+          status: `${selected} ${focused} ${disabled}`,
+          pagination: getArrayIndex(options, focused),
+        }
+      );
+    }
+    return '';
+  },
+
+  onFilter: (props: any) => {
+    const { inputValue, resultsMessage } = props;
+
+    if (inputValue) {
+      return intl.formatMessage(
+        {
+          defaultMessage: '{message} for search term {term}',
+          id: 'gpTOIc',
+        },
+        {
+          message: resultsMessage,
+          term: inputValue,
+        }
+      );
+    }
+
+    return resultsMessage;
+  },
+});

--- a/frontend/components/forms/multi-combobox/index.ts
+++ b/frontend/components/forms/multi-combobox/index.ts
@@ -1,0 +1,3 @@
+export type { MultiComboboxProps } from './types';
+export { default } from './component';
+export { default as Option } from './option';

--- a/frontend/components/forms/multi-combobox/menu-option/component.tsx
+++ b/frontend/components/forms/multi-combobox/menu-option/component.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import { Check as CheckIcon } from 'react-feather';
+import { components } from 'react-select';
+
+import cx from 'classnames';
+
+import Icon from 'components/icon';
+
+import { MenuOptionProps } from './types';
+
+export const MenuOption: React.FC<MenuOptionProps> = (props: MenuOptionProps) => {
+  const { isSelected, children } = props;
+
+  return (
+    <components.Option {...props}>
+      <div className="flex items-center justify-between">
+        {children}
+        {isSelected && (
+          <Icon
+            aria-hidden={true}
+            icon={CheckIcon}
+            className="inline-block w-5 h-5 ml-2 text-green-dark shrink-0"
+          />
+        )}
+      </div>
+    </components.Option>
+  );
+};
+
+export default MenuOption;

--- a/frontend/components/forms/multi-combobox/menu-option/index.ts
+++ b/frontend/components/forms/multi-combobox/menu-option/index.ts
@@ -1,0 +1,2 @@
+export type { MenuOptionProps } from './types';
+export { default } from './component';

--- a/frontend/components/forms/multi-combobox/menu-option/types.ts
+++ b/frontend/components/forms/multi-combobox/menu-option/types.ts
@@ -1,0 +1,6 @@
+import { PropsWithChildren } from 'react';
+
+export type MenuOptionProps = PropsWithChildren<{
+  /** Whether the option is selected. */
+  isSelected: boolean;
+}>;

--- a/frontend/components/forms/multi-combobox/multi-value-remove/component.tsx
+++ b/frontend/components/forms/multi-combobox/multi-value-remove/component.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import { X as XIcon } from 'react-feather';
+
+import Icon from 'components/icon';
+
+import { MultiValueRemoveProps } from './types';
+
+export const MultiValueRemove: React.FC<MultiValueRemoveProps> = ({
+  innerProps: { ref, ...restInnerProps },
+}: MultiValueRemoveProps) => (
+  <div ref={ref} {...restInnerProps}>
+    <Icon
+      aria-hidden={true}
+      icon={XIcon}
+      className="inline-block w-4 h-4 text-current transition cursor-pointer"
+    />
+  </div>
+);
+
+export default MultiValueRemove;

--- a/frontend/components/forms/multi-combobox/multi-value-remove/index.ts
+++ b/frontend/components/forms/multi-combobox/multi-value-remove/index.ts
@@ -1,0 +1,2 @@
+export type { MultiValueRemoveProps } from './types';
+export { default } from './component';

--- a/frontend/components/forms/multi-combobox/multi-value-remove/types.ts
+++ b/frontend/components/forms/multi-combobox/multi-value-remove/types.ts
@@ -1,0 +1,6 @@
+export interface MultiValueRemoveProps {
+  innerProps: {
+    ref: React.MutableRefObject<HTMLDivElement>;
+    [key: string]: unknown;
+  };
+}

--- a/frontend/components/forms/multi-combobox/option/component.tsx
+++ b/frontend/components/forms/multi-combobox/option/component.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import { OptionProps } from './types';
+
+export const Option: React.FC<OptionProps<{}>> = () => null;
+
+export default Option;

--- a/frontend/components/forms/multi-combobox/option/index.ts
+++ b/frontend/components/forms/multi-combobox/option/index.ts
@@ -1,0 +1,2 @@
+export type { OptionProps } from './types';
+export { default } from './component';

--- a/frontend/components/forms/multi-combobox/option/types.ts
+++ b/frontend/components/forms/multi-combobox/option/types.ts
@@ -1,0 +1,3 @@
+import { ItemProps } from '@react-types/shared';
+
+export type OptionProps<T> = ItemProps<T>;

--- a/frontend/components/forms/multi-combobox/types.ts
+++ b/frontend/components/forms/multi-combobox/types.ts
@@ -1,0 +1,31 @@
+import { PropsWithChildren } from 'react';
+
+import { Path, Control, FieldPath, UseControllerProps } from 'react-hook-form';
+
+export type MultiComboboxProps<FormValues> = PropsWithChildren<{
+  /** ID attribute of the input */
+  id: string;
+  /** Name of the input */
+  name: Path<FormValues>;
+  /** Aria label to attach to the input */
+  'aria-label'?: string;
+  /** Placeholder of the input */
+  placeholder?: string;
+  /** Vertical alignment of the dropdown relative to the trigger. Default to `'bottom'`. */
+  direction?: 'bottom' | 'top';
+  /** String to attach to the input */
+  className?: string;
+  /** React Hook Form's `control` function */
+  control: Control<FormValues, FieldPath<FormValues>>;
+  /** Options for React Hook Form's `control` function */
+  controlOptions: UseControllerProps<FormValues, FieldPath<FormValues>>['rules'] & {
+    /** Whether the input is disabled */
+    disabled?: boolean;
+  };
+  /** List of disabled options */
+  disabledKeys?: string[];
+  /** Whether the dropdown needs to overflow its container. Default to `false`. */
+  overflow?: boolean;
+  /** Whether the user can clear the input. Default to `false`. */
+  clearable?: boolean;
+}>;

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -1,7 +1,4 @@
 {
-  "+U6ozc": {
-    "string": "Type"
-  },
   "+mzZak": {
     "string": "About {name}"
   },
@@ -17,6 +14,9 @@
   "/L6T3E": {
     "string": "Get connected"
   },
+  "/PlWea": {
+    "string": "Use up and down to choose options, press escape to exit the menu, press tab to select the option and exit the menu."
+  },
   "/VnDMl": {
     "string": "Other"
   },
@@ -28,9 +28,6 @@
   },
   "0SKBlf": {
     "string": "Go to page {pageNumber}"
-  },
-  "0WHWA/": {
-    "string": "insert the profile name"
   },
   "0cWjQP": {
     "string": "{title} - page {currentPage} out of {numPages}"
@@ -46,6 +43,9 @@
   },
   "1B1DeU": {
     "string": "HeCo Invest relies on the <span>ARIES Artificial Intelligence</span> model to estimate − in a scientifically-informed and accurate manner − the impact of each project in each one of our four dimensions of interest based on existing knowledge and data. These impacts are calculated on a scale from 0 to 10 as shown in the chart of impact."
+  },
+  "1MTH/x": {
+    "string": "option {optionName} {status}, {pagination}."
   },
   "1iEPTM": {
     "string": "General"
@@ -65,8 +65,14 @@
   "39AHJm": {
     "string": "Sign Up"
   },
+  "3dEg+E": {
+    "string": "{start} of {end}"
+  },
   "3l2y4U": {
     "string": "Person of contact"
+  },
+  "3tWxy0": {
+    "string": "Project developer type"
   },
   "47FYwb": {
     "string": "Cancel"
@@ -82,6 +88,9 @@
   },
   "4bznpU": {
     "string": "HeCo will support the improved management of ecosystems in the Amazon, Andes, Orinoco, Pacific, and Caribbean regions. This aims to ensure the long-term sustainability of natural capital, through creating and channeling new and additional financial flows from the public and private sectors into specific projects and initiatives."
+  },
+  "4vn+6A": {
+    "string": "{inputName} is focused, type to refine list, press down to open the menu, press left to focus selected values"
   },
   "5GLwZF": {
     "string": "Select the account language in which you want to write the content of this account. This will avoid mixed content in the platform."
@@ -103,6 +112,9 @@
   },
   "60xeYL": {
     "string": "Contribute to improving the production systems and livelihoods of local communities and indigenous people, to ensure their basic needs are met, while enhancing their adaptation to climate change."
+  },
+  "6b2CRH": {
+    "string": "User menu"
   },
   "6ukMW9": {
     "string": "Basque Centre for Climate Change"
@@ -173,8 +185,14 @@
   "BAC0rl": {
     "string": "<span>Community:</span> income, sustainable projects;"
   },
+  "CEQo2w": {
+    "string": "My preferences"
+  },
   "CYTiug": {
     "string": "HeCo Invest will benefit poor and vulnerable people living in HeCo priority landscapes."
+  },
+  "CiBvks": {
+    "string": "General information about the the project developer."
   },
   "CjpGzJ": {
     "string": "Create your profile"
@@ -187,6 +205,9 @@
   },
   "DQoGRx": {
     "string": "About the impact"
+  },
+  "DWQSFT": {
+    "string": "Use left and right to toggle between focused values, press backspace to remove the currently focused value"
   },
   "DkjIbR": {
     "string": "insert email"
@@ -243,6 +264,9 @@
   "ITdmlJ": {
     "string": "Contact information"
   },
+  "IXFPYD": {
+    "string": "Combobox"
+  },
   "IbrSk1": {
     "string": "Learn"
   },
@@ -267,11 +291,23 @@
   "JkLHGw": {
     "string": "Website"
   },
+  "Jwjqn/": {
+    "string": "focused"
+  },
+  "KlHNih": {
+    "string": "option {optionName} is disabled. Select another option."
+  },
   "KtecFi": {
     "string": "How do they work?"
   },
   "KvhWhT": {
     "string": "The <span>IDB Lab</span>, the <span>Paulson Institute</span> and the <span>World Wildlife Fund</span> are working together to develop a digital platform that connects governments, investors, donors, and philanthropists with carefully identified investment opportunities in <span>high priority locations</span> identified by programs such as Herencia Colombia (HeCo)."
+  },
+  "LmHPHR": {
+    "string": "Select the topics/sector categories that you work on"
+  },
+  "LtTjKV": {
+    "string": "selected"
   },
   "M1xKEI": {
     "string": "Language: {language}"
@@ -345,6 +381,12 @@
   "Qmlx+T": {
     "string": "Insert the email to receive the contact messages."
   },
+  "QncmS+": {
+    "string": "Use up and down to choose options, press Enter to select the currently focused option, press escape to exit the menu, press tab to select the option and exit the menu."
+  },
+  "RDCAd6": {
+    "string": "value {optionName} focused, {pagination}."
+  },
   "RXoqkD": {
     "string": "Mission"
   },
@@ -354,11 +396,17 @@
   "SQJto2": {
     "string": "Sign in"
   },
+  "Sv/Mtz": {
+    "string": "Project developer name"
+  },
   "Swj4mJ": {
     "string": "Select the {name} account"
   },
   "TH786p": {
     "string": "See my profile"
+  },
+  "U1OBY8": {
+    "string": "options {options}, selected."
   },
   "URLNhk": {
     "string": "The Inter-American Development Bank (IDB) is the largest source of development financing for Latin America and the Caribbean. Established in 1959, the IDB supports Latin American and Caribbean economic development, social development and regional integration by lending to governments and government agencies, including State corporations."
@@ -393,6 +441,9 @@
   "Vge+RX": {
     "string": "Footer"
   },
+  "ViF88C": {
+    "string": "Tell us about your work and impact priorities."
+  },
   "VkljLs": {
     "string": "Insert the phone number in case you would like to be contacted by phone."
   },
@@ -401,6 +452,9 @@
   },
   "W4Jolw": {
     "string": "IDB Lab is the innovation laboratory of the Inter-American Development Bank Group, the leading source of financing for improving lives in Latin America and the Caribbean. The IDB Lab promotes development through the private sector by identifying, supporting, testing, and piloting new solutions to development challenges. It seeks to create opportunities for poor and vulnerable populations affected by economic, social, or environmental factors in Latin America and the Caribbean."
+  },
+  "WAr33U": {
+    "string": "insert the name"
   },
   "WTuVeL": {
     "string": "Something went wrong while submitting your form. Please correct the errors before submitting again."
@@ -423,9 +477,6 @@
   "XkF/qg": {
     "string": "Profile picture of {name}"
   },
-  "Y6xIpg": {
-    "string": "Tell us about your work."
-  },
   "Y7/cBd": {
     "string": "Reach out for what you are looking for, from either <span>Investors</span> or <span>Project Developers</span> and <span>start the conversation</span>. Make sure to update us to help us track your contribution to preserving the Amazon: <span>the future is in your hands too!</span>"
   },
@@ -435,6 +486,9 @@
   "YB8bt5": {
     "string": "Expect to have impact on"
   },
+  "YE6fVO": {
+    "string": "{accountName} account"
+  },
   "ZEEVQX": {
     "string": "Social media"
   },
@@ -443,6 +497,9 @@
   },
   "ZRwGVc": {
     "string": "In line with your priorities"
+  },
+  "ZaT/7W": {
+    "string": "option {optionName}, selected."
   },
   "ZiErTG": {
     "string": "Be part of the biggest change in the Colombian Amazon"
@@ -458,9 +515,6 @@
   },
   "adPUXO": {
     "string": "Until approval you can continue exploring our database."
-  },
-  "aplkMy": {
-    "string": "General information about the account profile."
   },
   "bNpbHr": {
     "string": "Find other people with similar interests. Join forces, secure more investment and create a greater impact."
@@ -528,6 +582,9 @@
   "ghj0+t": {
     "string": "Geographies"
   },
+  "gpTOIc": {
+    "string": "{message} for search term {term}"
+  },
   "hLG9bm": {
     "string": "Project financial instrument"
   },
@@ -536,6 +593,9 @@
   },
   "hiQOgT": {
     "string": "<span>Biodiversity:</span> endemism, conservation/restoration potential, landscape connectivity;"
+  },
+  "hkIfkj": {
+    "string": "disabled"
   },
   "hxIQ/8": {
     "string": "Projects waiting funding"
@@ -557,9 +617,6 @@
   },
   "jwimQJ": {
     "string": "Ok"
-  },
-  "k5KxPA": {
-    "string": "Select the categories that interests you"
   },
   "kEXoaQ": {
     "string": "About your work"
@@ -584,9 +641,6 @@
   },
   "n0nU+Y": {
     "string": "Illustration of a person looking at a list of cards"
-  },
-  "n2WWAj": {
-    "string": "Project developer information"
   },
   "nBHzO6": {
     "string": "Artificial Intelligence for Environment & Sustainability (ARIES) is an international research project intending to make the first Artificial Intelligence (AI)-powered 'Knowledge Commons' to integrate citizens and scientists' multidisciplinary knowledge and achieve climate adaptation and mitigation faster."
@@ -624,17 +678,14 @@
   "qPKAOa": {
     "string": "Paulson Institute: The Paulson Institute (PI) is a non-partisan, independent “think and do tank” delivering solutions that contribute to a more resilient and sustainable world. PI operates at the intersection of economics, financial markets, and environmental protection by promoting market-based solutions to ensure green economic growth. Under their Financing Nature initiative, they are working to identify and implement innovative mechanisms that can rapidly mobilize substantial amounts of funding for nature conservation."
   },
-  "rBoq14": {
-    "string": "insert your answer (max 500 characters)"
-  },
   "rbrahO": {
     "string": "Close"
   },
   "rfVDxL": {
     "string": "Please enter your details below."
   },
-  "s+n2ku": {
-    "string": "Profile name"
+  "rhAEk6": {
+    "string": "option {optionName}, deselected."
   },
   "sMWFoV": {
     "string": "As an Investor / Funder"
@@ -659,6 +710,9 @@
   },
   "tS6cAK": {
     "string": "insert the number"
+  },
+  "twK/jv": {
+    "string": "Project developer profile"
   },
   "txUL0F": {
     "string": "Last name"
@@ -690,8 +744,14 @@
   "x/1DXz": {
     "string": "In the face of the economic and social crisis caused by the coronavirus pandemic, there is an urgent need to support the transition to a green, fair, and resilient economy that creates jobs, addresses inequality, and drives inclusive growth."
   },
+  "x6wKw3": {
+    "string": "All selected options have been cleared."
+  },
   "xQ4XkB": {
     "string": "Only by understanding nature’s contributions to people and the economy can we push for policy-making where nature counts."
+  },
+  "xXbJso": {
+    "string": "Sign out"
   },
   "xjBcRf": {
     "string": "Slide {slide} out of {total}"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -84,6 +84,7 @@
     "react-popper": "^2.2.5",
     "react-query": "^3.16.0",
     "react-redux": "^7.2.4",
+    "react-select": "^4.3.0",
     "react-stately": "^3.12.2",
     "rooks": "^5.10.0",
     "sharp": "^0.30.1",

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -82,3 +82,121 @@
     }
   }
 }
+
+@layer components {
+  /* The following styles are for the `Select` component */
+  .c-select {
+    @apply block;
+  }
+
+  .c-select .c-select-menu {
+    @apply relative top-2 left-1/2;
+  }
+
+  .c-select-menu--is-disabled {
+    @apply opacity-60;
+  }
+
+  .c-select .c-select-menu__control {
+    @apply min-h-0 px-4 py-1 text-base transition bg-white border border-solid rounded-lg border-beige;
+  }
+
+  .c-select.invalid .c-select-menu__control {
+    @apply border-red-600;
+  }
+
+  .c-select .c-select-menu__control:hover {
+    @apply shadow-sm border-beige;
+  }
+
+  .c-select.invalid .c-select-menu__control:hover {
+    @apply border-red-600;
+  }
+
+  .c-select .c-select-menu__control + div {
+    @apply z-30;
+  }
+
+  .c-select .c-select-menu__control--is-focused {
+    @apply shadow-sm border-green-dark ring-0;
+  }
+
+  .c-select .c-select-menu__control--is-focused:hover {
+    @apply border-green-dark;
+  }
+
+  .c-select .c-select-menu__control--menu-is-open {
+    @apply ring-opacity-0;
+  }
+
+  .c-select .c-select-menu__indicator {
+    @apply p-0;
+  }
+
+  .c-select .c-select-menu__indicator:hover {
+  }
+
+  .c-select .c-select-menu__indicator-separator {
+    @apply hidden;
+  }
+
+  .c-select .c-select-menu__value-container {
+    @apply relative h-auto p-0;
+  }
+
+  .c-select .c-select-menu__value-container--is-multi > div:first-of-type {
+    @apply ml-0;
+  }
+
+  .c-select .c-select-menu__multi-value {
+    @apply mx-0.5 bg-white border border-solid border-beige rounded-lg;
+  }
+
+  .c-select .c-select-menu__multi-value__label {
+    @apply py-0 pl-1.5 pr-1;
+  }
+
+  .c-select .c-select-menu__multi-value__remove {
+    @apply px-1.5 text-gray-600 rounded-r-lg transition;
+  }
+
+  .c-select .c-select-menu__multi-value__remove:hover {
+    @apply bg-green-light/20 text-green-dark;
+  }
+
+  .c-select .c-select-menu__placeholder {
+    @apply absolute m-0 text-gray-400 -translate-y-1/2 top-1/2;
+  }
+
+  .c-select .c-select-menu__placeholder + div {
+    @apply ml-0;
+  }
+
+  .c-select .c-select-menu__menu {
+    @apply overflow-hidden bg-white rounded-md shadow-2xl;
+  }
+
+  .c-select .c-select-menu__menu-list {
+    @apply p-0 overflow-y-auto max-h-72;
+  }
+
+  .c-select .c-select-menu__option {
+    @apply px-4 py-2 font-sans text-sm text-black transition cursor-pointer sm:py-2;
+  }
+
+  .c-select .c-select-menu__option:active {
+    @apply bg-green-light/20;
+  }
+
+  .c-select .c-select-menu__option--is-selected {
+    @apply bg-white text-green-dark;
+  }
+
+  .c-select .c-select-menu__option--is-focused {
+    @apply bg-green-light/20;
+  }
+
+  .c-select .c-select-menu__option--is-disabled {
+    @apply cursor-default opacity-40;
+  }
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -782,7 +782,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-jsx@npm:^7.16.7":
+"@babel/plugin-syntax-jsx@npm:^7.12.13, @babel/plugin-syntax-jsx@npm:^7.16.7":
   version: 7.16.7
   resolution: "@babel/plugin-syntax-jsx@npm:7.16.7"
   dependencies:
@@ -1530,6 +1530,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.8.7":
+  version: 7.17.9
+  resolution: "@babel/runtime@npm:7.17.9"
+  dependencies:
+    regenerator-runtime: ^0.13.4
+  checksum: 4d56bdb82890f386d5a57c40ef985a0ed7f0a78f789377a2d0c3e8826819e0f7f16ba0fe906d9b2241c5f7ca56630ef0653f5bb99f03771f7b87ff8af4bf5fe3
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.12.7, @babel/template@npm:^7.16.7, @babel/template@npm:^7.3.3":
   version: 7.16.7
   resolution: "@babel/template@npm:7.16.7"
@@ -1752,6 +1761,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emotion/babel-plugin@npm:^11.7.1":
+  version: 11.9.2
+  resolution: "@emotion/babel-plugin@npm:11.9.2"
+  dependencies:
+    "@babel/helper-module-imports": ^7.12.13
+    "@babel/plugin-syntax-jsx": ^7.12.13
+    "@babel/runtime": ^7.13.10
+    "@emotion/hash": ^0.8.0
+    "@emotion/memoize": ^0.7.5
+    "@emotion/serialize": ^1.0.2
+    babel-plugin-macros: ^2.6.1
+    convert-source-map: ^1.5.0
+    escape-string-regexp: ^4.0.0
+    find-root: ^1.1.0
+    source-map: ^0.5.7
+    stylis: 4.0.13
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 2d2c4fadd389862896bcbc5f42c9b9c1a199810173fcf14e5520506c7179c2ddb991b8832fd273f42104cf0dae98886ad8e767b5e38ad235b652d903c3b8a328
+  languageName: node
+  linkType: hard
+
 "@emotion/cache@npm:^10.0.27":
   version: 10.0.29
   resolution: "@emotion/cache@npm:10.0.29"
@@ -1761,6 +1792,19 @@ __metadata:
     "@emotion/utils": 0.11.3
     "@emotion/weak-memoize": 0.2.5
   checksum: 78b37fb0c2e513c90143a927abef229e995b6738ef8a92ce17abe2ed409b38859ddda7c14d7f4854d6f4e450b6db50231532f53a7fec4903d7ae775b2ae3fd64
+  languageName: node
+  linkType: hard
+
+"@emotion/cache@npm:^11.4.0, @emotion/cache@npm:^11.7.1":
+  version: 11.7.1
+  resolution: "@emotion/cache@npm:11.7.1"
+  dependencies:
+    "@emotion/memoize": ^0.7.4
+    "@emotion/sheet": ^1.1.0
+    "@emotion/utils": ^1.0.0
+    "@emotion/weak-memoize": ^0.2.5
+    stylis: 4.0.13
+  checksum: cf7aa8fe3bacfdedcda94b53e76a7635e122043439715fcfbf7f1a81340cfe6099a59134481a03ec3e0437466566d18528577d1e6ea92f5b98c372b8b38a8f35
   languageName: node
   linkType: hard
 
@@ -1791,7 +1835,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/hash@npm:0.8.0":
+"@emotion/hash@npm:0.8.0, @emotion/hash@npm:^0.8.0":
   version: 0.8.0
   resolution: "@emotion/hash@npm:0.8.0"
   checksum: 4b35d88a97e67275c1d990c96d3b0450451d089d1508619488fc0acb882cb1ac91e93246d471346ebd1b5402215941ef4162efe5b51534859b39d8b3a0e3ffaa
@@ -1814,6 +1858,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emotion/memoize@npm:^0.7.4, @emotion/memoize@npm:^0.7.5":
+  version: 0.7.5
+  resolution: "@emotion/memoize@npm:0.7.5"
+  checksum: 83da8d4a7649a92c72f960817692bc6be13cc13e107b9f7e878d63766525ed4402881bfeb3cda61145c050281e7e260f114a0a2870515527346f2ef896b915b3
+  languageName: node
+  linkType: hard
+
+"@emotion/react@npm:^11.1.1":
+  version: 11.9.0
+  resolution: "@emotion/react@npm:11.9.0"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@emotion/babel-plugin": ^11.7.1
+    "@emotion/cache": ^11.7.1
+    "@emotion/serialize": ^1.0.3
+    "@emotion/utils": ^1.1.0
+    "@emotion/weak-memoize": ^0.2.5
+    hoist-non-react-statics: ^3.3.1
+  peerDependencies:
+    "@babel/core": ^7.0.0
+    react: ">=16.8.0"
+  peerDependenciesMeta:
+    "@babel/core":
+      optional: true
+    "@types/react":
+      optional: true
+  checksum: 4ceb004f942fb7557a55ea17aad2c48c4cd48ed5a780ccdc2993e4bded2f94d7c1764bd2f4fbe53f5b26059263599cec64ff66d29447e281a58c60b39c72e5cc
+  languageName: node
+  linkType: hard
+
 "@emotion/serialize@npm:^0.11.15, @emotion/serialize@npm:^0.11.16":
   version: 0.11.16
   resolution: "@emotion/serialize@npm:0.11.16"
@@ -1827,10 +1901,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emotion/serialize@npm:^1.0.2, @emotion/serialize@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "@emotion/serialize@npm:1.0.3"
+  dependencies:
+    "@emotion/hash": ^0.8.0
+    "@emotion/memoize": ^0.7.4
+    "@emotion/unitless": ^0.7.5
+    "@emotion/utils": ^1.0.0
+    csstype: ^3.0.2
+  checksum: 99a9053bd98c99d63af542ebee029281eeaf653e3a12e97ee79bad7330c68408104c30be6fc07a528e38bb69aba680655181744b76ec6c6f459c121cb805fac2
+  languageName: node
+  linkType: hard
+
 "@emotion/sheet@npm:0.9.4":
   version: 0.9.4
   resolution: "@emotion/sheet@npm:0.9.4"
   checksum: 53bb833b4bb69ea2af04e1ecad164f78fb2614834d2820f584c909686a8e047c44e96a6e824798c5c558e6d95e10772454a9e5c473c5dbe0d198e50deb2815bc
+  languageName: node
+  linkType: hard
+
+"@emotion/sheet@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@emotion/sheet@npm:1.1.0"
+  checksum: a4b74e16a8fea1157413efe4904f5f679d724323cb605d66d20a0b98744422f5d411fca927ceb52e4de454a0a819c5273ca9496db9f011b4ecd17b9f1b212007
   languageName: node
   linkType: hard
 
@@ -1869,7 +1963,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/unitless@npm:0.7.5":
+"@emotion/unitless@npm:0.7.5, @emotion/unitless@npm:^0.7.5":
   version: 0.7.5
   resolution: "@emotion/unitless@npm:0.7.5"
   checksum: f976e5345b53fae9414a7b2e7a949aa6b52f8bdbcc84458b1ddc0729e77ba1d1dfdff9960e0da60183877873d3a631fa24d9695dd714ed94bcd3ba5196586a6b
@@ -1883,7 +1977,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/weak-memoize@npm:0.2.5":
+"@emotion/utils@npm:^1.0.0, @emotion/utils@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@emotion/utils@npm:1.1.0"
+  checksum: d3b681ca3a23b07033ac6c6937e71010a5549ac8ccec325eb6c91a7e48d9a73db83fa5dadc58be981bb125d7c00fedca868ea4362b1da9e02866615f96be4df1
+  languageName: node
+  linkType: hard
+
+"@emotion/weak-memoize@npm:0.2.5, @emotion/weak-memoize@npm:^0.2.5":
   version: 0.2.5
   resolution: "@emotion/weak-memoize@npm:0.2.5"
   checksum: 27d402b0c683b94658220b6d47840346ee582329ca2a15ec9c233492e0f1a27687ccb233b76eedc922f2e185e444cc89f7b97a81a1d3e5ae9f075bab08e965ea
@@ -8261,7 +8362,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-macros@npm:^2.0.0, babel-plugin-macros@npm:^2.8.0":
+"babel-plugin-macros@npm:^2.0.0, babel-plugin-macros@npm:^2.6.1, babel-plugin-macros@npm:^2.8.0":
   version: 2.8.0
   resolution: "babel-plugin-macros@npm:2.8.0"
   dependencies:
@@ -10215,6 +10316,16 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.1.2
   checksum: 58d9f1c4a96daf77eddc63ae1236b826e1cddd6db66bbf39b18d7e21896d99365b376593352d52a60969d67fa4a8dbef26adc1439fa2c1b355efa37cacbaf637
+  languageName: node
+  linkType: hard
+
+"dom-helpers@npm:^5.0.1":
+  version: 5.2.1
+  resolution: "dom-helpers@npm:5.2.1"
+  dependencies:
+    "@babel/runtime": ^7.8.7
+    csstype: ^3.0.2
+  checksum: 863ba9e086f7093df3376b43e74ce4422571d404fc9828bf2c56140963d5edf0e56160f9b2f3bb61b282c07f8fc8134f023c98fd684bddcb12daf7b0f14d951c
   languageName: node
   linkType: hard
 
@@ -12473,6 +12584,7 @@ __metadata:
     react-popper: ^2.2.5
     react-query: ^3.16.0
     react-redux: ^7.2.4
+    react-select: ^4.3.0
     react-stately: ^3.12.2
     rooks: ^5.10.0
     sharp: ^0.30.1
@@ -12530,7 +12642,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.2":
+"hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.1, hoist-non-react-statics@npm:^3.3.2":
   version: 3.3.2
   resolution: "hoist-non-react-statics@npm:3.3.2"
   dependencies:
@@ -15023,6 +15135,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"memoize-one@npm:^5.0.0":
+  version: 5.2.1
+  resolution: "memoize-one@npm:5.2.1"
+  checksum: a3cba7b824ebcf24cdfcd234aa7f86f3ad6394b8d9be4c96ff756dafb8b51c7f71320785fbc2304f1af48a0467cbbd2a409efc9333025700ed523f254cb52e3d
+  languageName: node
+  linkType: hard
+
 "memoizerific@npm:^1.11.3":
   version: 1.11.3
   resolution: "memoizerific@npm:1.11.3"
@@ -16958,7 +17077,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.0.0, prop-types@npm:^15.6.0, prop-types@npm:^15.7.2":
+"prop-types@npm:^15.0.0, prop-types@npm:^15.5.8, prop-types@npm:^15.6.0, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -17407,11 +17526,22 @@ __metadata:
   linkType: hard
 
 "react-hook-form@npm:^7.28.0":
-  version: 7.28.0
-  resolution: "react-hook-form@npm:7.28.0"
+  version: 7.30.0
+  resolution: "react-hook-form@npm:7.30.0"
   peerDependencies:
-    react: ^16.8.0 || ^17
-  checksum: e70637236113b26bae121cccd6f1ad9df3bd808e5e83311175f69c1b55524ea5240d6914c1c355f6df2e38b27c2103f2b8b17d911409bcfce26cf6fb4107caee
+    react: ^16.8.0 || ^17 || ^18
+  checksum: 7af442c80e1d8e04b6345f4f46177974d82488e81cc12b165d6ff1c69ba0f6234bd2ef0f7b51dda34f77b36fe74464815bbb0f4c77dc2cd9793f8e89d528ae25
+  languageName: node
+  linkType: hard
+
+"react-input-autosize@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "react-input-autosize@npm:3.0.0"
+  dependencies:
+    prop-types: ^15.5.8
+  peerDependencies:
+    react: ^16.3.0 || ^17.0.0
+  checksum: cc3309ddc87446ade742c7d0e88ef089dd8b6981f21506a2bb27daf01a8803ac697f64157c4ffc7e81dfcf3892b54a4072dbc3652fd9addcf6d22dd0b87ab723
   languageName: node
   linkType: hard
 
@@ -17581,6 +17711,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-select@npm:^4.3.0":
+  version: 4.3.1
+  resolution: "react-select@npm:4.3.1"
+  dependencies:
+    "@babel/runtime": ^7.12.0
+    "@emotion/cache": ^11.4.0
+    "@emotion/react": ^11.1.1
+    memoize-one: ^5.0.0
+    prop-types: ^15.6.0
+    react-input-autosize: ^3.0.0
+    react-transition-group: ^4.3.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  checksum: e87e0b42a662ddce7957a69a3029ea769b22264c197cbd1d8bde1ce631e49c5c5f42414773364674a7a6a8431340e1ede49220583bf1dcd966b63e9bd25cfc12
+  languageName: node
+  linkType: hard
+
 "react-sizeme@npm:^3.0.1":
   version: 3.0.2
   resolution: "react-sizeme@npm:3.0.2"
@@ -17646,6 +17794,21 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
   checksum: da3d0192825df3d9f27eef33e7eddf928359a7e3e2b01ae7f7f672ecf4e5c1f7a34f27bdde9ccc24e2e9fbe1d1b9dd2a39c7d47323c9bdf63e7b9bd05c325a71
+  languageName: node
+  linkType: hard
+
+"react-transition-group@npm:^4.3.0":
+  version: 4.4.2
+  resolution: "react-transition-group@npm:4.4.2"
+  dependencies:
+    "@babel/runtime": ^7.5.5
+    dom-helpers: ^5.0.1
+    loose-envify: ^1.4.0
+    prop-types: ^15.6.2
+  peerDependencies:
+    react: ">=16.6.0"
+    react-dom: ">=16.6.0"
+  checksum: b67bf5b3e86dbab72d658b9a52a3589e5960583ab28c7c66272427d8fe30d4c7de422d5046ae96bd2683cdf80cc3264b2516f5ce80cae1dbe6cf3ca6dda392c5
   languageName: node
   linkType: hard
 
@@ -19302,6 +19465,13 @@ __metadata:
     babel-plugin-macros:
       optional: true
   checksum: 4958238ac8b8e90ac7d906aca3821e3ffb0c70c34c78b87d27f0f11c830c8237c8f4c0e7952dc51373d6fa097b16a023dcc7c9ededd402d8483b5ed2d8cefda9
+  languageName: node
+  linkType: hard
+
+"stylis@npm:4.0.13":
+  version: 4.0.13
+  resolution: "stylis@npm:4.0.13"
+  checksum: 8ea7a87028b6383c6a982231c4b5b6150031ce028e0fdaf7b2ace82253d28a8af50cc5a9da8a421d3c7c4441592f393086e332795add672aa4a825f0fe3713a3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds a new `<MultiCombobox />` form input to be used in the project creation form (to link a project to several project developers).

The component doesn't use [React Aria](https://react-spectrum.adobe.com/react-aria/index.html) as the `<Combobox />` component does because it doesn't support multiple values at this point. Instead, the component uses [React Select](https://react-select.com/home) but it keeps the same props as React Aria would provide to simplify a future migration.

## Testing instructions

Have a look around in Storybook.

## Tracking

[LET-349](https://vizzuality.atlassian.net/browse/LET-349).
