### PR TITLE
fix: use correct geos lib at Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -14,7 +14,7 @@ RUN apk update && \
       tzdata \
       postgresql-dev \
       imagemagick \
-      libgeos-dev \
+      geos-dev \
     && rm -rf /var/cache/apk/*
 
 RUN echo 'gem: -N' >> ~/.gemrc


### PR DESCRIPTION
There is no `libgeos-dev` package, but there is `geos-dev`. Fixing Dockerfile to use correct one ;)