### PR TITLE
Add pagination component + usePagination hook

### DIFF
--- a/frontend/components/button/constants.ts
+++ b/frontend/components/button/constants.ts
@@ -14,4 +14,5 @@ export const COLOR_THEMES: Record<NonNullable<ButtonCommonProps['theme']>, strin
 export const SIZE_THEMES: Record<NonNullable<ButtonCommonProps['size']>, string> = {
   base: `px-10 py-4`,
   small: `px-6 py-2`,
+  smallest: `px-0 py-0`,
 };

--- a/frontend/components/button/types.ts
+++ b/frontend/components/button/types.ts
@@ -12,7 +12,7 @@ export interface ButtonCommonProps {
     | 'secondary-white'
     | 'naked';
   /** Size of the button */
-  size?: 'base' | 'small';
+  size?: 'base' | 'small' | 'smallest';
   /** Icon of the button */
   icon?: IconProps['icon'];
 }

--- a/frontend/components/pagination/component.stories.tsx
+++ b/frontend/components/pagination/component.stories.tsx
@@ -1,0 +1,56 @@
+import { action } from '@storybook/addon-actions';
+import { Story, Meta } from '@storybook/react/types-6-0';
+
+import Pagination, { PaginationProps } from '.';
+
+export default {
+  component: Pagination,
+  title: 'Components/Pagination',
+  argTypes: {},
+} as Meta;
+
+const Template: Story<PaginationProps> = ({ ...props }: PaginationProps) => {
+  const handlePageClick = (page) => action('Page clicked')(page);
+
+  return <Pagination {...props} onPageClick={handlePageClick} />;
+};
+
+export const Default: Story<PaginationProps> = Template.bind({});
+
+Default.args = {
+  numItems: 10,
+  currentPage: 2,
+  totalPages: 10,
+  totalItems: 98,
+  numNumberButtons: undefined,
+};
+
+export const FirstPage: Story<PaginationProps> = Template.bind({});
+
+FirstPage.args = {
+  numItems: 10,
+  currentPage: 1,
+  totalPages: 10,
+  totalItems: 98,
+  numNumberButtons: undefined,
+};
+
+export const LastPage: Story<PaginationProps> = Template.bind({});
+
+LastPage.args = {
+  numItems: 10,
+  currentPage: 10,
+  totalPages: 10,
+  totalItems: 98,
+  numNumberButtons: undefined,
+};
+
+export const CustomNumButtons: Story<PaginationProps> = Template.bind({});
+
+CustomNumButtons.args = {
+  numItems: 10,
+  currentPage: 5,
+  totalPages: 10,
+  totalItems: 98,
+  numNumberButtons: 4,
+};

--- a/frontend/components/pagination/component.tsx
+++ b/frontend/components/pagination/component.tsx
@@ -93,10 +93,10 @@ const Pagination: React.FC<PaginationProps> = ({
         })}
       >
         <nav aria-label={intl.formatMessage({ defaultMessage: 'Pagination', id: 'ZATT08' })}>
-          <ol className="flex flex-wrap items-center justify-center gap-2 py-2">
+          <ol className="flex flex-wrap items-center justify-center gap-2 py-3">
             <li>
               <Button
-                className="justify-center w-10 h-10"
+                className="justify-center w-10 h-10 focus-visible:!outline-green-dark"
                 size="smallest"
                 theme="primary-white"
                 aria-label={intl.formatMessage({
@@ -111,7 +111,7 @@ const Pagination: React.FC<PaginationProps> = ({
             </li>
             <li>
               <Button
-                className="justify-center w-10 h-10"
+                className="justify-center w-10 h-10 focus-visible:!outline-green-dark"
                 size="smallest"
                 theme="primary-white"
                 aria-label={intl.formatMessage({
@@ -130,7 +130,7 @@ const Pagination: React.FC<PaginationProps> = ({
               return (
                 <li key={buttonNumber} aria-current={isCurrent}>
                   <Button
-                    className="justify-center w-10 h-10"
+                    className="justify-center w-10 h-10 focus-visible:!outline-green-dark"
                     size="smallest"
                     theme={theme}
                     aria-label={intl.formatMessage(
@@ -153,7 +153,7 @@ const Pagination: React.FC<PaginationProps> = ({
             })}
             <li>
               <Button
-                className="justify-center w-10 h-10"
+                className="justify-center w-10 h-10 focus-visible:!outline-green-dark"
                 size="smallest"
                 theme="primary-white"
                 aria-label={intl.formatMessage({
@@ -168,7 +168,7 @@ const Pagination: React.FC<PaginationProps> = ({
             </li>
             <li>
               <Button
-                className="justify-center w-10 h-10"
+                className="justify-center w-10 h-10 focus-visible:!outline-green-dark"
                 size="smallest"
                 theme="primary-white"
                 aria-label={intl.formatMessage({

--- a/frontend/components/pagination/component.tsx
+++ b/frontend/components/pagination/component.tsx
@@ -1,0 +1,198 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import {
+  ChevronsLeft as ChevronsLeftIcon,
+  ChevronLeft as ChevronLeftIcon,
+  ChevronRight as ChevronRightIcon,
+  ChevronsRight as ChevronsRightIcon,
+} from 'react-feather';
+import { useIntl, FormattedMessage } from 'react-intl';
+
+import cx from 'classnames';
+
+import { noop } from 'lodash-es';
+
+import Button from 'components/button';
+
+import { PaginationProps } from './types';
+
+const Pagination: React.FC<PaginationProps> = ({
+  className,
+  isLoading = false,
+  reverseDisplay = false,
+  numItems,
+  currentPage,
+  totalPages,
+  totalItems,
+  numNumberButtons = 8,
+  onPageClick = noop,
+}: PaginationProps) => {
+  const intl = useIntl();
+
+  const [pagination, setPagination] = useState({
+    numItems: undefined,
+    currentPage: undefined,
+    totalPages: undefined,
+    totalItems: undefined,
+  });
+
+  useEffect(() => {
+    // Do not update pagination if data is loading.
+    if (isLoading) return;
+    setPagination({ numItems, currentPage, totalPages, totalItems });
+  }, [currentPage, isLoading, numItems, totalItems, totalPages]);
+
+  const calcPagingRange = useCallback(() => {
+    // https://codereview.stackexchange.com/a/183472
+    const min = 1;
+    let length = numNumberButtons;
+
+    if (length > pagination.totalPages) length = pagination.totalPages;
+
+    let start = pagination.currentPage - Math.floor(length / 2);
+    start = Math.max(start, min);
+    start = Math.min(start, min + pagination.totalPages - length);
+
+    return Array.from({ length: length }, (el, i) => start + i);
+  }, [numNumberButtons, pagination]);
+
+  const rangeButtons = calcPagingRange();
+
+  const handleFirstClick = () => {
+    onPageClick(1);
+  };
+
+  const handlePreviousClick = () => {
+    if (pagination.currentPage <= 1) return;
+    onPageClick(pagination.currentPage - 1);
+  };
+
+  const handleRangeButtonClick = (pageNumber) => {
+    onPageClick(pageNumber);
+  };
+
+  const handleNextClick = () => {
+    if (pagination.currentPage >= pagination.totalPages) return;
+    onPageClick(currentPage + 1);
+  };
+
+  const handleLastClick = () => {
+    onPageClick(pagination.totalPages);
+  };
+
+  // We don't have enough values to display the pagination; show nothing.
+  if (Object.values(pagination).some((val) => isNaN(val))) return null;
+
+  return (
+    <div className={className}>
+      <div
+        className={cx({
+          'flex items-center': true,
+          'flex-col': reverseDisplay,
+          'flex-col-reverse': !reverseDisplay,
+        })}
+      >
+        <nav aria-label={intl.formatMessage({ defaultMessage: 'Pagination', id: 'ZATT08' })}>
+          <ol className="flex flex-wrap items-center justify-center gap-2 py-2">
+            <li>
+              <Button
+                className="justify-center w-10 h-10"
+                size="smallest"
+                theme="primary-white"
+                aria-label={intl.formatMessage({
+                  defaultMessage: 'Goto first page',
+                  id: '6JknYY',
+                })}
+                disabled={pagination.currentPage <= 1}
+                onClick={handleFirstClick}
+              >
+                <ChevronsLeftIcon className="w-4 h-4" />
+              </Button>
+            </li>
+            <li>
+              <Button
+                className="justify-center w-10 h-10"
+                size="smallest"
+                theme="primary-white"
+                aria-label={intl.formatMessage({
+                  defaultMessage: 'Goto previous page',
+                  id: 'PNhgnM',
+                })}
+                disabled={pagination.currentPage <= 1}
+                onClick={handlePreviousClick}
+              >
+                <ChevronLeftIcon className="w-4 h-4" />
+              </Button>
+            </li>
+            {rangeButtons.map((buttonNumber) => {
+              const isCurrent = buttonNumber === pagination.currentPage;
+              const theme = isCurrent ? 'primary-green' : 'primary-white';
+              return (
+                <li key={buttonNumber} aria-current={isCurrent}>
+                  <Button
+                    className="justify-center w-10 h-10"
+                    size="smallest"
+                    theme={theme}
+                    aria-label={intl.formatMessage(
+                      {
+                        defaultMessage: 'Goto page {page}',
+                        id: 'LOFIuA',
+                      },
+                      { page: buttonNumber }
+                    )}
+                    disabled={isCurrent}
+                    key={buttonNumber}
+                    onClick={() => {
+                      handleRangeButtonClick(buttonNumber);
+                    }}
+                  >
+                    {buttonNumber}
+                  </Button>
+                </li>
+              );
+            })}
+            <li>
+              <Button
+                className="justify-center w-10 h-10"
+                size="smallest"
+                theme="primary-white"
+                aria-label={intl.formatMessage({
+                  defaultMessage: 'Goto next page',
+                  id: 'yv7uMQ',
+                })}
+                disabled={pagination.currentPage >= pagination.totalPages}
+                onClick={handleNextClick}
+              >
+                <ChevronRightIcon className="w-4 h-4" />
+              </Button>
+            </li>
+            <li>
+              <Button
+                className="justify-center w-10 h-10"
+                size="smallest"
+                theme="primary-white"
+                aria-label={intl.formatMessage({
+                  defaultMessage: 'Goto last page',
+                  id: 'LKIG+a',
+                })}
+                disabled={pagination.currentPage >= pagination.totalPages}
+                onClick={handleLastClick}
+              >
+                <ChevronsRightIcon className="w-4 h-4" />
+              </Button>
+            </li>
+          </ol>
+        </nav>
+        <div className="flex justify-center text-sm" aria-live="polite" aria-atomic="true">
+          <FormattedMessage
+            defaultMessage="{numItems} of {totalItems} entries"
+            values={{ numItems, totalItems }}
+            id="HyAD0J"
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Pagination;

--- a/frontend/components/pagination/component.tsx
+++ b/frontend/components/pagination/component.tsx
@@ -100,8 +100,8 @@ const Pagination: React.FC<PaginationProps> = ({
                 size="smallest"
                 theme="primary-white"
                 aria-label={intl.formatMessage({
-                  defaultMessage: 'Goto first page',
-                  id: '6JknYY',
+                  defaultMessage: 'Go to first page',
+                  id: 'F4dsUN',
                 })}
                 disabled={pagination.currentPage <= 1}
                 onClick={handleFirstClick}
@@ -115,8 +115,8 @@ const Pagination: React.FC<PaginationProps> = ({
                 size="smallest"
                 theme="primary-white"
                 aria-label={intl.formatMessage({
-                  defaultMessage: 'Goto previous page',
-                  id: 'PNhgnM',
+                  defaultMessage: 'Go to previous page',
+                  id: 'NYErt1',
                 })}
                 disabled={pagination.currentPage <= 1}
                 onClick={handlePreviousClick}
@@ -135,8 +135,8 @@ const Pagination: React.FC<PaginationProps> = ({
                     theme={theme}
                     aria-label={intl.formatMessage(
                       {
-                        defaultMessage: 'Goto page {page}',
-                        id: 'LOFIuA',
+                        defaultMessage: 'Go to page {page}',
+                        id: 'wQteLO',
                       },
                       { page: buttonNumber }
                     )}
@@ -157,8 +157,8 @@ const Pagination: React.FC<PaginationProps> = ({
                 size="smallest"
                 theme="primary-white"
                 aria-label={intl.formatMessage({
-                  defaultMessage: 'Goto next page',
-                  id: 'yv7uMQ',
+                  defaultMessage: 'Go to next page',
+                  id: 'nkDaFL',
                 })}
                 disabled={pagination.currentPage >= pagination.totalPages}
                 onClick={handleNextClick}
@@ -172,8 +172,8 @@ const Pagination: React.FC<PaginationProps> = ({
                 size="smallest"
                 theme="primary-white"
                 aria-label={intl.formatMessage({
-                  defaultMessage: 'Goto last page',
-                  id: 'LKIG+a',
+                  defaultMessage: 'Go to last page',
+                  id: 'fMrPOR',
                 })}
                 disabled={pagination.currentPage >= pagination.totalPages}
                 onClick={handleLastClick}

--- a/frontend/components/pagination/index.ts
+++ b/frontend/components/pagination/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { PaginationProps } from './types';

--- a/frontend/components/pagination/types.ts
+++ b/frontend/components/pagination/types.ts
@@ -1,0 +1,23 @@
+export type PaginationProps = {
+  /** Classnames to be applied */
+  className?: string;
+  /**
+   * Whether data is currently being loaded. Will cause pagination to freeze its current state.
+   * Defaults to `false`.
+   * */
+  isLoading?: boolean;
+  /** Whether to reverse the display of buttons/entries */
+  reverseDisplay?: boolean;
+  /** Number of items being displayed */
+  numItems: number;
+  /** Current page number */
+  currentPage: number;
+  /** Total number of pages */
+  totalPages: number;
+  /** Total number of items/records */
+  totalItems: number;
+  /** Number of Number buttons to display. defaults to 8 */
+  numNumberButtons?: number;
+  /** Callback for when the user chooses a page */
+  onPageClick?: (page: number) => void;
+};

--- a/frontend/hooks/usePagination.ts
+++ b/frontend/hooks/usePagination.ts
@@ -1,0 +1,69 @@
+import { useMemo, useState, useEffect } from 'react';
+
+import { useRouter } from 'next/router';
+
+export const usePagination = (meta) => {
+  const router = useRouter();
+  const { query } = router;
+
+  // We're keeping a because when data is being fetched, meta will be null.
+  // This allows us to keep the pagination visible until new data arrives.
+  const [paginationProps, setPaginationProps] = useState<{
+    numItems: number;
+    totalItems: number;
+    currentPage: number;
+    totalPages: number;
+  }>({
+    numItems: undefined,
+    totalItems: undefined,
+    currentPage: undefined,
+    totalPages: undefined,
+  });
+
+  const queryParams = useMemo(
+    () => ({
+      page: parseInt(query.page as string) || 1,
+      search: (query.search as string) || '',
+    }),
+    [query]
+  );
+
+  useEffect(() => {
+    if (!meta) return;
+
+    const { itemsPerPage, totalItems, currentPage, totalPages } = {
+      itemsPerPage: parseInt(meta.per_page),
+      totalItems: parseInt(meta.total),
+      currentPage: parseInt(meta.page),
+      totalPages: parseInt(meta.pages),
+    };
+
+    // If we're on the current page, the number of items being displayed may not match the
+    // items per page. We can use the modulo operator to divide total items by the items per page
+    // to get the remainder. If it's 0, the number of items is the same number as per page. If not
+    // we use the remainder.
+    const numItems = (() => {
+      if (currentPage === totalPages) {
+        const remainingItems = totalItems % itemsPerPage;
+        return remainingItems === 0 ? itemsPerPage : remainingItems;
+      } else {
+        return itemsPerPage;
+      }
+    })();
+
+    setPaginationProps({ numItems, totalItems, currentPage, totalPages });
+  }, [meta]);
+
+  const handlePageClick = (page: number) => {
+    router.push({ query: { ...queryParams, page } });
+  };
+
+  if (!paginationProps) return null;
+
+  return {
+    props: {
+      ...paginationProps,
+      onPageClick: handlePageClick,
+    },
+  };
+};

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -143,6 +143,9 @@
   "60xeYL": {
     "string": "Contribute to improving the production systems and livelihoods of local communities and indigenous people, to ensure their basic needs are met, while enhancing their adaptation to climate change."
   },
+  "6JknYY": {
+    "string": "Goto first page"
+  },
   "6MoU6D": {
     "string": "Explain how the solution or project can be replicated in other contexts and geographies. Think practically about the existing opportunities, the partners and allies needed as well as the barriers that this replication effort may face such as climate issues, regulations and legal frameworks, land tenure, institutional capacity, etc."
   },
@@ -347,6 +350,9 @@
   "HnG9/3": {
     "string": "Insert password"
   },
+  "HyAD0J": {
+    "string": "{numItems} of {totalItems} entries"
+  },
   "HzKhBJ": {
     "developer_comment": "Description shown in search engines",
     "string": "HeCo Invest is a digital collaborative platform aimed to support filling the conservation financing gap in the Amazon Basin by optimizing project financing channels in this region."
@@ -410,6 +416,12 @@
   },
   "KvhWhT": {
     "string": "The <span>IDB Lab</span>, the <span>Paulson Institute</span> and the <span>World Wildlife Fund</span> are working together to develop a digital platform that connects governments, investors, donors, and philanthropists with carefully identified investment opportunities in <span>high priority locations</span> identified by programs such as Herencia Colombia (HeCo)."
+  },
+  "LKIG+a": {
+    "string": "Goto last page"
+  },
+  "LOFIuA": {
+    "string": "Goto page {page}"
   },
   "LmHPHR": {
     "string": "Select the topics/sector categories that you work on"
@@ -482,6 +494,9 @@
   },
   "PIZ1dD": {
     "string": "Search biodiversity"
+  },
+  "PNhgnM": {
+    "string": "Goto previous page"
   },
   "PTr6+3": {
     "string": "Contribute to climate solutions through investments that reduce CO2 emissions and conserve or restore forest-related carbon sinks."
@@ -647,6 +662,9 @@
   },
   "Z8971h": {
     "string": "Verified"
+  },
+  "ZATT08": {
+    "string": "Pagination"
   },
   "ZEEVQX": {
     "string": "Social media"
@@ -1091,6 +1109,9 @@
   },
   "yqJ5XD": {
     "string": "Select the amount of money that you need"
+  },
+  "yv7uMQ": {
+    "string": "Goto next page"
   },
   "z3yOZn": {
     "string": "This .kml/.kmz file does not have a valid XML syntax. Please try to validate it and resolve the issues."

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -143,9 +143,6 @@
   "60xeYL": {
     "string": "Contribute to improving the production systems and livelihoods of local communities and indigenous people, to ensure their basic needs are met, while enhancing their adaptation to climate change."
   },
-  "6JknYY": {
-    "string": "Goto first page"
-  },
   "6MoU6D": {
     "string": "Explain how the solution or project can be replicated in other contexts and geographies. Think practically about the existing opportunities, the partners and allies needed as well as the barriers that this replication effort may face such as climate issues, regulations and legal frameworks, land tenure, institutional capacity, etc."
   },
@@ -311,6 +308,9 @@
   "F1+h/t": {
     "string": "For project developers"
   },
+  "F4dsUN": {
+    "string": "Go to first page"
+  },
   "FJfVJJ": {
     "string": "Access user-friendly tools that help turn a good idea into a proposal ready to be reviewed by an investor or funder."
   },
@@ -417,12 +417,6 @@
   "KvhWhT": {
     "string": "The <span>IDB Lab</span>, the <span>Paulson Institute</span> and the <span>World Wildlife Fund</span> are working together to develop a digital platform that connects governments, investors, donors, and philanthropists with carefully identified investment opportunities in <span>high priority locations</span> identified by programs such as Herencia Colombia (HeCo)."
   },
-  "LKIG+a": {
-    "string": "Goto last page"
-  },
-  "LOFIuA": {
-    "string": "Goto page {page}"
-  },
   "LmHPHR": {
     "string": "Select the topics/sector categories that you work on"
   },
@@ -455,6 +449,9 @@
   },
   "NIQVjS": {
     "string": "Support the consolidation of their lands governance structures and capacities for sound management."
+  },
+  "NYErt1": {
+    "string": "Go to previous page"
   },
   "NjKSap": {
     "string": "Online presence"
@@ -494,9 +491,6 @@
   },
   "PIZ1dD": {
     "string": "Search biodiversity"
-  },
-  "PNhgnM": {
-    "string": "Goto previous page"
   },
   "PTr6+3": {
     "string": "Contribute to climate solutions through investments that reduce CO2 emissions and conserve or restore forest-related carbon sinks."
@@ -792,6 +786,9 @@
   "fDd10o": {
     "string": "Instrument type"
   },
+  "fMrPOR": {
+    "string": "Go to last page"
+  },
   "fnihsY": {
     "string": "Leave"
   },
@@ -911,6 +908,9 @@
   },
   "nhAnF3": {
     "string": "I want to find opportunities to invest / donate"
+  },
+  "nkDaFL": {
+    "string": "Go to next page"
   },
   "o+Vt3t": {
     "string": "Partnership between:"
@@ -1047,6 +1047,9 @@
   "vygPIS": {
     "string": "Leave project creation form"
   },
+  "wQteLO": {
+    "string": "Go to page {page}"
+  },
   "wSZR47": {
     "string": "Submit"
   },
@@ -1109,9 +1112,6 @@
   },
   "yqJ5XD": {
     "string": "Select the amount of money that you need"
-  },
-  "yv7uMQ": {
-    "string": "Goto next page"
   },
   "z3yOZn": {
     "string": "This .kml/.kmz file does not have a valid XML syntax. Please try to validate it and resolve the issues."


### PR DESCRIPTION
This PR adds a reusable pagination component, as well as a `usePagination` hook to facilitate using the `meta` returned by the endpoint to create props usable by said component. 

Accessibility based on: http://web-accessibility.carnegiemuseums.org/code/navigation/

## Testing instructions

~Testing the navigation in staging can be done here: https://heco-invest-frontend-lahef12in-vizzuality1.vercel.app/discover (staging for the ongoing #159)~

Test that the pagination displays correctly (and, if using the link above, works correctly). 

## Tracking

[LET-396](https://vizzuality.atlassian.net/browse/LET-396)

## Screenshot
<img width="612" alt="Screenshot 2022-05-10 at 10 50 22" src="https://user-images.githubusercontent.com/6273795/167601231-ed910792-a9a1-4279-a60b-3b2147d4f321.png">



