### PR TITLE
Add BadgeNavigation component

### DIFF
--- a/frontend/components/badge-navigation/component.stories.tsx
+++ b/frontend/components/badge-navigation/component.stories.tsx
@@ -1,0 +1,47 @@
+import { Story, Meta } from '@storybook/react/types-6-0';
+
+import BadgeNavigation, { BadgeNavigationProps } from '.';
+
+export default {
+  component: BadgeNavigation,
+  title: 'Components/BadgeNavigation',
+  argTypes: {},
+} as Meta;
+
+const Template: Story<BadgeNavigationProps> = ({ ...props }: BadgeNavigationProps) => (
+  <div className="flex items-center justify-center h-48 bg-background-dark">
+    <BadgeNavigation {...props} />
+  </div>
+);
+
+export const Default: Story<BadgeNavigationProps> = Template.bind({});
+
+Default.args = {
+  activeId: 'second-id',
+  items: [
+    {
+      id: 'first-id',
+      name: 'First',
+      link: 'http://www.example.com/first',
+      number: 10,
+    },
+    {
+      id: 'second-id',
+      name: 'Second',
+      link: 'http://www.example.com/second',
+      number: 4,
+    },
+    {
+      id: 'third-id',
+      name: 'Third',
+      link: 'http://www.example.com/third',
+      number: 10,
+    },
+    {
+      id: 'fourth-id',
+      name: 'Fourth',
+      link: 'http://www.example.com/fourth',
+      number: 200,
+    },
+  ],
+};

--- a/frontend/components/badge-navigation/component.tsx
+++ b/frontend/components/badge-navigation/component.tsx
@@ -19,7 +19,7 @@ export const BadgeNavigation: FC<BadgeNavigationProps> = ({
 
   return (
     <div className={className}>
-      <nav aria-label={intl.formatMessage({ defaultMessage: 'Navigation', id: 'fBg+7V' })}>
+      <nav>
         <ol className="flex gap-2 border rounded-full whitespace-nowrap border-beige">
           {items.map(({ id, name, link, number }) => {
             const isActive = id === activeId;

--- a/frontend/components/badge-navigation/component.tsx
+++ b/frontend/components/badge-navigation/component.tsx
@@ -1,0 +1,56 @@
+import { FC } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import cx from 'classnames';
+
+import Link from 'next/link';
+
+import Tag from 'components/tag';
+
+import { BadgeNavigationProps } from './types';
+
+export const BadgeNavigation: FC<BadgeNavigationProps> = ({
+  className,
+  activeId,
+  items,
+}: BadgeNavigationProps) => {
+  const intl = useIntl();
+
+  return (
+    <div className={className}>
+      <nav aria-label={intl.formatMessage({ defaultMessage: 'Navigation', id: 'fBg+7V' })}>
+        <ol className="flex gap-2 border rounded-full whitespace-nowrap border-beige">
+          {items.map(({ id, name, link, number }) => {
+            const isActive = id === activeId;
+
+            return (
+              <li key={link}>
+                <Link href={link}>
+                  <a aria-current={isActive ? 'location' : false}>
+                    <Tag
+                      className={cx({
+                        'text-sm transition-colors border': true,
+                        'bg-white font-semibold text-black': isActive,
+                        'text-green-dark border-transparent': !isActive,
+                      })}
+                    >
+                      {name}
+                      {number !== undefined && (
+                        <span className="flex items-center justify-center w-6 h-6 px-1 ml-2 text-xs font-semibold text-black border rounded-full min-w-min bg-background-dark border-beige">
+                          {number}
+                        </span>
+                      )}
+                    </Tag>
+                  </a>
+                </Link>
+              </li>
+            );
+          })}
+        </ol>
+      </nav>
+    </div>
+  );
+};
+
+export default BadgeNavigation;

--- a/frontend/components/badge-navigation/component.tsx
+++ b/frontend/components/badge-navigation/component.tsx
@@ -19,20 +19,24 @@ export const BadgeNavigation: FC<BadgeNavigationProps> = ({
 
   return (
     <div className={className}>
-      <nav>
-        <ol className="flex gap-2 border rounded-full whitespace-nowrap border-beige">
+      <nav className="relative mx-2">
+        <span className="absolute left-0 right-0 border rounded-full top-2 bottom-2 border-beige" />
+        <ol className="flex gap-2 py-2 whitespace-nowrap">
           {items.map(({ id, name, link, number }) => {
             const isActive = id === activeId;
 
             return (
-              <li key={link}>
+              <li key={link} className="z-10 transition-all">
                 <Link href={link}>
-                  <a aria-current={isActive ? 'location' : false}>
+                  <a
+                    className="flex rounded-full focus-visible:outline focus-visible:outline-green-dark focus-visible:outline-2 focus-visible:outline-offset-2"
+                    aria-current={isActive ? 'location' : false}
+                  >
                     <Tag
                       className={cx({
-                        'text-sm transition-colors border': true,
-                        'bg-white font-semibold text-black': isActive,
-                        'text-green-dark border-transparent': !isActive,
+                        'text-sm hover:font-medium hover:text-black': true,
+                        'bg-white font-semibold text-black shadow-sm': isActive,
+                        'text-green-dark border-none p-px': !isActive,
                       })}
                     >
                       {name}

--- a/frontend/components/badge-navigation/index.ts
+++ b/frontend/components/badge-navigation/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { BadgeNavigationProps, BadgeNavigationType } from './types';

--- a/frontend/components/badge-navigation/types.ts
+++ b/frontend/components/badge-navigation/types.ts
@@ -1,0 +1,12 @@
+export type BadgeNavigationType = {
+  id: string;
+  name: string;
+  link: string;
+  number?: number;
+};
+
+export type BadgeNavigationProps = {
+  className?: string;
+  activeId?: string;
+  items: BadgeNavigationType[];
+};

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -771,6 +771,9 @@
   "et2m37": {
     "string": "insert URL"
   },
+  "fBg+7V": {
+    "string": "Navigation"
+  },
   "fDd10o": {
     "string": "Instrument type"
   },

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -771,9 +771,6 @@
   "et2m37": {
     "string": "insert URL"
   },
-  "fBg+7V": {
-    "string": "Navigation"
-  },
   "fDd10o": {
     "string": "Instrument type"
   },


### PR DESCRIPTION
This PR adds a basic navigation bar with badges (which in turn use the `Tag` component for styling purposes). 

Accessibility based on: http://web-accessibility.carnegiemuseums.org/code/navigation/

## Testing instructions

~Testing the navigation in staging can be done here: https://heco-invest-frontend-lahef12in-vizzuality1.vercel.app/discover (staging for the ongoing #159)~

Test that the navigation displays correctly. 

## Tracking

[LET-414](https://vizzuality.atlassian.net/browse/LET-414)

## Screenshot
<img width="651" alt="Screenshot 2022-05-10 at 10 45 41" src="https://user-images.githubusercontent.com/6273795/167600367-6dfb4330-0145-4f69-9c98-530925b1aa27.png">


