### PR TITLE
fix: add max size validation to image uploader

### DIFF
--- a/frontend/components/forms/image-uploader/component.stories.tsx
+++ b/frontend/components/forms/image-uploader/component.stories.tsx
@@ -22,9 +22,17 @@ interface FormValues {
 }
 
 const Template: Story<ImageUploaderProps<FormValues>> = (args: ImageUploaderProps<FormValues>) => {
-  const { register } = useForm<FormValues>();
+  const { register, clearErrors, setError, setValue } = useForm<FormValues>();
 
-  return <ImageUploader register={register} {...args} />;
+  return (
+    <ImageUploader
+      clearError={clearErrors}
+      setError={setError}
+      setValue={setValue}
+      register={register}
+      {...args}
+    />
+  );
 };
 
 export const Default: Story<ImageUploaderProps<FormValues>> = Template.bind({});
@@ -36,14 +44,20 @@ Default.args = {
 const TemplateWithLabel: Story<ImageUploaderProps<FormValues>> = (
   args: ImageUploaderProps<FormValues>
 ) => {
-  const { register } = useForm<FormValues>();
+  const { register, clearErrors, setError, setValue } = useForm<FormValues>();
 
   return (
     <>
       <label htmlFor={args.id} className="mb-2">
         Profile picture
       </label>
-      <ImageUploader register={register} {...args} />
+      <ImageUploader
+        clearError={clearErrors}
+        setError={setError}
+        setValue={setValue}
+        register={register}
+        {...args}
+      />
     </>
   );
 };
@@ -62,6 +76,9 @@ const TemplateWithForm: Story<ImageUploaderProps<FormValues>> = (
     register,
     handleSubmit,
     formState: { errors },
+    clearErrors,
+    setError,
+    setValue,
   } = useForm<FormValues>({
     // Using the native validation, we're able to style the inputs using the `valid` and `invalid` pseudo class
     shouldUseNativeValidation: true,
@@ -77,7 +94,14 @@ const TemplateWithForm: Story<ImageUploaderProps<FormValues>> = (
       <label htmlFor={args.id} className="mb-2">
         Profile image
       </label>
-      <ImageUploader register={register} aria-describedby="form-error" {...args} />
+      <ImageUploader
+        clearError={clearErrors}
+        setError={setError}
+        setValue={setValue}
+        register={register}
+        {...args}
+        aria-describedby="form-error"
+      />
       {errors.picture?.message && (
         <p id="form-error" className="pl-2 mt-1 text-xs text-red-700">
           {errors.picture?.message}

--- a/frontend/components/forms/image-uploader/component.tsx
+++ b/frontend/components/forms/image-uploader/component.tsx
@@ -36,7 +36,6 @@ export const ImageUploader = <FormValues extends FieldValues>({
       id: 'F++AYx',
     })
   ) => {
-    console.log('error');
     setImagePreview(null);
     setValue(name, undefined);
     setError(name, {

--- a/frontend/components/forms/image-uploader/component.tsx
+++ b/frontend/components/forms/image-uploader/component.tsx
@@ -7,6 +7,8 @@ import cx from 'classnames';
 
 import Image from 'next/image';
 
+import { FILE_UPLOADER_MAX_SIZE, bytesToMegabytes } from 'helpers/pages';
+
 import { directUpload } from 'services/direct-upload/directUpload';
 
 import { ImageUploaderProps } from './types';
@@ -21,34 +23,57 @@ export const ImageUploader = <FormValues extends FieldValues>({
   registerOptions,
   setError,
   setValue,
+  maxSize = FILE_UPLOADER_MAX_SIZE,
+  clearError,
   ...rest
 }: ImageUploaderProps<FormValues>) => {
   const { formatMessage } = useIntl();
   const [imagePreview, setImagePreview] = useState<string>();
 
+  const setInputError = (
+    message: string = formatMessage({
+      defaultMessage: 'Something went wrong with the picture upload',
+      id: 'F++AYx',
+    })
+  ) => {
+    console.log('error');
+    setImagePreview(null);
+    setValue(name, undefined);
+    setError(name, {
+      message,
+    });
+  };
+
   const handleUploadImage = async (e: ChangeEvent<HTMLInputElement>) => {
     if (e.currentTarget.files?.length) {
+      clearError(name);
       const file = e.currentTarget.files[0];
+      if (maxSize && file.size >= maxSize) {
+        setInputError(
+          formatMessage(
+            {
+              defaultMessage: 'The image is larger than {maxSize}MB',
+              id: 'IBlTCs',
+            },
+            {
+              maxSize: bytesToMegabytes(maxSize).toFixed(0),
+            }
+          )
+        );
+        return;
+      }
+
       const src = URL.createObjectURL(file);
       await directUpload(file)
         .then(({ signed_id }) => {
           setImagePreview(src);
           setValue(name, signed_id as any);
         })
-        .catch((error: Error) => {
-          setValue(name, undefined);
-          setError(name, {
-            message:
-              error.message ||
-              formatMessage({
-                defaultMessage: 'Something went wrong with the picture upload',
-                id: 'F++AYx',
-              }),
-          });
-          setImagePreview(null);
+        .catch(() => {
+          setInputError();
         });
     } else {
-      setImagePreview(null);
+      setInputError();
     }
   };
 

--- a/frontend/components/forms/image-uploader/types.ts
+++ b/frontend/components/forms/image-uploader/types.ts
@@ -2,6 +2,7 @@ import {
   FieldPath,
   Path,
   RegisterOptions,
+  UseFormClearErrors,
   UseFormRegister,
   UseFormSetError,
   UseFormSetValue,
@@ -26,4 +27,8 @@ export type ImageUploaderProps<FormValues> = {
   setValue: UseFormSetValue<any>;
   /** React Hook Form's 'setError' function */
   setError: UseFormSetError<any>;
+  /** React Hook Form's 'clearError' function */
+  clearError: UseFormClearErrors<any>;
+  /** Max image size in bytes */
+  maxSize?: number;
 };

--- a/frontend/containers/forms/uploader/component.tsx
+++ b/frontend/containers/forms/uploader/component.tsx
@@ -8,17 +8,13 @@ import classNames from 'classnames';
 
 import Image from 'next/image';
 
+import { FILE_UPLOADER_MAX_SIZE, bytesToMegabytes } from 'helpers/pages';
+
 import { ProjectImageGallery } from 'types/project';
 
 import { directUpload } from 'services/direct-upload/directUpload';
 
 import { UploaderProps, UploadErrorCode } from './types';
-
-export const bytesToMegabytes = (bytes: number): number => {
-  return bytes / (1024 * 1024);
-};
-
-export const FILE_UPLOADER_MAX_SIZE = 1.5 * 1024 * 1024;
 
 export const Uploader = <FormValues extends FieldValues>({
   fileTypes,

--- a/frontend/helpers/pages.ts
+++ b/frontend/helpers/pages.ts
@@ -48,3 +48,11 @@ export function useGetAlert(error?: AxiosError<ErrorResponse>): string[] {
         ];
   }
 }
+
+/** Function to convert bytes in megabites */
+export const bytesToMegabytes = (bytes: number): number => {
+  return bytes / (1024 * 1024);
+};
+
+/** Constant to define the default max allowed file size to upload */
+export const FILE_UPLOADER_MAX_SIZE = 5 * 1024 * 1024;

--- a/frontend/pages/project-developers/new.tsx
+++ b/frontend/pages/project-developers/new.tsx
@@ -289,6 +289,7 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, FormPageLayoutProps
                 id="picture"
                 register={register}
                 preview
+                clearError={clearErrors}
               />
               <ErrorMessage id="picture-error" errorText={errors?.picture?.message} />
             </div>


### PR DESCRIPTION
This PR adds an file size validation to the image-uploader component, on the PD form

## Testing instructions

The user can't upload a file larger than 5MB
An error is displayed in this case

## Tracking

It is not a jira task, but is related to https://vizzuality.atlassian.net/browse/LET-352
