### PR TITLE
Add forms/ProjectGallery component

### DIFF
--- a/frontend/containers/forms/project-gallery/component.stories.tsx
+++ b/frontend/containers/forms/project-gallery/component.stories.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+
+import { SubmitHandler, useForm } from 'react-hook-form';
+
+import { action } from '@storybook/addon-actions';
+import { Story, Meta } from '@storybook/react/types-6-0';
+
+import Button from 'components/button';
+
+import ProjectGallery, { ProjectGalleryProps } from '.';
+
+export default {
+  component: ProjectGallery,
+  title: 'Containers/Forms/ProjectGallery',
+  argTypes: {
+    register: { control: { disable: true } },
+  },
+} as Meta;
+
+interface FormValues {
+  coverImage: string;
+}
+
+const Template: Story<ProjectGalleryProps<FormValues>> = (
+  args: ProjectGalleryProps<FormValues>
+) => {
+  const {
+    register,
+    setValue,
+    clearErrors,
+    formState: { errors },
+  } = useForm<FormValues>();
+
+  return (
+    <div className="p-4">
+      <fieldset>
+        <legend className="mb-2 font-sans font-semibold text-gray-800">Project Gallery</legend>
+        <ProjectGallery
+          className="h-96"
+          setValue={setValue}
+          clearErrors={clearErrors}
+          errors={errors}
+          register={register}
+          {...args}
+        />
+      </fieldset>
+    </div>
+  );
+};
+
+export const Default: Story<ProjectGalleryProps<FormValues>> = Template.bind({});
+Default.args = {
+  name: 'coverImage',
+  images: [...Array(4)].map((_, index) => ({
+    id: `id-${index}`,
+    title: `Image ${index + 1}`,
+    src: 'https://placekitten.com/g/768/400',
+  })),
+};
+
+export const DefaultSelected: Story<ProjectGalleryProps<FormValues>> = Template.bind({});
+DefaultSelected.args = {
+  name: 'coverImage',
+  images: [...Array(4)].map((_, index) => ({
+    id: `id-${index}`,
+    title: `Image ${index + 1}`,
+    src: 'https://placekitten.com/g/768/400',
+  })),
+  defaultSelected: 'id-1',
+};
+
+const TemplateWithForm: Story<ProjectGalleryProps<FormValues>> = (
+  args: ProjectGalleryProps<FormValues>
+) => {
+  const {
+    register,
+    setValue,
+    handleSubmit,
+    clearErrors,
+    formState: { errors },
+  } = useForm<FormValues>({
+    shouldUseNativeValidation: true,
+    shouldFocusError: true,
+    reValidateMode: 'onChange',
+  });
+
+  const onSubmit: SubmitHandler<FormValues> = (data) => action('onSubmit')(data);
+
+  return (
+    <div className="p-4">
+      <form
+        // `noValidate` here prevents the browser from not submitting the form if there's a validation
+        // error. We absolutely want the form to be submitted so that React Hook Form is made aware of
+        // the validation errors and we can display errors below inputs.
+        noValidate
+        onSubmit={handleSubmit(onSubmit)}
+      >
+        <fieldset name={args.name}>
+          <legend className="mb-2 font-sans font-semibold text-gray-800">Project Gallery</legend>
+          <ProjectGallery
+            className="h-96"
+            setValue={setValue}
+            clearErrors={clearErrors}
+            errors={errors}
+            register={register}
+            {...args}
+          />
+          {errors[args.name]?.message && (
+            <p id="form-error" className="pl-2 mt-1 text-xs text-red-700">
+              {errors[args.name]?.message}
+            </p>
+          )}
+        </fieldset>
+
+        <Button type="submit" className="mt-2">
+          Submit
+        </Button>
+        <p className="mt-2 text-xs text-gray-50">
+          Submit the form to see the Gallery error state (selecting an image is required).
+        </p>
+      </form>
+    </div>
+  );
+};
+
+export const ErrorState: Story<ProjectGalleryProps<FormValues>> = TemplateWithForm.bind({});
+
+// Issue: https://github.com/react-hook-form/react-hook-form/issues/4449
+// Workaround: https://github.com/storybookjs/storybook/issues/12747
+ErrorState.parameters = {
+  docs: {
+    source: {
+      type: 'code',
+    },
+  },
+};
+
+ErrorState.args = {
+  name: 'coverImage',
+  images: [...Array(4)].map((_, index) => ({
+    id: `id-${index}`,
+    title: `Image ${index + 1}`,
+    src: 'https://placekitten.com/g/768/400',
+  })),
+  registerOptions: {
+    required: 'Selecting a cover image is required.',
+  },
+};

--- a/frontend/containers/forms/project-gallery/component.tsx
+++ b/frontend/containers/forms/project-gallery/component.tsx
@@ -1,0 +1,54 @@
+import { useMemo } from 'react';
+
+import { Camera as CameraIcon } from 'react-feather';
+import { FieldValues } from 'react-hook-form';
+
+import ProjectGalleryImage from './project-gallery-image';
+import type { ProjectGalleryProps } from './types';
+
+export const ProjectGallery = <FormValues extends FieldValues>({
+  className,
+  name,
+  images,
+  defaultSelected,
+  register,
+  registerOptions,
+  errors,
+}: ProjectGalleryProps<FormValues>) => {
+  // Number of images to display. If not enough images are supplied, placeholders will be generated.
+  const numImages = 6;
+
+  const numPlaceholders = useMemo(
+    () => numImages - (images?.length || 0),
+    [images?.length, numImages]
+  );
+
+  return (
+    <div className={className}>
+      <div className="grid flex-grow h-full grid-cols-3 auto-rows-fr gap-x-2 gap-y-4" role="group">
+        {images.map((image) => (
+          <ProjectGalleryImage
+            key={image.id}
+            name={name}
+            image={image}
+            register={register}
+            registerOptions={registerOptions}
+            invalid={errors && errors[name]}
+            defaultSelected={image.id === defaultSelected}
+          />
+        ))}
+        {[...Array(numPlaceholders)].map((_, index) => (
+          <div
+            key={index}
+            aria-hidden={true}
+            className="relative flex items-center justify-center rounded bg-background-dark text-beige"
+          >
+            <CameraIcon className="w-2/12 h-2/12" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ProjectGallery;

--- a/frontend/containers/forms/project-gallery/index.ts
+++ b/frontend/containers/forms/project-gallery/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { ProjectGalleryProps } from './types';

--- a/frontend/containers/forms/project-gallery/project-gallery-image/component.tsx
+++ b/frontend/containers/forms/project-gallery/project-gallery-image/component.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react';
+
+import { FieldValues } from 'react-hook-form';
+import { FormattedMessage } from 'react-intl';
+
+import cx from 'classnames';
+
+import Image from 'next/image';
+
+import { useFocusRing } from '@react-aria/focus';
+
+import type { ProjectGalleryImageProps } from './types';
+
+export const ProjectGalleryImage = <FormValues extends FieldValues>({
+  name,
+  image,
+  register,
+  registerOptions,
+  invalid: invalidProp = false,
+  defaultSelected = false,
+  ...rest
+}: ProjectGalleryImageProps<FormValues>) => {
+  const [invalid, setInvalid] = useState<boolean>(invalidProp);
+  const { isFocusVisible, focusProps } = useFocusRing();
+  const { id, title, src } = image;
+
+  useEffect(() => {
+    setInvalid(invalidProp);
+  }, [invalidProp]);
+
+  return (
+    <div className="relative rounded">
+      <input
+        id={id}
+        type="radio"
+        className="sr-only peer"
+        value={id}
+        onInvalid={() => setInvalid(true)}
+        defaultChecked={defaultSelected}
+        {...register(name, registerOptions)}
+        {...focusProps}
+        {...rest}
+      />
+      <label htmlFor={id} className="overflow-hidden rounded cursor-pointer">
+        <span className="sr-only">{image.title}</span>
+        <Image
+          aria-hidden={true}
+          className="rounded"
+          src={src}
+          title={title}
+          alt={title}
+          layout="fill"
+          objectFit="cover"
+        />
+      </label>
+      <span
+        aria-hidden={true}
+        className={cx({
+          'absolute left-0 top-0 w-full h-full bg-transparent pointer-events-none hover:shadow border-2 rounded transition':
+            true,
+          'peer-disabled:shadow-none peer-disabled:cursor-default peer-disabled:opacity-60 peer-checked:border-green-dark':
+            true,
+          'ring-2 ring-green-dark ring-offset-2': isFocusVisible,
+          'peer-invalid:border-red-700': invalid,
+        })}
+      />
+      <span
+        aria-hidden={true}
+        className={cx({
+          'py-1 px-2 rounded-bl rounded-tr bg-green-dark text-white text-xs': true,
+          'absolute left-0 bottom-0 transition opacity-0 peer-checked:opacity-100': true,
+        })}
+      >
+        <FormattedMessage defaultMessage="Cover" id="hl9bd4" />
+      </span>
+    </div>
+  );
+};
+
+export default ProjectGalleryImage;

--- a/frontend/containers/forms/project-gallery/project-gallery-image/index.ts
+++ b/frontend/containers/forms/project-gallery/project-gallery-image/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { ProjectGalleryImageType } from './types';

--- a/frontend/containers/forms/project-gallery/project-gallery-image/types.ts
+++ b/frontend/containers/forms/project-gallery/project-gallery-image/types.ts
@@ -1,0 +1,30 @@
+import { UseFormRegisterReturn, RegisterOptions, FieldPath } from 'react-hook-form';
+
+export type ProjectGalleryImageType = {
+  /** Image ID */
+  id: string;
+  /** Title of the image */
+  title: string;
+  /** Source for the image */
+  src: string;
+};
+
+export type ProjectGalleryImageProps<FormValues> = {
+  /** Classes to apply to the container */
+  className?: string;
+  /** Image to display */
+  image: ProjectGalleryImageType;
+  /** Whether the image is the default checked one in the group. Defaults to `false` */
+  defaultSelected?: boolean;
+  /**
+   * Name of the image group (will be assigned to each individual `<Tag />`)
+   * Defaults to inferring it from the first Tag's name.
+   **/
+  name?: string;
+  /** React Hook Form's `register` callback */
+  register: (name, RegisterOptions) => UseFormRegisterReturn;
+  /** Options for React Hook Form's `register` callback */
+  registerOptions?: RegisterOptions<FormValues, FieldPath<FormValues>>;
+  /** Whether the input is invalid. Defaults to `false`. */
+  invalid?: boolean;
+};

--- a/frontend/containers/forms/project-gallery/types.ts
+++ b/frontend/containers/forms/project-gallery/types.ts
@@ -1,0 +1,34 @@
+import {
+  UseFormSetValue,
+  UseFormClearErrors,
+  FieldErrors,
+  SetValueConfig,
+  UseFormRegisterReturn,
+  FieldPath,
+  RegisterOptions,
+} from 'react-hook-form';
+
+import type { ProjectGalleryImageType } from './project-gallery-image';
+
+export type ProjectGalleryProps<FormValues> = {
+  /** Classes to apply to the container */
+  className?: string;
+  /** Images to display */
+  images: ProjectGalleryImageType[];
+  /** Default selected image (by id) */
+  defaultSelected?: string;
+  /** Name for the images checkboxes */
+  name: string;
+  /** React Hook Form's `setValue` function */
+  setValue: UseFormSetValue<any>;
+  /** Options for `setValue` function. Defaults to `{ shouldDirty: true }`. */
+  setValueOptions?: SetValueConfig;
+  /** ReactHook Form's `clearErrors` callback */
+  clearErrors: UseFormClearErrors<any>;
+  /** React Hook Form's `register` callback */
+  register: (name, RegisterOptions) => UseFormRegisterReturn;
+  /** Options for React Hook Form's `register` callback */
+  registerOptions?: RegisterOptions<FormValues, FieldPath<FormValues>>;
+  /** Form validation errors */
+  errors: FieldErrors<FormValues>;
+};

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -597,6 +597,9 @@
   "hkIfkj": {
     "string": "disabled"
   },
+  "hl9bd4": {
+    "string": "Cover"
+  },
   "hxIQ/8": {
     "string": "Projects waiting funding"
   },


### PR DESCRIPTION
This PR adds a small "gallery" to be used on the Project form. It is meant to display the uploaded project photos and allow the user to select one of them to be used as the project cover photo. 

We assume a max of 6 images (which the component doesn't restrict); if not enough images have been added yet then placeholders for them will be displayed, as per designs. 

Behaviour and implementation is similar to (read copied from) the [form/SDGs](https://github.com/Vizzuality/heco-invest/pull/107) component. 

Sizing is adaptive; height the full parent's height (to keep it consistent with the uploader this component will be displayed next to), width is responsive. 

## Testing instructions

Verify that: 
- Image placeholders are added when less than 6 images have been passed  
- An image can be selected as the cover image  
- Error states are shown as expected, and they go away when an image is selected as cover  

## Tracking

[LET-346](https://vizzuality.atlassian.net/browse/LET-346)

## Screenshots

<img width="1371" alt="Screenshot 2022-04-26 at 12 02 16" src="https://user-images.githubusercontent.com/6273795/165286249-9074ba3b-17ad-45d9-9da9-986ce438239b.png">
<img width="1379" alt="Screenshot 2022-04-26 at 12 03 02" src="https://user-images.githubusercontent.com/6273795/165286335-c17e3ed7-5806-4e54-80ea-44f578a39a8c.png">

