### PR TITLE
Search page layout & API connection

### DIFF
--- a/frontend/containers/discover-search/component.tsx
+++ b/frontend/containers/discover-search/component.tsx
@@ -11,6 +11,7 @@ import Icon from 'components/icon';
 import { DiscoverSearchProps } from './types';
 
 export const DiscoverSearch: FC<DiscoverSearchProps> = ({
+  className,
   defaultValue = '',
   onSearch = noop,
 }: DiscoverSearchProps) => {
@@ -22,23 +23,25 @@ export const DiscoverSearch: FC<DiscoverSearchProps> = ({
   };
 
   return (
-    <div className="z-10 flex items-center w-full h-16 max-w-3xl gap-4 py-3 pl-6 pr-3 text-black bg-white border rounded-full xl:h-20 drop-shadow-xl">
-      <Icon aria-hidden={true} icon={SearchIcon} className="w-8 h-8 text-green-dark" />
-      <form role="search" className="flex w-full h-full gap-3" onSubmit={handleSearch}>
-        <label htmlFor="header-search" className="sr-only">
-          <FormattedMessage defaultMessage="Search" id="xmcVZ0" />
-        </label>
-        <input
-          id="header-search"
-          type="search"
-          defaultValue={defaultValue}
-          className="w-full h-full px-2 text-lg rounded-full outline-none autofill:bg-transparent"
-          onChange={(e) => setSearchText(e.target.value)}
-        />
-        <Button type="submit" className="h-full" theme="primary-orange">
-          Search
-        </Button>
-      </form>
+    <div className={className}>
+      <div className="z-10 flex items-center w-full h-16 gap-4 py-3 pl-6 pr-3 text-black bg-white border rounded-full xl:h-20 drop-shadow-xl">
+        <Icon aria-hidden={true} icon={SearchIcon} className="w-8 h-8 text-green-dark" />
+        <form role="search" className="flex w-full h-full gap-3" onSubmit={handleSearch}>
+          <label htmlFor="header-search" className="sr-only">
+            <FormattedMessage defaultMessage="Search" id="xmcVZ0" />
+          </label>
+          <input
+            id="header-search"
+            type="search"
+            defaultValue={defaultValue}
+            className="w-full h-full px-2 text-lg rounded-full outline-none autofill:bg-transparent"
+            onChange={(e) => setSearchText(e.target.value)}
+          />
+          <Button type="submit" className="h-full" theme="primary-orange">
+            Search
+          </Button>
+        </form>
+      </div>
     </div>
   );
 };

--- a/frontend/containers/discover-search/types.ts
+++ b/frontend/containers/discover-search/types.ts
@@ -1,4 +1,6 @@
 export type DiscoverSearchProps = {
+  /** Classes to apply to the container */
+  className?: string;
   /** Default value for the input. Defaults to `''` */
   defaultValue?: string;
   /** Callback for when a search is performed */

--- a/frontend/enums/index.ts
+++ b/frontend/enums/index.ts
@@ -14,14 +14,14 @@ export enum Paths {
   SignOut = '/sign-out',
   Settings = '/settings',
   Project = '/project',
-  Projects = '/search/projects',
+  Projects = '/discover/projects',
   ProjectCreation = '/projects/new',
   ProjectDeveloper = '/project-developer',
-  ProjectDevelopers = '/search/project-developers',
+  ProjectDevelopers = '/discover/project-developers',
   OpenCall = '/open-call',
-  OpenCalls = '/search/open-calls',
+  OpenCalls = '/discover/open-calls',
   Investor = '/investor',
-  Investors = '/search/investors',
+  Investors = '/discover/investors',
 }
 
 export enum UserRoles {

--- a/frontend/hooks/use-scroll-on-query.js
+++ b/frontend/hooks/use-scroll-on-query.js
@@ -1,0 +1,23 @@
+import { useEffect, useCallback } from 'react';
+
+import { useRouter } from 'next/router';
+
+/**
+ * @param {MutableRefObject} ref Ref of the element to scroll
+ * @param {boolean} autoScroll Whether to auto scroll on query change
+ */
+export const useScrollOnQuery = ({ ref: elementRef, autoScroll = true }) => {
+  const { query } = useRouter();
+
+  const scroll = useCallback(() => {
+    const element = elementRef.current || window;
+    element.scroll({ top: 0 });
+  }, [elementRef]);
+
+  useEffect(() => {
+    if (!autoScroll) return;
+    scroll();
+  }, [autoScroll, query, scroll]);
+
+  return { scroll };
+};

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -363,6 +363,9 @@
   "I9iCt5": {
     "string": "From which investor or funder? (optional)"
   },
+  "IBlTCs": {
+    "string": "The image is larger than {maxSize}MB"
+  },
   "IMe8OV": {
     "string": "Nature based solutions are estimated to compensate up to 30% of global emissions."
   },

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -549,6 +549,9 @@
   "TJo5E6": {
     "string": "Preview"
   },
+  "TfXhCr": {
+    "string": "No projects"
+  },
   "U1OBY8": {
     "string": "options {options}, selected."
   },

--- a/frontend/layouts/discover-page/component.tsx
+++ b/frontend/layouts/discover-page/component.tsx
@@ -1,0 +1,112 @@
+import React, { FC, useEffect, useMemo, useState } from 'react';
+
+import cx from 'classnames';
+
+import { useRouter } from 'next/router';
+
+import DiscoverSearch from 'containers/discover-search';
+
+import LayoutContainer from 'components/layout-container';
+import { Paths } from 'enums';
+
+import { useProjectsList } from 'services/projects/projectService';
+
+import Header from './header';
+import Navigation from './navigation';
+import { DiscoverPageLayoutProps } from './types';
+
+export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
+  screenHeightLg = false,
+  children,
+}: DiscoverPageLayoutProps) => {
+  const router = useRouter();
+  const { query } = router;
+
+  // We're keeping data in a state so that, while we're fetching new data,
+  // we can keep the existing one visible in the screen (and add a loading spinner).
+  const [projects, setProjects] = useState({ data: undefined, meta: undefined });
+
+  const queryParams = useMemo(
+    () => ({
+      page: parseInt(query.page as string) || 1,
+      search: (query.search as string) || '',
+    }),
+    [query]
+  );
+
+  const {
+    data: projectsData,
+    isFetching: isFetchingProjects,
+    isLoading: isLoadingProjects,
+  } = useProjectsList(queryParams);
+
+  useEffect(() => {
+    if (isFetchingProjects) return;
+    setProjects(projectsData);
+  }, [isFetchingProjects, projectsData]);
+
+  const stats = {
+    projects: projects?.meta?.total,
+    projectDevelopers: 0,
+    investors: 0,
+    openCalls: 0,
+  };
+
+  const { data, meta, loading } = useMemo(() => {
+    // TODO: Find a way to improve this.
+    if (router.pathname.startsWith(Paths.Projects))
+      return { ...projects, loading: isLoadingProjects };
+    // if (router.pathname.startsWith(Paths.ProjectDevelopers)) return projectDevelopers;
+    // if (router.pathname.startsWith(Paths.Investors)) return investors;
+    // if (router.pathname.startsWith(Paths.OpenCalls)) return openCalls;
+  }, [isLoadingProjects, projects, router.pathname]) || { data: [], meta: [] };
+
+  const handleSearch = (searchText: string) => {
+    router.push({ query: { ...queryParams, page: 1, search: searchText } });
+  };
+
+  const childrenWithProps = React.Children.map(children, (child) => {
+    if (React.isValidElement(child)) {
+      return React.cloneElement(child, { data, meta, loading });
+    }
+
+    return child;
+  });
+
+  return (
+    <div className="fixed top-0 bottom-0 left-0 right-0 h-screen bg-background-dark">
+      <div className="flex flex-col h-screen">
+        <div>
+          <Header />
+          <LayoutContainer className="z-10 flex justify-center pt-1 mt-20 mb-2 pointer-events-none xl:mb-6 xl:mt-0 xl:left-0 xl:right-0 xl:h-20 xl:fixed xl:top-3">
+            <DiscoverSearch
+              className="w-full max-w-3xl pointer-events-auto"
+              defaultValue={queryParams.search}
+              onSearch={handleSearch}
+            />
+          </LayoutContainer>
+        </div>
+        <main className="flex flex-col flex-grow h-screen overflow-y-scroll">
+          <LayoutContainer className="xl:mt-28">
+            <div className="flex items-center gap-6 mt-2 mb-4 space-between">
+              {/*<div>Sort</div>*/}
+              <Navigation stats={stats} />
+              {/*<div>Share</div>*/}
+            </div>
+          </LayoutContainer>
+          <LayoutContainer
+            className={cx({
+              'mb-4 lg:mb-0 lg:overflow-y-scroll': true,
+              'h-screen': !screenHeightLg,
+              'flex-grow lg:overflow-hidden': screenHeightLg,
+            })}
+          >
+            {childrenWithProps}
+          </LayoutContainer>
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default DiscoverPageLayout;

--- a/frontend/layouts/discover-page/component.tsx
+++ b/frontend/layouts/discover-page/component.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useMemo, useState } from 'react';
+import React, { FC, useMemo } from 'react';
 
 import cx from 'classnames';
 
@@ -22,10 +22,6 @@ export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
   const router = useRouter();
   const { query } = router;
 
-  // We're keeping data in a state so that, while we're fetching new data,
-  // we can keep the existing one visible in the screen (and add a loading spinner).
-  const [projects, setProjects] = useState({ data: undefined, meta: undefined });
-
   const queryParams = useMemo(
     () => ({
       page: parseInt(query.page as string) || 1,
@@ -34,16 +30,13 @@ export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
     [query]
   );
 
-  const {
-    data: projectsData,
-    isFetching: isFetchingProjects,
-    isLoading: isLoadingProjects,
-  } = useProjectsList(queryParams);
+  const queryOptions = { keepPreviousData: true };
 
-  useEffect(() => {
-    if (isFetchingProjects) return;
-    setProjects(projectsData);
-  }, [isFetchingProjects, projectsData]);
+  const {
+    data: projects,
+    isLoading: isLoadingProjects,
+    isFetching: isFetchingProjects,
+  } = useProjectsList(queryParams, queryOptions);
 
   const stats = {
     projects: projects?.meta?.total,
@@ -55,11 +48,11 @@ export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
   const { data, meta, loading } = useMemo(() => {
     // TODO: Find a way to improve this.
     if (router.pathname.startsWith(Paths.Projects))
-      return { ...projects, loading: isLoadingProjects };
+      return { ...projects, loading: isLoadingProjects || isFetchingProjects };
     // if (router.pathname.startsWith(Paths.ProjectDevelopers)) return projectDevelopers;
     // if (router.pathname.startsWith(Paths.Investors)) return investors;
     // if (router.pathname.startsWith(Paths.OpenCalls)) return openCalls;
-  }, [isLoadingProjects, projects, router.pathname]) || { data: [], meta: [] };
+  }, [isFetchingProjects, isLoadingProjects, projects, router.pathname]) || { data: [], meta: [] };
 
   const handleSearch = (searchText: string) => {
     router.push({ query: { ...queryParams, page: 1, search: searchText } }, undefined, {

--- a/frontend/layouts/discover-page/component.tsx
+++ b/frontend/layouts/discover-page/component.tsx
@@ -62,7 +62,9 @@ export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
   }, [isLoadingProjects, projects, router.pathname]) || { data: [], meta: [] };
 
   const handleSearch = (searchText: string) => {
-    router.push({ query: { ...queryParams, page: 1, search: searchText } });
+    router.push({ query: { ...queryParams, page: 1, search: searchText } }, undefined, {
+      shallow: true,
+    });
   };
 
   const childrenWithProps = React.Children.map(children, (child) => {

--- a/frontend/layouts/discover-page/header/component.tsx
+++ b/frontend/layouts/discover-page/header/component.tsx
@@ -1,0 +1,53 @@
+import { FC } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import NextHead from 'next/head';
+import Link from 'next/link';
+
+import Button from 'components/button';
+import LayoutContainer from 'components/layout-container';
+import Menu, { MenuItem } from 'components/menu';
+
+import { HeaderProps } from './types';
+
+export const Header: FC<HeaderProps> = ({}: HeaderProps) => {
+  const intl = useIntl();
+
+  return (
+    <>
+      <header className="fixed top-0 z-10 w-full text-white border-b bg-green-dark backdrop-blur-sm">
+        <LayoutContainer>
+          <div className="flex items-center justify-between h-18">
+            <Link href="/">
+              <a className="font-semibold">HeCo Invest</a>
+            </Link>
+            {/* Making space for the Search container in the layout, just in case */}
+            <span className="max-w-3xl" />
+            <Menu
+              Trigger={
+                <Button
+                  type="button"
+                  size="small"
+                  theme="primary-white"
+                  aria-label={intl.formatMessage({ defaultMessage: 'Menu', id: 'tKMlOc' })}
+                >
+                  Menu
+                </Button>
+              }
+              align="end"
+              direction="bottom"
+              onAction={() => {}}
+            >
+              <MenuItem key="menu-item-1">Item 1</MenuItem>
+              <MenuItem key="menu-item-2">Item 2</MenuItem>
+              <MenuItem key="menu-item-3">Item 3</MenuItem>
+            </Menu>
+          </div>
+        </LayoutContainer>
+      </header>
+    </>
+  );
+};
+
+export default Header;

--- a/frontend/layouts/discover-page/header/index.ts
+++ b/frontend/layouts/discover-page/header/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { HeaderProps } from './types';

--- a/frontend/layouts/discover-page/header/types.ts
+++ b/frontend/layouts/discover-page/header/types.ts
@@ -1,0 +1,1 @@
+export type HeaderProps = {};

--- a/frontend/layouts/discover-page/index.ts
+++ b/frontend/layouts/discover-page/index.ts
@@ -1,0 +1,2 @@
+export type { DiscoverPageLayoutProps } from './types';
+export { default } from './component';

--- a/frontend/layouts/discover-page/navigation/component.tsx
+++ b/frontend/layouts/discover-page/navigation/component.tsx
@@ -11,36 +11,52 @@ import { NavigationProps } from './types';
 
 export const Navigation: FC<NavigationProps> = ({ stats }: NavigationProps) => {
   const intl = useIntl();
-  const { asPath } = useRouter();
+  const { asPath, query } = useRouter();
+
+  // Pick the query params we want to preserve in the navigation links (search, filters, sorting)
+  const queryParams = {
+    ...(query.search && { search: query.search as string }),
+    // TODO: Filters
+    // TODO: Sorting
+  };
+
+  // Build a query string to append to each link
+  const queryString = Object.keys(queryParams).length
+    ? `?${new URLSearchParams(queryParams).toString()}`
+    : '';
 
   const navigationItems = [
     {
       id: 'projects',
       name: intl.formatMessage({ defaultMessage: 'Projects', id: 'UxTJRa' }),
-      link: Paths.Projects,
+      path: Paths.Projects,
+      link: `${Paths.Projects}${queryString}`,
       number: stats?.projects,
     },
     {
       id: 'open-calls',
       name: intl.formatMessage({ defaultMessage: 'Open Calls', id: 'wpyHb9' }),
-      link: Paths.OpenCalls,
+      path: Paths.OpenCalls,
+      link: `${Paths.OpenCalls}${queryString}`,
       number: stats?.openCalls,
     },
     {
       id: 'project-developers',
       name: intl.formatMessage({ defaultMessage: 'Project Developers', id: '+K9fF0' }),
-      link: Paths.ProjectDevelopers,
+      path: Paths.ProjectDevelopers,
+      link: `${Paths.ProjectDevelopers}${queryString}`,
       number: stats?.projectDevelopers,
     },
     {
       id: 'investors',
       name: intl.formatMessage({ defaultMessage: 'Investors', id: 'zdIaHp' }),
-      link: Paths.Investors,
+      path: Paths.Investors,
+      link: `${Paths.Investors}${queryString}`,
       number: stats?.investors,
     },
   ];
 
-  const activeId = navigationItems.find(({ id, link }) => asPath.startsWith(link))?.id;
+  const activeId = navigationItems.find(({ path }) => asPath.startsWith(path))?.id;
 
   return (
     <div className="flex items-center w-full pb-3 -mb-3 overflow-x-scroll">

--- a/frontend/layouts/discover-page/navigation/component.tsx
+++ b/frontend/layouts/discover-page/navigation/component.tsx
@@ -1,0 +1,56 @@
+import { FC } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import { useRouter } from 'next/router';
+
+import BadgeNavigation from 'components/badge-navigation';
+import { Paths } from 'enums';
+
+import { NavigationProps } from './types';
+
+export const Navigation: FC<NavigationProps> = ({ stats }: NavigationProps) => {
+  const intl = useIntl();
+  const { asPath } = useRouter();
+
+  const navigationItems = [
+    {
+      id: 'projects',
+      name: intl.formatMessage({ defaultMessage: 'Projects', id: 'UxTJRa' }),
+      link: Paths.Projects,
+      number: stats?.projects,
+    },
+    {
+      id: 'open-calls',
+      name: intl.formatMessage({ defaultMessage: 'Open Calls', id: 'wpyHb9' }),
+      link: Paths.OpenCalls,
+      number: stats?.openCalls,
+    },
+    {
+      id: 'project-developers',
+      name: intl.formatMessage({ defaultMessage: 'Project Developers', id: '+K9fF0' }),
+      link: Paths.ProjectDevelopers,
+      number: stats?.projectDevelopers,
+    },
+    {
+      id: 'investors',
+      name: intl.formatMessage({ defaultMessage: 'Investors', id: 'zdIaHp' }),
+      link: Paths.Investors,
+      number: stats?.investors,
+    },
+  ];
+
+  const activeId = navigationItems.find(({ id, link }) => asPath.startsWith(link))?.id;
+
+  return (
+    <div className="flex items-center w-full pb-3 -mb-3 overflow-x-scroll">
+      <BadgeNavigation
+        className="flex items-center justify-center flex-grow"
+        activeId={activeId}
+        items={navigationItems}
+      />
+    </div>
+  );
+};
+
+export default Navigation;

--- a/frontend/layouts/discover-page/navigation/index.ts
+++ b/frontend/layouts/discover-page/navigation/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { NavigationProps } from './types';

--- a/frontend/layouts/discover-page/navigation/types.ts
+++ b/frontend/layouts/discover-page/navigation/types.ts
@@ -1,0 +1,13 @@
+export type NavigationProps = {
+  /** Stats (number of each item) to show on the navigation tags */
+  stats?: {
+    /** Num projects */
+    projects?: number;
+    /** Num project developers */
+    projectDevelopers?: number;
+    /** Num investors */
+    investors?: number;
+    /** Num open calls */
+    openCalls?: number;
+  };
+};

--- a/frontend/layouts/discover-page/types.ts
+++ b/frontend/layouts/discover-page/types.ts
@@ -1,0 +1,9 @@
+import { PropsWithChildren } from 'react';
+
+export type DiscoverPageLayoutProps = PropsWithChildren<{
+  /**
+   * Whether the content of the layout will be fixed to the screen height with scrollable
+   * content. Only applies on large screens. Defaults to `false`
+   **/
+  screenHeightLg: boolean;
+}>;

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -63,4 +63,13 @@ module.exports = {
       },
     ];
   },
+  async redirects() {
+    return [
+      {
+        source: '/discover',
+        destination: '/discover/projects',
+        permanent: true,
+      },
+    ];
+  },
 };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -103,6 +103,7 @@
     "sharp": "^0.30.1",
     "slugify": "^1.6.5",
     "tailwindcss": "^3.0.23",
+    "url-search-params-polyfill": "^8.1.1",
     "use-debounce": "^6.0.1",
     "yup": "^0.32.11"
   },

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -16,6 +16,9 @@ import { LayoutStaticProp } from 'types';
 
 import 'styles/globals.css';
 
+// Polyfills
+import 'url-search-params-polyfill';
+
 type Props = AppProps & {
   Component: {
     layout?: LayoutStaticProp;

--- a/frontend/pages/discover/investors.tsx
+++ b/frontend/pages/discover/investors.tsx
@@ -1,0 +1,38 @@
+import { groupBy } from 'lodash-es';
+
+import { loadI18nMessages } from 'helpers/i18n';
+
+import DiscoverPageLayout, { DiscoverPageLayoutProps } from 'layouts/discover-page';
+import { PageComponent } from 'types';
+import { GroupedEnums as GroupedEnumsType } from 'types/enums';
+
+import { getEnums } from 'services/enums/enumService';
+
+export const getServerSideProps = async ({ locale }) => {
+  const enums = await getEnums();
+
+  return {
+    props: {
+      intlMessages: await loadI18nMessages({ locale }),
+      enums: groupBy(enums, 'type'),
+    },
+  };
+};
+
+type InvestorsPageProps = {
+  enums: GroupedEnumsType;
+};
+
+const InvestorsPage: PageComponent<InvestorsPageProps, DiscoverPageLayoutProps> = ({ enums }) => {
+  return (
+    <div className="flex w-full gap-5">
+      <span>Page: Investors</span>
+    </div>
+  );
+};
+
+InvestorsPage.layout = {
+  Component: DiscoverPageLayout,
+};
+
+export default InvestorsPage;

--- a/frontend/pages/discover/open-calls.tsx
+++ b/frontend/pages/discover/open-calls.tsx
@@ -1,0 +1,38 @@
+import { groupBy } from 'lodash-es';
+
+import { loadI18nMessages } from 'helpers/i18n';
+
+import DiscoverPageLayout, { DiscoverPageLayoutProps } from 'layouts/discover-page';
+import { PageComponent } from 'types';
+import { GroupedEnums as GroupedEnumsType } from 'types/enums';
+
+import { getEnums } from 'services/enums/enumService';
+
+export const getServerSideProps = async ({ locale }) => {
+  const enums = await getEnums();
+
+  return {
+    props: {
+      intlMessages: await loadI18nMessages({ locale }),
+      enums: groupBy(enums, 'type'),
+    },
+  };
+};
+
+type OpenCallsPageProps = {
+  enums: GroupedEnumsType;
+};
+
+const OpenCallsPage: PageComponent<OpenCallsPageProps, DiscoverPageLayoutProps> = ({ enums }) => {
+  return (
+    <div className="flex w-full gap-5">
+      <span>Page: OpenCalls</span>
+    </div>
+  );
+};
+
+OpenCallsPage.layout = {
+  Component: DiscoverPageLayout,
+};
+
+export default OpenCallsPage;

--- a/frontend/pages/discover/project-developers.tsx
+++ b/frontend/pages/discover/project-developers.tsx
@@ -1,0 +1,40 @@
+import { groupBy } from 'lodash-es';
+
+import { loadI18nMessages } from 'helpers/i18n';
+
+import DiscoverPageLayout, { DiscoverPageLayoutProps } from 'layouts/discover-page';
+import { PageComponent } from 'types';
+import { GroupedEnums as GroupedEnumsType } from 'types/enums';
+
+import { getEnums } from 'services/enums/enumService';
+
+export const getServerSideProps = async ({ locale }) => {
+  const enums = await getEnums();
+
+  return {
+    props: {
+      intlMessages: await loadI18nMessages({ locale }),
+      enums: groupBy(enums, 'type'),
+    },
+  };
+};
+
+type ProjectDevelopersPageProps = {
+  enums: GroupedEnumsType;
+};
+
+const ProjectDevelopersPage: PageComponent<ProjectDevelopersPageProps, DiscoverPageLayoutProps> = ({
+  enums,
+}) => {
+  return (
+    <div className="flex w-full gap-5">
+      <span>Page: Project Developers</span>
+    </div>
+  );
+};
+
+ProjectDevelopersPage.layout = {
+  Component: DiscoverPageLayout,
+};
+
+export default ProjectDevelopersPage;

--- a/frontend/pages/discover/projects.tsx
+++ b/frontend/pages/discover/projects.tsx
@@ -1,0 +1,82 @@
+import { useRef } from 'react';
+
+import { FormattedMessage } from 'react-intl';
+
+import { useScrollOnQuery } from 'hooks/use-scroll-on-query';
+import { usePagination } from 'hooks/usePagination';
+
+import { loadI18nMessages } from 'helpers/i18n';
+
+import ProjectCard from 'containers/project-card';
+
+import Loading from 'components/loading';
+import Map from 'components/map';
+import Pagination from 'components/pagination';
+import DiscoverPageLayout, { DiscoverPageLayoutProps } from 'layouts/discover-page';
+import { PageComponent } from 'types';
+import { Project as ProjectType } from 'types/project';
+
+export const getServerSideProps = async ({ locale }) => {
+  return {
+    props: {
+      intlMessages: await loadI18nMessages({ locale }),
+    },
+  };
+};
+
+type ProjectsPageProps = {
+  data: ProjectType[];
+  meta: Record<string, string>;
+  loading: boolean;
+};
+
+const ProjectsPage: PageComponent<ProjectsPageProps, DiscoverPageLayoutProps> = ({
+  data: projects = [],
+  loading = false,
+  meta,
+}) => {
+  const projectsContainerRef = useRef(null);
+  const { props: paginationProps } = usePagination(meta);
+
+  useScrollOnQuery({ ref: projectsContainerRef });
+
+  const hasProjects = projects?.length > 0 || false;
+
+  return (
+    <div className="flex flex-col w-full h-full pb-2 lg:p-1 lg:-m-1 lg:gap-0 lg:overflow-hidden lg:flex-row">
+      <div className="relative flex flex-col w-full lg:overflow-hidden lg:w-5/12">
+        <div
+          ref={projectsContainerRef}
+          className="relative flex-grow lg:pr-2.5 lg:overflow-y-scroll"
+        >
+          {loading && (
+            <span className="absolute z-20 flex items-center justify-center bg-gray-600 bg-opacity-20 top-1 bottom-1 left-1 right-2 rounded-2xl">
+              <Loading visible={loading} iconClassName="w-10 h-10" />
+            </span>
+          )}
+          <div className="flex flex-col">
+            {projects.map((project) => (
+              <ProjectCard className="m-1" key={project.id} project={project} />
+            ))}
+            {!loading && !hasProjects && (
+              <FormattedMessage defaultMessage="No projects" id="TfXhCr" />
+            )}
+          </div>
+        </div>
+        {hasProjects && <Pagination className="w-full pt-2 -mb-2" {...paginationProps} />}
+      </div>
+      <aside className="flex-grow min-h-full p-2 m-1 bg-white rounded-2xl lg:min-h-0">
+        <Map className="lg:overflow-hidden rounded-xl" onMapViewportChange={() => {}} />
+      </aside>
+    </div>
+  );
+};
+
+ProjectsPage.layout = {
+  Component: DiscoverPageLayout,
+  props: {
+    screenHeightLg: true,
+  },
+};
+
+export default ProjectsPage;

--- a/frontend/pages/discover/projects.tsx
+++ b/frontend/pages/discover/projects.tsx
@@ -2,6 +2,8 @@ import { useRef } from 'react';
 
 import { FormattedMessage } from 'react-intl';
 
+import cx from 'classnames';
+
 import { useScrollOnQuery } from 'hooks/use-scroll-on-query';
 import { usePagination } from 'hooks/usePagination';
 
@@ -47,10 +49,14 @@ const ProjectsPage: PageComponent<ProjectsPageProps, DiscoverPageLayoutProps> = 
       <div className="relative flex flex-col w-full lg:overflow-hidden lg:w-5/12">
         <div
           ref={projectsContainerRef}
-          className="relative flex-grow lg:pr-2.5 lg:overflow-y-scroll"
+          className={cx({
+            'relative flex-grow lg:pr-2.5': true,
+            'lg:overflow-y-scroll': !loading,
+            'lg:pointer-events-none lg:overflow-hidden': loading,
+          })}
         >
           {loading && (
-            <span className="absolute z-20 flex items-center justify-center bg-gray-600 bg-opacity-20 top-1 bottom-1 left-1 right-2 rounded-2xl">
+            <span className="absolute bottom-0 z-20 flex items-center justify-center bg-gray-600 bg-opacity-20 top-1 left-1 right-3 rounded-2xl">
               <Loading visible={loading} iconClassName="w-10 h-10" />
             </span>
           )}

--- a/frontend/services/projects/projectService.ts
+++ b/frontend/services/projects/projectService.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { useQuery } from 'react-query';
+import { UseQueryResult, useQuery } from 'react-query';
 
 import { AxiosRequestConfig } from 'axios';
 
@@ -8,6 +8,38 @@ import { Queries } from 'enums';
 import { Project } from 'types/project';
 
 import API from 'services/api';
+import { staticDataQueryOptions } from 'services/helpers';
+import { PagedResponse, ErrorResponse, PagedRequest, ResponseData } from 'services/types';
+
+/** Get a paged list of project developers */
+const getProjects = async (params?: PagedRequest): Promise<PagedResponse<Project>> => {
+  const { search, page, ...rest } = params;
+  const config: AxiosRequestConfig = {
+    url: '/api/v1/projects',
+    method: 'GET',
+    params: { ...rest, 'filter[full_text]': params.search, 'page[number]': params.page },
+  };
+  return await API.request(config).then((result) => result.data);
+};
+
+/** Hook to use the the Project Developers list */
+export function useProjectsList(
+  params?: PagedRequest
+): UseQueryResult<PagedResponse<Project>> & { projects: Project[] } {
+  const query = useQuery(
+    [Queries.ProjectDeveloperList, params],
+    () => getProjects(params),
+    staticDataQueryOptions
+  );
+
+  return useMemo(
+    () => ({
+      ...query,
+      projects: query?.data?.data || [],
+    }),
+    [query]
+  );
+}
 
 /** Get a Project using an id and, optionally, the wanted fields */
 export const getProject = async (

--- a/frontend/services/projects/projectService.ts
+++ b/frontend/services/projects/projectService.ts
@@ -11,7 +11,7 @@ import API from 'services/api';
 import { staticDataQueryOptions } from 'services/helpers';
 import { PagedResponse, ErrorResponse, PagedRequest, ResponseData } from 'services/types';
 
-/** Get a paged list of project developers */
+/** Get a paged list of projects */
 const getProjects = async (params?: PagedRequest): Promise<PagedResponse<Project>> => {
   const { search, page, ...rest } = params;
   const config: AxiosRequestConfig = {
@@ -22,7 +22,7 @@ const getProjects = async (params?: PagedRequest): Promise<PagedResponse<Project
   return await API.request(config).then((result) => result.data);
 };
 
-/** Hook to use the the Project Developers list */
+/** Hook to use the the projects list */
 export function useProjectsList(
   params?: PagedRequest
 ): UseQueryResult<PagedResponse<Project>> & { projects: Project[] } {

--- a/frontend/services/projects/projectService.ts
+++ b/frontend/services/projects/projectService.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { UseQueryResult, useQuery } from 'react-query';
+import { UseQueryResult, useQuery, UseQueryOptions } from 'react-query';
 
 import { AxiosRequestConfig } from 'axios';
 
@@ -9,7 +9,7 @@ import { Project } from 'types/project';
 
 import API from 'services/api';
 import { staticDataQueryOptions } from 'services/helpers';
-import { PagedResponse, ErrorResponse, PagedRequest, ResponseData } from 'services/types';
+import { PagedResponse, PagedRequest } from 'services/types';
 
 /** Get a paged list of projects */
 const getProjects = async (params?: PagedRequest): Promise<PagedResponse<Project>> => {
@@ -24,13 +24,13 @@ const getProjects = async (params?: PagedRequest): Promise<PagedResponse<Project
 
 /** Hook to use the the projects list */
 export function useProjectsList(
-  params?: PagedRequest
+  params?: PagedRequest,
+  options?: UseQueryOptions<PagedResponse<Project>>
 ): UseQueryResult<PagedResponse<Project>> & { projects: Project[] } {
-  const query = useQuery(
-    [Queries.ProjectDeveloperList, params],
-    () => getProjects(params),
-    staticDataQueryOptions
-  );
+  const query = useQuery([Queries.ProjectDeveloperList, params], () => getProjects(params), {
+    ...staticDataQueryOptions,
+    ...options,
+  });
 
   return useMemo(
     () => ({

--- a/frontend/services/types.ts
+++ b/frontend/services/types.ts
@@ -3,6 +3,8 @@ export type PagedRequest = {
   'page[number]'?: number;
   'page[size]'?: number;
   fields?: string[];
+  search?: string;
+  page?: number;
 };
 
 /** Default API single item response structure */

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -14241,6 +14241,7 @@ __metadata:
     storybook-react-intl: ^1.0.5
     tailwindcss: ^3.0.23
     typescript: ^4.5.5
+    url-search-params-polyfill: ^8.1.1
     use-debounce: ^6.0.1
     webpack: ^5.68.0
     yup: ^0.32.11
@@ -22326,6 +22327,13 @@ __metadata:
     file-loader:
       optional: true
   checksum: c1122a992c6cff70a7e56dfc2b7474534d48eb40b2cc75467cde0c6972e7597faf8e43acb4f45f93c2473645dfd803bcbc20960b57544dd1e4c96e77f72ba6fd
+  languageName: node
+  linkType: hard
+
+"url-search-params-polyfill@npm:^8.1.1":
+  version: 8.1.1
+  resolution: "url-search-params-polyfill@npm:8.1.1"
+  checksum: c63169a8a70a256e73203c4404acf4fdbb38075f3f888ea38f92b09dc896190180cc9c072c927d7bb995c5a35e7729be8c4f7e876f83f8f8ab6fac263c971725
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds a base working `DiscoverPageLayout` to be used by all four of the search pages _(Projects, Project Developers, Investors, Open Calls)_, as well as a discover projects page (with functional search and pagination), as well as placeholder pages. 

-----

**In this PR:**  
- Layout to be used in the Discover/Search pages  
  - is connected to the API, is currently set up to handle searching for projects
    _with a couple examples on how to add the remaining ones._   
  - can handle search (for searching) and page params (for pagination)   
  - is reactive to query param changes, as well as current page in order to fetch the correct data  
  - is responsive / compatible with mobile
- Projects page, which:  
  - is connected to the API  
  - pagination works  
  - searching works  
  - Will scroll projects list to top when the user changes a page  

-----

The layout makes use of the previously built components:  
- `DiscoverSearch` which takes care of the user search input  
- `BadgeNavigation` which takes care of of the navigation  

This layout is responsible for:  
- Based on the route and existing query params (currently `search` and `page`), fetch the data;  
- Pass the correct dataset to the Child element, which in this case will be the active page  
- Pass the query state to the child page (whether is loading/fetching data, so that a spinner can be shown on the page)  

It also supports:  
- `screenHeightLg` prop, which will make it so that, when the prop is set to `true`, the layout will be of a fixed height matching the screen height. This prop is currently used in the Discover/Projects page.  

**Notes:** 
- User and Menu header to be added separately in [LET-439](https://vizzuality.atlassian.net/browse/LET-439)  
- Project details card to be added separately in [LET-399](https://vizzuality.atlassian.net/browse/LET-399)

## Testing instructions

Verify that:  
- All four pages load correctly (`/discover/` + `projects`|`project-developers`|`investors`|`open-calls`)   
- Visiting `/discover` redirects to `/discover/projects`  
- The project page loads correctly  
- A list of projects is shown  
- User can search projects  
- Projects pagination works  
- Clicking on a project card will take the user to the respective project page
  _project card has not yet been implemented_

## Tracking

[LET-395](https://vizzuality.atlassian.net/browse/LET-395)

## Video

https://user-images.githubusercontent.com/6273795/168284700-8da7ea4e-f173-4524-98fa-94b9a30deea9.mp4


