### PR TITLE
feature: project creation form/add field errors from the API

### DIFF
--- a/frontend/helpers/pages.ts
+++ b/frontend/helpers/pages.ts
@@ -15,7 +15,7 @@ export function getServiceErrors<FormValues>(
     : [error.message];
 
   let errorPages: number[] = [];
-  const fieldErrors: Path<FormValues>[] = [];
+  const fieldErrors: { fieldName: Path<FormValues>; message: string }[] = [];
 
   errors.forEach((errorMessage) => {
     inputs.forEach((fields, index) => {
@@ -26,7 +26,7 @@ export function getServiceErrors<FormValues>(
           if (!errorPages.includes(index)) {
             errorPages.push(index);
           }
-          fieldErrors.push(field);
+          fieldErrors.push({ fieldName: field, message: errorMessage });
         }
       });
     });

--- a/frontend/pages/projects/new.tsx
+++ b/frontend/pages/projects/new.tsx
@@ -75,6 +75,7 @@ const Project: PageComponent<ProjectProps, FormPageLayoutProps> = () => {
     setValue,
     clearErrors,
     resetField,
+    setError,
   } = useForm<ProjectForm>({
     resolver,
     shouldUseNativeValidation: true,
@@ -87,15 +88,15 @@ const Project: PageComponent<ProjectProps, FormPageLayoutProps> = () => {
     (data: ProjectCreationPayload) =>
       createProject.mutate(data, {
         onError: (error) => {
-          const { errorPages } = getServiceErrors<ProjectForm>(error, formPageInputs);
-          // fieldErrors.forEach((field) => setError(field, { message: '' }));
+          const { errorPages, fieldErrors } = getServiceErrors<ProjectForm>(error, formPageInputs);
+          fieldErrors.forEach(({ fieldName, message }) => setError(fieldName, { message }));
           errorPages.length && setCurrentPage(errorPages[0]);
         },
         onSuccess: (result) => {
           push({ pathname: '/projects/pending/', search: `project=${result.data.slug}` });
         },
       }),
-    [createProject, push]
+    [createProject, push, setError]
   );
 
   const onSubmit: SubmitHandler<ProjectForm> = (values: ProjectForm) => {


### PR DESCRIPTION
This PR adds to the inputs the relative error messages coming from API.
    

## Testing instructions

* When the form is submitted and the API response is an error, if it relates to a form field, the error message should be displayed below the field

## Tracking

It is the missing part of the task [LET-352 Project creation form](https://vizzuality.atlassian.net/browse/LET-352)

## Screenshot
![Screenshot 2022-05-06 at 09 15 17](https://user-images.githubusercontent.com/48164343/167086478-b3c1fda4-e503-441d-8496-de3bf50a4c32.png)
