### PR TITLE
Add breadcrumbs component to Project/Project Developer/Investor pages

### DIFF
--- a/frontend/.storybook/preview.js
+++ b/frontend/.storybook/preview.js
@@ -3,6 +3,8 @@ import React from 'react';
 import { OverlayProvider } from '@react-aria/overlays';
 import { QueryClient, QueryClientProvider } from 'react-query';
 
+import { RouterContext } from 'next/dist/shared/lib/router-context';
+
 import { SSRProvider } from '@react-aria/ssr';
 import { reactIntl, localesNames } from './react-intl.js';
 import '../styles/globals.css';
@@ -20,6 +22,7 @@ export const parameters = {
       ],
     },
   },
+  nextRouter: { Provider: RouterContext.Provider },
   reactIntl,
   locale: reactIntl.defaultLocale,
   locales: localesNames,

--- a/frontend/containers/breadcrumbs/component.stories.tsx
+++ b/frontend/containers/breadcrumbs/component.stories.tsx
@@ -1,0 +1,78 @@
+import { Story, Meta } from '@storybook/react/types-6-0';
+
+import Breadcrumbs, { BreadcrumbsProps } from '.';
+
+export default {
+  component: Breadcrumbs,
+  title: 'Containers/Breadcrumbs',
+  argTypes: {},
+} as Meta;
+
+const Template: Story<BreadcrumbsProps> = ({ ...props }: BreadcrumbsProps) => (
+  <Breadcrumbs {...props} />
+);
+
+export const Default: Story<BreadcrumbsProps> = Template.bind({});
+
+Default.args = {};
+
+Default.story = {
+  parameters: {
+    nextRouter: {
+      route: '/project/about/new',
+      asPath: '/project/about/new',
+    },
+  },
+};
+
+export const DynamicUrl: Story<BreadcrumbsProps> = Template.bind({});
+
+DynamicUrl.args = {
+  substitutions: {
+    id: { name: 'HeCo project' },
+  },
+};
+
+DynamicUrl.story = {
+  parameters: {
+    nextRouter: {
+      route: '/project-developer/[id]',
+      asPath: '/project-developer/pd-slug',
+      query: {
+        id: 'pd-slug',
+      },
+    },
+  },
+};
+
+export const Substitutions: Story<BreadcrumbsProps> = Template.bind({});
+
+Substitutions.args = {
+  substitutions: {
+    platform: { name: 'HeCo project' },
+    about: { link: 'http://www.example.com' },
+    'our-work': { name: 'Substituted name' },
+  },
+};
+
+Substitutions.story = {
+  parameters: {
+    nextRouter: {
+      route: '/platform/about/our-work',
+      asPath: '/platform/about/our-work',
+    },
+  },
+};
+
+export const PrettyNames: Story<BreadcrumbsProps> = Template.bind({});
+
+PrettyNames.args = {};
+
+PrettyNames.story = {
+  parameters: {
+    nextRouter: {
+      route: '/about-us/our-work/blog',
+      asPath: '/about-us/our-work/blog',
+    },
+  },
+};

--- a/frontend/containers/breadcrumbs/component.tsx
+++ b/frontend/containers/breadcrumbs/component.tsx
@@ -2,6 +2,8 @@ import { FC } from 'react';
 
 import { useIntl } from 'react-intl';
 
+import cx from 'classnames';
+
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 
@@ -83,26 +85,38 @@ export const Breadcrumbs: FC<BreadcrumbsProps> = ({
   }, []);
 
   return (
-    <div className={className}>
-      <div className="flex gap-3 text-sm text-gray-400">
+    <nav
+      className={className}
+      aria-label={intl.formatMessage({ defaultMessage: 'Breadcrumbs', id: 'ByoZDD' })}
+    >
+      <ol className="flex gap-3 text-sm text-gray-400">
         {breadcrumbs.map(({ name, link }, index) => {
           const isLastBreadcrumb = index === breadcrumbs.length - 1;
 
-          return isLastBreadcrumb ? (
-            <span key={`separator-${index}`} className="text-black">
-              {name}
-            </span>
-          ) : (
-            <>
+          return (
+            <li key={name}>
               <Link key={link} href={link}>
-                <a>{name}</a>
+                <a
+                  className={cx({
+                    'transition-all rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-dark':
+                      true,
+                    'text-black cursor-pointer': isLastBreadcrumb,
+                  })}
+                  aria-current={isLastBreadcrumb ? 'location' : false}
+                >
+                  {name}
+                </a>
               </Link>
-              <span>/</span>
-            </>
+              {!isLastBreadcrumb && (
+                <span aria-hidden="true" className="ml-3">
+                  /
+                </span>
+              )}
+            </li>
           );
         })}
-      </div>
-    </div>
+      </ol>
+    </nav>
   );
 };
 

--- a/frontend/containers/breadcrumbs/component.tsx
+++ b/frontend/containers/breadcrumbs/component.tsx
@@ -1,0 +1,109 @@
+import { FC } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+import { Paths } from 'enums';
+
+import type { BreadcrumbsProps } from './types';
+
+export const Breadcrumbs: FC<BreadcrumbsProps> = ({
+  className,
+  substitutions: propSubstitutions = {},
+}: BreadcrumbsProps) => {
+  const intl = useIntl();
+  const { route, asPath } = useRouter();
+
+  // Predefined substitutions for this project. Ideally this would live in a constants file,
+  // but due to the need to use `react-intl` they're kept here.
+  const substitutions = {
+    'project-developer': {
+      name: intl.formatMessage({ defaultMessage: 'Project Developers', id: '+K9fF0' }),
+      link: Paths.ProjectDevelopers,
+    },
+    project: {
+      name: intl.formatMessage({ defaultMessage: 'Projects', id: 'UxTJRa' }),
+      link: Paths.Projects,
+    },
+    'open-call': {
+      name: intl.formatMessage({ defaultMessage: 'Open Calls', id: 'wpyHb9' }),
+      link: Paths.OpenCalls,
+    },
+    investor: {
+      name: intl.formatMessage({ defaultMessage: 'Investors', id: 'zdIaHp' }),
+      link: Paths.Investors,
+    },
+  };
+
+  const routeSegments = route.split('/').slice(1);
+  const pathSegments = asPath.split('/').slice(1);
+
+  const nameFromPathname = (text: string) =>
+    text
+      .replace(/(-|_)/, ' ') // Change Dashes and Underscores into spaces
+      .split(' ') // Split into an array of words
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1)) // Uppercase words' first letters
+      .join(' '); // Join back into a string
+
+  const breadcrumbs = routeSegments.reduce((acc, segment, index) => {
+    // Detect whether a route/path segment is for a dynamic route and extract the [param].
+    const match = /^\[(.*)\]$/.exec(segment);
+    const query = match && match[1];
+
+    // Figuring out the name to display on the breadcrumb
+    const name =
+      // Name passed as a substitution via prop
+      propSubstitutions[query]?.name ||
+      propSubstitutions[segment]?.name ||
+      // or name defined in the internal substitutions
+      substitutions[segment]?.name ||
+      // or as a fallback, we'll use the query or, if none, the route segment itself
+      nameFromPathname(query || segment);
+
+    // path is only used in this reducer to automatically build links
+    const lastPath = acc.length ? acc[acc.length - 1].path : '';
+    const path = `${lastPath}/${pathSegments[index]}`;
+
+    // Use the path as a link unless a link unless one has been specified in the substitutions
+    // Figuring out the link the breadcrumb should link to
+    const link =
+      // Link passed as a substitution via prop
+      propSubstitutions[query]?.link ||
+      propSubstitutions[segment]?.link ||
+      // or link defined in the internal substitutions
+      substitutions[segment]?.link ||
+      // or as a fallback, we'll use the path
+      path;
+
+    acc.push({ name, path, link });
+
+    return acc;
+  }, []);
+
+  return (
+    <div className={className}>
+      <div className="flex gap-3 text-sm text-gray-400">
+        {breadcrumbs.map(({ name, link }, index) => {
+          const isLastBreadcrumb = index === breadcrumbs.length - 1;
+
+          return isLastBreadcrumb ? (
+            <span key={`separator-${index}`} className="text-black">
+              {name}
+            </span>
+          ) : (
+            <>
+              <Link key={link} href={link}>
+                <a>{name}</a>
+              </Link>
+              <span>/</span>
+            </>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default Breadcrumbs;

--- a/frontend/containers/breadcrumbs/component.tsx
+++ b/frontend/containers/breadcrumbs/component.tsx
@@ -39,50 +39,55 @@ export const Breadcrumbs: FC<BreadcrumbsProps> = ({
     },
   };
 
-  const routeSegments = route.split('/').slice(1);
-  const pathSegments = asPath.split('/').slice(1);
+  const routeSegments: string[] = route.split('/').slice(1);
+  const pathSegments: string[] = asPath.split('/').slice(1);
 
-  const nameFromPathname = (text: string) =>
+  const nameFromPathname = (text: string): string =>
     text
       .replace(/(-|_)/, ' ') // Change Dashes and Underscores into spaces
       .split(' ') // Split into an array of words
       .map((word) => word.charAt(0).toUpperCase() + word.slice(1)) // Uppercase words' first letters
       .join(' '); // Join back into a string
 
-  const breadcrumbs = routeSegments.reduce((acc, segment, index) => {
-    // Detect whether a route/path segment is for a dynamic route and extract the [param].
-    const match = /^\[(.*)\]$/.exec(segment);
-    const query = match && match[1];
+  const breadcrumbs: {
+    name: string;
+    link: string;
+  }[] = routeSegments
+    .reduce((acc, segment, index) => {
+      // Detect whether a route/path segment is for a dynamic route and extract the [param].
+      const match: RegExpExecArray = /^\[(.*)\]$/.exec(segment);
+      const query: string = match && match[1];
 
-    // Figuring out the name to display on the breadcrumb
-    const name =
-      // Name passed as a substitution via prop
-      propSubstitutions[query]?.name ||
-      propSubstitutions[segment]?.name ||
-      // or name defined in the internal substitutions
-      substitutions[segment]?.name ||
-      // or as a fallback, we'll use the query or, if none, the route segment itself
-      nameFromPathname(query || segment);
+      // Figuring out the name to display on the breadcrumb
+      const name: string =
+        // Name passed as a substitution via prop
+        propSubstitutions[query]?.name ||
+        propSubstitutions[segment]?.name ||
+        // or name defined in the internal substitutions
+        substitutions[segment]?.name ||
+        // or as a fallback, we'll use the query or, if none, the route segment itself
+        nameFromPathname(query || segment);
 
-    // path is only used in this reducer to automatically build links
-    const lastPath = acc.length ? acc[acc.length - 1].path : '';
-    const path = `${lastPath}/${pathSegments[index]}`;
+      // path is only used in this reducer to automatically build links
+      const lastPath: string = acc.length ? acc[acc.length - 1].path : '';
+      const path: string = `${lastPath}/${pathSegments[index]}`;
 
-    // Use the path as a link unless a link unless one has been specified in the substitutions
-    // Figuring out the link the breadcrumb should link to
-    const link =
-      // Link passed as a substitution via prop
-      propSubstitutions[query]?.link ||
-      propSubstitutions[segment]?.link ||
-      // or link defined in the internal substitutions
-      substitutions[segment]?.link ||
-      // or as a fallback, we'll use the path
-      path;
+      // Use the path as a link unless a link unless one has been specified in the substitutions
+      // Figuring out the link the breadcrumb should link to
+      const link: string =
+        // Link passed as a substitution via prop
+        propSubstitutions[query]?.link ||
+        propSubstitutions[segment]?.link ||
+        // or link defined in the internal substitutions
+        substitutions[segment]?.link ||
+        // or as a fallback, we'll use the path
+        path;
 
-    acc.push({ name, path, link });
+      acc.push({ name, path, link });
 
-    return acc;
-  }, []);
+      return acc;
+    }, [])
+    .map(({ name, link }) => ({ name, link }));
 
   return (
     <nav

--- a/frontend/containers/breadcrumbs/index.ts
+++ b/frontend/containers/breadcrumbs/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { BreadcrumbsProps } from './types';

--- a/frontend/containers/breadcrumbs/types.ts
+++ b/frontend/containers/breadcrumbs/types.ts
@@ -1,0 +1,19 @@
+export type BreadcrumbsProps = {
+  /** Classes to apply to the container */
+  className?: string;
+  /**
+   * Name/Link substitutions to make on the route segments
+   * Eg:
+   *  {
+   *    id: 'Project name'
+   *    'about-project': { name: 'Custom vreadcrumb name', link: 'http://www.example.com' }
+   *  }
+   **/
+  substitutions?: Record<
+    string,
+    {
+      name?: string;
+      link?: string;
+    }
+  >;
+};

--- a/frontend/enums/index.ts
+++ b/frontend/enums/index.ts
@@ -14,7 +14,14 @@ export enum Paths {
   SignOut = '/sign-out',
   Settings = '/settings',
   Project = '/project',
+  Projects = '/search/projects',
   ProjectCreation = '/projects/new',
+  ProjectDeveloper = '/project-developer',
+  ProjectDevelopers = '/search/project-developers',
+  OpenCall = '/open-call',
+  OpenCalls = '/search/open-calls',
+  Investor = '/investor',
+  Investors = '/search/investors',
 }
 
 export enum UserRoles {

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -1,4 +1,7 @@
 {
+  "+K9fF0": {
+    "string": "Project Developers"
+  },
   "+mzZak": {
     "string": "About {name}"
   },
@@ -292,6 +295,9 @@
   },
   "EwRIOm": {
     "string": "User"
+  },
+  "F++AYx": {
+    "string": "Something went wrong with the picture upload"
   },
   "F1+h/t": {
     "string": "For project developers"
@@ -986,6 +992,9 @@
   },
   "wkkhPR": {
     "string": "See project developer profile"
+  },
+  "wpyHb9": {
+    "string": "Open Calls"
   },
   "wvoA3H": {
     "string": "Picture"

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -248,6 +248,9 @@
   "BkLlj6": {
     "string": "What’s the impact of your project and what do you want to achieve"
   },
+  "ByoZDD": {
+    "string": "Breadcrumbs"
+  },
   "C0sD76": {
     "string": "insert number (max 24)"
   },

--- a/frontend/pages/investor/[id]/index.tsx
+++ b/frontend/pages/investor/[id]/index.tsx
@@ -3,6 +3,7 @@ import { useIntl, FormattedMessage } from 'react-intl';
 
 import { loadI18nMessages } from 'helpers/i18n';
 
+import Breadcrumbs from 'containers/breadcrumbs';
 import ProfileHeader from 'containers/profile-header';
 import SDGs from 'containers/sdgs';
 import { SocialType } from 'containers/social-contact/website-social-contact';
@@ -89,8 +90,16 @@ const InvestorPage: PageComponent<{}, StaticPageLayoutProps> = (props) => {
     <>
       <Head title={`${aboutInfo.name} - ${aboutInfo.description}`} description={aboutInfo.text} />
 
-      <LayoutContainer className="-mt-10 lg:-mt-16">
+      <LayoutContainer className="-mt-10 md:mt-0 lg:-mt-16">
+        <Breadcrumbs
+          className="px-4 sm:px-6 lg:px-8"
+          substitutions={{
+            id: { name: aboutInfo.name },
+          }}
+        />
+
         <ProfileHeader
+          className="mt-6"
           logo={aboutInfo.logo}
           title={aboutInfo.name}
           subtitle={aboutInfo.description}

--- a/frontend/pages/project-developer/[id]/index.tsx
+++ b/frontend/pages/project-developer/[id]/index.tsx
@@ -1,5 +1,3 @@
-import { useMemo } from 'react';
-
 import { FormattedMessage } from 'react-intl';
 
 import { decycle } from 'cycle';
@@ -7,6 +5,7 @@ import { chunk, groupBy } from 'lodash-es';
 
 import { loadI18nMessages } from 'helpers/i18n';
 
+import Breadcrumbs from 'containers/breadcrumbs';
 import ProfileHeader from 'containers/profile-header';
 import ProjectCard from 'containers/project-card';
 import { SOCIAL_DATA } from 'containers/social-contact/constants';
@@ -111,8 +110,15 @@ const ProjectDeveloperPage: PageComponent<ProjectDeveloperPageProps, StaticPageL
         description={projectDeveloper.about}
       />
 
-      <LayoutContainer className="-mt-10 lg:-mt-16">
+      <LayoutContainer className="-mt-10 md:mt-0 lg:-mt-16">
+        <Breadcrumbs
+          className="px-4 sm:px-6 lg:px-8"
+          substitutions={{
+            id: { name: projectDeveloper.name },
+          }}
+        />
         <ProfileHeader
+          className="mt-6"
           logo={projectDeveloper.picture.medium}
           title={projectDeveloper.name}
           subtitle={projectDeveloperTypeName}

--- a/frontend/pages/project/[id]/index.tsx
+++ b/frontend/pages/project/[id]/index.tsx
@@ -2,6 +2,8 @@ import { groupBy } from 'lodash-es';
 
 import { loadI18nMessages } from 'helpers/i18n';
 
+import Breadcrumbs from 'containers/breadcrumbs';
+
 import Head from 'components/head';
 import LayoutContainer from 'components/layout-container';
 import { StaticPageLayoutProps } from 'layouts/static-page';
@@ -47,7 +49,13 @@ const ProjectPage: PageComponent<ProjectPageProps, StaticPageLayoutProps> = ({
     <>
       <Head title={project.name} description={project.description} />
 
-      <LayoutContainer className="-mt-10 lg:-mt-16">
+      <LayoutContainer className="-mt-10 md:mt-0 lg:-mt-16">
+        <Breadcrumbs
+          className="px-4 sm:px-6 lg:px-8"
+          substitutions={{
+            id: { name: project.name },
+          }}
+        />
         {/*<ProjectHeader/>*/} ProjectHeader
       </LayoutContainer>
 


### PR DESCRIPTION
This PR adds a "simple" breadcrumbs component, to be use in the PD, Project, Investor, Open Call public pages. 

It's very project specific but although the breadcrumbs are generated almost automatically (just needs the name of the PD/Project/etc passed via prop), it still retains enough flexibility to be used in other ways, if required. Examples can be found in Storybook. 

They're also accessible, following the description/examples found [here](https://www.aditus.io/patterns/breadcrumbs/).

**In this PR:**  
- Added a `containers/Breadcrumbs` component  
- Set up the new component in the Project Developer, Project, Investor pages. 

**Note:**  
The breadcrumbs suggest that, for instance when viewing a Project page, that there is a link to an index of Project pages. I hardcoded links to a `/search/projects` page and so on, just for example/testing purposes. We will need to adjust these links as the respective search pages are created. 

Fallbacks for when the substitution/name for a dynamic url param hasn't been passed have been implemented to avoid development errors; the component can infer the breadcrumb name based on the route path segments. 

## Testing instructions

Open _a_ Project Developer, Project, Investor page and verify that the breadcrumbs show correctly. 

## Tracking

[LET-341](https://vizzuality.atlassian.net/browse/LET-341)

## Screenshot
<img width="1679" alt="Screenshot 2022-05-04 at 16 56 11" src="https://user-images.githubusercontent.com/6273795/166721665-5a2f48eb-ac62-4921-97b3-7f6857844ccb.png">

