### PR TITLE
Tweak project card component for the search results

### DIFF
--- a/frontend/containers/project-card/component.stories.tsx
+++ b/frontend/containers/project-card/component.stories.tsx
@@ -1,4 +1,8 @@
+import { action } from '@storybook/addon-actions';
 import { Story, Meta } from '@storybook/react/types-6-0';
+
+import projectMock from 'mockups/project.json';
+import { Project as ProjectType } from 'types/project';
 
 import ProjectCard, { ProjectCardProps } from '.';
 
@@ -8,33 +12,17 @@ export default {
   argTypes: {},
 } as Meta;
 
-const Template: Story<ProjectCardProps> = ({
-  id,
-  category,
-  name,
-  instrument,
-  amount,
-  link: href,
-  onClick,
-}: ProjectCardProps) => (
-  <ProjectCard
-    key={id}
-    id={id}
-    category={category}
-    name={name}
-    instrument={instrument}
-    amount={amount}
-    link={`/project/${id}`}
-    onClick={onClick}
-  />
-);
+const Template: Story<ProjectCardProps> = ({ project }: ProjectCardProps) => {
+  const onClick = (projectId: string) => action('onClick')(projectId);
+  return <ProjectCard project={project} onClick={onClick} />;
+};
 
 export const Default: Story<ProjectCardProps> = Template.bind({});
 Default.args = {
-  id: 'project-id',
-  category: 'Tourism & recreation',
-  name: 'Circulo de Creaciones Cidaticas Circreadi',
-  instrument: 'Grant',
-  amount: 25000,
-  link: '/project/circulo-creaciones',
+  project: { ...projectMock, trusted: false } as ProjectType,
+};
+
+export const Verified: Story<ProjectCardProps> = Template.bind({});
+Verified.args = {
+  project: projectMock as ProjectType,
 };

--- a/frontend/containers/project-card/types.ts
+++ b/frontend/containers/project-card/types.ts
@@ -1,18 +1,10 @@
+import { Project as ProjectType } from 'types/project';
+
 export type ProjectCardProps = {
   /** Classnames to apply to the wrapper */
   className?: string;
-  /** Id of the project */
-  id: string;
-  /** Investment category */
-  category: string;
-  /** Project name */
-  name: string;
-  /** Instrument type */
-  instrument: string;
-  /** Amount of money invested (in USD) */
-  amount: number;
-  /** Link to follow when the user clicks on a card */
-  link?: string;
+  /** Projects list */
+  project: ProjectType;
   /** onClick callback */
-  onClick?: () => void;
+  onClick?: (projectId: string) => void;
 };

--- a/frontend/containers/project-header/component.tsx
+++ b/frontend/containers/project-header/component.tsx
@@ -68,7 +68,7 @@ export const ProjectHeader: FC<ProjectHeaderProps> = ({
   const instrumentTypesStr = useMemo(
     () =>
       allInstrumentTypes
-        ?.filter(({ id }) => project.instrument_types.includes(id))
+        ?.filter(({ id }) => project.instrument_types?.includes(id))
         .map(({ name }, idx) => (idx === 0 ? name : name.toLowerCase()))
         .join(', '),
     [allInstrumentTypes, project.instrument_types]
@@ -96,7 +96,7 @@ export const ProjectHeader: FC<ProjectHeaderProps> = ({
         )}
         <LayoutContainer className="flex flex-col justify-between lg:min-h-[18rem]">
           <div className="flex justify-center gap-2 mb-4 lg:justify-start">
-            {project.verified && (
+            {project.trusted && (
               <Tag className="bg-white text-green-dark">
                 <CheckCircleIcon className="w-4 h-4 mr-3" />
                 <FormattedMessage defaultMessage="Verified" id="Z8971h" />

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -293,6 +293,9 @@
   "E/YxHp": {
     "string": "When will the project have the Verification badge?"
   },
+  "E1kj21": {
+    "string": "Project verification"
+  },
   "Ec0M9T": {
     "string": "Please briefly describe the main groups of activities or components for the implementation of the project. It is not necessary to be very detailed, just a logical sequence of the general lines of action. These groups of activities should be used to define the estimated budget below. No more than three groups of activities or components"
   },
@@ -1046,6 +1049,9 @@
   },
   "x/1DXz": {
     "string": "In the face of the economic and social crisis caused by the coronavirus pandemic, there is an urgent need to support the transition to a green, fair, and resilient economy that creates jobs, addresses inequality, and drives inclusive growth."
+  },
+  "x/AykP": {
+    "string": "Project ticket size"
   },
   "x6wKw3": {
     "string": "All selected options have been cleared."

--- a/frontend/mockups/project.json
+++ b/frontend/mockups/project.json
@@ -38,7 +38,7 @@
     "language": "en",
     "geometry": {},
     "favourite": null,
-    "verified": true,
+    "trusted": true,
     "project_developer": {
         "type": "project_developer",
         "id": "3117d9f4-6dff-4fb0-9510-eb8b0e6e77da",

--- a/frontend/pages/project-developer/[id]/index.tsx
+++ b/frontend/pages/project-developer/[id]/index.tsx
@@ -96,17 +96,7 @@ const ProjectDeveloperPage: PageComponent<ProjectDeveloperPageProps, StaticPageL
     },
   ];
 
-  const projects = projectDeveloper.projects.map((project) => ({
-    id: `project-${project.id}`,
-    slug: project.slug,
-    name: project.name,
-    category: enums[EnumTypes.Category].find(({ id }) => id === project.category)?.name,
-    instrument: enums[EnumTypes.InstrumentType]
-      .filter(({ id }) => projectDeveloper.projects[0].instrument_types?.includes(id))
-      .reduce((acc, instrument) => [...acc, instrument.name], [])
-      .join(', '),
-    amount: project.received_funding_amount_usd || 0,
-  }));
+  const { projects } = projectDeveloper;
 
   return (
     <>
@@ -166,16 +156,8 @@ const ProjectDeveloperPage: PageComponent<ProjectDeveloperPageProps, StaticPageL
             <Carousel className="mt-12">
               {chunk(projects, 3).map((projectsChunk, index) => (
                 <Slide key={`slide-${index}`} className="flex flex-col gap-2">
-                  {projectsChunk.map(({ id, slug, category, name, instrument, amount }) => (
-                    <ProjectCard
-                      key={id}
-                      id={id}
-                      category={category}
-                      name={name}
-                      instrument={instrument}
-                      amount={amount}
-                      link={`${Paths.Project}/${slug}`}
-                    />
+                  {projectsChunk.map((project) => (
+                    <ProjectCard key={project.id} project={project} />
                   ))}
                 </Slide>
               ))}

--- a/frontend/types/project.ts
+++ b/frontend/types/project.ts
@@ -43,7 +43,7 @@ export type ProjectBase = {
   ticket_size?: TicketSizes;
   language: Languages;
   project_images: ProjectImageType[];
-  verified?: boolean;
+  trusted?: boolean;
   project_developer?: any; // Cannot use ProjectDeveloperType because linting will complain about circular references
 };
 


### PR DESCRIPTION
**In this PR:** 

`ProjectCard`:  
- Now takes a `project` as prop, instead of multiple props   
- Added a _Verified_ badge for verified projects (`trusted`)  
- If an `onClick` callback is passed, it'll execute it (with the project `id` as an argument), if not, it'll link to the project public page    
- The _Ticket size_ and _Instrument types_ strings displayed in the card, are built automatically  
  _from the translated names/descriptions coming from the API (`enums`)_
  _This prevents having the code responsible for it duplicated in multiple views, plus should make future changes easier_  
- Fixed the _Ticket size_ displayed in the project cards  
  _they were displaying the amount in USD instead_  

Others:  
  - Updated the project type 
    _`verified` to `trusted`, the ladder being what the property name is called_  
  - Updated the project developer page to be compatible with the new project card usage  

## Testing instructions

Verify that the ProjectCard displays correctly. 

## Tracking

[LET-394](https://vizzuality.atlassian.net/browse/LET-394)

## Screenshot  
<img width="547" alt="Screenshot 2022-05-11 at 15 11 39" src="https://user-images.githubusercontent.com/6273795/167870537-72029b62-be82-4bc5-a8c2-253d870771c2.png">

