### PR TITLE
LET-253 Add role binding for service account for requests to signBlob

### DIFF
--- a/infrastructure/base/modules/cloudrun/main.tf
+++ b/infrastructure/base/modules/cloudrun/main.tf
@@ -96,3 +96,12 @@ resource "google_cloud_run_service_iam_policy" "noauth" {
 
   policy_data = data.google_iam_policy.noauth.policy_data
 }
+
+resource "google_service_account_iam_binding" "admin-account-iam" {
+  service_account_id = google_service_account.service_account.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+
+  members = [
+    "serviceAccount:${google_service_account.service_account.email}",
+  ]
+}


### PR DESCRIPTION
Adds Service Account Token Creator role to the service account in order to have permission to make requests to signBlob.

https://vizzuality.atlassian.net/browse/LET-253?atlOrigin=eyJpIjoiNDk4NTcwN2NlMDkxNDA1N2I0YjA3ZGU0ZTk3N2FlYzciLCJwIjoiaiJ9