### PR TITLE
Fix console error on Carousel Paging buttons not having a unique key

### DIFF
--- a/frontend/components/carousel/paging/component.tsx
+++ b/frontend/components/carousel/paging/component.tsx
@@ -15,6 +15,7 @@ export const Paging: FC<PagingProps> = ({ className, numSlides, currentSlide, on
     <div className={className}>
       {times(numSlides, (slide) => (
         <button
+          key={`slide-${slide}`}
           aria-label={intl.formatMessage(
             {
               defaultMessage: 'Slide {slideNumber}',


### PR DESCRIPTION
Fix the following Carousel warning, cause by the `Carousel` paging buttons not having a `key` prop:  

&nbsp; 

<img width="727" alt="Screenshot 2022-04-28 at 09 18 42" src="https://user-images.githubusercontent.com/6273795/165709482-484e9ba9-31a8-4528-9483-35c22ab8f51d.png">



## Testing instructions

Verify that when loading a page with the carousel (eg: project developer page), the warning no longer appears in the terminal

## Tracking

N/A
