### PR TITLE
fix: ENV variables inside routes can be either true or "true"

### DIFF
--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     post "/rails/active_storage/direct_uploads", to: "active_storage/direct_uploads#create"
   end
 
-  draw :backoffice if ENV["IS_API_INSTANCE"]
-  draw :api if ENV["IS_API_INSTANCE"]
-  draw :jobs if ENV["IS_JOBS_INSTANCE"]
+  draw :backoffice if ENV["IS_API_INSTANCE"].to_s == "true"
+  draw :api if ENV["IS_API_INSTANCE"].to_s == "true"
+  draw :jobs if ENV["IS_JOBS_INSTANCE"].to_s == "true"
 end


### PR DESCRIPTION
ENV variables controlling available routes were not working properly when boolean value was taken from terraform. Making sure that only `true` or `"true"` are truthy expressions and `false` or `"false"` is falsey .