### PR TITLE
Connect the PD public page with the API

### DIFF
--- a/frontend/containers/profile-header/component.tsx
+++ b/frontend/containers/profile-header/component.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useState, useEffect } from 'react';
 
 import { Heart as HeartIcon } from 'react-feather';
 import { FormattedMessage, useIntl } from 'react-intl';
@@ -18,7 +18,7 @@ import type { ProfileHeaderProps } from './types';
 
 export const ProfileHeader: FC<ProfileHeaderProps> = ({
   className,
-  logo,
+  logo: logoProp,
   title,
   subtitle,
   text,
@@ -32,6 +32,12 @@ export const ProfileHeader: FC<ProfileHeaderProps> = ({
   onContactClick = () => noop,
 }: ProfileHeaderProps) => {
   const intl = useIntl();
+
+  const [logo, setLogo] = useState<string>(logoProp);
+
+  useEffect(() => {
+    setLogo(logoProp);
+  }, [logoProp]);
 
   return (
     <div className={className}>
@@ -49,7 +55,8 @@ export const ProfileHeader: FC<ProfileHeaderProps> = ({
                 layout="responsive"
                 width="100%"
                 height="100%"
-                objectFit="contain"
+                objectFit="cover"
+                onError={() => setLogo('/images/placeholders/profile-logo.png')}
               />
             </div>
             <div className="mb-4 text-center lg:text-left">

--- a/frontend/containers/profile-header/types.ts
+++ b/frontend/containers/profile-header/types.ts
@@ -14,7 +14,7 @@ export type ProfileHeaderProps = {
   /** Text to display */
   text: string;
   /** Original language in which the profile was written in */
-  originalLanguage?: LanguageType;
+  originalLanguage: LanguageType;
   /** Num projects waiting funded */
   numNotFunded?: number;
   /** Num projects funded */

--- a/frontend/containers/tags-grid/component.tsx
+++ b/frontend/containers/tags-grid/component.tsx
@@ -14,6 +14,9 @@ export const TagsGrid: FC<TagsGridProps> = ({ className, rows }: TagsGridProps) 
   const gridCells = rows.reduce((arr, { title, type, tags }) => {
     const id = slugify(title);
 
+    // Do not display grid rows that have no tags
+    if (!tags?.length) return arr;
+
     return [
       ...arr,
       { cellType: 'title', key: `title-${id}`, id, title },
@@ -35,11 +38,12 @@ export const TagsGrid: FC<TagsGridProps> = ({ className, rows }: TagsGridProps) 
         if (cellType === 'tags') {
           return (
             <span key={key} aria-labelledby={id} className="flex flex-wrap gap-x-4 gap-y-2">
-              {type === 'default' && tags.map((tag) => <Tag key={tag}>{tag}</Tag>)}
+              {type === 'default' &&
+                tags.map((tag) => <Tag key={tag?.id || tag}>{tag?.name || tag}</Tag>)}
               {type === 'category' &&
-                tags.map((tag) => (
-                  <CategoryTag key={tag.id} category={tag.id}>
-                    {tag.name}
+                tags.map(({ id, name }) => (
+                  <CategoryTag key={id} category={id}>
+                    {name}
                   </CategoryTag>
                 ))}
             </span>

--- a/frontend/containers/tags-grid/types.ts
+++ b/frontend/containers/tags-grid/types.ts
@@ -1,12 +1,10 @@
-import type { CategoryType } from 'types/category';
-
 export type TagsGridRowType = {
   /** Label for the tags list */
   title: string;
   /** Type of tags to display. Defaults to `default` */
   type?: 'default' | 'category';
   /** Array of strings for `default` tags, or array of { id, title } for `category` tags */
-  tags: string[] | { id: CategoryType; name: string }[];
+  tags: string[] | { id: string; name: string }[];
 };
 
 export type TagsGridProps = {

--- a/frontend/enums/index.ts
+++ b/frontend/enums/index.ts
@@ -65,6 +65,7 @@ export enum EnumTypes {
   LocationType = 'location_type',
   ProjectDevelopmentStage = 'project_development_stage',
   TargetGroup = 'project_target_group',
+  Mosaic = 'mosaic',
 }
 
 /** Project development stages */

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -5,6 +5,9 @@ module.exports = {
     locales: locales.map(({ locale }) => locale),
     defaultLocale: locales.find((locale) => locale.default).locale,
   },
+  images: {
+    domains: ['heco.vizzuality.com', 'staging.heco.vizzuality.com'],
+  },
   swcMinify: true,
   eslint: {
     dirs: [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,6 +62,7 @@
     "autoprefixer": "^10.4.2",
     "axios": "^0.21.1",
     "classnames": "^2.3.1",
+    "cycle": "^1.0.3",
     "d3-ease": "^2.0.0",
     "downshift": "^6.1.3",
     "final-form": "^4.20.2",

--- a/frontend/pages/investor/[id]/index.tsx
+++ b/frontend/pages/investor/[id]/index.tsx
@@ -97,6 +97,7 @@ const InvestorPage: PageComponent<{}, StaticPageLayoutProps> = (props) => {
         website={aboutInfo.website}
         social={aboutInfo.social}
         contact={aboutInfo.contact}
+        originalLanguage="en"
       />
 
       <LayoutContainer layout="narrow" className="mt-24 mb-20 md:mt-40">

--- a/frontend/pages/project-developer/[id]/index.tsx
+++ b/frontend/pages/project-developer/[id]/index.tsx
@@ -1,108 +1,126 @@
-// import { useRouter } from 'next/router';
-import { useIntl } from 'react-intl';
+import { useMemo } from 'react';
+
 import { FormattedMessage } from 'react-intl';
 
-import { chunk } from 'lodash-es';
+import { decycle } from 'cycle';
+import { chunk, groupBy } from 'lodash-es';
 
 import { loadI18nMessages } from 'helpers/i18n';
 
 import ProfileHeader from 'containers/profile-header';
 import ProjectCard from 'containers/project-card';
-import { SocialType } from 'containers/social-contact/website-social-contact';
+import { SOCIAL_DATA } from 'containers/social-contact/constants';
 import TagsGrid, { TagsGridRowType } from 'containers/tags-grid';
 
 import Carousel, { Slide } from 'components/carousel';
 import Head from 'components/head';
 import LayoutContainer from 'components/layout-container';
+import { EnumTypes, Paths } from 'enums';
 import { StaticPageLayoutProps } from 'layouts/static-page';
 import { PageComponent } from 'types';
+import { CategoryType } from 'types/category';
+import { GroupedEnums as GroupedEnumsType } from 'types/enums';
+import { ProjectDeveloper as ProjectDeveloperType } from 'types/projectDeveloper';
 
-export async function getStaticProps(ctx) {
+import { getEnums } from 'services/enums/enumService';
+import { getProjectDeveloper } from 'services/project-developers/projectDevelopersService';
+
+export const getServerSideProps = async ({ params: { id }, locale }) => {
+  let projectDeveloper;
+
+  // If getting the project developer fails, it's most likely because the record has
+  // not been found. Let's return a 404. Anything else will trigger a 500 by default.
+  try {
+    ({ data: projectDeveloper } = await getProjectDeveloper(id, { includes: 'projects' }));
+  } catch (e) {
+    return { notFound: true };
+  }
+
+  const enums = await getEnums();
+
   return {
     props: {
-      intlMessages: await loadI18nMessages(ctx),
+      intlMessages: await loadI18nMessages({ locale }),
+      enums: groupBy(enums, 'type'),
+      // Fixing issues with circular references (caused by the inclusion of projects)
+      // https://github.com/vercel/next.js/discussions/10992#discussioncomment-59574
+      projectDeveloper: decycle(projectDeveloper),
     },
   };
-}
+};
 
-export async function getStaticPaths() {
-  return {
-    paths: [],
-    fallback: true,
-  };
-}
+type ProjectDeveloperPageProps = {
+  projectDeveloper: ProjectDeveloperType;
+  enums: GroupedEnumsType;
+};
 
-const InvestorPage: PageComponent<{}, StaticPageLayoutProps> = (props) => {
-  const intl = useIntl();
-  // const { query } = useRouter();
-  // const { id } = query;
+const ProjectDeveloperPage: PageComponent<ProjectDeveloperPageProps, StaticPageLayoutProps> = ({
+  projectDeveloper,
+  enums,
+}) => {
+  const projectDeveloperTypeName = enums[EnumTypes.ProjectDeveloperType].find(
+    ({ id }) => id === projectDeveloper.project_developer_type
+  )?.name;
 
-  const aboutInfo: {
-    logo: string;
-    name: string;
-    description: string;
-    text: string;
-    website: string;
-    social: SocialType[];
-    contact: string;
-  } = {
-    name: 'Herencia Columbia',
-    description: 'Non Governamental Agency',
-    text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Iaculis gravida auctor enim, id nisl nisl sem tristique. Rhoncus vestibulum vitae diam dignissim imperdiet. Lacus, morbi non cras maecenas cras scelerisque eget. Rutrum tincidunt sed elit rhoncus nunc nisl pulvinar consectetur tincidunt. Nunc quisque potenti velit suscipit volutpat tellus',
-    logo: '/images/placeholders/profile-logo.png',
-    website: 'https://www.site.com',
-    social: [
-      { id: 'linked-in', url: 'https://www.linkedin.com' },
-      { id: 'twitter', url: 'https://www.twitter.com' },
-      { id: 'facebook', url: 'https://www.facebook.com' },
-      { id: 'instagram', url: 'https://www.instagram.com' },
-    ],
-    contact: 'Joel Bean',
+  const funding = {
+    funded: projectDeveloper.projects.filter(({ received_funding }) => received_funding === true)
+      .length,
+    notFunded: projectDeveloper.projects.filter(
+      ({ looking_for_funding }) => looking_for_funding === true
+    ).length,
   };
 
-  const tagsGridRows: TagsGridRowType[] = [
+  const social = SOCIAL_DATA.map((item) => item.id)
+    .reduce((acc, social) => [...acc, { id: social, url: projectDeveloper[social] }], [])
+    .filter((social) => social.url);
+
+  const tagsRows: TagsGridRowType[] = [
     {
       title: 'Categories of interest',
       type: 'category',
-      tags: [
-        { id: 'tourism-and-recreation', name: 'Tourism & Recreation' },
-        { id: 'non-timber-forest-production', name: 'Non-timber forest production' },
-      ],
+      tags: enums[EnumTypes.Category].filter(({ id }) =>
+        projectDeveloper.categories?.includes(id as CategoryType)
+      ),
     },
     {
       title: 'Areas of work',
-      tags: ['Corazón Amazonía'],
+      tags: enums[EnumTypes.Mosaic].filter(({ id }) => projectDeveloper.mosaics?.includes(id)),
     },
     {
       title: 'Impact',
-      tags: ['Biodiversity', 'Social'],
+      tags: enums[EnumTypes.Impact].filter(({ id }) => projectDeveloper.impacts?.includes(id)),
     },
   ];
 
-  const projects = [...Array(6)].map((_, index) => {
-    return {
-      id: `project-${index}`,
-      name: `Circulo de Creaciones Cidaticas Circreadi ${index}`,
-      category: 'Tourism & recreation',
-      instrument: 'Grant',
-      amount: 25000,
-    };
-  });
+  const projects = projectDeveloper.projects.map((project) => ({
+    id: `project-${project.id}`,
+    slug: project.slug,
+    name: project.name,
+    category: enums[EnumTypes.Category].find(({ id }) => id === project.category)?.name,
+    instrument: enums[EnumTypes.InstrumentType]
+      .filter(({ id }) => projectDeveloper.projects[0].instrument_types?.includes(id))
+      .reduce((acc, instrument) => [...acc, instrument.name], [])
+      .join(', '),
+    amount: project.received_funding_amount_usd || 0,
+  }));
 
   return (
     <>
-      <Head title={`${aboutInfo.name} - ${aboutInfo.description}`} description={aboutInfo.text} />
+      <Head
+        title={`${projectDeveloper.name} - ${projectDeveloperTypeName}`}
+        description={projectDeveloper.about}
+      />
 
       <ProfileHeader
-        logo={aboutInfo.logo}
-        title={aboutInfo.name}
-        subtitle={aboutInfo.description}
-        text={aboutInfo.text}
-        website={aboutInfo.website}
-        social={aboutInfo.social}
-        contact={aboutInfo.contact}
-        numNotFunded={10}
-        numFunded={3}
+        logo={projectDeveloper.picture.medium}
+        title={projectDeveloper.name}
+        subtitle={projectDeveloperTypeName}
+        text={projectDeveloper.about}
+        website={projectDeveloper.website}
+        social={social}
+        numNotFunded={funding.funded}
+        numFunded={funding.notFunded}
+        originalLanguage={projectDeveloper.language}
       />
 
       <LayoutContainer layout="narrow" className="mt-24 mb-20 md:mt-40">
@@ -117,14 +135,9 @@ const InvestorPage: PageComponent<{}, StaticPageLayoutProps> = (props) => {
           <h3 className="mt-10 mb-3 text-xl font-semibold md:mt-14">
             <FormattedMessage defaultMessage="Mission" id="RXoqkD" />
           </h3>
-          <p className="my-3">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Tincidunt enim pharetra velit
-            tortor mauris aenean. Adipiscing sed ornare at ipsum pellentesque.Lorem ipsum dolor sit
-            amet, consectetur adipiscing elit. Tincidunt enim pharetra velit tortor mauris aenean.
-            Adipiscing sed ornare at ipsum pellentesque.
-          </p>
+          <p className="my-3">{projectDeveloper.mission}</p>
 
-          <TagsGrid className="mt-10 md:mt-14" rows={tagsGridRows} />
+          <TagsGrid className="mt-10 md:mt-14" rows={tagsRows} />
         </section>
 
         {projects.length > 0 && (
@@ -139,7 +152,7 @@ const InvestorPage: PageComponent<{}, StaticPageLayoutProps> = (props) => {
             <Carousel className="mt-12">
               {chunk(projects, 3).map((projectsChunk, index) => (
                 <Slide key={`slide-${index}`} className="flex flex-col gap-2">
-                  {projectsChunk.map(({ id, category, name, instrument, amount }) => (
+                  {projectsChunk.map(({ id, slug, category, name, instrument, amount }) => (
                     <ProjectCard
                       key={id}
                       id={id}
@@ -147,7 +160,7 @@ const InvestorPage: PageComponent<{}, StaticPageLayoutProps> = (props) => {
                       name={name}
                       instrument={instrument}
                       amount={amount}
-                      link={`/project/${id}`}
+                      link={`${Paths.Project}/${slug}`}
                     />
                   ))}
                 </Slide>
@@ -160,7 +173,7 @@ const InvestorPage: PageComponent<{}, StaticPageLayoutProps> = (props) => {
   );
 };
 
-InvestorPage.layout = {
+ProjectDeveloperPage.layout = {
   props: {
     headerProps: {
       transparent: true,
@@ -171,4 +184,4 @@ InvestorPage.layout = {
   },
 };
 
-export default InvestorPage;
+export default ProjectDeveloperPage;

--- a/frontend/services/project-developers/projectDevelopersService.ts
+++ b/frontend/services/project-developers/projectDevelopersService.ts
@@ -42,17 +42,27 @@ export function useProjectDevelopersList(
 }
 
 /** Get a Project Developer using an id and, optionally, the wanted fields */
-export const getProjectDeveloper = async (id: string): Promise<ProjectDeveloper> => {
+export const getProjectDeveloper = async (
+  id: string,
+  params?: {
+    fields?: string;
+    includes?: string;
+  }
+): Promise<{
+  data: ProjectDeveloper;
+  included: any[]; // TODO: Project[] | User[]
+}> => {
   const config: AxiosRequestConfig = {
     url: `/api/v1/project_developers/${id}`,
     method: 'GET',
+    params: params,
   };
-  return await API.request(config).then((response) => response.data.data);
+  return await API.request(config).then((response) => response.data);
 };
 
 /** Use query for a single Project Developer */
-export function useProjectDeveloper(id: string) {
-  const query = useQuery([Queries.ProjectDeveloper, id], () => getProjectDeveloper(id));
+export function useProjectDeveloper(id: string, params) {
+  const query = useQuery([Queries.ProjectDeveloper, id], () => getProjectDeveloper(id, params));
 
   return useMemo(
     () => ({

--- a/frontend/types/project.ts
+++ b/frontend/types/project.ts
@@ -1,10 +1,11 @@
-import { DevelopmentStages, Languages, TicketSizes } from 'enums';
+import { DevelopmentStages, TicketSizes } from 'enums';
 
 /** Project entity structure */
 export type Project = {
   id: string;
   type: 'project';
-  categories: string;
+  slug: string;
+  category: string;
   description: string;
   development_stage: DevelopmentStages;
   estimated_duration_in_months: number;

--- a/frontend/types/projectDeveloper.ts
+++ b/frontend/types/projectDeveloper.ts
@@ -4,6 +4,13 @@ import { Languages } from 'enums';
 
 import { CategoryType } from './category';
 import { Enum } from './enums';
+import { Project } from './project';
+
+export type ProjectDeveloperPicture = {
+  small: string;
+  medium: string;
+  large: string;
+};
 
 export type ProjectDeveloper = {
   id: string;
@@ -21,8 +28,11 @@ export type ProjectDeveloper = {
   project_developer_type: string;
   categories: CategoryType[];
   impacts: string[];
+  mosaics: string[];
   language: Languages;
+  picture: ProjectDeveloperPicture;
   entity_legal_registration_number: string;
+  projects?: Project[];
 };
 
 export type ProjectDeveloperSetupForm = ProjectDeveloper & {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -9968,6 +9968,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cycle@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "cycle@npm:1.0.3"
+  checksum: b9f131094fb832a8c4ba18c6d2dc9c87fc80d3242847a45f0a5f70911b2acab68abc1c25eb23e5155fcf2135a27d8fcc3635556745b03b488c4f360cfbc352df
+  languageName: node
+  linkType: hard
+
 "cyclist@npm:^1.0.1":
   version: 1.0.1
   resolution: "cyclist@npm:1.0.1"
@@ -12555,6 +12562,7 @@ __metadata:
     autoprefixer: ^10.4.2
     axios: ^0.21.1
     classnames: ^2.3.1
+    cycle: ^1.0.3
     d3-ease: ^2.0.0
     downshift: ^6.1.3
     eslint: ^8.9.0


### PR DESCRIPTION
This PR connects the Project Developer public page to the API. 

**Notes:**  
- Header / contact information
  - changes/functionality are to be implemented in [LET-353](https://vizzuality.atlassian.net/browse/LET-353)  
  - Added a logo fallback to the `ProfileHeader` component, just so we can pass the image as a prop without a crash
  - Configured `next.config.js` to load images from the `heco.vizuallity.com` and `staging.heco.vizzuality.com` domains
- Project cards  
   - Verified tag and funding amount formatting are a bit wonky, but not relevant to the API connection for this particular page. 

## Testing instructions

Verify that: 
- A project developer page for an existing project developer displays information from the API  
- The language a page was originally written in is displayed below the header 
- Trying to access a non-existant project developer shows the 404 view  

## Tracking

[LET-355](https://vizzuality.atlassian.net/browse/LET-355)

## Screenshot

![screencapture-localhost-3000-project-developer-sarodrigues-2022-04-28-07_07_48](https://user-images.githubusercontent.com/6273795/165687896-f89c1cd2-6113-4910-a8e5-4288b9a6d47a.png)


