### PR TITLE
fix: define empty schema for rswag endpoints so json is properly setup

### DIFF
--- a/backend/spec/requests/api/v1/favourite_project_developers_spec.rb
+++ b/backend/spec/requests/api/v1/favourite_project_developers_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "API V1 Favourite Project Developer", type: :request do
       produces "application/json"
       security [csrf: [], cookie_auth: []]
       parameter name: :project_developer_id, in: :path, type: :string
+      parameter name: :empty, in: :body, schema: {type: :object}, required: false
 
       let(:project_developer_id) { @project_developer.id }
 
@@ -37,6 +38,7 @@ RSpec.describe "API V1 Favourite Project Developer", type: :request do
       produces "application/json"
       security [csrf: [], cookie_auth: []]
       parameter name: :project_developer_id, in: :path, type: :string
+      parameter name: :empty, in: :body, schema: {type: :object}, required: false
 
       let(:project_developer_id) { @project_developer.id }
 

--- a/backend/spec/requests/api/v1/favourite_projects_spec.rb
+++ b/backend/spec/requests/api/v1/favourite_projects_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "API V1 Favourite Project", type: :request do
       produces "application/json"
       security [csrf: [], cookie_auth: []]
       parameter name: :project_id, in: :path, type: :string
+      parameter name: :empty, in: :body, schema: {type: :object}, required: false
 
       let(:project_id) { @project.id }
 
@@ -37,6 +38,7 @@ RSpec.describe "API V1 Favourite Project", type: :request do
       produces "application/json"
       security [csrf: [], cookie_auth: []]
       parameter name: :project_id, in: :path, type: :string
+      parameter name: :empty, in: :body, schema: {type: :object}, required: false
 
       let(:project_id) { @project.id }
 

--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -27,7 +27,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 2c7c3101-f1cb-4315-b3cc-e73540b37ecb
+                  id: e086933f-4375-49cd-bc0f-6016c10ff5cf
                   type: project_developer
                   attributes:
                     name: Kutch-Spencer
@@ -57,22 +57,22 @@ paths:
                     - amazon-heart
                     - amazonian-piedmont-massif
                     picture:
-                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsTm1VMk1UUTBaaTFpWWpOakxUUmpZek10T1dabFlTMHpaakEzTnpNd01HTXhaRGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--eb9b2f2d3d47cfc01681949bfa931176badfe00a/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1eb0cccee7522d208acd539788e1cc169cbbe2bf/picture.jpg
-                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsTm1VMk1UUTBaaTFpWWpOakxUUmpZek10T1dabFlTMHpaakEzTnpNd01HTXhaRGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--eb9b2f2d3d47cfc01681949bfa931176badfe00a/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--b9054379195e77680b08961676ba21361613fb9f/picture.jpg
-                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsTm1VMk1UUTBaaTFpWWpOakxUUmpZek10T1dabFlTMHpaakEzTnpNd01HTXhaRGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--eb9b2f2d3d47cfc01681949bfa931176badfe00a/picture.jpg
+                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTjJabFl6aGtZeTAxTmpjMUxUUTVOR010T1RObU1pMW1NRFE0TkRBMU1EWmtabUVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f03b3f44402f1d0f9e3dcfd60b1fd4e7567141da/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTjJabFl6aGtZeTAxTmpjMUxUUTVOR010T1RObU1pMW1NRFE0TkRBMU1EWmtabUVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f03b3f44402f1d0f9e3dcfd60b1fd4e7567141da/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTjJabFl6aGtZeTAxTmpjMUxUUTVOR010T1RObU1pMW1NRFE0TkRBMU1EWmtabUVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f03b3f44402f1d0f9e3dcfd60b1fd4e7567141da/picture.jpg
                     favourite: false
                   relationships:
                     owner:
                       data:
-                        id: 2ebae589-ba37-4785-ae47-4ffa9587197a
+                        id: 767dace2-2c63-4f17-a802-cc36c6207e8e
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data:
-                      - id: f45d5777-a547-4f31-b47e-8a109bd3434c
+                      - id: db15b14d-de62-47d0-9513-c8b8933223c3
                         type: project
-                      - id: 785e9e6a-e291-40c7-a8b1-7ff96acab791
+                      - id: a173eafe-9e22-46cb-b208-2e15f10d5a76
                         type: project
               schema:
                 type: object
@@ -102,7 +102,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 4c560cc7-a4af-49d2-8381-fd2736d86bb5
+                  id: c2d92753-0191-4a9c-87bc-a20dcea185d0
                   type: project_developer
                   attributes:
                     name: Name
@@ -129,14 +129,14 @@ paths:
                     mosaics:
                     - amazon-heart
                     picture:
-                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TkRReE4ySTVaQzA1TmprMkxUUTVOamN0WW1JNU9TMDNNbVV3WkdVNE5tUmlaakFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--211c4bf004a69c8cab21aa14a746f5a7792edae6/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1eb0cccee7522d208acd539788e1cc169cbbe2bf/picture.jpg
-                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TkRReE4ySTVaQzA1TmprMkxUUTVOamN0WW1JNU9TMDNNbVV3WkdVNE5tUmlaakFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--211c4bf004a69c8cab21aa14a746f5a7792edae6/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--b9054379195e77680b08961676ba21361613fb9f/picture.jpg
-                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TkRReE4ySTVaQzA1TmprMkxUUTVOamN0WW1JNU9TMDNNbVV3WkdVNE5tUmlaakFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--211c4bf004a69c8cab21aa14a746f5a7792edae6/picture.jpg
+                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5Tm1Gak1qSXhOUzB5TUdFMkxUUTROR010T0RVd1lpMDROMkk1WXpBM1pEZGpOVFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e50dccf7ae821eedfa77f2aab6a7312a374e5df6/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5Tm1Gak1qSXhOUzB5TUdFMkxUUTROR010T0RVd1lpMDROMkk1WXpBM1pEZGpOVFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e50dccf7ae821eedfa77f2aab6a7312a374e5df6/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5Tm1Gak1qSXhOUzB5TUdFMkxUUTROR010T0RVd1lpMDROMkk1WXpBM1pEZGpOVFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e50dccf7ae821eedfa77f2aab6a7312a374e5df6/picture.jpg
                     favourite: false
                   relationships:
                     owner:
                       data:
-                        id: ca1d9725-b7b1-43f0-9d19-574c4719c73e
+                        id: da0ad858-6dcd-4ab0-b0f9-e7904d3222b0
                         type: user
                     projects:
                       data: []
@@ -274,7 +274,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 5384507e-b123-445a-a5a1-93e6332ccaa9
+                  id: 2843d082-d448-43bf-9972-9a2f6132ae9b
                   type: project_developer
                   attributes:
                     name: Name
@@ -301,14 +301,14 @@ paths:
                     mosaics:
                     - amazon-heart
                     picture:
-                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TlRnM01ERXdaQzAwWmpobUxUUXdPV1l0WW1Zd1ppMW1NMk16TnpJek1HUmxNR1VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e377063bbcb5dd7d660ff04c56703df287d7bbdc/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1eb0cccee7522d208acd539788e1cc169cbbe2bf/picture.jpg
-                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TlRnM01ERXdaQzAwWmpobUxUUXdPV1l0WW1Zd1ppMW1NMk16TnpJek1HUmxNR1VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e377063bbcb5dd7d660ff04c56703df287d7bbdc/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--b9054379195e77680b08961676ba21361613fb9f/picture.jpg
-                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TlRnM01ERXdaQzAwWmpobUxUUXdPV1l0WW1Zd1ppMW1NMk16TnpJek1HUmxNR1VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e377063bbcb5dd7d660ff04c56703df287d7bbdc/picture.jpg
+                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqWVRWbU0ySXhaQzFrT0RobExUUmpZbVF0WW1ReFpTMWpZVFU0TkRreE5tVTFPVEVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--9cdba379f4ae45ae05a59ceebd63b2f00a1f691a/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqWVRWbU0ySXhaQzFrT0RobExUUmpZbVF0WW1ReFpTMWpZVFU0TkRreE5tVTFPVEVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--9cdba379f4ae45ae05a59ceebd63b2f00a1f691a/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqWVRWbU0ySXhaQzFrT0RobExUUmpZbVF0WW1ReFpTMWpZVFU0TkRreE5tVTFPVEVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--9cdba379f4ae45ae05a59ceebd63b2f00a1f691a/picture.jpg
                     favourite: false
                   relationships:
                     owner:
                       data:
-                        id: 7961b892-d42b-423d-90f6-3e65144539ba
+                        id: 6d604922-e5b4-4073-a6d7-23701391c845
                         type: user
                     projects:
                       data: []
@@ -418,7 +418,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 9515dbc4-272c-46f9-852d-449149e0eec4
+                  id: bb64285f-bdcc-4b22-ace9-5d02cb25b593
                   type: project
                   attributes:
                     name: Project Name
@@ -462,37 +462,37 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 59929899-b455-4636-b7ed-09e6aaabff03
+                        id: f4c63b6a-3604-457e-83b3-f0d4f7076f12
                         type: project_developer
                     involved_project_developers:
                       data:
-                      - id: fabbe366-d37b-4d65-b236-6d7f1f5730b4
+                      - id: 75e3e5a5-00f6-413a-affd-e354090b0f4f
                         type: project_developer
-                      - id: '091bfe4f-b2d1-4554-aeab-da704848b9bf'
+                      - id: c4b26dbc-7bfe-4d14-ba7f-95596f976320
                         type: project_developer
                     project_images:
                       data:
-                      - id: 23056519-b0bc-4d61-9270-7b762f15911b
+                      - id: 83ef9074-50e6-4ac3-9850-411518f4104c
                         type: project_image
-                      - id: 3115a2b9-1acb-458b-8a62-89516e1ff8ee
+                      - id: 96f1e5fa-26f3-4c75-9edb-880bf7a8610f
                         type: project_image
                 included:
-                - id: 23056519-b0bc-4d61-9270-7b762f15911b
+                - id: 83ef9074-50e6-4ac3-9850-411518f4104c
                   type: project_image
                   attributes:
                     cover: true
                     file:
-                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpTTJSaFpqQmtNaTA1T0RNekxUUmxZalF0T1dWallpMWlZalJoWXpBM09EWTRPRFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0fbdd063947c0fd37a89f72b62b4c924d927c699/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1eb0cccee7522d208acd539788e1cc169cbbe2bf/picture.jpg
-                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpTTJSaFpqQmtNaTA1T0RNekxUUmxZalF0T1dWallpMWlZalJoWXpBM09EWTRPRFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0fbdd063947c0fd37a89f72b62b4c924d927c699/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--b9054379195e77680b08961676ba21361613fb9f/picture.jpg
-                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpTTJSaFpqQmtNaTA1T0RNekxUUmxZalF0T1dWallpMWlZalJoWXpBM09EWTRPRFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0fbdd063947c0fd37a89f72b62b4c924d927c699/picture.jpg
-                - id: 3115a2b9-1acb-458b-8a62-89516e1ff8ee
+                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTkdFNE9EWmxOaTAxTXpNeExUUXdOMll0T0RVNU5DMWpPR1pqTmpZME1Ea3lPV1VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f094fe7096a398f877465281ff95905b3cb2c7da/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTkdFNE9EWmxOaTAxTXpNeExUUXdOMll0T0RVNU5DMWpPR1pqTmpZME1Ea3lPV1VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f094fe7096a398f877465281ff95905b3cb2c7da/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTkdFNE9EWmxOaTAxTXpNeExUUXdOMll0T0RVNU5DMWpPR1pqTmpZME1Ea3lPV1VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f094fe7096a398f877465281ff95905b3cb2c7da/picture.jpg
+                - id: 96f1e5fa-26f3-4c75-9edb-880bf7a8610f
                   type: project_image
                   attributes:
                     cover: false
                     file:
-                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5TVROak9UVXhOeTFoTWpabExUUmpaR1V0WWpZd055MHlNVGt5WXpjMVlXTTRNMlFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0711f2301a96f44e24d30981978e5658e12dd6e3/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1eb0cccee7522d208acd539788e1cc169cbbe2bf/picture.jpg
-                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5TVROak9UVXhOeTFoTWpabExUUmpaR1V0WWpZd055MHlNVGt5WXpjMVlXTTRNMlFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0711f2301a96f44e24d30981978e5658e12dd6e3/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--b9054379195e77680b08961676ba21361613fb9f/picture.jpg
-                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5TVROak9UVXhOeTFoTWpabExUUmpaR1V0WWpZd055MHlNVGt5WXpjMVlXTTRNMlFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0711f2301a96f44e24d30981978e5658e12dd6e3/picture.jpg
+                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6T1RNeU1HWTJNeTA1T0RBd0xUUXhORGd0T1dGa055MDNOR1ZtTTJRMlpHVXlOak1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--8fbb7279c68aa89085df5c2bae163a87cf22fb6f/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6T1RNeU1HWTJNeTA1T0RBd0xUUXhORGd0T1dGa055MDNOR1ZtTTJRMlpHVXlOak1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--8fbb7279c68aa89085df5c2bae163a87cf22fb6f/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6T1RNeU1HWTJNeTA1T0RBd0xUUXhORGd0T1dGa055MDNOR1ZtTTJRMlpHVXlOak1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--8fbb7279c68aa89085df5c2bae163a87cf22fb6f/picture.jpg
               schema:
                 type: object
                 properties:
@@ -724,7 +724,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: b4fcc269-94d7-4582-9c83-ce777d63a6fe
+                  id: 6b881329-13f7-4f39-8df9-335a0a21265a
                   type: user
                   attributes:
                     first_name: Dawna
@@ -1147,6 +1147,11 @@ paths:
                   code:
         '200':
           description: success
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
     delete:
       summary: Mark Project Developer as non-favourite
       tags:
@@ -1171,6 +1176,11 @@ paths:
                   code:
         '200':
           description: success
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
   "/api/v1/projects/{project_id}/favourite_project":
     post:
       summary: Mark Project as favourite
@@ -1196,6 +1206,11 @@ paths:
                   code:
         '200':
           description: success
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
     delete:
       summary: Mark Project as non-favourite
       tags:
@@ -1220,6 +1235,11 @@ paths:
                   code:
         '200':
           description: success
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
   "/api/v1/investors":
     get:
       summary: Returns list of the investors
@@ -1281,7 +1301,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: 9316ce47-fbf9-4c46-becf-a1fc27662215
+                - id: '0590c1a1-4cbf-4cbb-8daf-62db2ce82dda'
                   type: investor
                   attributes:
                     name: Kutch-Spencer
@@ -1323,15 +1343,15 @@ paths:
                     contact_email: contact@example.com
                     contact_phone: "+57-1-xxx-xx-xx"
                     picture:
-                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0WmpFeFlUSm1aaTFtWTJRMExUUmxOekl0WW1NME5pMHhOMll4T0RRellUWm1aakFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6fb576f0c93ca67175632cbc78b56fde55f610a5/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1eb0cccee7522d208acd539788e1cc169cbbe2bf/picture.jpg
-                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0WmpFeFlUSm1aaTFtWTJRMExUUmxOekl0WW1NME5pMHhOMll4T0RRellUWm1aakFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6fb576f0c93ca67175632cbc78b56fde55f610a5/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--b9054379195e77680b08961676ba21361613fb9f/picture.jpg
-                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0WmpFeFlUSm1aaTFtWTJRMExUUmxOekl0WW1NME5pMHhOMll4T0RRellUWm1aakFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6fb576f0c93ca67175632cbc78b56fde55f610a5/picture.jpg
+                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrTXpNMk5ESXpNeTB6TnpJd0xUUTBNbVF0T1RZd1pDMDJNV05rTTJKak1EaGxabVlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--afbe3deb2e9392ac06002da5ae2ddfc2a518d170/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrTXpNMk5ESXpNeTB6TnpJd0xUUTBNbVF0T1RZd1pDMDJNV05rTTJKak1EaGxabVlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--afbe3deb2e9392ac06002da5ae2ddfc2a518d170/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrTXpNMk5ESXpNeTB6TnpJd0xUUTBNbVF0T1RZd1pDMDJNV05rTTJKak1EaGxabVlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--afbe3deb2e9392ac06002da5ae2ddfc2a518d170/picture.jpg
                   relationships:
                     owner:
                       data:
-                        id: 40d4c51e-82e0-4aa8-b9a0-ae5917cbeaed
+                        id: e4f06caa-8ec5-427f-a1c1-e043a820a09a
                         type: user
-                - id: e12e6651-108e-49a5-b811-bfa120f3e8bc
+                - id: 9171a9c5-7a8a-4d6a-84f1-11233c5f85f7
                   type: investor
                   attributes:
                     name: Bartoletti and Sons
@@ -1373,15 +1393,15 @@ paths:
                     contact_email: contact@example.com
                     contact_phone: "+57-1-xxx-xx-xx"
                     picture:
-                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWszWmpKall6Z3paaTFrTVdFekxUUm1abUl0WWpBNFlTMWtaV1JtTVRjMlptVTBaRElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--59417843fc7083bb071ba48f75ab3370b8e2e3ee/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1eb0cccee7522d208acd539788e1cc169cbbe2bf/picture.jpg
-                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWszWmpKall6Z3paaTFrTVdFekxUUm1abUl0WWpBNFlTMWtaV1JtTVRjMlptVTBaRElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--59417843fc7083bb071ba48f75ab3370b8e2e3ee/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--b9054379195e77680b08961676ba21361613fb9f/picture.jpg
-                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWszWmpKall6Z3paaTFrTVdFekxUUm1abUl0WWpBNFlTMWtaV1JtTVRjMlptVTBaRElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--59417843fc7083bb071ba48f75ab3370b8e2e3ee/picture.jpg
+                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTldObVpHWXhOeTA1WTJNNExUUmpabVF0WWpZNU5pMW1aalpoTTJZM01qa3pNbVlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--9450c3964d6ba203c91ce0384c07d68f7a243f5c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTldObVpHWXhOeTA1WTJNNExUUmpabVF0WWpZNU5pMW1aalpoTTJZM01qa3pNbVlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--9450c3964d6ba203c91ce0384c07d68f7a243f5c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTldObVpHWXhOeTA1WTJNNExUUmpabVF0WWpZNU5pMW1aalpoTTJZM01qa3pNbVlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--9450c3964d6ba203c91ce0384c07d68f7a243f5c/picture.jpg
                   relationships:
                     owner:
                       data:
-                        id: c2c44932-6e07-4fa5-9e87-eceda0ffaafe
+                        id: 536d0241-3bda-43da-9392-e0b12bf37ce5
                         type: user
-                - id: 8cfc82b2-eb07-4a1c-be48-3e028d9611f4
+                - id: 57d40987-15c5-4646-9a9e-a5006b7dc406
                   type: investor
                   attributes:
                     name: Hane, Lehner and Goyette
@@ -1423,15 +1443,15 @@ paths:
                     contact_email: contact@example.com
                     contact_phone: "+57-1-xxx-xx-xx"
                     picture:
-                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3TmpZd1lXUTRNUzB3WldJMkxUUTVOelV0T1dSaU5pMDFabU0xT0RJMU16aGtOVFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2fc1dc150df02746b762f00d2e21908bd323972c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1eb0cccee7522d208acd539788e1cc169cbbe2bf/picture.jpg
-                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3TmpZd1lXUTRNUzB3WldJMkxUUTVOelV0T1dSaU5pMDFabU0xT0RJMU16aGtOVFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2fc1dc150df02746b762f00d2e21908bd323972c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--b9054379195e77680b08961676ba21361613fb9f/picture.jpg
-                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3TmpZd1lXUTRNUzB3WldJMkxUUTVOelV0T1dSaU5pMDFabU0xT0RJMU16aGtOVFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2fc1dc150df02746b762f00d2e21908bd323972c/picture.jpg
+                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyWkdNelpXRmhOUzFtWldWbUxUUmxOelF0T0dNME5DMDVZMlJtTm1NNE1UUTBNalVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--81b88c8dd56cef5372042ad4155acd0d00daaf1d/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyWkdNelpXRmhOUzFtWldWbUxUUmxOelF0T0dNME5DMDVZMlJtTm1NNE1UUTBNalVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--81b88c8dd56cef5372042ad4155acd0d00daaf1d/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyWkdNelpXRmhOUzFtWldWbUxUUmxOelF0T0dNME5DMDVZMlJtTm1NNE1UUTBNalVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--81b88c8dd56cef5372042ad4155acd0d00daaf1d/picture.jpg
                   relationships:
                     owner:
                       data:
-                        id: 85c34c58-5026-4c8b-b30d-3d2269da64e2
+                        id: 8577d859-3ef9-4811-b049-ad8e56ba9f29
                         type: user
-                - id: c9a25b0f-d72d-4e19-89a5-024b447b7e6e
+                - id: 20b3b755-578f-4c48-a83e-c3db758a2da1
                   type: investor
                   attributes:
                     name: Hilpert, Waters and Johnston
@@ -1473,15 +1493,15 @@ paths:
                     contact_email: contact@example.com
                     contact_phone: "+57-1-xxx-xx-xx"
                     picture:
-                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsWWpObFltUmxZaTB6TmpCbExUUXdZalF0T1RnM1lTMHlOakEwTmpWbE5EVm1abUVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--76b11d38a39145ed247ef47b20778cbc0e2f5973/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1eb0cccee7522d208acd539788e1cc169cbbe2bf/picture.jpg
-                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsWWpObFltUmxZaTB6TmpCbExUUXdZalF0T1RnM1lTMHlOakEwTmpWbE5EVm1abUVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--76b11d38a39145ed247ef47b20778cbc0e2f5973/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--b9054379195e77680b08961676ba21361613fb9f/picture.jpg
-                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsWWpObFltUmxZaTB6TmpCbExUUXdZalF0T1RnM1lTMHlOakEwTmpWbE5EVm1abUVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--76b11d38a39145ed247ef47b20778cbc0e2f5973/picture.jpg
+                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqWlRWalpqSmxNUzAwTmpjd0xUUXhNVGd0T0dZNE9DMWlZV1ptTnprd05URTNOVE1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--16c790078b5183d227922ac372d3309c7a08e044/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqWlRWalpqSmxNUzAwTmpjd0xUUXhNVGd0T0dZNE9DMWlZV1ptTnprd05URTNOVE1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--16c790078b5183d227922ac372d3309c7a08e044/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqWlRWalpqSmxNUzAwTmpjd0xUUXhNVGd0T0dZNE9DMWlZV1ptTnprd05URTNOVE1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--16c790078b5183d227922ac372d3309c7a08e044/picture.jpg
                   relationships:
                     owner:
                       data:
-                        id: 2c2fd6b3-5bde-4892-8af0-018f2c50755b
+                        id: 0de8a5f2-0b07-4a51-b8e6-ed5b79e3101e
                         type: user
-                - id: 57616995-5219-4362-8ae3-833e3a4b7e5f
+                - id: 255819df-8c3c-4754-b7e8-a3a3f8ae3f5e
                   type: investor
                   attributes:
                     name: Jacobson, Fritsch and Stanton
@@ -1523,15 +1543,15 @@ paths:
                     contact_email: contact@example.com
                     contact_phone: "+57-1-xxx-xx-xx"
                     picture:
-                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5TTJFMVptWTNNUzA0WldGakxUUXlOREV0T0RFeVlTMDBPV0V5T0RjMk1USmxORFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--9c70353347cfd8d77d5fb6fd2cddf1a53ac75473/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1eb0cccee7522d208acd539788e1cc169cbbe2bf/picture.jpg
-                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5TTJFMVptWTNNUzA0WldGakxUUXlOREV0T0RFeVlTMDBPV0V5T0RjMk1USmxORFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--9c70353347cfd8d77d5fb6fd2cddf1a53ac75473/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--b9054379195e77680b08961676ba21361613fb9f/picture.jpg
-                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5TTJFMVptWTNNUzA0WldGakxUUXlOREV0T0RFeVlTMDBPV0V5T0RjMk1USmxORFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--9c70353347cfd8d77d5fb6fd2cddf1a53ac75473/picture.jpg
+                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsT0ROalpEQTNNQzFoTnpVNUxUUTFOekV0T1RRM09DMDBZemt4WldRd056Vm1ORFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--38a1a29af79fc3fbbba40457c6391ca2ae07fb4e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsT0ROalpEQTNNQzFoTnpVNUxUUTFOekV0T1RRM09DMDBZemt4WldRd056Vm1ORFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--38a1a29af79fc3fbbba40457c6391ca2ae07fb4e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsT0ROalpEQTNNQzFoTnpVNUxUUTFOekV0T1RRM09DMDBZemt4WldRd056Vm1ORFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--38a1a29af79fc3fbbba40457c6391ca2ae07fb4e/picture.jpg
                   relationships:
                     owner:
                       data:
-                        id: 856cd857-4381-4a0e-8d66-91859dd2d959
+                        id: '08975bf8-0921-413f-ba8c-3ae817ef88c0'
                         type: user
-                - id: bc2c668d-d726-4171-a4c6-a7cc6d9cac40
+                - id: a301b16a-1603-4a2f-8af6-0bde14edb5e9
                   type: investor
                   attributes:
                     name: Keebler, Kub and Zemlak
@@ -1573,15 +1593,15 @@ paths:
                     contact_email: contact@example.com
                     contact_phone: "+57-1-xxx-xx-xx"
                     picture:
-                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWszT1dabU1HUTFZeTB6WVdOaExUUmhOMkl0T1dKbU1DMW1OVFkwTURjMU5XVXpaaklHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e44b7cc1158c302241559ad186e2fce0391c5f61/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1eb0cccee7522d208acd539788e1cc169cbbe2bf/picture.jpg
-                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWszT1dabU1HUTFZeTB6WVdOaExUUmhOMkl0T1dKbU1DMW1OVFkwTURjMU5XVXpaaklHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e44b7cc1158c302241559ad186e2fce0391c5f61/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--b9054379195e77680b08961676ba21361613fb9f/picture.jpg
-                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWszT1dabU1HUTFZeTB6WVdOaExUUmhOMkl0T1dKbU1DMW1OVFkwTURjMU5XVXpaaklHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e44b7cc1158c302241559ad186e2fce0391c5f61/picture.jpg
+                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsWmpCaU1EWXdNQzFtTmpnekxUUmtZalF0WVRsbE9TMHpPRFUzTVROa1lUTTVOV1VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--134e3d8229f05dd6720d904f8d8a3f5dd7dd96d1/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsWmpCaU1EWXdNQzFtTmpnekxUUmtZalF0WVRsbE9TMHpPRFUzTVROa1lUTTVOV1VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--134e3d8229f05dd6720d904f8d8a3f5dd7dd96d1/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsWmpCaU1EWXdNQzFtTmpnekxUUmtZalF0WVRsbE9TMHpPRFUzTVROa1lUTTVOV1VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--134e3d8229f05dd6720d904f8d8a3f5dd7dd96d1/picture.jpg
                   relationships:
                     owner:
                       data:
-                        id: f0578ab0-8d79-4e1f-a280-87ca9c9baf3f
+                        id: c5fbe2a1-f735-4fcf-8dc9-c5dcbdfa2ab0
                         type: user
-                - id: 4d79719c-9ee6-467d-a71d-8a6bef880ccc
+                - id: 6120dd4f-aed6-4e4c-9cd3-3f2955636f73
                   type: investor
                   attributes:
                     name: Becker LLC
@@ -1623,13 +1643,13 @@ paths:
                     contact_email: contact@example.com
                     contact_phone: "+57-1-xxx-xx-xx"
                     picture:
-                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WVdKbVltRTBZeTFtTUdJMkxUUTNPVFF0WVdaaE5TMHdaVGcyT0RRMk1HSTROMkVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--729865e27705935a5a2e428bb82b6ff1521e5866/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1eb0cccee7522d208acd539788e1cc169cbbe2bf/picture.jpg
-                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WVdKbVltRTBZeTFtTUdJMkxUUTNPVFF0WVdaaE5TMHdaVGcyT0RRMk1HSTROMkVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--729865e27705935a5a2e428bb82b6ff1521e5866/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--b9054379195e77680b08961676ba21361613fb9f/picture.jpg
-                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WVdKbVltRTBZeTFtTUdJMkxUUTNPVFF0WVdaaE5TMHdaVGcyT0RRMk1HSTROMkVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--729865e27705935a5a2e428bb82b6ff1521e5866/picture.jpg
+                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWszWm1RM09XRTVOeTB4TVRVekxUUmhaakl0T0RneE1TMDNNRE14WmpZME5EVTROR0lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--aa16c21b243f06c1b1bff56b39911cdd1aeebe24/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWszWm1RM09XRTVOeTB4TVRVekxUUmhaakl0T0RneE1TMDNNRE14WmpZME5EVTROR0lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--aa16c21b243f06c1b1bff56b39911cdd1aeebe24/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWszWm1RM09XRTVOeTB4TVRVekxUUmhaakl0T0RneE1TMDNNRE14WmpZME5EVTROR0lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--aa16c21b243f06c1b1bff56b39911cdd1aeebe24/picture.jpg
                   relationships:
                     owner:
                       data:
-                        id: b03dfa4b-86be-4806-8b8a-d136edef4cbe
+                        id: ab81083f-f72c-497d-904d-7c60ca9b5134
                         type: user
                 meta:
                   page: 1
@@ -1684,7 +1704,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 9316ce47-fbf9-4c46-becf-a1fc27662215
+                  id: '0590c1a1-4cbf-4cbb-8daf-62db2ce82dda'
                   type: investor
                   attributes:
                     name: Kutch-Spencer
@@ -1726,13 +1746,13 @@ paths:
                     contact_email: contact@example.com
                     contact_phone: "+57-1-xxx-xx-xx"
                     picture:
-                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0WmpFeFlUSm1aaTFtWTJRMExUUmxOekl0WW1NME5pMHhOMll4T0RRellUWm1aakFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6fb576f0c93ca67175632cbc78b56fde55f610a5/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1eb0cccee7522d208acd539788e1cc169cbbe2bf/picture.jpg
-                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0WmpFeFlUSm1aaTFtWTJRMExUUmxOekl0WW1NME5pMHhOMll4T0RRellUWm1aakFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6fb576f0c93ca67175632cbc78b56fde55f610a5/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--b9054379195e77680b08961676ba21361613fb9f/picture.jpg
-                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0WmpFeFlUSm1aaTFtWTJRMExUUmxOekl0WW1NME5pMHhOMll4T0RRellUWm1aakFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6fb576f0c93ca67175632cbc78b56fde55f610a5/picture.jpg
+                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrTXpNMk5ESXpNeTB6TnpJd0xUUTBNbVF0T1RZd1pDMDJNV05rTTJKak1EaGxabVlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--afbe3deb2e9392ac06002da5ae2ddfc2a518d170/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrTXpNMk5ESXpNeTB6TnpJd0xUUTBNbVF0T1RZd1pDMDJNV05rTTJKak1EaGxabVlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--afbe3deb2e9392ac06002da5ae2ddfc2a518d170/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrTXpNMk5ESXpNeTB6TnpJd0xUUTBNbVF0T1RZd1pDMDJNV05rTTJKak1EaGxabVlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--afbe3deb2e9392ac06002da5ae2ddfc2a518d170/picture.jpg
                   relationships:
                     owner:
                       data:
-                        id: 40d4c51e-82e0-4aa8-b9a0-ae5917cbeaed
+                        id: e4f06caa-8ec5-427f-a1c1-e043a820a09a
                         type: user
               schema:
                 type: object
@@ -1781,7 +1801,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: 3aa672fe-8020-4921-94cf-4a9999cb2a2f
+                - id: 9c3319d6-8542-4984-ae70-13fde0eb54cd
                   type: location
                   attributes:
                     name: Canada
@@ -1791,7 +1811,7 @@ paths:
                       data:
                     regions:
                       data: []
-                - id: ead5be0e-7577-4700-8040-f947bfb37236
+                - id: 19b1e998-1a31-494c-98d7-fcd06a5ae549
                   type: location
                   attributes:
                     name: Papua New Guinea
@@ -1799,11 +1819,11 @@ paths:
                   relationships:
                     parent:
                       data:
-                        id: 3aa672fe-8020-4921-94cf-4a9999cb2a2f
+                        id: 9c3319d6-8542-4984-ae70-13fde0eb54cd
                         type: location
                     regions:
                       data: []
-                - id: 27d255a1-4bc4-47a1-a19c-fc70ea1af164
+                - id: 4ee30ffa-364c-4437-96dc-022d6b6b5d64
                   type: location
                   attributes:
                     name: Jamaica
@@ -1811,13 +1831,13 @@ paths:
                   relationships:
                     parent:
                       data:
-                        id: ead5be0e-7577-4700-8040-f947bfb37236
+                        id: 19b1e998-1a31-494c-98d7-fcd06a5ae549
                         type: location
                     regions:
                       data:
-                      - id: 337a38ba-b5be-4313-a974-59c5970e7ab4
+                      - id: 2a22fe01-b0ad-41a9-8194-86ee38a1d802
                         type: location
-                - id: 337a38ba-b5be-4313-a974-59c5970e7ab4
+                - id: 2a22fe01-b0ad-41a9-8194-86ee38a1d802
                   type: location
                   attributes:
                     name: Libyan Arab Jamahiriya
@@ -1827,7 +1847,7 @@ paths:
                       data:
                     regions:
                       data: []
-                - id: 56fd3ff2-e855-4189-8293-13cb3537df6b
+                - id: 82b03ed4-fc15-40e3-9de8-3f4831158bf9
                   type: location
                   attributes:
                     name: India
@@ -1835,13 +1855,13 @@ paths:
                   relationships:
                     parent:
                       data:
-                        id: ead5be0e-7577-4700-8040-f947bfb37236
+                        id: 19b1e998-1a31-494c-98d7-fcd06a5ae549
                         type: location
                     regions:
                       data:
-                      - id: 1e2ed84a-87ad-4687-8a79-d344e8252fa8
+                      - id: 2e0abc15-8bbd-4eb9-af94-89210ff34a19
                         type: location
-                - id: 1e2ed84a-87ad-4687-8a79-d344e8252fa8
+                - id: 2e0abc15-8bbd-4eb9-af94-89210ff34a19
                   type: location
                   attributes:
                     name: Mayotte
@@ -1851,7 +1871,7 @@ paths:
                       data:
                     regions:
                       data: []
-                - id: d59b5c1e-d7b1-48f4-97be-8508c2a4afe7
+                - id: 8c3eb635-36e4-4f54-be71-42d8f2ba6ab9
                   type: location
                   attributes:
                     name: Puerto Rico
@@ -1859,13 +1879,13 @@ paths:
                   relationships:
                     parent:
                       data:
-                        id: ead5be0e-7577-4700-8040-f947bfb37236
+                        id: 19b1e998-1a31-494c-98d7-fcd06a5ae549
                         type: location
                     regions:
                       data:
-                      - id: ab5d4260-6719-442e-95a3-ad3a59655ef9
+                      - id: 16d34607-7765-488a-af28-0bc5d2b19e94
                         type: location
-                - id: ab5d4260-6719-442e-95a3-ad3a59655ef9
+                - id: 16d34607-7765-488a-af28-0bc5d2b19e94
                   type: location
                   attributes:
                     name: Sierra Leone
@@ -1919,7 +1939,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 27d255a1-4bc4-47a1-a19c-fc70ea1af164
+                  id: 4ee30ffa-364c-4437-96dc-022d6b6b5d64
                   type: location
                   attributes:
                     name: Jamaica
@@ -1927,11 +1947,11 @@ paths:
                   relationships:
                     parent:
                       data:
-                        id: ead5be0e-7577-4700-8040-f947bfb37236
+                        id: 19b1e998-1a31-494c-98d7-fcd06a5ae549
                         type: location
                     regions:
                       data:
-                      - id: 337a38ba-b5be-4313-a974-59c5970e7ab4
+                      - id: 2a22fe01-b0ad-41a9-8194-86ee38a1d802
                         type: location
               schema:
                 type: object
@@ -1993,7 +2013,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: ff1df6ad-f73a-47f3-80a3-7e830a5a5daf
+                - id: 7e4e9242-fddb-4dfb-a4bf-4f8c6ce6e396
                   type: open_call
                   attributes:
                     name: Open call 1
@@ -2010,14 +2030,14 @@ paths:
                       tempora exercitationem. Qui dolorem quo.
                     impact_description: Enim repellat pariatur. Earum modi eos. Libero
                       tempora exercitationem. Qui dolorem quo.
-                    closing_at: '2023-03-02T09:40:08.031Z'
+                    closing_at: '2023-03-02T14:48:27.067Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: 8c893d27-e359-4bc9-899a-d681d3aaa6c9
+                        id: 9ef85934-ce43-4e1a-acb5-46aae06afaf5
                         type: investor
-                - id: 2014c5fc-71c7-43bc-b0e9-c8eddbcbf0af
+                - id: 9afd2e0a-12e0-43c3-9db8-b8f220bc59f9
                   type: open_call
                   attributes:
                     name: Open call 2
@@ -2034,14 +2054,14 @@ paths:
                       Sunt commodi tempore. Voluptatem et corrupti.
                     impact_description: Placeat commodi libero. Quo recusandae repellat.
                       Sunt commodi tempore. Voluptatem et corrupti.
-                    closing_at: '2023-03-02T09:40:08.090Z'
+                    closing_at: '2023-03-02T14:48:27.136Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: 0e11d0a1-027a-4b07-b605-2ec9c78809ab
+                        id: 4c11172b-292f-4422-9219-97878db21226
                         type: investor
-                - id: 75955d63-ef0f-44df-b44b-c330969a1ffc
+                - id: b3db5ef6-cdeb-495a-aeaa-8abf9ee74581
                   type: open_call
                   attributes:
                     name: Open call 3
@@ -2058,14 +2078,14 @@ paths:
                       nesciunt voluptas. Suscipit ex cum.
                     impact_description: Et quaerat omnis. Harum voluptas atque. Quo
                       nesciunt voluptas. Suscipit ex cum.
-                    closing_at: '2023-03-02T09:40:08.133Z'
+                    closing_at: '2023-03-02T14:48:27.189Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: 353cf3b2-f292-49d9-a31f-15c3e6d72008
+                        id: f17758e5-d877-4e7f-9e5e-135a88635cc1
                         type: investor
-                - id: f4160d74-aa5f-4b10-8e6d-96c93dca7651
+                - id: 70a639c8-df3f-45aa-af0f-0418da3ca841
                   type: open_call
                   attributes:
                     name: Open call 4
@@ -2082,14 +2102,14 @@ paths:
                       Sit neque eos. Expedita molestiae quia.
                     impact_description: Dolores fugiat nesciunt. Ut laborum dolores.
                       Sit neque eos. Expedita molestiae quia.
-                    closing_at: '2023-03-02T09:40:08.187Z'
+                    closing_at: '2023-03-02T14:48:27.240Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: cf1b7518-633d-4780-ac7d-38f2f60de19d
+                        id: 579acc82-2f03-4b46-87b6-dc2ffd97cf5d
                         type: investor
-                - id: b9bb264d-3e5c-4148-9401-a41964a04add
+                - id: c8fc8940-0c5f-40d6-a7c4-d2a3a568457d
                   type: open_call
                   attributes:
                     name: Open call 5
@@ -2106,14 +2126,14 @@ paths:
                       recusandae eum. Eius ex est.
                     impact_description: Autem et et. Voluptatem neque quibusdam. Repellat
                       recusandae eum. Eius ex est.
-                    closing_at: '2023-03-02T09:40:08.249Z'
+                    closing_at: '2023-03-02T14:48:27.290Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: 5e59f787-5a2f-41fb-8a86-96c77716953f
+                        id: ce644ea1-a41f-4f80-9779-a0bb202e9b8f
                         type: investor
-                - id: 7caa7afa-8036-447b-9318-7f397b186a8c
+                - id: 26cb3e1b-19b2-4645-9982-6829e965f07c
                   type: open_call
                   attributes:
                     name: Open call 6
@@ -2130,14 +2150,14 @@ paths:
                       Eligendi sapiente voluptatem. Quas rerum officia.
                     impact_description: Porro soluta beatae. Quia ratione facilis.
                       Eligendi sapiente voluptatem. Quas rerum officia.
-                    closing_at: '2023-03-02T09:40:08.296Z'
+                    closing_at: '2023-03-02T14:48:27.346Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: 9ddb76cf-4ed6-4e63-af2b-586337f3d1b9
+                        id: 6e9076da-c79e-4d30-a7b0-61bf1e5d166c
                         type: investor
-                - id: b15a57ae-ac22-4761-b507-690037560e82
+                - id: 37054992-af48-491c-a769-388b1eba7dd9
                   type: open_call
                   attributes:
                     name: Open call 7
@@ -2154,12 +2174,12 @@ paths:
                       laudantium et. Sed recusandae aut.
                     impact_description: Mollitia aut vel. Qui illum accusantium. Et
                       laudantium et. Sed recusandae aut.
-                    closing_at: '2023-03-02T09:40:08.337Z'
+                    closing_at: '2023-03-02T14:48:27.398Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: c6efa844-419c-4f16-bd6e-8a68e535f447
+                        id: 1dd772ed-9c5c-49db-b0ed-9ee0ae520f49
                         type: investor
                 meta:
                   page: 1
@@ -2214,7 +2234,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: ff1df6ad-f73a-47f3-80a3-7e830a5a5daf
+                  id: 7e4e9242-fddb-4dfb-a4bf-4f8c6ce6e396
                   type: open_call
                   attributes:
                     name: Open call 1
@@ -2231,12 +2251,12 @@ paths:
                       tempora exercitationem. Qui dolorem quo.
                     impact_description: Enim repellat pariatur. Earum modi eos. Libero
                       tempora exercitationem. Qui dolorem quo.
-                    closing_at: '2023-03-02T09:40:08.031Z'
+                    closing_at: '2023-03-02T14:48:27.067Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: 8c893d27-e359-4bc9-899a-d681d3aaa6c9
+                        id: 9ef85934-ce43-4e1a-acb5-46aae06afaf5
                         type: investor
               schema:
                 type: object
@@ -2292,7 +2312,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: 664516fb-0457-4c68-99ae-5faef10ac350
+                - id: e086797f-7e4f-4ca0-b4a6-85f58397be68
                   type: project_developer
                   attributes:
                     name: Bartoletti and Sons
@@ -2322,22 +2342,22 @@ paths:
                     - amazon-heart
                     - amazonian-piedmont-massif
                     picture:
-                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5TVRGbFpqTTNNeTAwTVdKaExUUXhNMkl0WVdGa05TMHpNREkyT1RKaE5qa3hNR0lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4eaa7d925ad42c88e117012fe0df37e13c7a6aea/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1eb0cccee7522d208acd539788e1cc169cbbe2bf/picture.jpg
-                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5TVRGbFpqTTNNeTAwTVdKaExUUXhNMkl0WVdGa05TMHpNREkyT1RKaE5qa3hNR0lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4eaa7d925ad42c88e117012fe0df37e13c7a6aea/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--b9054379195e77680b08961676ba21361613fb9f/picture.jpg
-                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5TVRGbFpqTTNNeTAwTVdKaExUUXhNMkl0WVdGa05TMHpNREkyT1RKaE5qa3hNR0lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4eaa7d925ad42c88e117012fe0df37e13c7a6aea/picture.jpg
+                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWldVNFpUWTJaQzAyWkRWaUxUUmxZV010WWpkbFlTMWlOMlpsTWpjeE9EZGxZVGdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--be4d675d1cc2f12293bc0a79e1ead70135ce9997/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWldVNFpUWTJaQzAyWkRWaUxUUmxZV010WWpkbFlTMWlOMlpsTWpjeE9EZGxZVGdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--be4d675d1cc2f12293bc0a79e1ead70135ce9997/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWldVNFpUWTJaQzAyWkRWaUxUUmxZV010WWpkbFlTMWlOMlpsTWpjeE9EZGxZVGdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--be4d675d1cc2f12293bc0a79e1ead70135ce9997/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 55c91d6d-4f27-42fa-b70a-26de7f419f4e
+                        id: a7e0f614-e268-4950-b439-0619cf050133
                         type: user
                     projects:
                       data:
-                      - id: f1665acf-cb1d-4a6b-9591-1bc79a39d81d
+                      - id: 11685f88-483b-4231-8258-d72e0491b6cf
                         type: project
                     involved_projects:
                       data: []
-                - id: e9803a3b-e7dd-4f2d-bbd8-378cdb162c08
+                - id: 618aede7-f39d-491b-8930-93162217f60f
                   type: project_developer
                   attributes:
                     name: Hane, Lehner and Goyette
@@ -2367,22 +2387,22 @@ paths:
                     - amazon-heart
                     - amazonian-piedmont-massif
                     picture:
-                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTkRWaE5UZG1OeTA0WVdOaUxUUTJZVEl0T1RBd09TMDJaRE5oTnpZd1pEWTNNRElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--76ab8c7d2caaa237b9fe2909585383d06d4e7b12/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1eb0cccee7522d208acd539788e1cc169cbbe2bf/picture.jpg
-                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTkRWaE5UZG1OeTA0WVdOaUxUUTJZVEl0T1RBd09TMDJaRE5oTnpZd1pEWTNNRElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--76ab8c7d2caaa237b9fe2909585383d06d4e7b12/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--b9054379195e77680b08961676ba21361613fb9f/picture.jpg
-                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTkRWaE5UZG1OeTA0WVdOaUxUUTJZVEl0T1RBd09TMDJaRE5oTnpZd1pEWTNNRElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--76ab8c7d2caaa237b9fe2909585383d06d4e7b12/picture.jpg
+                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TTJRMk5ERTBZeTB6TTJaakxUUmpNV1l0T0dOak5TMHpaVFEyTmpVNU56SXhPRFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--15572ae8f80b6e546407a553d6ca85a977e11408/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TTJRMk5ERTBZeTB6TTJaakxUUmpNV1l0T0dOak5TMHpaVFEyTmpVNU56SXhPRFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--15572ae8f80b6e546407a553d6ca85a977e11408/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TTJRMk5ERTBZeTB6TTJaakxUUmpNV1l0T0dOak5TMHpaVFEyTmpVNU56SXhPRFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--15572ae8f80b6e546407a553d6ca85a977e11408/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 161f6828-2c90-4937-81e4-31c269028ee3
+                        id: 12bcb1ec-c3d6-4110-a452-26e875cd342c
                         type: user
                     projects:
                       data:
-                      - id: 91e8a372-bf23-46a0-8f98-93cfc9ffa6ae
+                      - id: b1fdd185-c81d-4cad-a2d6-1c380d61756a
                         type: project
                     involved_projects:
                       data: []
-                - id: 88e59f64-5700-454a-b0c1-9367892076e3
+                - id: b26142e4-93f1-4ec8-8394-a5db9a7fedd8
                   type: project_developer
                   attributes:
                     name: Kutch-Spencer
@@ -2411,24 +2431,24 @@ paths:
                     - amazon-heart
                     - amazonian-piedmont-massif
                     picture:
-                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WkRkalkyVmpOaTFrTTJZNExUUXhOVEl0T1RReU1TMDVNRFE0WlRJd056Rm1ORFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c79573da9e7be6b94dfc749c4e065caeb030f064/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1eb0cccee7522d208acd539788e1cc169cbbe2bf/picture.jpg
-                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WkRkalkyVmpOaTFrTTJZNExUUXhOVEl0T1RReU1TMDVNRFE0WlRJd056Rm1ORFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c79573da9e7be6b94dfc749c4e065caeb030f064/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--b9054379195e77680b08961676ba21361613fb9f/picture.jpg
-                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WkRkalkyVmpOaTFrTTJZNExUUXhOVEl0T1RReU1TMDVNRFE0WlRJd056Rm1ORFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c79573da9e7be6b94dfc749c4e065caeb030f064/picture.jpg
+                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3Wm1ObVpqazBOeTB6WkRRNUxUUXhNMkl0WWpWaE1pMHdaREZoTWpjd1ltTTROVFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--3ca5aa19c72c4ee25e9ee28d295848c2d555ad16/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3Wm1ObVpqazBOeTB6WkRRNUxUUXhNMkl0WWpWaE1pMHdaREZoTWpjd1ltTTROVFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--3ca5aa19c72c4ee25e9ee28d295848c2d555ad16/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3Wm1ObVpqazBOeTB6WkRRNUxUUXhNMkl0WWpWaE1pMHdaREZoTWpjd1ltTTROVFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--3ca5aa19c72c4ee25e9ee28d295848c2d555ad16/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 4df48a8b-56b7-4ef4-b013-0b2ce5a7c78d
+                        id: 4f9df31e-2cb2-4dc8-9d3e-b321162c517c
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data:
-                      - id: f1665acf-cb1d-4a6b-9591-1bc79a39d81d
+                      - id: 11685f88-483b-4231-8258-d72e0491b6cf
                         type: project
-                      - id: 91e8a372-bf23-46a0-8f98-93cfc9ffa6ae
+                      - id: b1fdd185-c81d-4cad-a2d6-1c380d61756a
                         type: project
-                - id: e9f93111-a599-48ff-b3b8-a6fa15aa1257
+                - id: c98196b4-fee1-4250-a0f0-8072adb2e6b8
                   type: project_developer
                   attributes:
                     name: Hilpert, Waters and Johnston
@@ -2458,20 +2478,20 @@ paths:
                     - amazon-heart
                     - amazonian-piedmont-massif
                     picture:
-                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0WVdGaVltRTBOQzA0TjJGbExUUTJNemt0WWpVd1pTMDJNR0V4WTJJeFpEYzRNelVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6255813dd4132e7f9bf14cad5658f94ad11f41db/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1eb0cccee7522d208acd539788e1cc169cbbe2bf/picture.jpg
-                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0WVdGaVltRTBOQzA0TjJGbExUUTJNemt0WWpVd1pTMDJNR0V4WTJJeFpEYzRNelVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6255813dd4132e7f9bf14cad5658f94ad11f41db/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--b9054379195e77680b08961676ba21361613fb9f/picture.jpg
-                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0WVdGaVltRTBOQzA0TjJGbExUUTJNemt0WWpVd1pTMDJNR0V4WTJJeFpEYzRNelVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6255813dd4132e7f9bf14cad5658f94ad11f41db/picture.jpg
+                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswTjJVMk9XVXdZUzFpTm1ObExUUXlZVEl0T1RnMk1pMDFabU0xWVRJeU5qTTNNMk1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--7529e5e1b2f91c2bde7e1370e77b04ee0a8401c4/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswTjJVMk9XVXdZUzFpTm1ObExUUXlZVEl0T1RnMk1pMDFabU0xWVRJeU5qTTNNMk1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--7529e5e1b2f91c2bde7e1370e77b04ee0a8401c4/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswTjJVMk9XVXdZUzFpTm1ObExUUXlZVEl0T1RnMk1pMDFabU0xWVRJeU5qTTNNMk1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--7529e5e1b2f91c2bde7e1370e77b04ee0a8401c4/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 80238252-08f4-4652-bf8e-1fd331b5ae7d
+                        id: 409f49fd-60c5-4359-859c-6032223f74fb
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data: []
-                - id: 669a6407-f5b7-4060-a30f-cf28fd7f8f02
+                - id: 23d139b1-d02d-4383-8565-05c976d1cfd8
                   type: project_developer
                   attributes:
                     name: Jacobson, Fritsch and Stanton
@@ -2501,20 +2521,20 @@ paths:
                     - amazon-heart
                     - amazonian-piedmont-massif
                     picture:
-                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyT0RKbVpUTXpZeTFqWTJVekxUUTVNamN0WWpBeVppMHpOelkwT1dVM09ESTFORGtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--dc64d3370aadbd6a0eb4c15d5b9409d7f3b0714c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1eb0cccee7522d208acd539788e1cc169cbbe2bf/picture.jpg
-                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyT0RKbVpUTXpZeTFqWTJVekxUUTVNamN0WWpBeVppMHpOelkwT1dVM09ESTFORGtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--dc64d3370aadbd6a0eb4c15d5b9409d7f3b0714c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--b9054379195e77680b08961676ba21361613fb9f/picture.jpg
-                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyT0RKbVpUTXpZeTFqWTJVekxUUTVNamN0WWpBeVppMHpOelkwT1dVM09ESTFORGtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--dc64d3370aadbd6a0eb4c15d5b9409d7f3b0714c/picture.jpg
+                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6T1RGbVpUZzFaaTFqWlRVeUxUUXlORFF0WWpGak15MDRNakl3WmpZd05EWmtZMlFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--38af5afe714847bf9881fe3fdae301d106b3295c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6T1RGbVpUZzFaaTFqWlRVeUxUUXlORFF0WWpGak15MDRNakl3WmpZd05EWmtZMlFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--38af5afe714847bf9881fe3fdae301d106b3295c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6T1RGbVpUZzFaaTFqWlRVeUxUUXlORFF0WWpGak15MDRNakl3WmpZd05EWmtZMlFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--38af5afe714847bf9881fe3fdae301d106b3295c/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 7b971fc6-c14e-461a-bcaf-3572f542a1b3
+                        id: 9d76cbe0-16ae-4458-9acc-224336682281
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data: []
-                - id: f3bb8e45-5c38-4d2d-a558-6d3744087c04
+                - id: badd36f4-4eb1-4a79-a6eb-2555d1e2439d
                   type: project_developer
                   attributes:
                     name: Keebler, Kub and Zemlak
@@ -2544,20 +2564,20 @@ paths:
                     - amazon-heart
                     - amazonian-piedmont-massif
                     picture:
-                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1WlRSaE9USXlaUzFqTVRrNUxUUmpNRFl0T0dFME1pMHdOek13WVdZeFlqZzNNREVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--bff2a87516676a990adf0aba4c0d928ea70e9f71/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1eb0cccee7522d208acd539788e1cc169cbbe2bf/picture.jpg
-                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1WlRSaE9USXlaUzFqTVRrNUxUUmpNRFl0T0dFME1pMHdOek13WVdZeFlqZzNNREVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--bff2a87516676a990adf0aba4c0d928ea70e9f71/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--b9054379195e77680b08961676ba21361613fb9f/picture.jpg
-                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1WlRSaE9USXlaUzFqTVRrNUxUUmpNRFl0T0dFME1pMHdOek13WVdZeFlqZzNNREVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--bff2a87516676a990adf0aba4c0d928ea70e9f71/picture.jpg
+                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoTWpJM1kyWXpPUzA1WkRBM0xUUm1Zemd0WW1VNE1TMWlaalUwWVdNMU1UZzRORElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--daca243c2ce1f25aa614df37c76cd7b38b029d05/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoTWpJM1kyWXpPUzA1WkRBM0xUUm1Zemd0WW1VNE1TMWlaalUwWVdNMU1UZzRORElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--daca243c2ce1f25aa614df37c76cd7b38b029d05/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoTWpJM1kyWXpPUzA1WkRBM0xUUm1Zemd0WW1VNE1TMWlaalUwWVdNMU1UZzRORElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--daca243c2ce1f25aa614df37c76cd7b38b029d05/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 97f57ce0-3eb1-420e-9bb9-7304c85c6e2c
+                        id: dece5d98-875f-494d-b9c7-e986bd90fe79
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data: []
-                - id: e9a90103-b1ab-48e7-b39b-4e3352e63a6e
+                - id: 22205b3e-73c6-4608-abd6-3f2656540d1b
                   type: project_developer
                   attributes:
                     name: Becker LLC
@@ -2587,20 +2607,20 @@ paths:
                     - amazon-heart
                     - amazonian-piedmont-massif
                     picture:
-                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTVdVME1EUXhZeTFpTnpFNUxUUTJOamt0WVdRNU1TMWpOR1U1WlRFek5UZGxPR0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c825d7c0adc3f44bb8bc7d43c5b89031d4cb1933/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1eb0cccee7522d208acd539788e1cc169cbbe2bf/picture.jpg
-                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTVdVME1EUXhZeTFpTnpFNUxUUTJOamt0WVdRNU1TMWpOR1U1WlRFek5UZGxPR0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c825d7c0adc3f44bb8bc7d43c5b89031d4cb1933/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--b9054379195e77680b08961676ba21361613fb9f/picture.jpg
-                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTVdVME1EUXhZeTFpTnpFNUxUUTJOamt0WVdRNU1TMWpOR1U1WlRFek5UZGxPR0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c825d7c0adc3f44bb8bc7d43c5b89031d4cb1933/picture.jpg
+                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTlRFeFpHWXlZeTB4WVRaa0xUUXpaR0l0WWpZME1TMHpOVFF5WXpWaE9XRmtNRFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--29a2acd792c92544ed18761f78181db5229a55e0/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTlRFeFpHWXlZeTB4WVRaa0xUUXpaR0l0WWpZME1TMHpOVFF5WXpWaE9XRmtNRFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--29a2acd792c92544ed18761f78181db5229a55e0/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTlRFeFpHWXlZeTB4WVRaa0xUUXpaR0l0WWpZME1TMHpOVFF5WXpWaE9XRmtNRFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--29a2acd792c92544ed18761f78181db5229a55e0/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: f2f19ede-39ec-452e-a710-16819418701f
+                        id: fb7b84ef-cbb4-4aa7-9dfa-20cc5aedf3ad
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data: []
-                - id: 91325487-4f1e-432d-b3f7-1fd3ff22f57e
+                - id: 79b94407-eeff-4b49-a88f-7fbc82c4714f
                   type: project_developer
                   attributes:
                     name: Runolfsson and Sons
@@ -2630,20 +2650,20 @@ paths:
                     - amazon-heart
                     - amazonian-piedmont-massif
                     picture:
-                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsT0dZNE1EazJNQzB3TkRBd0xUUTRORGd0WVdJNFpDMW1NbU5rTURJek5HTXlPR1FHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e944ffb987f5b66d3a423a8ebc575935d783c11e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1eb0cccee7522d208acd539788e1cc169cbbe2bf/picture.jpg
-                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsT0dZNE1EazJNQzB3TkRBd0xUUTRORGd0WVdJNFpDMW1NbU5rTURJek5HTXlPR1FHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e944ffb987f5b66d3a423a8ebc575935d783c11e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--b9054379195e77680b08961676ba21361613fb9f/picture.jpg
-                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsT0dZNE1EazJNQzB3TkRBd0xUUTRORGd0WVdJNFpDMW1NbU5rTURJek5HTXlPR1FHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e944ffb987f5b66d3a423a8ebc575935d783c11e/picture.jpg
+                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqWm1JM1lUVmlNeTAwTURnM0xUUTJOREF0WVRBeVpTMDNPVEU0WkdJM09HRTRPRFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0884155330e80a2809997c65a96ccc172bda47ed/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqWm1JM1lUVmlNeTAwTURnM0xUUTJOREF0WVRBeVpTMDNPVEU0WkdJM09HRTRPRFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0884155330e80a2809997c65a96ccc172bda47ed/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqWm1JM1lUVmlNeTAwTURnM0xUUTJOREF0WVRBeVpTMDNPVEU0WkdJM09HRTRPRFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0884155330e80a2809997c65a96ccc172bda47ed/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 6c7d366a-89bc-41cd-837b-6f4499f00d09
+                        id: f69437fe-d472-42aa-b354-4570c3d0703f
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data: []
-                - id: 8595a27a-783f-4217-af82-174b017a7296
+                - id: 174300f1-06d1-45db-a30d-0053640f1867
                   type: project_developer
                   attributes:
                     name: Ritchie, Glover and Ward
@@ -2673,14 +2693,14 @@ paths:
                     - amazon-heart
                     - amazonian-piedmont-massif
                     picture:
-                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqT1RZMU5ETXpPUzFpWWpObUxUUTFPVEV0WVRJM015MWxOemM0TmpJNFpqQXdObU1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4624d9ebf03740e3098d6007bc54bde2e0f942cb/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1eb0cccee7522d208acd539788e1cc169cbbe2bf/picture.jpg
-                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqT1RZMU5ETXpPUzFpWWpObUxUUTFPVEV0WVRJM015MWxOemM0TmpJNFpqQXdObU1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4624d9ebf03740e3098d6007bc54bde2e0f942cb/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--b9054379195e77680b08961676ba21361613fb9f/picture.jpg
-                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqT1RZMU5ETXpPUzFpWWpObUxUUTFPVEV0WVRJM015MWxOemM0TmpJNFpqQXdObU1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4624d9ebf03740e3098d6007bc54bde2e0f942cb/picture.jpg
+                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyWVdNM09ERmhOeTA1TXpreUxUUm1NakV0WWpNMU9TMHdObVEyT0RNd05qQm1OVGdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--1ab08bcb8070c290295eb46e2e40d603091dd78a/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyWVdNM09ERmhOeTA1TXpreUxUUm1NakV0WWpNMU9TMHdObVEyT0RNd05qQm1OVGdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--1ab08bcb8070c290295eb46e2e40d603091dd78a/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyWVdNM09ERmhOeTA1TXpreUxUUm1NakV0WWpNMU9TMHdObVEyT0RNd05qQm1OVGdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--1ab08bcb8070c290295eb46e2e40d603091dd78a/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 47009779-89a4-4faf-a13c-62ab4a04bc63
+                        id: 0b8269cb-eadb-41d3-84f4-5969a8263332
                         type: user
                     projects:
                       data: []
@@ -2745,7 +2765,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 88e59f64-5700-454a-b0c1-9367892076e3
+                  id: b26142e4-93f1-4ec8-8394-a5db9a7fedd8
                   type: project_developer
                   attributes:
                     name: Kutch-Spencer
@@ -2774,22 +2794,22 @@ paths:
                     - amazon-heart
                     - amazonian-piedmont-massif
                     picture:
-                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WkRkalkyVmpOaTFrTTJZNExUUXhOVEl0T1RReU1TMDVNRFE0WlRJd056Rm1ORFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c79573da9e7be6b94dfc749c4e065caeb030f064/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1eb0cccee7522d208acd539788e1cc169cbbe2bf/picture.jpg
-                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WkRkalkyVmpOaTFrTTJZNExUUXhOVEl0T1RReU1TMDVNRFE0WlRJd056Rm1ORFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c79573da9e7be6b94dfc749c4e065caeb030f064/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--b9054379195e77680b08961676ba21361613fb9f/picture.jpg
-                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WkRkalkyVmpOaTFrTTJZNExUUXhOVEl0T1RReU1TMDVNRFE0WlRJd056Rm1ORFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c79573da9e7be6b94dfc749c4e065caeb030f064/picture.jpg
+                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3Wm1ObVpqazBOeTB6WkRRNUxUUXhNMkl0WWpWaE1pMHdaREZoTWpjd1ltTTROVFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--3ca5aa19c72c4ee25e9ee28d295848c2d555ad16/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3Wm1ObVpqazBOeTB6WkRRNUxUUXhNMkl0WWpWaE1pMHdaREZoTWpjd1ltTTROVFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--3ca5aa19c72c4ee25e9ee28d295848c2d555ad16/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3Wm1ObVpqazBOeTB6WkRRNUxUUXhNMkl0WWpWaE1pMHdaREZoTWpjd1ltTTROVFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--3ca5aa19c72c4ee25e9ee28d295848c2d555ad16/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 4df48a8b-56b7-4ef4-b013-0b2ce5a7c78d
+                        id: 4f9df31e-2cb2-4dc8-9d3e-b321162c517c
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data:
-                      - id: f1665acf-cb1d-4a6b-9591-1bc79a39d81d
+                      - id: 11685f88-483b-4231-8258-d72e0491b6cf
                         type: project
-                      - id: 91e8a372-bf23-46a0-8f98-93cfc9ffa6ae
+                      - id: b1fdd185-c81d-4cad-a2d6-1c380d61756a
                         type: project
               schema:
                 type: object
@@ -2863,7 +2883,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: ae869cab-0eb4-444a-8f38-d3c1ca330ab2
+                - id: b442fdbf-84db-4a8f-ad70-ebfb247c0f2e
                   type: project
                   attributes:
                     name: Project 1
@@ -2915,21 +2935,21 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: fa08de23-486a-4be3-bff0-5906a95b94a7
+                        id: 1372c7ba-e32e-4368-a02e-7e6a9cb1252d
                         type: project_developer
                     involved_project_developers:
                       data:
-                      - id: 0a4e1fc7-0af3-4927-931a-ec9fbb3b8ee9
+                      - id: 74ef4ee5-1e0d-45ef-bea1-ff4e588cf327
                         type: project_developer
-                      - id: 7cc60139-649e-4aa9-b6af-b13940366a06
+                      - id: 6911ebb0-3f3c-4936-8f59-83de1bdff230
                         type: project_developer
                     project_images:
                       data:
-                      - id: 427ade5d-d124-442b-a509-0f1a4e0265e0
+                      - id: 151ceb92-12f0-4a91-b8e3-c024bebd4b8e
                         type: project_image
-                      - id: 15d02102-b8d3-46ec-ba0a-fbfb09b792f0
+                      - id: 5090ce67-1a83-4483-8515-b74180e83b4c
                         type: project_image
-                - id: b5504080-ca46-44b0-a54d-88bcca95af09
+                - id: 24b11a1c-d7c2-4852-8747-28d39a5af3a5
                   type: project
                   attributes:
                     name: Project 2
@@ -2981,13 +3001,13 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 26e31caf-e2d3-4355-9c0e-7259457f44cb
+                        id: 79b8e31a-ca92-4868-99d7-0d4be999a636
                         type: project_developer
                     involved_project_developers:
                       data: []
                     project_images:
                       data: []
-                - id: b4a9416b-31e4-4712-a9bd-befdd04213eb
+                - id: 45c9ce27-725b-4e35-a5ea-bd24ed34b02f
                   type: project
                   attributes:
                     name: Project 3
@@ -3039,13 +3059,13 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 5f76438f-4b49-490c-961c-3518e47a9da6
+                        id: a9cdaba4-c06f-4dab-94c2-f08938cd726d
                         type: project_developer
                     involved_project_developers:
                       data: []
                     project_images:
                       data: []
-                - id: a345c8b1-f290-404f-9fb6-853fb08a75ea
+                - id: 0ed8e118-06ea-4ba3-8636-83e915018a56
                   type: project
                   attributes:
                     name: Project 4
@@ -3097,13 +3117,13 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 22385e0b-aea2-40c0-98cf-9216fd8e7196
+                        id: e7e6a862-edae-4a53-8ea9-05a9f369b6d3
                         type: project_developer
                     involved_project_developers:
                       data: []
                     project_images:
                       data: []
-                - id: 7805c9fe-5fcc-4949-82c9-5cca6f8d95dd
+                - id: e106a1e1-1696-4f71-bf4c-896a3ed44b78
                   type: project
                   attributes:
                     name: Project 5
@@ -3155,13 +3175,13 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: f176e3cd-43cf-485b-8325-b8a51334b20f
+                        id: b7d023b3-91f7-4b5a-98e0-3e513e43369d
                         type: project_developer
                     involved_project_developers:
                       data: []
                     project_images:
                       data: []
-                - id: 0ec027fc-301c-43ec-8ea5-de62e59379c9
+                - id: '090f8f50-42f6-4320-8896-94b3b4b6f75b'
                   type: project
                   attributes:
                     name: Project 6
@@ -3213,13 +3233,13 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: ae876ee4-2269-49ad-b366-53cc04a001c8
+                        id: 2b8fec2d-4e53-4f30-92ba-74f3faf78e12
                         type: project_developer
                     involved_project_developers:
                       data: []
                     project_images:
                       data: []
-                - id: b3047162-4f1b-4625-8fee-3ff407f31527
+                - id: 5863f3b3-909a-4fab-b566-02634e32ca8e
                   type: project
                   attributes:
                     name: Project 7
@@ -3271,7 +3291,7 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: a666bab3-84ee-410c-8436-49913d31a56f
+                        id: 384c4ea4-160e-4f95-843c-bebc064747e9
                         type: project_developer
                     involved_project_developers:
                       data: []
@@ -3336,7 +3356,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: ae869cab-0eb4-444a-8f38-d3c1ca330ab2
+                  id: b442fdbf-84db-4a8f-ad70-ebfb247c0f2e
                   type: project
                   attributes:
                     name: Project 1
@@ -3388,19 +3408,19 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: fa08de23-486a-4be3-bff0-5906a95b94a7
+                        id: 1372c7ba-e32e-4368-a02e-7e6a9cb1252d
                         type: project_developer
                     involved_project_developers:
                       data:
-                      - id: 0a4e1fc7-0af3-4927-931a-ec9fbb3b8ee9
+                      - id: 74ef4ee5-1e0d-45ef-bea1-ff4e588cf327
                         type: project_developer
-                      - id: 7cc60139-649e-4aa9-b6af-b13940366a06
+                      - id: 6911ebb0-3f3c-4936-8f59-83de1bdff230
                         type: project_developer
                     project_images:
                       data:
-                      - id: 427ade5d-d124-442b-a509-0f1a4e0265e0
+                      - id: 151ceb92-12f0-4a91-b8e3-c024bebd4b8e
                         type: project_image
-                      - id: 15d02102-b8d3-46ec-ba0a-fbfb09b792f0
+                      - id: 5090ce67-1a83-4483-8515-b74180e83b4c
                         type: project_image
               schema:
                 type: object
@@ -3442,7 +3462,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: bc2546e9-a5ab-45c6-91d9-8c5e5fd0d53d
+                  id: 2f155b38-df29-4551-a763-0d889dd91154
                   type: user
                   attributes:
                     first_name: Dawna
@@ -3490,7 +3510,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 4cf7b0dc-3156-40e9-aadb-a0a8bb730757
+                  id: 41c91adb-a187-4dc3-9889-023dfb687b13
                   type: user
                   attributes:
                     first_name: Dawna
@@ -3617,7 +3637,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: c6dd916b-e37e-4071-840e-b2491c00c4f2
+                  id: '02853f85-b07a-44c0-a051-31b21caa7e0c'
                   type: user
                   attributes:
                     first_name: Jan
@@ -3688,7 +3708,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: fb5cea7b-500a-482a-b368-eae460352b81
+                  id: f8bf109c-0dd1-4816-8c70-08781019ae85
                   type: user
                   attributes:
                     first_name: Dawna
@@ -3724,19 +3744,19 @@ paths:
           content:
             application/json:
               example:
-                id: 8ac63249-4063-4eb4-b3fc-d0c68bdb5fb0
-                key: rorg79cm5xi7mr8vh7enqb2piqr1
+                id: ba88a398-d64a-463c-8458-f26b06231c44
+                key: 82hm6rbbim83wl2ioauo8pgdqx89
                 filename: test.jpg
                 content_type: image/jpeg
                 metadata: {}
                 service_name: test
                 byte_size: 32326
                 checksum: QYeLAwqIj9HrwITqtTYaEw==
-                created_at: '2022-05-02T09:40:11.830Z'
-                signed_id: eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0WVdNMk16STBPUzAwTURZekxUUmxZalF0WWpObVl5MWtNR00yT0dKa1lqVm1ZakFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--8d4f417e75d37db40a5267679074313755846590
-                attachable_sgid: BAh7CEkiCGdpZAY6BkVUSSJWZ2lkOi8vYmFja2VuZC9BY3RpdmVTdG9yYWdlOjpCbG9iLzhhYzYzMjQ5LTQwNjMtNGViNC1iM2ZjLWQwYzY4YmRiNWZiMD9leHBpcmVzX2luBjsAVEkiDHB1cnBvc2UGOwBUSSIPYXR0YWNoYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--92305e1acb52f5c4c95ee9fe3e6e3e4e3bc5870a
+                created_at: '2022-05-02T14:48:31.952Z'
+                signed_id: eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpWVRnNFlUTTVPQzFrTmpSaExUUTJNMk10T0RRMU9DMW1NalppTURZeU16RmpORFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--b658153dda5aca99d9cd14ce7312731205deea18
+                attachable_sgid: BAh7CEkiCGdpZAY6BkVUSSJWZ2lkOi8vYmFja2VuZC9BY3RpdmVTdG9yYWdlOjpCbG9iL2JhODhhMzk4LWQ2NGEtNDYzYy04NDU4LWYyNmIwNjIzMWM0ND9leHBpcmVzX2luBjsAVEkiDHB1cnBvc2UGOwBUSSIPYXR0YWNoYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--a85116396eeb96b119d4a69a8bcb452206a1366b
                 direct_upload:
-                  url: http://www.example.com/backend/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDam9JYTJWNVNTSWhjbTl5WnpjNVkyMDFlR2szYlhJNGRtZzNaVzV4WWpKd2FYRnlNUVk2QmtWVU9oRmpiMjUwWlc1MFgzUjVjR1ZKSWc5cGJXRm5aUzlxY0dWbkJqc0dWRG9UWTI5dWRHVnVkRjlzWlc1bmRHaHBBa1orT2cxamFHVmphM04xYlVraUhWRlpaVXhCZDNGSmFqbEljbmRKVkhGMFZGbGhSWGM5UFFZN0JsUTZFWE5sY25acFkyVmZibUZ0WlRvSmRHVnpkQT09IiwiZXhwIjoiMjAyMi0wNS0wMlQwOTo0NToxMS44MzNaIiwicHVyIjoiYmxvYl90b2tlbiJ9fQ==--b8b718c0690b6fa19859527af2ad0cd11806d5ad
+                  url: http://www.example.com/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDam9JYTJWNVNTSWhPREpvYlRaeVltSnBiVGd6ZDJ3eWFXOWhkVzg0Y0dka2NYZzRPUVk2QmtWVU9oRmpiMjUwWlc1MFgzUjVjR1ZKSWc5cGJXRm5aUzlxY0dWbkJqc0dWRG9UWTI5dWRHVnVkRjlzWlc1bmRHaHBBa1orT2cxamFHVmphM04xYlVraUhWRlpaVXhCZDNGSmFqbEljbmRKVkhGMFZGbGhSWGM5UFFZN0JsUTZFWE5sY25acFkyVmZibUZ0WlRvSmRHVnpkQT09IiwiZXhwIjoiMjAyMi0wNS0wMlQxNDo1MzozMS45NTZaIiwicHVyIjoiYmxvYl90b2tlbiJ9fQ==--b42994ec18a2e3042b8e3186e3cb6d5c137d1f06
                   headers:
                     Content-Type: image/jpeg
               schema:


### PR DESCRIPTION
Rswag has issue to properly setup content type to `application/json` if there is no schema defined at all. This PR adds empty schema to appropriate endpoints so rswag uses correct content type even in this case.