### PR TITLE
Temp disable origin check for rails controllers

### DIFF
--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -15,6 +15,8 @@ Rails.application.configure do
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
+  # TODO: fix this later, directupload is checkin it on staging but we want to allow non https localhost requests
+  config.action_controller.forgery_protection_origin_check = false
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).


### PR DESCRIPTION
This is just temp solution to unblock frontend, before Infrastructure changes.

https://vizzuality.atlassian.net/browse/LET-371