### PR TITLE
Fix/frontend/api deserialization

### DIFF
--- a/frontend/containers/forms/sdgs/component.tsx
+++ b/frontend/containers/forms/sdgs/component.tsx
@@ -41,13 +41,13 @@ export const SDGs = <FormValues extends FieldValues>({
     >
       <div role="group">
         <div className="flex flex-wrap items-center gap-2">
-          {sdgs.map(({ id, attributes }) => (
+          {sdgs.map(({ id, name: title, image }) => (
             <SDG
               key={id}
               id={id}
               name={name}
-              image={attributes.image}
-              title={attributes.name}
+              image={image}
+              title={title}
               register={register}
               registerOptions={registerOptions}
               invalid={errors && errors[name]}

--- a/frontend/containers/project-form-pages/pages/general-information.tsx
+++ b/frontend/containers/project-form-pages/pages/general-information.tsx
@@ -42,8 +42,6 @@ const GeneralInformation = ({
     setShowInvolvedProjectDevelopers(!!Number(e.target.value));
   };
 
-  console.log(locations);
-
   return (
     <div>
       <h1 className="font-serif text-3xl font-semibold mb-2.5">

--- a/frontend/containers/project-form-pages/pages/general-information.tsx
+++ b/frontend/containers/project-form-pages/pages/general-information.tsx
@@ -42,6 +42,8 @@ const GeneralInformation = ({
     setShowInvolvedProjectDevelopers(!!Number(e.target.value));
   };
 
+  console.log(locations);
+
   return (
     <div>
       <h1 className="font-serif text-3xl font-semibold mb-2.5">
@@ -123,7 +125,7 @@ const GeneralInformation = ({
                 className="mt-2.5"
                 placeholder={formatMessage({ defaultMessage: 'select', id: 'J4SQjQ' })}
               >
-                {locations?.country?.map(({ id, attributes: { name } }) => (
+                {locations?.country?.map(({ id, name }) => (
                   <Option key={id}>{name}</Option>
                 ))}
               </Combobox>
@@ -144,7 +146,7 @@ const GeneralInformation = ({
                 className="mt-2.5"
                 placeholder={formatMessage({ defaultMessage: 'select', id: 'J4SQjQ' })}
               >
-                {locations?.department?.map(({ id, attributes: { name } }) => (
+                {locations?.department?.map(({ id, name }) => (
                   <Option key={id}>{name}</Option>
                 ))}
               </Combobox>
@@ -165,7 +167,7 @@ const GeneralInformation = ({
                 className="mt-2.5"
                 placeholder={formatMessage({ defaultMessage: 'select', id: 'J4SQjQ' })}
               >
-                {locations?.municipality?.map(({ id, attributes: { name } }) => (
+                {locations?.municipality?.map(({ id, name }) => (
                   <Option key={id}>{name}</Option>
                 ))}
               </Combobox>
@@ -268,11 +270,9 @@ const GeneralInformation = ({
                   // The hardcoded option Not Listed
                   {
                     id: 'not-listed',
-                    attributes: {
-                      name: formatMessage({ defaultMessage: 'Not listed', id: '8rAlFa' }),
-                    },
+                    name: formatMessage({ defaultMessage: 'Not listed', id: '8rAlFa' }),
                   },
-                ]?.map(({ id, attributes: { name } }) => (
+                ]?.map(({ id, name }) => (
                   <Option key={id}>{name}</Option>
                 ))}
               </MultiCombobox>

--- a/frontend/containers/sdgs/component.tsx
+++ b/frontend/containers/sdgs/component.tsx
@@ -13,15 +13,15 @@ export const SDGs: FC<SDGsProps> = ({ className, size = 'small', sdgs = [] }: SD
   return (
     <div className={cx('flex flex-wrap items-center gap-2', className)}>
       {sdgs.map(({ id }) => {
-        const { attributes } = sdgsData.find((sdg) => sdg.id === id);
+        const { name, image } = sdgsData.find((sdg) => sdg.id === id);
 
         return (
           <span key={id}>
             <Image
               className="rounded"
-              src={attributes.image}
-              alt={attributes.name}
-              title={attributes.name}
+              src={image}
+              alt={name}
+              title={name}
               width={SDGS_SIZES[size]}
               height={SDGS_SIZES[size]}
               layout="fixed"

--- a/frontend/containers/tags-grid/component.stories.tsx
+++ b/frontend/containers/tags-grid/component.stories.tsx
@@ -17,10 +17,10 @@ Default.args = {
       title: 'Invests in',
       type: 'category',
       tags: [
-        { id: 'tourism-and-recreation', title: 'Tourism & Recreation' },
-        { id: 'non-timber-forest-production', title: 'Non-timber forest production' },
-        { id: 'sustainable-agrosystems', title: 'Sustainable agrosystems' },
-        { id: 'forestry-and-agroforestry', title: 'Forestry & agroforestry' },
+        { id: 'tourism-and-recreation', name: 'Tourism & Recreation' },
+        { id: 'non-timber-forest-production', name: 'Non-timber forest production' },
+        { id: 'sustainable-agrosystems', name: 'Sustainable agrosystems' },
+        { id: 'forestry-and-agroforestry', name: 'Forestry & agroforestry' },
       ],
     },
     {

--- a/frontend/containers/tags-grid/component.tsx
+++ b/frontend/containers/tags-grid/component.tsx
@@ -39,7 +39,7 @@ export const TagsGrid: FC<TagsGridProps> = ({ className, rows }: TagsGridProps) 
               {type === 'category' &&
                 tags.map((tag) => (
                   <CategoryTag key={tag.id} category={tag.id}>
-                    {tag.title}
+                    {tag.name}
                   </CategoryTag>
                 ))}
             </span>

--- a/frontend/containers/tags-grid/types.ts
+++ b/frontend/containers/tags-grid/types.ts
@@ -6,7 +6,7 @@ export type TagsGridRowType = {
   /** Type of tags to display. Defaults to `default` */
   type?: 'default' | 'category';
   /** Array of strings for `default` tags, or array of { id, title } for `category` tags */
-  tags: string[] | { id: CategoryType; title: string }[];
+  tags: string[] | { id: CategoryType; name: string }[];
 };
 
 export type TagsGridProps = {

--- a/frontend/enums/index.ts
+++ b/frontend/enums/index.ts
@@ -13,6 +13,7 @@ export enum Paths {
   FAQ = '/faq',
   SignOut = '/sign-out',
   Settings = '/settings',
+  Project = '/project',
 }
 
 export enum UserRoles {
@@ -80,4 +81,5 @@ export enum TicketSizes {
   Validation = 'validation',
   Scaling = 'scaling',
   SDGType = 'sdg',
+  Mosaic = 'mosaic',
 }

--- a/frontend/helpers/user.ts
+++ b/frontend/helpers/user.ts
@@ -4,8 +4,8 @@ import { User } from 'types/user';
  * Return the initials of the user
  */
 export const getUserInitials = (user: User) => {
-  if (user?.attributes) {
-    const { first_name, last_name } = user.attributes;
+  if (user) {
+    const { first_name, last_name } = user;
     return `${first_name.substring(0, 1)}${last_name.substring(0, 1)}`.toUpperCase();
   }
   return '';

--- a/frontend/layouts/static-page/header/component.tsx
+++ b/frontend/layouts/static-page/header/component.tsx
@@ -38,7 +38,7 @@ export const Header: React.FC<HeaderProps> = ({
   const investor = undefined;
   // Important!!! Include the current investor when available
 
-  const account = projectDeveloper?.attributes || investor;
+  const account = projectDeveloper || investor;
 
   const { scrollY }: ReturnType<typeof useWindowScrollPosition> =
     // The `window` check is required because the hook is not SSR-ready yet:
@@ -142,9 +142,9 @@ export const Header: React.FC<HeaderProps> = ({
                       </div>
                       <div className="pb-2 pl-2 pr-2 border-b border-bg-dark">
                         <span className="text-green-dark">
-                          {user.attributes.first_name} {user.attributes.last_name}
+                          {user.first_name} {user.last_name}
                         </span>
-                        <span className="block text-gray-400">{user.attributes.email}</span>
+                        <span className="block text-gray-400">{user.email}</span>
                       </div>
                     </div>
                   }

--- a/frontend/mockups/sdgs.json
+++ b/frontend/mockups/sdgs.json
@@ -2,137 +2,103 @@
   {
     "id": "no-poverty",
     "type": "sdg",
-    "attributes": {
-      "name": "No poverty",
-      "image": "/images/sdgs/1-no-poverty.png"
-    }
+    "name": "No poverty",
+    "image": "/images/sdgs/1-no-poverty.png"
   },
   {
     "id": "zero-hunger",
     "type": "sdg",
-    "attributes": {
-      "name": "Zero hunger",
-      "image": "/images/sdgs/2-zero-hunger.png"
-    }
+    "name": "Zero hunger",
+    "image": "/images/sdgs/2-zero-hunger.png"
   },
   {
     "id": "good-health",
     "type": "sdg",
-    "attributes": {
-      "name": "Good health and well-being",
-      "image": "/images/sdgs/3-good-health.png"
-    }
+    "name": "Good health and well-being",
+    "image": "/images/sdgs/3-good-health.png"
   },
   {
     "id": "quality-education",
     "type": "sdg",
-    "attributes": {
-      "name": "Quality education",
-      "image": "/images/sdgs/4-quality-education.png"
-    }
+    "name": "Quality education",
+    "image": "/images/sdgs/4-quality-education.png"
   },
   {
     "id": "gender-equality",
     "type": "sdg",
-    "attributes": {
-      "name": "Gender equality",
-      "image": "/images/sdgs/5-gender-equality.png"
-    }
+    "name": "Gender equality",
+    "image": "/images/sdgs/5-gender-equality.png"
   },
   {
     "id": "clean-water",
     "type": "sdg",
-    "attributes": {
-      "name": "Clean water and sanitation",
-      "image": "/images/sdgs/6-clean-water.png"
-    }
+    "name": "Clean water and sanitation",
+    "image": "/images/sdgs/6-clean-water.png"
   },
   {
     "id": "clean-energy",
     "type": "sdg",
-    "attributes": {
-      "name": "Affordable and clean energy",
-      "image": "/images/sdgs/7-clean-energy.png"
-    }
+    "name": "Affordable and clean energy",
+    "image": "/images/sdgs/7-clean-energy.png"
   },
   {
     "id": "decent-work",
     "type": "sdg",
-    "attributes": {
-      "name": "Decent work and economic growth",
-      "image": "/images/sdgs/8-decent-work.png"
-    }
+    "name": "Decent work and economic growth",
+    "image": "/images/sdgs/8-decent-work.png"
   },
   {
     "id": "industry-innovation",
     "type": "sdg",
-    "attributes": {
-      "name": "Industry innovation and infrastructure",
-      "image": "/images/sdgs/9-industry-innovation.png"
-    }
+    "name": "Industry innovation and infrastructure",
+    "image": "/images/sdgs/9-industry-innovation.png"
   },
   {
     "id": "reduced-inequalities",
     "type": "sdg",
-    "attributes": {
-      "name": "Reduced inequalities",
-      "image": "/images/sdgs/10-reduced-inequalities.png"
-    }
+    "name": "Reduced inequalities",
+    "image": "/images/sdgs/10-reduced-inequalities.png"
   },
   {
     "id": "sustainable-cities",
     "type": "sdg",
-    "attributes": {
-      "name": "Sustainable cities and communities",
-      "image": "/images/sdgs/11-sustainable-cities.png"
-    }
+    "name": "Sustainable cities and communities",
+    "image": "/images/sdgs/11-sustainable-cities.png"
   },
   {
     "id": "responsible-consumption",
     "type": "sdg",
-    "attributes": {
-      "name": "Responsible consumption and production",
-      "image": "/images/sdgs/12-responsible-consumption.png"
-    }
+    "name": "Responsible consumption and production",
+    "image": "/images/sdgs/12-responsible-consumption.png"
   },
   {
     "id": "climate-action",
     "type": "sdg",
-    "attributes": {
-      "name": "Climate action",
-      "image": "/images/sdgs/13-climate-action.png"
-    }
+    "name": "Climate action",
+    "image": "/images/sdgs/13-climate-action.png"
   },
   {
     "id": "life-below-water",
     "type": "sdg",
-    "attributes": {
-      "name": "Life below water",
-      "image": "/images/sdgs/14-life-below-water.png"
-    }
+    "name": "Life below water",
+    "image": "/images/sdgs/14-life-below-water.png"
   },
   {
     "id": "life-on-land",
     "type": "sdg",
-    "attributes": {
-      "name": "Life on land",
-      "image": "/images/sdgs/15-life-on-land.png"
-    }
+    "name": "Life on land",
+    "image": "/images/sdgs/15-life-on-land.png"
   },
   {
     "id": "peace-justice",
     "type": "sdg",
-    "attributes": {
-      "name": "Peace, justice and strong institutions",
-      "image": "/images/sdgs/16-peace-justice.png"
-    }
+    "name": "Peace, justice and strong institutions",
+    "image": "/images/sdgs/16-peace-justice.png"
   },
   {
     "id": "partnership",
     "type": "sdg",
-    "attributes": {
-      "name": "Partnerships for the goals",
-      "image": "/images/sdgs/17-partnership.png"
-    }
+    "name": "Partnerships for the goals",
+    "image": "/images/sdgs/17-partnership.png"
   }
 ]

--- a/frontend/pages/investor/[id]/index.tsx
+++ b/frontend/pages/investor/[id]/index.tsx
@@ -56,10 +56,10 @@ const InvestorPage: PageComponent<{}, StaticPageLayoutProps> = (props) => {
       title: 'Invests in',
       type: 'category',
       tags: [
-        { id: 'tourism-and-recreation', title: 'Tourism & Recreation' },
-        { id: 'non-timber-forest-production', title: 'Non-timber forest production' },
-        { id: 'sustainable-agrosystems', title: 'Sustainable agrosystems' },
-        { id: 'forestry-and-agroforestry', title: 'Forestry & agroforestry' },
+        { id: 'tourism-and-recreation', name: 'Tourism & Recreation' },
+        { id: 'non-timber-forest-production', name: 'Non-timber forest production' },
+        { id: 'sustainable-agrosystems', name: 'Sustainable agrosystems' },
+        { id: 'forestry-and-agroforestry', name: 'Forestry & agroforestry' },
       ],
     },
     {

--- a/frontend/pages/project-developer/[id]/index.tsx
+++ b/frontend/pages/project-developer/[id]/index.tsx
@@ -65,8 +65,8 @@ const InvestorPage: PageComponent<{}, StaticPageLayoutProps> = (props) => {
       title: 'Categories of interest',
       type: 'category',
       tags: [
-        { id: 'tourism-and-recreation', title: 'Tourism & Recreation' },
-        { id: 'non-timber-forest-production', title: 'Non-timber forest production' },
+        { id: 'tourism-and-recreation', name: 'Tourism & Recreation' },
+        { id: 'non-timber-forest-production', name: 'Non-timber forest production' },
       ],
     },
     {

--- a/frontend/pages/project-developers/new.tsx
+++ b/frontend/pages/project-developers/new.tsx
@@ -56,13 +56,13 @@ export async function getStaticProps(ctx) {
 
 type ProjectDeveloperProps = InferGetStaticPropsType<typeof getStaticProps>;
 
-const getItemsInfoText = (items: Enum[] | Locations[]) => {
+const getItemsInfoText = (items) => {
   return (
     <ul>
-      {items?.map(({ attributes, id }) => (
+      {items?.map(({ id, name, description }) => (
         <li key={id}>
-          <p className="font-sans text-sm font-semibold text-white">{attributes.name}</p>
-          <p className="mb-4 font-sans text-sm font-normal text-white">{attributes.description}</p>
+          <p className="font-sans text-sm font-semibold text-white">{name}</p>
+          <p className="mb-4 font-sans text-sm font-normal text-white">{description}</p>
         </li>
       ))}
     </ul>
@@ -324,7 +324,7 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, FormPageLayoutProps
                     aria-describedby="project-developer-type-error"
                     aria-labelledby="project-developer-type-label"
                   >
-                    {project_developer_type?.map(({ attributes: { name }, id }) => (
+                    {project_developer_type?.map(({ id, name }) => (
                       <Option key={id}>{name}</Option>
                     ))}
                   </Combobox>
@@ -515,7 +515,7 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, FormPageLayoutProps
                         {item.type === 'category' && (
                           <CategoryTagDot category={item.id as CategoryType} />
                         )}
-                        {item.attributes.name}
+                        {item.name}
                       </Tag>
                     ))}
                   </TagGroup>

--- a/frontend/pages/sign-in/index.tsx
+++ b/frontend/pages/sign-in/index.tsx
@@ -52,7 +52,7 @@ const SignIn: PageComponent<SignInPageProps, AuthPageLayoutProps> = () => {
     (data: SignIn) =>
       signIn.mutate(data, {
         onSuccess: () => {
-          if (user?.attributes.role === UserRoles.Light) {
+          if (user?.role === UserRoles.Light) {
             push(Paths.AccountType);
           } else {
             push(Paths.Dashboard);

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -21,12 +21,16 @@ const API = axios.create({
 
 const onResponseSuccess = (response) => {
   try {
-    const parsedData = JSON.parse(response);
     return {
-      data: dataFormatter.deserialize(parsedData),
-      meta: parsedData.meta,
+      data: {
+        // Deserialized data
+        data: !!response.data && dataFormatter.deserialize(response.data),
+        // Metadata (pagination) if any
+        ...(!!response.data.meta && { meta: response.data.meta }),
+      },
     };
   } catch (error) {
+    console.error('API deserialization error', error);
     return response;
   }
 };

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -24,7 +24,7 @@ const onResponseSuccess = (response) => {
     return {
       data: {
         // Deserialized data
-        data: !!response.data && dataFormatter.deserialize(response.data),
+        data: response.data ? dataFormatter.deserialize(response.data) : null,
         // Metadata (pagination) if any
         ...(response.data.meta ? { meta: response.data.meta } : {}),
       },

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -26,7 +26,7 @@ const onResponseSuccess = (response) => {
         // Deserialized data
         data: !!response.data && dataFormatter.deserialize(response.data),
         // Metadata (pagination) if any
-        ...(!!response.data.meta && { meta: response.data.meta }),
+        ...(response.data.meta ? { meta: response.data.meta } : {}),
       },
     };
   } catch (error) {

--- a/frontend/services/locations/locations.ts
+++ b/frontend/services/locations/locations.ts
@@ -51,7 +51,7 @@ export const useGroupedLocations = (
     staticDataQueryOptions
   );
 
-  const locations = groupBy(query.data, 'attributes.location_type') as {
+  const locations = groupBy(query.data, 'location_type') as {
     [key in LocationsTypes]: Locations[];
   };
 

--- a/frontend/services/project-developers/projectDevelopersService.ts
+++ b/frontend/services/project-developers/projectDevelopersService.ts
@@ -72,7 +72,7 @@ export const useCurrentProjectDeveloper = (user: User) => {
 
   const query = useQuery([Queries.Account, user], getCurrentProjectDeveloper, {
     // Creates the conditional to only fetch the data if the user is a project developer user
-    enabled: user?.attributes?.role === UserRoles.ProjectDeveloper,
+    enabled: user?.role === UserRoles.ProjectDeveloper,
     ...staticDataQueryOptions,
   });
 

--- a/frontend/types/enums.ts
+++ b/frontend/types/enums.ts
@@ -3,12 +3,10 @@ import { EnumTypes } from 'enums';
 export type Enum = {
   id: string;
   type: EnumTypes;
-  attributes: {
-    name: string;
-    color?: string;
-    description?: string;
-    image?: string;
-  };
+  name: string;
+  color?: string;
+  description?: string;
+  image?: string;
 };
 
 export type GroupedEnums = {

--- a/frontend/types/locations.ts
+++ b/frontend/types/locations.ts
@@ -10,19 +10,6 @@ export type LocationsParams = {
 export type Locations = {
   id: string;
   type: 'location';
-  attributes: {
-    name: string;
-    location_type: LocationsTypes;
-  };
-  relationships: {
-    parent: {
-      data: {
-        id: string;
-        type: 'location';
-      };
-    };
-    regions: {
-      data: { id: string; type: 'location' }[];
-    };
-  };
+  name: string;
+  location_type: LocationsTypes;
 };

--- a/frontend/types/project.ts
+++ b/frontend/types/project.ts
@@ -1,7 +1,9 @@
 import { DevelopmentStages, Languages, TicketSizes } from 'enums';
 
-/** Common Project types */
-export type ProjectBase = {
+/** Project entity structure */
+export type Project = {
+  id: string;
+  type: 'project';
   categories: string;
   description: string;
   development_stage: DevelopmentStages;
@@ -26,32 +28,8 @@ export type ProjectBase = {
   ticket_size?: TicketSizes;
 };
 
-/** Project entity structure */
-export type Project = {
-  id: string;
-  type: 'project';
-  attributes: ProjectBase & {
-    slug: string;
-    language: Languages;
-  };
-  relationships: {
-    project_developer: {
-      data: {
-        id: string;
-        type: 'project_developer';
-      };
-    };
-    involved_project_developers: {
-      data: {
-        id: string;
-        type: 'project_developer';
-      }[];
-    };
-  };
-};
-
 /** Project Form inputs */
-export type ProjectForm = ProjectBase & {
+export type ProjectForm = Project & {
   country_id: string;
   department_id: string;
   funding_plan: string;

--- a/frontend/types/projectDeveloper.ts
+++ b/frontend/types/projectDeveloper.ts
@@ -5,7 +5,9 @@ import { Languages } from 'enums';
 import { CategoryType } from './category';
 import { Enum } from './enums';
 
-type ProjectDeveloperBase = {
+export type ProjectDeveloper = {
+  id: string;
+  type: 'project_developer';
   name: string;
   about: string;
   website?: string;
@@ -23,35 +25,7 @@ type ProjectDeveloperBase = {
   entity_legal_registration_number: string;
 };
 
-export type ProjectDeveloper = {
-  id: string;
-  type: 'project_developer';
-  attributes: ProjectDeveloperBase & {
-    slug: string;
-    review_status: 'approved';
-    picture: {
-      small: string;
-      medium: string;
-      original: string;
-    };
-  };
-  relationships: {
-    owner: {
-      data: {
-        id: string;
-        type: 'user';
-      };
-    };
-    locations: {
-      data: {
-        id: string;
-        type: 'location';
-      }[];
-    };
-  };
-};
-
-export type ProjectDeveloperSetupForm = ProjectDeveloperBase & {
+export type ProjectDeveloperSetupForm = ProjectDeveloper & {
   picture: File;
   mosaics?: string[];
 };

--- a/frontend/types/user.ts
+++ b/frontend/types/user.ts
@@ -20,21 +20,16 @@ export interface SignupDto {
 export interface User {
   id: string;
   type: 'user';
-  attributes: {
-    first_name: string;
-    last_name: string;
-    email: string;
-    role: UserRoles;
-    confirmed: boolean;
-  };
+  first_name: string;
+  last_name: string;
+  email: string;
+  role: UserRoles;
+  confirmed: boolean;
 }
 
 export type UserAccount = {
-  attributes: {
-    name: string;
-    slug: string;
-  };
   id: string;
-  relationships: {};
+  name: string;
+  slug: string;
   type: 'project_developer' | 'investor';
 };


### PR DESCRIPTION
While working on [LET-355](https://vizzuality.atlassian.net/browse/LET-355), it came to my attention that the API service's deserialisation is not working _at all_. 

This PR aims to fix that. 

Major visible changes after deserialisation is fixed:  

- We won't have to dig into `attributes` anymore
  _(it was the biggest hint that deserialisation was not working, but I missed it)_  
- Simplified types 
  _we no longer need to specify `attributes`, `relationships`_  
- `includes` will now work 

**Notes:**  

The one commit that fixes serialization is this one: https://github.com/Vizzuality/heco-invest/pull/121/commits/983628b7ac7ddf9f99c247e25dfaeabd21ab9d28  

The remaining changes are to make everything compatible with serialised data. I may have missed a type or two here and there, but it's a lot of files to touch. 

## Testing instructions

Test that the application works normally

## Tracking

N/A

## Deserialised data example: 
Query: `https://staging.heco.vizzuality.com/backend/api/v1/project_developers/sarodrigues?includes=projects
`
_(If there was pagination in this endpoint, there'd be a `meta` property next to `data` containing the pagination info)_

![Screenshot 2022-04-27 at 13 02 33](https://user-images.githubusercontent.com/6273795/165513969-f1b416f8-84d1-4565-8ed9-36b0b70567c8.png)

