### PR TITLE
Add DiscoverSearch component

### DIFF
--- a/frontend/containers/discover-search/component.stories.tsx
+++ b/frontend/containers/discover-search/component.stories.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+
+import { Story, Meta } from '@storybook/react/types-6-0';
+
+import DiscoverSearch, { DiscoverSearchProps } from '.';
+
+export default {
+  component: DiscoverSearch,
+  title: 'Containers/DiscoverSearch',
+  argTypes: {},
+} as Meta;
+
+const Template: Story<DiscoverSearchProps> = ({ ...props }: DiscoverSearchProps) => {
+  const handleSearch = (searchText) => {
+    console.log(searchText);
+  };
+
+  return (
+    <div className="flex items-center justify-center h-48 bg-background-dark">
+      <DiscoverSearch onSearch={handleSearch} />
+    </div>
+  );
+};
+
+export const Default: Story<DiscoverSearchProps> = Template.bind({});
+
+Default.args = {};

--- a/frontend/containers/discover-search/component.tsx
+++ b/frontend/containers/discover-search/component.tsx
@@ -1,0 +1,46 @@
+import { FC, useState } from 'react';
+
+import { Search as SearchIcon } from 'react-feather';
+import { FormattedMessage } from 'react-intl';
+
+import { noop } from 'lodash-es';
+
+import Button from 'components/button';
+import Icon from 'components/icon';
+
+import { DiscoverSearchProps } from './types';
+
+export const DiscoverSearch: FC<DiscoverSearchProps> = ({
+  defaultValue = '',
+  onSearch = noop,
+}: DiscoverSearchProps) => {
+  const [searchText, setSearchText] = useState<string>(defaultValue);
+
+  const handleSearch = (e) => {
+    e.preventDefault();
+    onSearch(searchText);
+  };
+
+  return (
+    <div className="z-10 flex items-center w-full h-16 max-w-3xl gap-4 py-3 pl-6 pr-3 text-black bg-white border rounded-full xl:h-20 drop-shadow-xl">
+      <Icon aria-hidden={true} icon={SearchIcon} className="w-8 h-8 text-green-dark" />
+      <form role="search" className="flex w-full h-full gap-3" onSubmit={handleSearch}>
+        <label htmlFor="header-search" className="sr-only">
+          <FormattedMessage defaultMessage="Search" id="xmcVZ0" />
+        </label>
+        <input
+          id="header-search"
+          type="search"
+          defaultValue={defaultValue}
+          className="w-full h-full px-2 text-lg rounded-full outline-none autofill:bg-transparent"
+          onChange={(e) => setSearchText(e.target.value)}
+        />
+        <Button type="submit" className="h-full" theme="primary-orange">
+          Search
+        </Button>
+      </form>
+    </div>
+  );
+};
+
+export default DiscoverSearch;

--- a/frontend/containers/discover-search/index.ts
+++ b/frontend/containers/discover-search/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { DiscoverSearchProps } from './types';

--- a/frontend/containers/discover-search/types.ts
+++ b/frontend/containers/discover-search/types.ts
@@ -1,5 +1,5 @@
 export type DiscoverSearchProps = {
-  /** Default value for the input. Defaults to `false` */
+  /** Default value for the input. Defaults to `''` */
   defaultValue?: string;
   /** Callback for when a search is performed */
   onSearch?: (searchText: string) => void;

--- a/frontend/containers/discover-search/types.ts
+++ b/frontend/containers/discover-search/types.ts
@@ -1,0 +1,6 @@
+export type DiscoverSearchProps = {
+  /** Default value for the input. Defaults to `false` */
+  defaultValue?: string;
+  /** Callback for when a search is performed */
+  onSearch?: (searchText: string) => void;
+};


### PR DESCRIPTION
This PR adds a basic search bar to be used in the discover/search pages. At the moment, it's just a search input (other capabilities to be added in other tasks). 

Accessibility based on: http://web-accessibility.carnegiemuseums.org/code/search/

## Testing instructions

Testing the search input in staging can be done here: https://heco-invest-frontend-lahef12in-vizzuality1.vercel.app/discover (staging for the ongoing #159)

Test that the search displays correctly. 

## Tracking

[LET-393](https://vizzuality.atlassian.net/browse/LET-393)

## Screenshot

<img width="1677" alt="Screenshot 2022-05-10 at 10 53 36" src="https://user-images.githubusercontent.com/6273795/167601892-bb2af756-392c-4f95-8f43-6c00b96b0c46.png">


