### PR TITLE
Profile header styling change + barebones project page

### DIFF
--- a/frontend/containers/profile-header/component.tsx
+++ b/frontend/containers/profile-header/component.tsx
@@ -41,7 +41,7 @@ export const ProfileHeader: FC<ProfileHeaderProps> = ({
 
   return (
     <div className={className}>
-      <div className="pt-24 pb-12 bg-center bg-cover sm:pt-40 md:pt-56 bg-radial-green-dark bg-green-dark">
+      <div className="py-10 mx-4 bg-center bg-cover lg:mx-0 lg:px-4 lg:py-18 rounded-2xl bg-radial-green-dark bg-green-dark">
         <LayoutContainer className="flex justify-between">
           <div className="flex flex-col items-center w-full gap-6 lg:items-end lg:flex-row lg:w-6/12">
             <div className="overflow-hidden bg-white w-52 h-52 rounded-2xl">
@@ -59,7 +59,7 @@ export const ProfileHeader: FC<ProfileHeaderProps> = ({
                 onError={() => setLogo('/images/placeholders/profile-logo.png')}
               />
             </div>
-            <div className="mb-4 text-center lg:text-left">
+            <div className="-mb-2 text-center lg:mb-4 lg:text-left">
               <h1 className="font-serif text-3xl text-white">{title}</h1>
               <p className="mt-2 text-xl text-gray-400">{subtitle}</p>
             </div>
@@ -82,11 +82,11 @@ export const ProfileHeader: FC<ProfileHeaderProps> = ({
           )}
           <p>{text}</p>
         </div>
-        <div className="p-6 bg-white drop-shadow-xl lg:mb-[-70%] h-full lg:translate-y-[-70%] lg:max-w-4/12 rounded-2xl mt-8 lg:mt-0">
+        <div className="lg:mr-4 p-6 bg-white drop-shadow-xl lg:mb-[-70%] h-full lg:translate-y-[-70%] lg:max-w-4/12 rounded-2xl mt-8 lg:mt-0">
           {typeof numFunded === 'number' && typeof numNotFunded === 'number' && (
             <>
-              <div className="flex">
-                <div className="flex flex-col items-center w-1/2 gap-2 text-center">
+              <div className="flex flex-col md:flex-row">
+                <div className="flex flex-col items-center w-full gap-2 text-center md:w-1/2">
                   <span id="num-projects-waiting-funding" className="text-2xl font-semibold">
                     {numNotFunded}
                   </span>
@@ -94,7 +94,7 @@ export const ProfileHeader: FC<ProfileHeaderProps> = ({
                     <FormattedMessage defaultMessage="Projects waiting funding" id="hxIQ/8" />
                   </span>
                 </div>
-                <div className="flex flex-col items-center w-1/2 gap-2 text-center">
+                <div className="flex flex-col items-center w-full gap-2 text-center md:w-1/2">
                   <span id="num-projects-waiting-funding" className="text-2xl font-semibold">
                     {numFunded}
                   </span>
@@ -115,12 +115,17 @@ export const ProfileHeader: FC<ProfileHeaderProps> = ({
             contact={contact}
           />
 
-          <div className="flex justify-between gap-4 mt-8">
-            <Button theme="secondary-green" icon={HeartIcon} onClick={onFavoriteClick}>
+          <div className="flex flex-col justify-between gap-4 mt-8 lg:flex-row">
+            <Button
+              className="justify-center"
+              theme="secondary-green"
+              icon={HeartIcon}
+              onClick={onFavoriteClick}
+            >
               <FormattedMessage defaultMessage="Favorite" id="5Hzwqs" />
             </Button>
             <Button
-              className="w-full max-w-[200px] justify-center"
+              className="w-full lg:max-w-[200px] justify-center"
               theme="primary-green"
               onClick={onContactClick}
             >

--- a/frontend/enums/index.ts
+++ b/frontend/enums/index.ts
@@ -32,6 +32,8 @@ export enum Queries {
   ProjectDeveloper = 'project_developer',
   /** The current user Project Developer */
   CurrentProjectDeveloper = 'current_project_developer',
+  /** Single project */
+  Project = 'project',
   /** List of investors */
   InvestorList = 'investors',
   /** Single investor  */

--- a/frontend/pages/investor/[id]/index.tsx
+++ b/frontend/pages/investor/[id]/index.tsx
@@ -89,16 +89,18 @@ const InvestorPage: PageComponent<{}, StaticPageLayoutProps> = (props) => {
     <>
       <Head title={`${aboutInfo.name} - ${aboutInfo.description}`} description={aboutInfo.text} />
 
-      <ProfileHeader
-        logo={aboutInfo.logo}
-        title={aboutInfo.name}
-        subtitle={aboutInfo.description}
-        text={aboutInfo.text}
-        website={aboutInfo.website}
-        social={aboutInfo.social}
-        contact={aboutInfo.contact}
-        originalLanguage="en"
-      />
+      <LayoutContainer className="-mt-10 lg:-mt-16">
+        <ProfileHeader
+          logo={aboutInfo.logo}
+          title={aboutInfo.name}
+          subtitle={aboutInfo.description}
+          text={aboutInfo.text}
+          website={aboutInfo.website}
+          social={aboutInfo.social}
+          contact={aboutInfo.contact}
+          originalLanguage="en"
+        />
+      </LayoutContainer>
 
       <LayoutContainer layout="narrow" className="mt-24 mb-20 md:mt-40">
         <section aria-labelledby="profile-investment-info">
@@ -179,15 +181,6 @@ const InvestorPage: PageComponent<{}, StaticPageLayoutProps> = (props) => {
   );
 };
 
-InvestorPage.layout = {
-  props: {
-    headerProps: {
-      transparent: true,
-    },
-    mainProps: {
-      topMargin: false,
-    },
-  },
-};
+InvestorPage.layout = {};
 
 export default InvestorPage;

--- a/frontend/pages/project-developer/[id]/index.tsx
+++ b/frontend/pages/project-developer/[id]/index.tsx
@@ -111,17 +111,19 @@ const ProjectDeveloperPage: PageComponent<ProjectDeveloperPageProps, StaticPageL
         description={projectDeveloper.about}
       />
 
-      <ProfileHeader
-        logo={projectDeveloper.picture.medium}
-        title={projectDeveloper.name}
-        subtitle={projectDeveloperTypeName}
-        text={projectDeveloper.about}
-        website={projectDeveloper.website}
-        social={social}
-        numNotFunded={funding.funded}
-        numFunded={funding.notFunded}
-        originalLanguage={projectDeveloper.language}
-      />
+      <LayoutContainer className="-mt-10 lg:-mt-16">
+        <ProfileHeader
+          logo={projectDeveloper.picture.medium}
+          title={projectDeveloper.name}
+          subtitle={projectDeveloperTypeName}
+          text={projectDeveloper.about}
+          website={projectDeveloper.website}
+          social={social}
+          numNotFunded={funding.funded}
+          numFunded={funding.notFunded}
+          originalLanguage={projectDeveloper.language}
+        />
+      </LayoutContainer>
 
       <LayoutContainer layout="narrow" className="mt-24 mb-20 md:mt-40">
         <section aria-labelledby="project-developer-overview">
@@ -173,15 +175,6 @@ const ProjectDeveloperPage: PageComponent<ProjectDeveloperPageProps, StaticPageL
   );
 };
 
-ProjectDeveloperPage.layout = {
-  props: {
-    headerProps: {
-      transparent: true,
-    },
-    mainProps: {
-      topMargin: false,
-    },
-  },
-};
+ProjectDeveloperPage.layout = {};
 
 export default ProjectDeveloperPage;

--- a/frontend/pages/project/[id]/index.tsx
+++ b/frontend/pages/project/[id]/index.tsx
@@ -1,0 +1,71 @@
+import { groupBy } from 'lodash-es';
+
+import { loadI18nMessages } from 'helpers/i18n';
+
+import Head from 'components/head';
+import LayoutContainer from 'components/layout-container';
+import { StaticPageLayoutProps } from 'layouts/static-page';
+import { PageComponent } from 'types';
+import { GroupedEnums as GroupedEnumsType } from 'types/enums';
+import { Project as ProjectType } from 'types/project';
+
+import { getEnums } from 'services/enums/enumService';
+import { getProject } from 'services/projects/projectService';
+
+export const getServerSideProps = async ({ params: { id }, locale }) => {
+  let project;
+
+  // If getting the project fails, it's most likely because the record has
+  // not been found. Let's return a 404. Anything else will trigger a 500 by default.
+  try {
+    ({ data: project } = await getProject(id));
+  } catch (e) {
+    return { notFound: true };
+  }
+
+  const enums = await getEnums();
+
+  return {
+    props: {
+      intlMessages: await loadI18nMessages({ locale }),
+      enums: groupBy(enums, 'type'),
+      project: project,
+    },
+  };
+};
+
+type ProjectPageProps = {
+  project: ProjectType;
+  enums: GroupedEnumsType;
+};
+
+const ProjectPage: PageComponent<ProjectPageProps, StaticPageLayoutProps> = ({
+  project,
+  enums,
+}) => {
+  return (
+    <>
+      <Head title={project.name} description={project.description} />
+
+      <LayoutContainer className="-mt-10 lg:-mt-16">
+        {/*<ProjectHeader/>*/} ProjectHeader
+      </LayoutContainer>
+
+      <LayoutContainer className="mb-20 mt-18">
+        <section>Overview</section>
+        <section>Impact</section>
+        <section>Funding &amp; Development</section>
+      </LayoutContainer>
+
+      <div className="bg-background-middle">
+        <LayoutContainer className="py-18">
+          <section>Project developers</section>
+        </LayoutContainer>
+      </div>
+    </>
+  );
+};
+
+ProjectPage.layout = {};
+
+export default ProjectPage;

--- a/frontend/services/projects/projectService.ts
+++ b/frontend/services/projects/projectService.ts
@@ -1,0 +1,42 @@
+import { useMemo } from 'react';
+
+import { useQuery } from 'react-query';
+
+import { AxiosRequestConfig } from 'axios';
+
+import { Queries } from 'enums';
+import { Project } from 'types/project';
+
+import API from 'services/api';
+
+/** Get a Project using an id and, optionally, the wanted fields */
+export const getProject = async (
+  id: string,
+  params?: {
+    fields?: string;
+    includes?: string;
+  }
+): Promise<{
+  data: Project;
+  included: any[]; // TODO
+}> => {
+  const config: AxiosRequestConfig = {
+    url: `/api/v1/projects/${id}`,
+    method: 'GET',
+    params: params,
+  };
+  return await API.request(config).then((response) => response.data);
+};
+
+/** Use query for a single Project */
+export function useProject(id: string, params) {
+  const query = useQuery([Queries.Project, id], () => getProject(id, params));
+
+  return useMemo(
+    () => ({
+      ...query,
+      project: query.data,
+    }),
+    [query]
+  );
+}


### PR DESCRIPTION
This PR is meant to keep other tasks unblocked while work on [LET-353 (FE - Update the header and contact section of the PD public page)](https://vizzuality.atlassian.net/browse/LET-353) is ongoing. That way work on `LET-353` can be entirely self contained, without causing conflicts with other ongoing tasks. 

**In this PR:**  
- Design changes to the `ProfileHeader` component  
- Added a barebones `project/{id}` page with placeholders for content, as well as the base service to fetch a single project    
  _Virtually the same implementation done in `project-developer/{id}`_
  _It already fetches the `project` from the API_

## Testing instructions

N/A

## Tracking

Part of the ongoing [LET-353 ](https://vizzuality.atlassian.net/browse/LET-353)

## Screenshots 

**Developer profile header**  
<img width="1680" alt="Screenshot 2022-04-28 at 11 23 09" src="https://user-images.githubusercontent.com/6273795/165732350-ad0ec737-ae6d-4374-8cf0-118dfd77726c.png">

**Barebones project page with placeholders** 
<img width="1680" alt="Screenshot 2022-04-28 at 11 24 14" src="https://user-images.githubusercontent.com/6273795/165732551-374cc152-623f-406a-a294-830cb07d588d.png">

