### PR TITLE
feat: Store progress of background jobs at Events table

### DIFF
--- a/backend/app/controllers/api/v1/background_job_events_controller.rb
+++ b/backend/app/controllers/api/v1/background_job_events_controller.rb
@@ -1,0 +1,32 @@
+module API
+  module V1
+    class BackgroundJobEventsController < BaseController
+      include API::Pagination
+
+      before_action :authenticate_user! # TODO: Only Admin can access!
+
+      def index
+        events = apply_filter_to BackgroundJobEvent.all
+        pagy_object, events = pagy(events, page: current_page, items: per_page)
+        render json: BackgroundJobEventSerializer.new(
+          events,
+          links: pagination_links(:api_v1_background_job_events_path, pagy_object),
+          meta: pagination_meta(pagy_object)
+        ).serializable_hash
+      end
+
+      private
+
+      def apply_filter_to(query)
+        query = query.where(status: filter_params[:status]) if filter_params[:status].present?
+        query = query.where(created_at: filter_params[:created_at_min]..) if filter_params[:created_at_min].present?
+        query = query.where(created_at: ..filter_params[:created_at_max]) if filter_params[:created_at_max].present?
+        query
+      end
+
+      def filter_params
+        params.fetch(:filter, {}).permit :status, :created_at_min, :created_at_max
+      end
+    end
+  end
+end

--- a/backend/app/jobs/application_job.rb
+++ b/backend/app/jobs/application_job.rb
@@ -1,7 +1,27 @@
 class ApplicationJob < ActiveJob::Base
-  # Automatically retry jobs that encountered a deadlock
-  # retry_on ActiveRecord::Deadlocked
+  discard_on ActiveJob::DeserializationError
 
-  # Most jobs are safe to ignore if the underlying records are no longer available
-  # discard_on ActiveJob::DeserializationError
+  before_enqueue { |job| upsert_event job, status: :enqueued }
+  before_perform { |job| upsert_event job, status: :processing }
+  after_perform { |job| upsert_event job, status: :completed }
+
+  around_perform :store_exception_at_event
+
+  private
+
+  def store_exception_at_event
+    yield
+  rescue Exception => e # rubocop:disable Lint/RescueException
+    upsert_event self, status: :crashed, message: e.backtrace
+    raise e
+  end
+
+  def upsert_event(job, **attr)
+    BackgroundJobEvent.find_or_initialize_by(id: job.job_id).tap do |event|
+      event.assign_attributes(
+        attr.merge(arguments: job.arguments, queue_name: job.queue_name, priority: job.priority, executions: job.executions)
+      )
+      event.save!
+    end
+  end
 end

--- a/backend/app/models/background_job_event.rb
+++ b/backend/app/models/background_job_event.rb
@@ -1,0 +1,5 @@
+class BackgroundJobEvent < ApplicationRecord
+  enum status: {enqueued: 0, processing: 1, completed: 2, crashed: 3}, _default: :enqueued
+
+  validates_presence_of :executions
+end

--- a/backend/app/serializers/api/v1/background_job_event_serializer.rb
+++ b/backend/app/serializers/api/v1/background_job_event_serializer.rb
@@ -1,0 +1,7 @@
+module API
+  module V1
+    class BackgroundJobEventSerializer < BaseSerializer
+      attributes :status, :arguments, :queue_name, :priority, :executions, :message, :created_at, :updated_at
+    end
+  end
+end

--- a/backend/config/routes/api.rb
+++ b/backend/config/routes/api.rb
@@ -22,6 +22,8 @@ namespace :api, format: "json" do
 
     resources :enums, only: [:index]
 
+    resources :background_job_events, only: [:index]
+
     scope "account", module: "accounts" do
       resource :project_developer, only: [:create, :update, :show]
       resource :investor, only: [:create, :update, :show]

--- a/backend/db/migrate/20220512174229_create_background_job_events.rb
+++ b/backend/db/migrate/20220512174229_create_background_job_events.rb
@@ -1,0 +1,14 @@
+class CreateBackgroundJobEvents < ActiveRecord::Migration[7.0]
+  def change
+    create_table :background_job_events, id: :uuid do |t|
+      t.integer :status, null: false, default: 0
+      t.jsonb :arguments, default: []
+      t.string :queue_name
+      t.string :priority
+      t.integer :executions, null: false, default: 0
+      t.jsonb :message
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_05_100023) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_12_174229) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -65,6 +65,17 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_05_100023) do
     t.uuid "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "background_job_events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.integer "status", default: 0, null: false
+    t.jsonb "arguments", default: []
+    t.string "queue_name"
+    t.string "priority"
+    t.integer "executions", default: 0, null: false
+    t.jsonb "message"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "favourite_project_developers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/backend/spec/factories/background_job_events.rb
+++ b/backend/spec/factories/background_job_events.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :background_job_event do
+    status { :enqueued }
+    arguments { ["test@test.test"] }
+    queue_name { "default" }
+    priority { nil }
+    executions { 1 }
+    message { nil }
+  end
+end

--- a/backend/spec/fixtures/snapshots/api/v1/background-job-events.json
+++ b/backend/spec/fixtures/snapshots/api/v1/background-job-events.json
@@ -1,0 +1,49 @@
+{
+  "data": [
+    {
+      "id": "463ae59e-60c5-4237-aa2e-3c74f579eafa",
+      "type": "background_job_event",
+      "attributes": {
+        "status": "crashed",
+        "arguments": [
+          "test@test.test"
+        ],
+        "queue_name": "default",
+        "priority": null,
+        "executions": 1,
+        "message": null,
+        "created_at": "2022-05-12T19:08:12.343Z",
+        "updated_at": "2022-05-12T19:08:12.343Z"
+      }
+    },
+    {
+      "id": "b032fc9e-6eb8-41c5-aad9-31fd8af1bb35",
+      "type": "background_job_event",
+      "attributes": {
+        "status": "enqueued",
+        "arguments": [
+          "test@test.test"
+        ],
+        "queue_name": "default",
+        "priority": null,
+        "executions": 1,
+        "message": null,
+        "created_at": "2022-05-02T19:08:12.365Z",
+        "updated_at": "2022-05-12T19:08:12.368Z"
+      }
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "per_page": 10,
+    "from": 1,
+    "to": 2,
+    "total": 2,
+    "pages": 1
+  },
+  "links": {
+    "first": "/api/v1/background_job_events?page%5Bsize%5D=10",
+    "self": "/api/v1/background_job_events?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+    "last": "/api/v1/background_job_events?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+  }
+}

--- a/backend/spec/jobs/application_job_spec.rb
+++ b/backend/spec/jobs/application_job_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+class DummyJob < ApplicationJob
+  def perform(argument)
+  end
+end
+
+class DummyWithExceptionJob < ApplicationJob
+  def perform(argument)
+    raise StandardError, "This is error!"
+  end
+end
+
+RSpec.describe ApplicationJob do
+  describe "stores monitoring events" do
+    let(:background_job_event) { BackgroundJobEvent.last }
+
+    context "when job is enqueued" do
+      before { DummyJob.perform_later("argument") }
+
+      it "stores monitoring event" do
+        expect(background_job_event.status).to eq("enqueued")
+        expect(background_job_event.arguments).to eq(["argument"])
+        expect(background_job_event.queue_name).to eq("default")
+        expect(background_job_event.priority).to be_nil
+        expect(background_job_event.executions).to eq(0)
+        expect(background_job_event.message).to be_nil
+      end
+    end
+
+    context "when job is completed" do
+      before { DummyJob.perform_now("argument") }
+
+      it "stores monitoring event" do
+        expect(background_job_event.status).to eq("completed")
+        expect(background_job_event.arguments).to eq(["argument"])
+        expect(background_job_event.queue_name).to eq("default")
+        expect(background_job_event.priority).to be_nil
+        expect(background_job_event.executions).to eq(1)
+        expect(background_job_event.message).to be_nil
+      end
+    end
+
+    context "when job fails with exception" do
+      it "stores monitoring event" do
+        expect { DummyWithExceptionJob.perform_now("argument") }.to raise_error(StandardError, "This is error!")
+        expect(background_job_event.status).to eq("crashed")
+        expect(background_job_event.arguments).to eq(["argument"])
+        expect(background_job_event.queue_name).to eq("default")
+        expect(background_job_event.priority).to be_nil
+        expect(background_job_event.executions).to eq(1)
+        expect(background_job_event.message).not_to be_nil
+      end
+    end
+
+    context "when multiple jobs is triggered" do
+      before do
+        DummyJob.perform_now("argument")
+        DummyJob.perform_now("argument")
+      end
+
+      it "stores correct number of events" do
+        expect(BackgroundJobEvent.count).to eq(2)
+      end
+    end
+  end
+end

--- a/backend/spec/models/background_job_event_spec.rb
+++ b/backend/spec/models/background_job_event_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe BackgroundJobEvent, type: :model do
+  subject { build(:background_job_event) }
+
+  it { is_expected.to be_valid }
+
+  it "should not be valid without executions" do
+    subject.executions = nil
+    expect(subject).to have(1).errors_on(:executions)
+  end
+end

--- a/backend/spec/requests/api/v1/background_job_events_spec.rb
+++ b/backend/spec/requests/api/v1/background_job_events_spec.rb
@@ -1,0 +1,58 @@
+require "swagger_helper"
+
+RSpec.describe "API V1 Background Job Events", type: :request do
+  before_all do
+    @crashed_event = create :background_job_event, status: :crashed
+    @late_event = create :background_job_event, created_at: 10.days.ago
+  end
+
+  path "/api/v1/background_job_events" do
+    get "Returns list of the background job events" do
+      tags "Background Job Events"
+      produces "application/json"
+      security [csrf: [], cookie_auth: []]
+      parameter name: "page[number]", in: :query, type: :integer, description: "Page number. Default: 1", required: false
+      parameter name: "page[size]", in: :query, type: :integer, description: "Per page items. Default: 10", required: false
+      parameter name: "filter[status]", in: :query, type: :string, description: "Filter records", required: false
+      parameter name: "filter[created_at_min]", in: :query, type: :string, description: "Filter records", required: false
+      parameter name: "filter[created_at_max]", in: :query, type: :string, description: "Filter records", required: false
+
+      let(:user) { create :user }
+
+      it_behaves_like "with not authorized error", csrf: true
+
+      response "200", :success do
+        schema type: :object, properties: {
+          data: {type: :array, items: {"$ref" => "#/components/schemas/background_job_event"}},
+          meta: {"$ref" => "#/components/schemas/pagination_meta"},
+          links: {"$ref" => "#/components/schemas/pagination_links"}
+        }
+        let("X-CSRF-TOKEN") { get_csrf_token }
+
+        before { sign_in user }
+
+        run_test!
+
+        it "matches snapshot", generate_swagger_example: true do
+          expect(response.body).to match_snapshot("api/v1/background-job-events")
+        end
+
+        context "when filtered by status" do
+          let("filter[status]") { :crashed }
+
+          it "returns only correct records" do
+            expect(response_json["data"].pluck("id")).to eq([@crashed_event.id])
+          end
+        end
+
+        context "when filtered by created at" do
+          let("filter[created_at_max]") { 2.days.ago }
+
+          it "returns only correct records" do
+            expect(response_json["data"].pluck("id")).to eq([@late_event.id])
+          end
+        end
+      end
+    end
+  end
+end

--- a/backend/spec/swagger_helper.rb
+++ b/backend/spec/swagger_helper.rb
@@ -239,6 +239,27 @@ RSpec.configure do |config|
             },
             required: %w[id type attributes relationships]
           },
+          background_job_event: {
+            type: :object,
+            properties: {
+              id: {type: :string},
+              type: {type: :string},
+              attributes: {
+                type: :object,
+                properties: {
+                  status: {type: :string},
+                  arguments: {type: :array},
+                  queue_name: {type: :string},
+                  priority: {type: :string, nullable: true},
+                  executions: {type: :integer},
+                  message: {type: :object, nullable: true},
+                  created_at: {type: :string},
+                  updated_at: {type: :string}
+                }
+              }
+            },
+            required: %w[id type attributes]
+          },
           enum: {
             type: :object,
             properties: {

--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -27,7 +27,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: cabf2bf2-49e8-49ed-b2aa-8a9d3b6acb3e
+                  id: 4649d7d6-0836-4a4e-bdef-15e5e1885f48
                   type: investor
                   attributes:
                     name: Kutch-Spencer
@@ -70,13 +70,13 @@ paths:
                     contact_email: contact@example.com
                     contact_phone: "+57-1-xxx-xx-xx"
                     picture:
-                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TmpOaE0yUTNPQzAyTldKaUxUUTRPRGt0T1RBMllpMHpOR1JpTXpRNFpUTmpaVEFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--689e129fa63f0d8e494fe5b79258683cbbda4eaf/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TmpOaE0yUTNPQzAyTldKaUxUUTRPRGt0T1RBMllpMHpOR1JpTXpRNFpUTmpaVEFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--689e129fa63f0d8e494fe5b79258683cbbda4eaf/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TmpOaE0yUTNPQzAyTldKaUxUUTRPRGt0T1RBMllpMHpOR1JpTXpRNFpUTmpaVEFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--689e129fa63f0d8e494fe5b79258683cbbda4eaf/picture.jpg
+                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WldKalptRmxZaTAwWVRJMExUUTVOVFV0T1RsbU1TMDVZelV4TnpJelpUZ3lNV1FHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--427f6b8654ff9fe13d2ea41e3a5e6aa2796269ed/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WldKalptRmxZaTAwWVRJMExUUTVOVFV0T1RsbU1TMDVZelV4TnpJelpUZ3lNV1FHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--427f6b8654ff9fe13d2ea41e3a5e6aa2796269ed/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WldKalptRmxZaTAwWVRJMExUUTVOVFV0T1RsbU1TMDVZelV4TnpJelpUZ3lNV1FHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--427f6b8654ff9fe13d2ea41e3a5e6aa2796269ed/picture.jpg
                   relationships:
                     owner:
                       data:
-                        id: 7fa1f1bd-5450-43d6-95c1-0bf897cd369a
+                        id: 5368dcdd-6315-47c2-95e2-4bc73560748d
                         type: user
               schema:
                 type: object
@@ -106,7 +106,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: f826660c-82f2-48d7-a183-cbb1bee61758
+                  id: 3ce59f7b-0cbf-4b7c-a181-2430b93b45ee
                   type: investor
                   attributes:
                     name: Name
@@ -142,13 +142,13 @@ paths:
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5WkdWak1UQmlaaTB3WTJVM0xUUXlNRGN0WVRjNVpTMWxPRGc1Tm1KaU9XRmhNamNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--fe66239e05495ac4f65996985522a2bc9f1713c2/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
-                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5WkdWak1UQmlaaTB3WTJVM0xUUXlNRGN0WVRjNVpTMWxPRGc1Tm1KaU9XRmhNamNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--fe66239e05495ac4f65996985522a2bc9f1713c2/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
-                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5WkdWak1UQmlaaTB3WTJVM0xUUXlNRGN0WVRjNVpTMWxPRGc1Tm1KaU9XRmhNamNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--fe66239e05495ac4f65996985522a2bc9f1713c2/test
+                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxWTJNd1pHVTVOeTB3WmpZNUxUUTBNRE10T0RZME1TMDRaV0UyTnpOallqaGpaakVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--1011ab65279f2dc6c84182bb3e7aa84776c34acc/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
+                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxWTJNd1pHVTVOeTB3WmpZNUxUUTBNRE10T0RZME1TMDRaV0UyTnpOallqaGpaakVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--1011ab65279f2dc6c84182bb3e7aa84776c34acc/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
+                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxWTJNd1pHVTVOeTB3WmpZNUxUUTBNRE10T0RZME1TMDRaV0UyTnpOallqaGpaakVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--1011ab65279f2dc6c84182bb3e7aa84776c34acc/test
                   relationships:
                     owner:
                       data:
-                        id: 124b23e3-a909-496d-9fb4-fd9bd714f0ef
+                        id: 96574017-9a5c-4e81-a752-25c7dd80936b
                         type: user
               schema:
                 type: object
@@ -321,7 +321,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 9e1ae6f3-a67c-4c2f-85f7-097eba68eda6
+                  id: 3b053e54-12da-4634-ba31-03e35c29e5a7
                   type: investor
                   attributes:
                     name: Name
@@ -357,13 +357,13 @@ paths:
                     contact_email: contact@example.com
                     contact_phone: '123456789'
                     picture:
-                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxT0RSaVpUUmlNUzAzWVRsa0xUUTBNMk10T0RFNE9TMW1NalJtTldSbU1HSXdaamNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--82ae5e88d770d9c399c845ba87f650bfced3ebc5/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
-                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxT0RSaVpUUmlNUzAzWVRsa0xUUTBNMk10T0RFNE9TMW1NalJtTldSbU1HSXdaamNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--82ae5e88d770d9c399c845ba87f650bfced3ebc5/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
-                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxT0RSaVpUUmlNUzAzWVRsa0xUUTBNMk10T0RFNE9TMW1NalJtTldSbU1HSXdaamNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--82ae5e88d770d9c399c845ba87f650bfced3ebc5/test
+                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqWTJOa1ptTm1aQzFrTnpVMkxUUTJNMkV0WWpObU5pMDJPREpoTkRrM09UZ3hZVGdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ee813328be2c181d1075fd25b44dc7d943a53f40/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
+                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqWTJOa1ptTm1aQzFrTnpVMkxUUTJNMkV0WWpObU5pMDJPREpoTkRrM09UZ3hZVGdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ee813328be2c181d1075fd25b44dc7d943a53f40/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
+                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqWTJOa1ptTm1aQzFrTnpVMkxUUTJNMkV0WWpObU5pMDJPREpoTkRrM09UZ3hZVGdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ee813328be2c181d1075fd25b44dc7d943a53f40/test
                   relationships:
                     owner:
                       data:
-                        id: c083c81b-94d4-4537-a5d0-7292c61db9c9
+                        id: 8b7f95d1-f931-43d2-b84e-d495c1507713
                         type: user
               schema:
                 type: object
@@ -506,7 +506,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 05cfcc05-a7e5-4c02-ae48-8b112b1ffc62
+                  id: 3462fa86-7972-406c-ae37-f58b08a58b79
                   type: project_developer
                   attributes:
                     name: Kutch-Spencer
@@ -536,22 +536,22 @@ paths:
                     contact_email: contact@example.com
                     contact_phone: "+57-1-xxx-xx-xx"
                     picture:
-                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWVRKaU1HUTBNeTA0TmpVMkxUUTRNMkV0T0RkbFlpMDJOVEptTUdJeVpUVmlZVFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--51576899d5ae887c77bb2ab5d4ca2093aaad9af0/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWVRKaU1HUTBNeTA0TmpVMkxUUTRNMkV0T0RkbFlpMDJOVEptTUdJeVpUVmlZVFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--51576899d5ae887c77bb2ab5d4ca2093aaad9af0/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWVRKaU1HUTBNeTA0TmpVMkxUUTRNMkV0T0RkbFlpMDJOVEptTUdJeVpUVmlZVFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--51576899d5ae887c77bb2ab5d4ca2093aaad9af0/picture.jpg
+                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxWWpFMU9EUTJZeTAyTW1ZMUxUUm1ZV1F0T1dWbE9TMWlPR1JsWkRoaU1tVm1NV0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--55cc7782d6e9387c3e58ff601f334eb6431ea6c1/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxWWpFMU9EUTJZeTAyTW1ZMUxUUm1ZV1F0T1dWbE9TMWlPR1JsWkRoaU1tVm1NV0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--55cc7782d6e9387c3e58ff601f334eb6431ea6c1/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxWWpFMU9EUTJZeTAyTW1ZMUxUUm1ZV1F0T1dWbE9TMWlPR1JsWkRoaU1tVm1NV0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--55cc7782d6e9387c3e58ff601f334eb6431ea6c1/picture.jpg
                     favourite: false
                   relationships:
                     owner:
                       data:
-                        id: b1fdadee-2f95-4c98-9983-a939963d037a
+                        id: ace4ca2d-29d4-4b7c-bbd0-ab6ca3e87db9
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data:
-                      - id: e3cf2ac9-5d71-4e86-88bb-6653b23286e4
+                      - id: e4a2623d-47cd-48e8-b511-a16fcd1bc921
                         type: project
-                      - id: 9f24225f-28ea-4285-bb90-18ca0b012bab
+                      - id: a1233d31-6263-45cf-9be7-0e440ec260bb
                         type: project
               schema:
                 type: object
@@ -581,7 +581,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 840f437a-f859-47b2-9305-8ff282167a70
+                  id: e2177c75-e489-4a9e-87d1-10c0a2546b4d
                   type: project_developer
                   attributes:
                     name: Name
@@ -608,14 +608,14 @@ paths:
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTmpkaE1XTm1NaTB4WW1NNExUUmlZell0WW1GaU9TMDNNelZrWW1Wak5HTTRaVEVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--547ac474263632a365acc92e1e04181dbd98e5c5/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
-                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTmpkaE1XTm1NaTB4WW1NNExUUmlZell0WW1GaU9TMDNNelZrWW1Wak5HTTRaVEVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--547ac474263632a365acc92e1e04181dbd98e5c5/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
-                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTmpkaE1XTm1NaTB4WW1NNExUUmlZell0WW1GaU9TMDNNelZrWW1Wak5HTTRaVEVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--547ac474263632a365acc92e1e04181dbd98e5c5/test
+                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WkRZeU56WXlPQzFqT1dNekxUUTRORFl0WVRjd055MWpZalUxWkRGa05qWXpNak1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--60c8e0f4116843e2a9996326c7f8881ae6a1f300/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
+                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WkRZeU56WXlPQzFqT1dNekxUUTRORFl0WVRjd055MWpZalUxWkRGa05qWXpNak1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--60c8e0f4116843e2a9996326c7f8881ae6a1f300/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
+                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WkRZeU56WXlPQzFqT1dNekxUUTRORFl0WVRjd055MWpZalUxWkRGa05qWXpNak1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--60c8e0f4116843e2a9996326c7f8881ae6a1f300/test
                     favourite: false
                   relationships:
                     owner:
                       data:
-                        id: 28293029-7a83-46ee-aef7-f133819a9d81
+                        id: c91c87b1-adeb-4148-aeed-1ee64d445624
                         type: user
                     projects:
                       data: []
@@ -750,7 +750,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 3f78f556-04bf-4f2b-a517-4d9a1fedeb57
+                  id: e39f5cd6-66c8-4330-a23a-81cff33c2f60
                   type: project_developer
                   attributes:
                     name: Name
@@ -777,14 +777,14 @@ paths:
                     contact_email: contact@example.com
                     contact_phone: "+57-1-xxx-xx-xx"
                     picture:
-                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TmpnNE5EQm1aQzFpTnpNeExUUm1PVE10WWprellpMDBOR1U1WkRsbU9UbGlNVE1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ac782e76cf65f0f85f0e9e019d4952723c6e0f3b/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
-                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TmpnNE5EQm1aQzFpTnpNeExUUm1PVE10WWprellpMDBOR1U1WkRsbU9UbGlNVE1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ac782e76cf65f0f85f0e9e019d4952723c6e0f3b/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
-                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TmpnNE5EQm1aQzFpTnpNeExUUm1PVE10WWprellpMDBOR1U1WkRsbU9UbGlNVE1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ac782e76cf65f0f85f0e9e019d4952723c6e0f3b/test
+                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3WWpFelptRmpNQzFqTlRJeExUUXdNR1V0WWpNd1pDMWhNakU1TUdJM05qa3hPRFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ca268a8a1d3825499b0036ff44556309ec80c6fc/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
+                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3WWpFelptRmpNQzFqTlRJeExUUXdNR1V0WWpNd1pDMWhNakU1TUdJM05qa3hPRFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ca268a8a1d3825499b0036ff44556309ec80c6fc/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
+                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3WWpFelptRmpNQzFqTlRJeExUUXdNR1V0WWpNd1pDMWhNakU1TUdJM05qa3hPRFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ca268a8a1d3825499b0036ff44556309ec80c6fc/test
                     favourite: false
                   relationships:
                     owner:
                       data:
-                        id: 8f82d68e-42e8-45e3-984c-d33da8a3fb9d
+                        id: 3d18e8ab-a3fc-4629-932d-84f4e0f41917
                         type: user
                     projects:
                       data: []
@@ -891,7 +891,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 8338a3ca-d1fa-4dba-8c37-1212e05c23c1
+                  id: da36ee90-5752-4844-a737-3841558f178f
                   type: project
                   attributes:
                     name: Project Name
@@ -935,37 +935,37 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 3256adb6-c63c-472e-9a29-b3d28c55e0f7
+                        id: 482667e1-9b21-4bc8-9383-d44f3b840224
                         type: project_developer
                     involved_project_developers:
                       data:
-                      - id: '07855e77-2c5a-4e48-8735-dff38b9c8eeb'
+                      - id: fb0ae484-721d-4495-9632-343a96348512
                         type: project_developer
-                      - id: 178bc396-61a7-4277-82a8-93129b625e4a
+                      - id: ab3c80ee-c36c-469d-a688-796187e204a7
                         type: project_developer
                     project_images:
                       data:
-                      - id: 1ccbc9d2-259d-4efb-9781-1cad994ea841
+                      - id: c981d198-42d2-4753-9794-9137803c454e
                         type: project_image
-                      - id: 87f2b384-87b8-43d2-b841-65dea17d9b48
+                      - id: d1a30740-4557-4070-a164-696ecf953ab9
                         type: project_image
                 included:
-                - id: 1ccbc9d2-259d-4efb-9781-1cad994ea841
+                - id: c981d198-42d2-4753-9794-9137803c454e
                   type: project_image
                   attributes:
                     cover: true
                     file:
-                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWkRCaU1qZGpPQzB6TkRFeExUUmxOREl0WW1VM01pMWpNVEUwT1dSak1URmhZbVFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e86519e5bbab0930c33a1c95f0abfcd0ad82eb29/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
-                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWkRCaU1qZGpPQzB6TkRFeExUUmxOREl0WW1VM01pMWpNVEUwT1dSak1URmhZbVFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e86519e5bbab0930c33a1c95f0abfcd0ad82eb29/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
-                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWkRCaU1qZGpPQzB6TkRFeExUUmxOREl0WW1VM01pMWpNVEUwT1dSak1URmhZbVFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e86519e5bbab0930c33a1c95f0abfcd0ad82eb29/test
-                - id: 87f2b384-87b8-43d2-b841-65dea17d9b48
+                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWm1VNFlURTBPUzFtWmpJM0xUUmhaR1l0T0RNM015MWpOV0UwT1RWa1lXSXlPV1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ad075f65d7ebf395c248052f9bfd8071b9a55876/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
+                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWm1VNFlURTBPUzFtWmpJM0xUUmhaR1l0T0RNM015MWpOV0UwT1RWa1lXSXlPV1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ad075f65d7ebf395c248052f9bfd8071b9a55876/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
+                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWm1VNFlURTBPUzFtWmpJM0xUUmhaR1l0T0RNM015MWpOV0UwT1RWa1lXSXlPV1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ad075f65d7ebf395c248052f9bfd8071b9a55876/test
+                - id: d1a30740-4557-4070-a164-696ecf953ab9
                   type: project_image
                   attributes:
                     cover: false
                     file:
-                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWkRCaU1qZGpPQzB6TkRFeExUUmxOREl0WW1VM01pMWpNVEUwT1dSak1URmhZbVFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e86519e5bbab0930c33a1c95f0abfcd0ad82eb29/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
-                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWkRCaU1qZGpPQzB6TkRFeExUUmxOREl0WW1VM01pMWpNVEUwT1dSak1URmhZbVFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e86519e5bbab0930c33a1c95f0abfcd0ad82eb29/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
-                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWkRCaU1qZGpPQzB6TkRFeExUUmxOREl0WW1VM01pMWpNVEUwT1dSak1URmhZbVFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e86519e5bbab0930c33a1c95f0abfcd0ad82eb29/test
+                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWm1VNFlURTBPUzFtWmpJM0xUUmhaR1l0T0RNM015MWpOV0UwT1RWa1lXSXlPV1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ad075f65d7ebf395c248052f9bfd8071b9a55876/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
+                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWm1VNFlURTBPUzFtWmpJM0xUUmhaR1l0T0RNM015MWpOV0UwT1RWa1lXSXlPV1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ad075f65d7ebf395c248052f9bfd8071b9a55876/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
+                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWm1VNFlURTBPUzFtWmpJM0xUUmhaR1l0T0RNM015MWpOV0UwT1RWa1lXSXlPV1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ad075f65d7ebf395c248052f9bfd8071b9a55876/test
               schema:
                 type: object
                 properties:
@@ -1153,6 +1153,106 @@ paths:
               - target_groups
               - impact_areas
               - sdgs
+  "/api/v1/background_job_events":
+    get:
+      summary: Returns list of the background job events
+      tags:
+      - Background Job Events
+      security:
+      - csrf: []
+        cookie_auth: []
+      parameters:
+      - name: page[number]
+        in: query
+        description: 'Page number. Default: 1'
+        required: false
+        schema:
+          type: integer
+      - name: page[size]
+        in: query
+        description: 'Per page items. Default: 10'
+        required: false
+        schema:
+          type: integer
+      - name: filter[status]
+        in: query
+        description: Filter records
+        required: false
+        schema:
+          type: string
+      - name: filter[created_at_min]
+        in: query
+        description: Filter records
+        required: false
+        schema:
+          type: string
+      - name: filter[created_at_max]
+        in: query
+        description: Filter records
+        required: false
+        schema:
+          type: string
+      responses:
+        '401':
+          description: Authentication failed
+          content:
+            application/json:
+              example:
+                errors:
+                - title: You need to sign in or sign up before continuing.
+                  code:
+        '200':
+          description: success
+          content:
+            application/json:
+              example:
+                data:
+                - id: 94bc5586-2c5f-469d-9027-dbc12009ece2
+                  type: background_job_event
+                  attributes:
+                    status: crashed
+                    arguments:
+                    - test@test.test
+                    queue_name: default
+                    priority:
+                    executions: 1
+                    message:
+                    created_at: '2022-05-12T19:09:16.170Z'
+                    updated_at: '2022-05-12T19:09:16.170Z'
+                - id: 97459535-2496-48f0-8160-62e3efe0773a
+                  type: background_job_event
+                  attributes:
+                    status: enqueued
+                    arguments:
+                    - test@test.test
+                    queue_name: default
+                    priority:
+                    executions: 1
+                    message:
+                    created_at: '2022-05-02T19:09:16.180Z'
+                    updated_at: '2022-05-12T19:09:16.181Z'
+                meta:
+                  page: 1
+                  per_page: 10
+                  from: 1
+                  to: 2
+                  total: 2
+                  pages: 1
+                links:
+                  first: "/api/v1/background_job_events?page%5Bsize%5D=10"
+                  self: "/api/v1/background_job_events?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+                  last: "/api/v1/background_job_events?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/background_job_event"
+                  meta:
+                    "$ref": "#/components/schemas/pagination_meta"
+                  links:
+                    "$ref": "#/components/schemas/pagination_links"
   "/api/v1/email_confirmation":
     post:
       summary: Sends an email with confirmation token
@@ -1191,7 +1291,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 74cf5ea2-df10-42d3-977d-a36c9a026076
+                  id: 3a8549b1-ae9c-412d-8359-75c0105173a8
                   type: user
                   attributes:
                     first_name: Dawna
@@ -1779,7 +1879,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: 9ae56bc3-924d-4a8e-9256-53aa14d8fa94
+                - id: ac5fb916-7d24-46b6-8a08-17b672ecdd87
                   type: investor
                   attributes:
                     name: Bartoletti and Sons
@@ -1821,15 +1921,15 @@ paths:
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoTlRkaVpXTXpNQzFsT1RrMkxUUTRNVGN0T1dNeU1pMDVNamRtTnpReU1UTXdZelFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--58f6f3323985390248462a5a7d4cccf45bcc5eb5/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoTlRkaVpXTXpNQzFsT1RrMkxUUTRNVGN0T1dNeU1pMDVNamRtTnpReU1UTXdZelFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--58f6f3323985390248462a5a7d4cccf45bcc5eb5/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoTlRkaVpXTXpNQzFsT1RrMkxUUTRNVGN0T1dNeU1pMDVNamRtTnpReU1UTXdZelFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--58f6f3323985390248462a5a7d4cccf45bcc5eb5/picture.jpg
+                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxWkdWa01qaG1NUzFqWVRka0xUUXhPV1F0T1dJd05DMHpOVFZqWW1GaU9UUXlabUlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5b50edef8e8fe4fd85cac733eb53a3fad4024892/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxWkdWa01qaG1NUzFqWVRka0xUUXhPV1F0T1dJd05DMHpOVFZqWW1GaU9UUXlabUlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5b50edef8e8fe4fd85cac733eb53a3fad4024892/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxWkdWa01qaG1NUzFqWVRka0xUUXhPV1F0T1dJd05DMHpOVFZqWW1GaU9UUXlabUlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5b50edef8e8fe4fd85cac733eb53a3fad4024892/picture.jpg
                   relationships:
                     owner:
                       data:
-                        id: b821f477-99a7-404f-a9d4-1a0d754ef887
+                        id: 2273eb7c-c30a-44df-a7c5-1737dabdd3ee
                         type: user
-                - id: 6ddbd291-ca90-4f83-8d95-51243cfc565d
+                - id: d4223e67-b87c-4a98-aa5c-292f82149feb
                   type: investor
                   attributes:
                     name: Becker LLC
@@ -1871,15 +1971,15 @@ paths:
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6T1daaE9ERmhNUzB4TUdZMUxUUTVaamt0WVdZM05DMHhaVFJpWkRabU5EVXpOamdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--398e4807595a07a4bce5599f3d3049a20bba9cf8/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6T1daaE9ERmhNUzB4TUdZMUxUUTVaamt0WVdZM05DMHhaVFJpWkRabU5EVXpOamdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--398e4807595a07a4bce5599f3d3049a20bba9cf8/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6T1daaE9ERmhNUzB4TUdZMUxUUTVaamt0WVdZM05DMHhaVFJpWkRabU5EVXpOamdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--398e4807595a07a4bce5599f3d3049a20bba9cf8/picture.jpg
+                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TnpjMk1qVmlOaTA0TkRsakxUUmtZekV0T1RaaE5TMHhORGczWldOaFpETmlZVGtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--9a55d6c496294d407112b2ee265c77e28de5e73a/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TnpjMk1qVmlOaTA0TkRsakxUUmtZekV0T1RaaE5TMHhORGczWldOaFpETmlZVGtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--9a55d6c496294d407112b2ee265c77e28de5e73a/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TnpjMk1qVmlOaTA0TkRsakxUUmtZekV0T1RaaE5TMHhORGczWldOaFpETmlZVGtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--9a55d6c496294d407112b2ee265c77e28de5e73a/picture.jpg
                   relationships:
                     owner:
                       data:
-                        id: d1fed9e4-a106-489c-b8ef-60785626381b
+                        id: e171d758-2625-4b22-892c-41ae2bcbf70b
                         type: user
-                - id: e418bb4e-3e98-4cca-b480-e86a36a20e4f
+                - id: 04a41b4d-adc3-4a22-a8d9-e95c4521ee66
                   type: investor
                   attributes:
                     name: Hane, Lehner and Goyette
@@ -1921,15 +2021,15 @@ paths:
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoTXpKaE1ESmtZeTAzTWpObUxUUXpZamt0WVRCaE1pMW1NVGxtWW1ReU9HTXlOak1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--99abb7d68010a39c5407c5bff9bb8002b471c10e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoTXpKaE1ESmtZeTAzTWpObUxUUXpZamt0WVRCaE1pMW1NVGxtWW1ReU9HTXlOak1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--99abb7d68010a39c5407c5bff9bb8002b471c10e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoTXpKaE1ESmtZeTAzTWpObUxUUXpZamt0WVRCaE1pMW1NVGxtWW1ReU9HTXlOak1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--99abb7d68010a39c5407c5bff9bb8002b471c10e/picture.jpg
+                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtTkdaall6aGxZUzA1TnpRM0xUUTNabUV0WVRjeE9TMDNaVFk1TURZM056ZzNPVGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--943033849bfb07f179ee0f180ffcad60850c7f9c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtTkdaall6aGxZUzA1TnpRM0xUUTNabUV0WVRjeE9TMDNaVFk1TURZM056ZzNPVGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--943033849bfb07f179ee0f180ffcad60850c7f9c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtTkdaall6aGxZUzA1TnpRM0xUUTNabUV0WVRjeE9TMDNaVFk1TURZM056ZzNPVGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--943033849bfb07f179ee0f180ffcad60850c7f9c/picture.jpg
                   relationships:
                     owner:
                       data:
-                        id: 87207d1b-94e4-4870-a737-b399778c9a7b
+                        id: b8d6c28b-dc59-4a65-88d3-77cb0ac01016
                         type: user
-                - id: e75d0b1b-f371-46d5-a24b-6143aab3c914
+                - id: f878d04e-5a48-4ec9-8cc4-8d726cc4192c
                   type: investor
                   attributes:
                     name: Hilpert, Waters and Johnston
@@ -1971,15 +2071,15 @@ paths:
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpT0RObFpqVTROaTB5TURJNExUUTJNR010WWpFMU1TMDNNR1ZqTlRsaE56RTNOVEVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--7dedbae834960ef4f67cf5de14d6620f430e3680/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpT0RObFpqVTROaTB5TURJNExUUTJNR010WWpFMU1TMDNNR1ZqTlRsaE56RTNOVEVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--7dedbae834960ef4f67cf5de14d6620f430e3680/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpT0RObFpqVTROaTB5TURJNExUUTJNR010WWpFMU1TMDNNR1ZqTlRsaE56RTNOVEVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--7dedbae834960ef4f67cf5de14d6620f430e3680/picture.jpg
+                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWWpWa1pHRmhZeTB6TW1Oa0xUUmpaR1l0T1dJeVpTMDVZVGd4TXpNNE1ETTJNV1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--3a138f5e37c2eee8bb90f1ceede1424cfde03b29/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWWpWa1pHRmhZeTB6TW1Oa0xUUmpaR1l0T1dJeVpTMDVZVGd4TXpNNE1ETTJNV1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--3a138f5e37c2eee8bb90f1ceede1424cfde03b29/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWWpWa1pHRmhZeTB6TW1Oa0xUUmpaR1l0T1dJeVpTMDVZVGd4TXpNNE1ETTJNV1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--3a138f5e37c2eee8bb90f1ceede1424cfde03b29/picture.jpg
                   relationships:
                     owner:
                       data:
-                        id: eae5e20f-a9b4-4f14-a9a3-149ed3b27601
+                        id: 0c0dfcec-3feb-4cdd-b72c-9a921cf75932
                         type: user
-                - id: 418ede6f-2b3d-4c91-a5f2-faae423a8d28
+                - id: 66ed38b3-7c2c-47ec-ad6e-6fc933e95521
                   type: investor
                   attributes:
                     name: Jacobson, Fritsch and Stanton
@@ -2021,15 +2121,15 @@ paths:
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3WmpOaE1EVm1PUzA1TkdFNExUUmxNR0V0T0RsbE9DMWlNR1kzTlRnNE16WmhOREFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--d8b626add051ec72d723e9532b89df160f167d16/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3WmpOaE1EVm1PUzA1TkdFNExUUmxNR0V0T0RsbE9DMWlNR1kzTlRnNE16WmhOREFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--d8b626add051ec72d723e9532b89df160f167d16/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3WmpOaE1EVm1PUzA1TkdFNExUUmxNR0V0T0RsbE9DMWlNR1kzTlRnNE16WmhOREFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--d8b626add051ec72d723e9532b89df160f167d16/picture.jpg
+                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswTUdOaU5HTmtaUzFsWlRZNUxUUXdaamt0T0dRNE15MWhNekE1TXpObVpqY3dPRFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--326e5230c28eee959cf0a21936786957b7d006f8/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswTUdOaU5HTmtaUzFsWlRZNUxUUXdaamt0T0dRNE15MWhNekE1TXpObVpqY3dPRFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--326e5230c28eee959cf0a21936786957b7d006f8/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswTUdOaU5HTmtaUzFsWlRZNUxUUXdaamt0T0dRNE15MWhNekE1TXpObVpqY3dPRFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--326e5230c28eee959cf0a21936786957b7d006f8/picture.jpg
                   relationships:
                     owner:
                       data:
-                        id: 46f6efda-49f0-444b-924a-4cd034b26662
+                        id: 485af59a-9d8b-4ddf-aa22-b6783217e220
                         type: user
-                - id: 817b6c97-b997-41c7-b0cc-293dffc084df
+                - id: d829ff0b-120f-435f-814d-6561382a11eb
                   type: investor
                   attributes:
                     name: Keebler, Kub and Zemlak
@@ -2071,15 +2171,15 @@ paths:
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrWVRBME5tVm1NUzA1WWpKaUxUUmxaRGt0T0ROaU55MW1Zak16WldGak0yTXhZVGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ee29a06c6c462fb3b5e504536d4604dd78ea4bac/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrWVRBME5tVm1NUzA1WWpKaUxUUmxaRGt0T0ROaU55MW1Zak16WldGak0yTXhZVGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ee29a06c6c462fb3b5e504536d4604dd78ea4bac/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrWVRBME5tVm1NUzA1WWpKaUxUUmxaRGt0T0ROaU55MW1Zak16WldGak0yTXhZVGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ee29a06c6c462fb3b5e504536d4604dd78ea4bac/picture.jpg
+                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TTJSaFpXUTVZeTFoWTJJNExUUmpZalF0T0Rjd01TMDRNVGcwTXpObFpHWTNNR1FHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f182523d225498d12fc3367e5551252a2f6dab95/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TTJSaFpXUTVZeTFoWTJJNExUUmpZalF0T0Rjd01TMDRNVGcwTXpObFpHWTNNR1FHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f182523d225498d12fc3367e5551252a2f6dab95/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TTJSaFpXUTVZeTFoWTJJNExUUmpZalF0T0Rjd01TMDRNVGcwTXpObFpHWTNNR1FHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f182523d225498d12fc3367e5551252a2f6dab95/picture.jpg
                   relationships:
                     owner:
                       data:
-                        id: e2a78b97-2f99-49a3-b919-3759b7049e80
+                        id: d6aefcd6-b0d6-44f6-9477-34f7db481093
                         type: user
-                - id: dd725f08-84ce-4b5a-a724-a58e1b2e2e4b
+                - id: a79eb371-2c33-489f-884b-30bb6ddd0b96
                   type: investor
                   attributes:
                     name: Kutch-Spencer
@@ -2121,15 +2221,15 @@ paths:
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3T1RGaFlUZGpOaTFqTnpRekxUUmxZVE10T0RGa05TMDNOakkzWkdNellqUTFaVFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6c1be72ee978f7766aae155c82e60e76e37db1f7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3T1RGaFlUZGpOaTFqTnpRekxUUmxZVE10T0RGa05TMDNOakkzWkdNellqUTFaVFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6c1be72ee978f7766aae155c82e60e76e37db1f7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3T1RGaFlUZGpOaTFqTnpRekxUUmxZVE10T0RGa05TMDNOakkzWkdNellqUTFaVFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6c1be72ee978f7766aae155c82e60e76e37db1f7/picture.jpg
+                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3WWpWalpEQXpPQzAxWkRFd0xUUXhaV1F0WW1ZeE1TMWxaams1TkdWbFpXVmxObUlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--39bcf0659be219d24ed0c22742d3f0afcd876a87/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3WWpWalpEQXpPQzAxWkRFd0xUUXhaV1F0WW1ZeE1TMWxaams1TkdWbFpXVmxObUlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--39bcf0659be219d24ed0c22742d3f0afcd876a87/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3WWpWalpEQXpPQzAxWkRFd0xUUXhaV1F0WW1ZeE1TMWxaams1TkdWbFpXVmxObUlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--39bcf0659be219d24ed0c22742d3f0afcd876a87/picture.jpg
                   relationships:
                     owner:
                       data:
-                        id: 67990342-bd98-4052-b143-3cb25c43cfeb
+                        id: 5bb93814-543d-47bb-95a4-e01894b8343a
                         type: user
-                - id: be92898e-6b01-4e78-8278-64baaafe5ce1
+                - id: 9545ec03-bb8d-4fd6-9f80-9905b1cfd6df
                   type: investor
                   attributes:
                     name: Runolfsson and Sons
@@ -2172,13 +2272,13 @@ paths:
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3WWpGalptSTJaaTFtTWpCbUxUUmxNek10T0dZNFppMHlOV1V4WmpRM04ySm1OakFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--cc9294da9c227236b860d24f622e9900fb968edc/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3WWpGalptSTJaaTFtTWpCbUxUUmxNek10T0dZNFppMHlOV1V4WmpRM04ySm1OakFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--cc9294da9c227236b860d24f622e9900fb968edc/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3WWpGalptSTJaaTFtTWpCbUxUUmxNek10T0dZNFppMHlOV1V4WmpRM04ySm1OakFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--cc9294da9c227236b860d24f622e9900fb968edc/picture.jpg
+                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TXpVMU1XUXpZUzFpWkRGbExUUXlabUl0WWpoa05pMWhOV1EyTURBM05qa3hZekFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--b86eb9039a9b073bc0e2f57e2131ea368c117e3e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TXpVMU1XUXpZUzFpWkRGbExUUXlabUl0WWpoa05pMWhOV1EyTURBM05qa3hZekFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--b86eb9039a9b073bc0e2f57e2131ea368c117e3e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TXpVMU1XUXpZUzFpWkRGbExUUXlabUl0WWpoa05pMWhOV1EyTURBM05qa3hZekFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--b86eb9039a9b073bc0e2f57e2131ea368c117e3e/picture.jpg
                   relationships:
                     owner:
                       data:
-                        id: 7a4422f0-5c47-4509-8195-ae4b2c35bd8a
+                        id: c249ffd9-0581-4a50-8aa5-e219439f0ff4
                         type: user
                 meta:
                   page: 1
@@ -2233,7 +2333,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: dd725f08-84ce-4b5a-a724-a58e1b2e2e4b
+                  id: a79eb371-2c33-489f-884b-30bb6ddd0b96
                   type: investor
                   attributes:
                     name: Kutch-Spencer
@@ -2275,13 +2375,13 @@ paths:
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3T1RGaFlUZGpOaTFqTnpRekxUUmxZVE10T0RGa05TMDNOakkzWkdNellqUTFaVFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6c1be72ee978f7766aae155c82e60e76e37db1f7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3T1RGaFlUZGpOaTFqTnpRekxUUmxZVE10T0RGa05TMDNOakkzWkdNellqUTFaVFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6c1be72ee978f7766aae155c82e60e76e37db1f7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3T1RGaFlUZGpOaTFqTnpRekxUUmxZVE10T0RGa05TMDNOakkzWkdNellqUTFaVFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6c1be72ee978f7766aae155c82e60e76e37db1f7/picture.jpg
+                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3WWpWalpEQXpPQzAxWkRFd0xUUXhaV1F0WW1ZeE1TMWxaams1TkdWbFpXVmxObUlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--39bcf0659be219d24ed0c22742d3f0afcd876a87/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3WWpWalpEQXpPQzAxWkRFd0xUUXhaV1F0WW1ZeE1TMWxaams1TkdWbFpXVmxObUlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--39bcf0659be219d24ed0c22742d3f0afcd876a87/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3WWpWalpEQXpPQzAxWkRFd0xUUXhaV1F0WW1ZeE1TMWxaams1TkdWbFpXVmxObUlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--39bcf0659be219d24ed0c22742d3f0afcd876a87/picture.jpg
                   relationships:
                     owner:
                       data:
-                        id: 67990342-bd98-4052-b143-3cb25c43cfeb
+                        id: 5bb93814-543d-47bb-95a4-e01894b8343a
                         type: user
               schema:
                 type: object
@@ -2330,7 +2430,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: 2019c325-f63b-4554-8b59-9b196c5ca739
+                - id: 6d789600-043b-474d-b679-5435f914a8ed
                   type: location
                   attributes:
                     name: Canada
@@ -2340,7 +2440,7 @@ paths:
                       data:
                     regions:
                       data: []
-                - id: 1f95570b-cd5b-4090-bf19-fb8e09eec050
+                - id: aaa029e6-b107-4900-9499-172580dd2d46
                   type: location
                   attributes:
                     name: Papua New Guinea
@@ -2348,11 +2448,11 @@ paths:
                   relationships:
                     parent:
                       data:
-                        id: 2019c325-f63b-4554-8b59-9b196c5ca739
+                        id: 6d789600-043b-474d-b679-5435f914a8ed
                         type: location
                     regions:
                       data: []
-                - id: e35dcc90-bc46-4116-85ac-fc6096f9396a
+                - id: 3f4dda4d-701a-4575-bc44-f3aab82f7a18
                   type: location
                   attributes:
                     name: Jamaica
@@ -2360,13 +2460,13 @@ paths:
                   relationships:
                     parent:
                       data:
-                        id: 1f95570b-cd5b-4090-bf19-fb8e09eec050
+                        id: aaa029e6-b107-4900-9499-172580dd2d46
                         type: location
                     regions:
                       data:
-                      - id: 6b8156ae-00ff-4663-b5d0-1caf47ccc794
+                      - id: fc8ec61c-98b6-4c27-8def-edaffb96fcb8
                         type: location
-                - id: 6b8156ae-00ff-4663-b5d0-1caf47ccc794
+                - id: fc8ec61c-98b6-4c27-8def-edaffb96fcb8
                   type: location
                   attributes:
                     name: Libyan Arab Jamahiriya
@@ -2376,7 +2476,7 @@ paths:
                       data:
                     regions:
                       data: []
-                - id: 578fda72-c517-4ce6-a1d2-d7a36ca037e3
+                - id: b2a5bd50-9c3e-43da-bab3-30dd6b483812
                   type: location
                   attributes:
                     name: India
@@ -2384,13 +2484,13 @@ paths:
                   relationships:
                     parent:
                       data:
-                        id: 1f95570b-cd5b-4090-bf19-fb8e09eec050
+                        id: aaa029e6-b107-4900-9499-172580dd2d46
                         type: location
                     regions:
                       data:
-                      - id: b286b926-6176-42c9-b7a6-0dda5bf1aa7f
+                      - id: fc1fd2bd-30dc-4b1b-a918-aa2655219bff
                         type: location
-                - id: b286b926-6176-42c9-b7a6-0dda5bf1aa7f
+                - id: fc1fd2bd-30dc-4b1b-a918-aa2655219bff
                   type: location
                   attributes:
                     name: Mayotte
@@ -2400,7 +2500,7 @@ paths:
                       data:
                     regions:
                       data: []
-                - id: c4864979-fea5-47c0-a738-798d3fcc09e9
+                - id: 601617fa-9e68-4af2-8e52-d8704699142d
                   type: location
                   attributes:
                     name: Puerto Rico
@@ -2408,13 +2508,13 @@ paths:
                   relationships:
                     parent:
                       data:
-                        id: 1f95570b-cd5b-4090-bf19-fb8e09eec050
+                        id: aaa029e6-b107-4900-9499-172580dd2d46
                         type: location
                     regions:
                       data:
-                      - id: 76ec72fe-75df-438d-b82c-68eb42adab64
+                      - id: fb169dce-cd74-453e-9501-79186fd96100
                         type: location
-                - id: 76ec72fe-75df-438d-b82c-68eb42adab64
+                - id: fb169dce-cd74-453e-9501-79186fd96100
                   type: location
                   attributes:
                     name: Sierra Leone
@@ -2468,7 +2568,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: e35dcc90-bc46-4116-85ac-fc6096f9396a
+                  id: 3f4dda4d-701a-4575-bc44-f3aab82f7a18
                   type: location
                   attributes:
                     name: Jamaica
@@ -2476,11 +2576,11 @@ paths:
                   relationships:
                     parent:
                       data:
-                        id: 1f95570b-cd5b-4090-bf19-fb8e09eec050
+                        id: aaa029e6-b107-4900-9499-172580dd2d46
                         type: location
                     regions:
                       data:
-                      - id: 6b8156ae-00ff-4663-b5d0-1caf47ccc794
+                      - id: fc8ec61c-98b6-4c27-8def-edaffb96fcb8
                         type: location
               schema:
                 type: object
@@ -2559,7 +2659,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: ca5d18c2-a79e-48c2-a4e8-9161a24e1719
+                - id: '06238f7b-0b61-4f7f-a494-2c4044c25155'
                   type: open_call
                   attributes:
                     name: Open call 1
@@ -2576,14 +2676,14 @@ paths:
                       tempora exercitationem. Qui dolorem quo.
                     impact_description: Enim repellat pariatur. Earum modi eos. Libero
                       tempora exercitationem. Qui dolorem quo.
-                    closing_at: '2023-03-06T08:36:02.402Z'
+                    closing_at: '2023-03-12T19:09:19.219Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: 8bf11afd-4e21-49f9-9cba-4a453d821253
+                        id: 180de883-cc7a-45fc-8011-a31e0231a431
                         type: investor
-                - id: b42be9f6-46b1-4b8a-a25c-0854ff385ed4
+                - id: c1ed68c7-a126-42d5-8cae-fa3ec511ed21
                   type: open_call
                   attributes:
                     name: Open call 2
@@ -2600,14 +2700,14 @@ paths:
                       Sunt commodi tempore. Voluptatem et corrupti.
                     impact_description: Placeat commodi libero. Quo recusandae repellat.
                       Sunt commodi tempore. Voluptatem et corrupti.
-                    closing_at: '2023-03-06T08:36:02.479Z'
+                    closing_at: '2023-03-12T19:09:19.325Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: 219e6d0e-e458-45bf-9010-8ef133c403b0
+                        id: 4cc1e556-54b1-445a-81e9-50fcebcd305e
                         type: investor
-                - id: 36f7ff0b-8239-4786-9277-3f505cfe4670
+                - id: 205827fa-5759-4665-826d-cce1095f5b0f
                   type: open_call
                   attributes:
                     name: Open call 3
@@ -2624,14 +2724,14 @@ paths:
                       nesciunt voluptas. Suscipit ex cum.
                     impact_description: Et quaerat omnis. Harum voluptas atque. Quo
                       nesciunt voluptas. Suscipit ex cum.
-                    closing_at: '2023-03-06T08:36:02.525Z'
+                    closing_at: '2023-03-12T19:09:19.374Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: dad12951-5d0d-426a-a275-0f02006379b7
+                        id: 4f096ba0-1a9b-4cb3-8be2-bc76be5c6862
                         type: investor
-                - id: f28106ee-3b60-4325-a4cf-35f221d6b071
+                - id: 6e2633e1-3067-4782-8e5d-14b8b817f7c9
                   type: open_call
                   attributes:
                     name: Open call 4
@@ -2648,14 +2748,14 @@ paths:
                       Sit neque eos. Expedita molestiae quia.
                     impact_description: Dolores fugiat nesciunt. Ut laborum dolores.
                       Sit neque eos. Expedita molestiae quia.
-                    closing_at: '2023-03-06T08:36:02.576Z'
+                    closing_at: '2023-03-12T19:09:19.425Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: b313ba9b-e304-44a5-bde4-0e0819dac6cf
+                        id: 2edf25c2-3181-4cd5-a2d0-00da6849bb42
                         type: investor
-                - id: 7d93303a-7d8a-4fcb-902d-b43c5867f6c9
+                - id: 847b11d1-a6ba-4e3d-9d02-bab5e761220e
                   type: open_call
                   attributes:
                     name: Open call 5
@@ -2672,14 +2772,14 @@ paths:
                       recusandae eum. Eius ex est.
                     impact_description: Autem et et. Voluptatem neque quibusdam. Repellat
                       recusandae eum. Eius ex est.
-                    closing_at: '2023-03-06T08:36:02.623Z'
+                    closing_at: '2023-03-12T19:09:19.475Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: 767310f8-685c-4ae9-938d-5b6c8638cf0e
+                        id: 50b9e738-8d4f-4af2-9bb7-75ae9558582d
                         type: investor
-                - id: d091d21e-357e-40c6-b17e-7da546916de1
+                - id: c77ccdc8-cdab-4146-b47d-8def8469ddb4
                   type: open_call
                   attributes:
                     name: Open call 6
@@ -2696,14 +2796,14 @@ paths:
                       Eligendi sapiente voluptatem. Quas rerum officia.
                     impact_description: Porro soluta beatae. Quia ratione facilis.
                       Eligendi sapiente voluptatem. Quas rerum officia.
-                    closing_at: '2023-03-06T08:36:02.677Z'
+                    closing_at: '2023-03-12T19:09:19.524Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: 86584e0f-a7d0-4424-b38b-0cfbe054a85e
+                        id: 9c92fdef-50c3-4379-b20b-bfd6cdc4e7b6
                         type: investor
-                - id: 30e485c6-9e44-45fe-92da-7250b65cd5a3
+                - id: a1f38cbf-6394-4b67-808d-277d7b3977b7
                   type: open_call
                   attributes:
                     name: Open call 7
@@ -2720,12 +2820,12 @@ paths:
                       laudantium et. Sed recusandae aut.
                     impact_description: Mollitia aut vel. Qui illum accusantium. Et
                       laudantium et. Sed recusandae aut.
-                    closing_at: '2023-03-06T08:36:02.728Z'
+                    closing_at: '2023-03-12T19:09:19.571Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: 3b300594-b392-4203-855d-b8fa3af4a25a
+                        id: 9ee14d6a-305d-441d-891c-13b2ae155f9b
                         type: investor
                 meta:
                   page: 1
@@ -2780,7 +2880,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: ca5d18c2-a79e-48c2-a4e8-9161a24e1719
+                  id: '06238f7b-0b61-4f7f-a494-2c4044c25155'
                   type: open_call
                   attributes:
                     name: Open call 1
@@ -2797,12 +2897,12 @@ paths:
                       tempora exercitationem. Qui dolorem quo.
                     impact_description: Enim repellat pariatur. Earum modi eos. Libero
                       tempora exercitationem. Qui dolorem quo.
-                    closing_at: '2023-03-06T08:36:02.402Z'
+                    closing_at: '2023-03-12T19:09:19.219Z'
                     language: en
                   relationships:
                     investor:
                       data:
-                        id: 8bf11afd-4e21-49f9-9cba-4a453d821253
+                        id: 180de883-cc7a-45fc-8011-a31e0231a431
                         type: investor
               schema:
                 type: object
@@ -2875,7 +2975,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: 17b25698-e727-40e2-afec-c3c08f94f7c4
+                - id: 55b9a956-de2b-4b88-bff4-2135aa037bdc
                   type: project_developer
                   attributes:
                     name: Bartoletti and Sons
@@ -2905,22 +3005,22 @@ paths:
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3TnpGaE1qTTRZUzAxTnpoa0xUUmlNMkV0WVRKaE1DMDJaVEV5TVdJNVpqazRabU1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c27c04b6be68cce946aa9358b24b86dcae5d944a/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3TnpGaE1qTTRZUzAxTnpoa0xUUmlNMkV0WVRKaE1DMDJaVEV5TVdJNVpqazRabU1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c27c04b6be68cce946aa9358b24b86dcae5d944a/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3TnpGaE1qTTRZUzAxTnpoa0xUUmlNMkV0WVRKaE1DMDJaVEV5TVdJNVpqazRabU1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c27c04b6be68cce946aa9358b24b86dcae5d944a/picture.jpg
+                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoTVdJeU5XTTJZeTA1WXpZMUxUUmxaVEV0T1RBMllpMDNaamM0WVRaaU5qRXdZamtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--992e302a8c0467c9492c66c27f8b084cf0265be6/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoTVdJeU5XTTJZeTA1WXpZMUxUUmxaVEV0T1RBMllpMDNaamM0WVRaaU5qRXdZamtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--992e302a8c0467c9492c66c27f8b084cf0265be6/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoTVdJeU5XTTJZeTA1WXpZMUxUUmxaVEV0T1RBMllpMDNaamM0WVRaaU5qRXdZamtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--992e302a8c0467c9492c66c27f8b084cf0265be6/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: a021304f-bca5-4e17-9ebc-781f2c413a84
+                        id: 751a62f6-9f66-4198-ba90-0240baccdf2d
                         type: user
                     projects:
                       data:
-                      - id: 044c9108-7985-462f-8183-d36a57524b10
+                      - id: 1b48093f-cee0-4ecc-9aa0-5499bc351404
                         type: project
                     involved_projects:
                       data: []
-                - id: d696b8f6-4349-48f0-96e8-ce2e21e577e9
+                - id: 442c5d88-0d4b-4c35-a4e3-9c2d5dab617d
                   type: project_developer
                   attributes:
                     name: Becker LLC
@@ -2950,20 +3050,20 @@ paths:
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTURObVpUVXlNQzAwTlRjeUxUUTNOek10WVRkaU9TMHdOV1F5T0RFMVlqY3dOVEFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--31e3d1346df75513ba3a4bd4a7b57e783becd7d9/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTURObVpUVXlNQzAwTlRjeUxUUTNOek10WVRkaU9TMHdOV1F5T0RFMVlqY3dOVEFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--31e3d1346df75513ba3a4bd4a7b57e783becd7d9/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTURObVpUVXlNQzAwTlRjeUxUUTNOek10WVRkaU9TMHdOV1F5T0RFMVlqY3dOVEFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--31e3d1346df75513ba3a4bd4a7b57e783becd7d9/picture.jpg
+                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpWXpVNFpHUTJNeTB6Tm1FMExUUXhNVFF0WW1ObU5pMWpPRGN6TldabFpURTNOV01HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4181656fa0de5a75c8a3fdcffd05bb8ce484162f/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpWXpVNFpHUTJNeTB6Tm1FMExUUXhNVFF0WW1ObU5pMWpPRGN6TldabFpURTNOV01HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4181656fa0de5a75c8a3fdcffd05bb8ce484162f/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpWXpVNFpHUTJNeTB6Tm1FMExUUXhNVFF0WW1ObU5pMWpPRGN6TldabFpURTNOV01HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4181656fa0de5a75c8a3fdcffd05bb8ce484162f/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 56be6e94-6caa-4fd7-944b-a47b7ae96c4f
+                        id: ff6ca04b-df7f-4dcd-8aac-db4b20b2bfee
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data: []
-                - id: d12daee7-e565-41ea-8934-bac371189a6c
+                - id: 724b4c23-8f15-4fb2-a839-9a7f353e8209
                   type: project_developer
                   attributes:
                     name: Gleichner-Bartoletti
@@ -2993,20 +3093,20 @@ paths:
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswWldFNU0ySTBaUzA0TXpZMExUUTJPV1F0WWpZek1pMW1PRGRsWmpVNU16a3dZMlVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--7e043388698c7dea7470b7c7d83fb5383dd7fe07/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswWldFNU0ySTBaUzA0TXpZMExUUTJPV1F0WWpZek1pMW1PRGRsWmpVNU16a3dZMlVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--7e043388698c7dea7470b7c7d83fb5383dd7fe07/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswWldFNU0ySTBaUzA0TXpZMExUUTJPV1F0WWpZek1pMW1PRGRsWmpVNU16a3dZMlVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--7e043388698c7dea7470b7c7d83fb5383dd7fe07/picture.jpg
+                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3WkdJeFltUTVaaTAzT1dKbUxUUTRNV1l0T0RGbU5DMDJZMlZsTkdNME1HUXpZVEVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c243ce3c2f6289d08e4bebeead8400a1d6ef54cf/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3WkdJeFltUTVaaTAzT1dKbUxUUTRNV1l0T0RGbU5DMDJZMlZsTkdNME1HUXpZVEVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c243ce3c2f6289d08e4bebeead8400a1d6ef54cf/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3WkdJeFltUTVaaTAzT1dKbUxUUTRNV1l0T0RGbU5DMDJZMlZsTkdNME1HUXpZVEVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c243ce3c2f6289d08e4bebeead8400a1d6ef54cf/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: df84388e-e633-49db-acf8-9b1068e3ab84
+                        id: 5ff39dd4-19dd-451e-8aca-911604828cc2
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data: []
-                - id: 322eff0b-6cc3-4e47-aab0-cfea56186967
+                - id: 4421db87-30ef-464a-9df0-5d1baefe14ef
                   type: project_developer
                   attributes:
                     name: Hane, Lehner and Goyette
@@ -3036,22 +3136,22 @@ paths:
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpT0RRd1ptUmlZUzB6TmpreUxUUTVNR0V0T0RnM01DMWtNR0UyWWpoa05qVmxPR1FHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--08c68be80d0d2c32f848257b3662729912fffc8d/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpT0RRd1ptUmlZUzB6TmpreUxUUTVNR0V0T0RnM01DMWtNR0UyWWpoa05qVmxPR1FHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--08c68be80d0d2c32f848257b3662729912fffc8d/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpT0RRd1ptUmlZUzB6TmpreUxUUTVNR0V0T0RnM01DMWtNR0UyWWpoa05qVmxPR1FHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--08c68be80d0d2c32f848257b3662729912fffc8d/picture.jpg
+                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6WkRaalkyWmlaQzAyT1RjMkxUUTBPVEl0T0RnNE55MHlOVFl5TnpVME16bGpNMlVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0957e4cdfcc15a2ae70ee13292cce83b34f86bdb/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6WkRaalkyWmlaQzAyT1RjMkxUUTBPVEl0T0RnNE55MHlOVFl5TnpVME16bGpNMlVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0957e4cdfcc15a2ae70ee13292cce83b34f86bdb/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6WkRaalkyWmlaQzAyT1RjMkxUUTBPVEl0T0RnNE55MHlOVFl5TnpVME16bGpNMlVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0957e4cdfcc15a2ae70ee13292cce83b34f86bdb/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 07551fd4-14a3-4fa2-98b2-67bab9c12dac
+                        id: 6e458b73-52c1-4155-bd46-022197f42a35
                         type: user
                     projects:
                       data:
-                      - id: 4f62ef35-d5a9-49d5-b79e-18151e9d3119
+                      - id: aed033d0-e3ee-4edf-b46b-86f0fa861118
                         type: project
                     involved_projects:
                       data: []
-                - id: a569cbcc-38ec-4212-97bf-c66a1606c808
+                - id: f326e601-8437-4025-a438-d2822924dc09
                   type: project_developer
                   attributes:
                     name: Hilpert, Waters and Johnston
@@ -3081,20 +3181,20 @@ paths:
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWszWXpZM1kyVmxaUzFrWkRsaUxUUTVNV0V0T1RjNVppMDNNemxpWlRabU9EVTVPREFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c796f183bc9e8771eb42bf93a9351c5f53bdd2ea/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWszWXpZM1kyVmxaUzFrWkRsaUxUUTVNV0V0T1RjNVppMDNNemxpWlRabU9EVTVPREFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c796f183bc9e8771eb42bf93a9351c5f53bdd2ea/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWszWXpZM1kyVmxaUzFrWkRsaUxUUTVNV0V0T1RjNVppMDNNemxpWlRabU9EVTVPREFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c796f183bc9e8771eb42bf93a9351c5f53bdd2ea/picture.jpg
+                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTlRKa05qRmxOQzB3TnpKaExUUXlORGt0WVdRMk5TMHdObUpqT0dWaU56QTRNRFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--42872f206078f75366302bd17d698f964360cb27/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTlRKa05qRmxOQzB3TnpKaExUUXlORGt0WVdRMk5TMHdObUpqT0dWaU56QTRNRFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--42872f206078f75366302bd17d698f964360cb27/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTlRKa05qRmxOQzB3TnpKaExUUXlORGt0WVdRMk5TMHdObUpqT0dWaU56QTRNRFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--42872f206078f75366302bd17d698f964360cb27/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: dca04e67-69bf-4cff-8196-ae4beb510756
+                        id: c0c71a4b-14b9-47ab-aed3-1c3bb9724c62
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data: []
-                - id: 5bd11762-a0f8-4a96-ac01-a5fdb301f9f8
+                - id: cf80b013-1fc1-4f93-8819-ff737831b780
                   type: project_developer
                   attributes:
                     name: Jacobson, Fritsch and Stanton
@@ -3124,20 +3224,20 @@ paths:
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTWpCbU1EY3pNQzB6TVdNMUxUUTJNell0WWpJeFpTMDRObUl5T1RRMlpURmpZbU1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--954bf04687f97c85a5951528aa348cf7b5b25d1a/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTWpCbU1EY3pNQzB6TVdNMUxUUTJNell0WWpJeFpTMDRObUl5T1RRMlpURmpZbU1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--954bf04687f97c85a5951528aa348cf7b5b25d1a/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTWpCbU1EY3pNQzB6TVdNMUxUUTJNell0WWpJeFpTMDRObUl5T1RRMlpURmpZbU1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--954bf04687f97c85a5951528aa348cf7b5b25d1a/picture.jpg
+                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WVRFMFptRTFOaTFoTldGaExUUTNaV1F0T1dReVlpMWtaREZrWkRrd05qUmxOakFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--d17da0130f9b8514f848f47858141333de6a56be/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WVRFMFptRTFOaTFoTldGaExUUTNaV1F0T1dReVlpMWtaREZrWkRrd05qUmxOakFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--d17da0130f9b8514f848f47858141333de6a56be/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WVRFMFptRTFOaTFoTldGaExUUTNaV1F0T1dReVlpMWtaREZrWkRrd05qUmxOakFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--d17da0130f9b8514f848f47858141333de6a56be/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 680c65dd-5adc-4e55-b3c8-79f38db95d04
+                        id: 89974e9c-a614-4faf-b006-da8fcf848eb2
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data: []
-                - id: 381974f7-a4c0-4a42-9964-d8f23356d4ae
+                - id: 9ba871ef-dbb7-4b20-8818-4e233f0ac406
                   type: project_developer
                   attributes:
                     name: Keebler, Kub and Zemlak
@@ -3167,20 +3267,20 @@ paths:
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTnpnNFlUVTVPUzAxTkdRNUxUUm1OVE10T0dRNVpDMHhaVEV3WkdNNE5UUXhNVGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2ed6e864390cfd67e25481f6860c64d582a13fbc/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTnpnNFlUVTVPUzAxTkdRNUxUUm1OVE10T0dRNVpDMHhaVEV3WkdNNE5UUXhNVGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2ed6e864390cfd67e25481f6860c64d582a13fbc/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTnpnNFlUVTVPUzAxTkdRNUxUUm1OVE10T0dRNVpDMHhaVEV3WkdNNE5UUXhNVGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2ed6e864390cfd67e25481f6860c64d582a13fbc/picture.jpg
+                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswTjJRMk5tSTVPQzFsT1RGa0xUUmxZelF0T0RkalpTMDNNREZsWkRVMFltRTRZV0lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--82351b9a3e9352604916e82d2e7a3f70c7270410/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswTjJRMk5tSTVPQzFsT1RGa0xUUmxZelF0T0RkalpTMDNNREZsWkRVMFltRTRZV0lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--82351b9a3e9352604916e82d2e7a3f70c7270410/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswTjJRMk5tSTVPQzFsT1RGa0xUUmxZelF0T0RkalpTMDNNREZsWkRVMFltRTRZV0lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--82351b9a3e9352604916e82d2e7a3f70c7270410/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: b3b59b46-b057-4f7a-bab0-27397b439283
+                        id: 7f06f965-9ef1-409f-8c8b-79ec194e0a13
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data: []
-                - id: 6edf6cec-9406-4bf4-b03c-fbd9f425dba1
+                - id: 439bafb9-5c5f-47d7-9f33-bc394be32606
                   type: project_developer
                   attributes:
                     name: Kutch-Spencer
@@ -3209,24 +3309,24 @@ paths:
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TVRKaFlUa3hOaTA1WkRJMUxUUmlNbUV0T1RjeE1DMWhORFJsTnpnek5HWTNZMlVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--3e1068ec0adc1babebd44b6a9b383d2d0664d2b7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TVRKaFlUa3hOaTA1WkRJMUxUUmlNbUV0T1RjeE1DMWhORFJsTnpnek5HWTNZMlVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--3e1068ec0adc1babebd44b6a9b383d2d0664d2b7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TVRKaFlUa3hOaTA1WkRJMUxUUmlNbUV0T1RjeE1DMWhORFJsTnpnek5HWTNZMlVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--3e1068ec0adc1babebd44b6a9b383d2d0664d2b7/picture.jpg
+                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTkRRM01XSXdPQzB3WW1ZeExUUmhPR1l0T0RRNE5DMDRabVZqTnpnMFl6TXhNekFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--17596cf0142d7a5ec92ef106455607f4d1997072/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTkRRM01XSXdPQzB3WW1ZeExUUmhPR1l0T0RRNE5DMDRabVZqTnpnMFl6TXhNekFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--17596cf0142d7a5ec92ef106455607f4d1997072/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTkRRM01XSXdPQzB3WW1ZeExUUmhPR1l0T0RRNE5DMDRabVZqTnpnMFl6TXhNekFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--17596cf0142d7a5ec92ef106455607f4d1997072/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: e93e8527-d2c5-48ca-8491-40e7747a1bc9
+                        id: 289a162c-fc38-41c4-8624-1a3fb6cd6040
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data:
-                      - id: 044c9108-7985-462f-8183-d36a57524b10
+                      - id: 1b48093f-cee0-4ecc-9aa0-5499bc351404
                         type: project
-                      - id: 4f62ef35-d5a9-49d5-b79e-18151e9d3119
+                      - id: aed033d0-e3ee-4edf-b46b-86f0fa861118
                         type: project
-                - id: 583e4220-09eb-446b-9600-e150bdd9bb25
+                - id: 4927b01f-05c4-4b7e-9d18-0e6f9776c919
                   type: project_developer
                   attributes:
                     name: Ritchie, Glover and Ward
@@ -3256,20 +3356,20 @@ paths:
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6T0RrME5UQmhPUzFsTXpBd0xUUTVNV0l0T1dFNE5pMDJPR1U0TXpZMU16STRaV01HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--653c8aacbf6cc2582c6ceb16672c52a8b6539dbe/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6T0RrME5UQmhPUzFsTXpBd0xUUTVNV0l0T1dFNE5pMDJPR1U0TXpZMU16STRaV01HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--653c8aacbf6cc2582c6ceb16672c52a8b6539dbe/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6T0RrME5UQmhPUzFsTXpBd0xUUTVNV0l0T1dFNE5pMDJPR1U0TXpZMU16STRaV01HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--653c8aacbf6cc2582c6ceb16672c52a8b6539dbe/picture.jpg
+                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxT1RFeVlqQXpPQzFtWW1Wa0xUUTVNak10T0dZek9TMHlaVGxsTnpJME9UVmhNV0lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--81b8e6ea9a86d5e8b7c5bcb49c75d8df19f0dbd3/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxT1RFeVlqQXpPQzFtWW1Wa0xUUTVNak10T0dZek9TMHlaVGxsTnpJME9UVmhNV0lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--81b8e6ea9a86d5e8b7c5bcb49c75d8df19f0dbd3/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxT1RFeVlqQXpPQzFtWW1Wa0xUUTVNak10T0dZek9TMHlaVGxsTnpJME9UVmhNV0lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--81b8e6ea9a86d5e8b7c5bcb49c75d8df19f0dbd3/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 61341a9d-5172-49e6-ac1c-98f84d21571d
+                        id: 3d7ba079-cd55-4fdf-bc76-f33e455c653b
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data: []
-                - id: 570a1580-8986-4748-9554-68698966a1bb
+                - id: '09096d7a-12f8-4d10-8ec9-6222bfd0e1c6'
                   type: project_developer
                   attributes:
                     name: Runolfsson and Sons
@@ -3299,14 +3399,14 @@ paths:
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsWldNME5XRTNOeTFsT0RjeUxUUm1OR1V0WVdJeE5pMHpaVFF3WVdFNE4yVTRabVlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--8caecd749fcb19252bc0bda39b15b65e9850dc5b/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsWldNME5XRTNOeTFsT0RjeUxUUm1OR1V0WVdJeE5pMHpaVFF3WVdFNE4yVTRabVlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--8caecd749fcb19252bc0bda39b15b65e9850dc5b/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsWldNME5XRTNOeTFsT0RjeUxUUm1OR1V0WVdJeE5pMHpaVFF3WVdFNE4yVTRabVlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--8caecd749fcb19252bc0bda39b15b65e9850dc5b/picture.jpg
+                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsTldRd05HRTFZUzFsTnpFd0xUUm1aRE10T1RBek9TMDNZemMzTW1Vek9XRXpOamdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f69483e50f26f6ece97171ac9e1341770cc22cbe/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsTldRd05HRTFZUzFsTnpFd0xUUm1aRE10T1RBek9TMDNZemMzTW1Vek9XRXpOamdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f69483e50f26f6ece97171ac9e1341770cc22cbe/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsTldRd05HRTFZUzFsTnpFd0xUUm1aRE10T1RBek9TMDNZemMzTW1Vek9XRXpOamdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f69483e50f26f6ece97171ac9e1341770cc22cbe/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 9298f1d2-d0a1-436f-bede-9ed8b0596093
+                        id: ff2b30f3-74ce-40ae-b156-dbd176f20328
                         type: user
                     projects:
                       data: []
@@ -3371,7 +3471,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 6edf6cec-9406-4bf4-b03c-fbd9f425dba1
+                  id: 439bafb9-5c5f-47d7-9f33-bc394be32606
                   type: project_developer
                   attributes:
                     name: Kutch-Spencer
@@ -3400,22 +3500,22 @@ paths:
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TVRKaFlUa3hOaTA1WkRJMUxUUmlNbUV0T1RjeE1DMWhORFJsTnpnek5HWTNZMlVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--3e1068ec0adc1babebd44b6a9b383d2d0664d2b7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TVRKaFlUa3hOaTA1WkRJMUxUUmlNbUV0T1RjeE1DMWhORFJsTnpnek5HWTNZMlVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--3e1068ec0adc1babebd44b6a9b383d2d0664d2b7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TVRKaFlUa3hOaTA1WkRJMUxUUmlNbUV0T1RjeE1DMWhORFJsTnpnek5HWTNZMlVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--3e1068ec0adc1babebd44b6a9b383d2d0664d2b7/picture.jpg
+                      small: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTkRRM01XSXdPQzB3WW1ZeExUUmhPR1l0T0RRNE5DMDRabVZqTnpnMFl6TXhNekFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--17596cf0142d7a5ec92ef106455607f4d1997072/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTkRRM01XSXdPQzB3WW1ZeExUUmhPR1l0T0RRNE5DMDRabVZqTnpnMFl6TXhNekFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--17596cf0142d7a5ec92ef106455607f4d1997072/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTkRRM01XSXdPQzB3WW1ZeExUUmhPR1l0T0RRNE5DMDRabVZqTnpnMFl6TXhNekFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--17596cf0142d7a5ec92ef106455607f4d1997072/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: e93e8527-d2c5-48ca-8491-40e7747a1bc9
+                        id: 289a162c-fc38-41c4-8624-1a3fb6cd6040
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data:
-                      - id: 044c9108-7985-462f-8183-d36a57524b10
+                      - id: 1b48093f-cee0-4ecc-9aa0-5499bc351404
                         type: project
-                      - id: 4f62ef35-d5a9-49d5-b79e-18151e9d3119
+                      - id: aed033d0-e3ee-4edf-b46b-86f0fa861118
                         type: project
               schema:
                 type: object
@@ -3506,7 +3606,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: 24baece3-966d-4d8e-ab05-cda5252a1147
+                - id: c01887f8-78c7-4b50-bf85-9b7bda5afca3
                   type: project
                   attributes:
                     name: Project 1
@@ -3558,21 +3658,21 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 545f1681-c2c0-4ade-9f9f-8276a7bea1d9
+                        id: 05e668fd-eb4f-4cbf-9f20-e33df8ff550c
                         type: project_developer
                     involved_project_developers:
                       data:
-                      - id: 28b0a985-92cb-4f5e-b984-a7996cfaeb15
+                      - id: b115beb9-9e36-4250-ace8-4e4028b6d913
                         type: project_developer
-                      - id: 52495bc2-b171-4bf1-91c5-7fb90ade767e
+                      - id: 1a689512-a1df-48f5-9544-a957912a095e
                         type: project_developer
                     project_images:
                       data:
-                      - id: ab55aaa5-60d6-423f-bbbc-acfb5af43899
+                      - id: 54489fac-644e-4d82-a2a0-68a1999e34a7
                         type: project_image
-                      - id: 70698690-1f01-4255-8cc4-8eea6db00b62
+                      - id: cc4d4177-12b2-4bac-b3d6-d85ad6627baa
                         type: project_image
-                - id: 3667d876-7738-4445-a87a-54e13a204c80
+                - id: 228cb002-edbd-48d2-ad82-9f7ad4bdad9a
                   type: project
                   attributes:
                     name: Project 2
@@ -3624,13 +3724,13 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 3ae96997-cae9-4b42-88ba-af29dab03461
+                        id: b3eb53cf-de7a-48d8-ba47-1beb762d8413
                         type: project_developer
                     involved_project_developers:
                       data: []
                     project_images:
                       data: []
-                - id: d9ebe492-123e-4854-93e3-bb40c3cd2f8e
+                - id: a07adfe2-f9a6-4951-b780-0d776b010e15
                   type: project
                   attributes:
                     name: Project 3
@@ -3682,13 +3782,13 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 284da549-ea67-4ad6-a3d2-7169d9beb5ef
+                        id: 417023bb-b11a-4176-baef-fbbb678eb1d8
                         type: project_developer
                     involved_project_developers:
                       data: []
                     project_images:
                       data: []
-                - id: 2770f4a5-16ae-4490-a95e-a0511f9645bd
+                - id: 5b894d7a-d263-4da2-a81b-2dfe46edee80
                   type: project
                   attributes:
                     name: Project 4
@@ -3740,13 +3840,13 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 2c9b9188-ad7d-4810-a037-d61ec30abfc7
+                        id: b63663fd-9c10-44f9-b6de-909acce7c4be
                         type: project_developer
                     involved_project_developers:
                       data: []
                     project_images:
                       data: []
-                - id: e6a45f27-4ee6-471a-ae86-931074199e1a
+                - id: 47dc10a8-bdd0-4455-a33f-1e212c273736
                   type: project
                   attributes:
                     name: Project 5
@@ -3798,13 +3898,13 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 938b2a3d-6db9-433b-8035-0ce2c14cd109
+                        id: 8b32285b-df4f-4ebb-876c-2f0570cbfe67
                         type: project_developer
                     involved_project_developers:
                       data: []
                     project_images:
                       data: []
-                - id: 75376cbb-c4a4-462f-862b-5f50fedffa51
+                - id: 306208c2-4ecc-46c7-84bc-1eb6f3d1d9f5
                   type: project
                   attributes:
                     name: Project 6
@@ -3856,13 +3956,13 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 7b72e994-3803-41c6-9412-f42bfa7b9b17
+                        id: f27b90f1-e37d-4957-89cc-16c99968c263
                         type: project_developer
                     involved_project_developers:
                       data: []
                     project_images:
                       data: []
-                - id: 1340bb3c-869a-41ed-ade3-a514b5bc885f
+                - id: 0b95dd49-5ee9-4157-bef5-cf88c2471d60
                   type: project
                   attributes:
                     name: Project 7
@@ -3914,7 +4014,7 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 91dcb875-8755-45da-b987-10f4888a6ddc
+                        id: 97c5297c-86d7-4ef6-97e2-0e5ffcf74a2a
                         type: project_developer
                     involved_project_developers:
                       data: []
@@ -3979,7 +4079,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 24baece3-966d-4d8e-ab05-cda5252a1147
+                  id: c01887f8-78c7-4b50-bf85-9b7bda5afca3
                   type: project
                   attributes:
                     name: Project 1
@@ -4031,19 +4131,19 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 545f1681-c2c0-4ade-9f9f-8276a7bea1d9
+                        id: 05e668fd-eb4f-4cbf-9f20-e33df8ff550c
                         type: project_developer
                     involved_project_developers:
                       data:
-                      - id: 28b0a985-92cb-4f5e-b984-a7996cfaeb15
+                      - id: b115beb9-9e36-4250-ace8-4e4028b6d913
                         type: project_developer
-                      - id: 52495bc2-b171-4bf1-91c5-7fb90ade767e
+                      - id: 1a689512-a1df-48f5-9544-a957912a095e
                         type: project_developer
                     project_images:
                       data:
-                      - id: ab55aaa5-60d6-423f-bbbc-acfb5af43899
+                      - id: 54489fac-644e-4d82-a2a0-68a1999e34a7
                         type: project_image
-                      - id: 70698690-1f01-4255-8cc4-8eea6db00b62
+                      - id: cc4d4177-12b2-4bac-b3d6-d85ad6627baa
                         type: project_image
               schema:
                 type: object
@@ -4085,7 +4185,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 7e51b056-453a-402f-a831-5f3b626ee4ef
+                  id: a548a807-f1c1-40b4-a5e3-487dce785520
                   type: user
                   attributes:
                     first_name: Dawna
@@ -4133,7 +4233,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 72b8ef3c-39d5-4a26-b32d-3ac6f3b43e95
+                  id: 83761826-7b0b-4d53-8cae-1eae8a4aeea0
                   type: user
                   attributes:
                     first_name: Dawna
@@ -4260,7 +4360,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: a67fb16b-24c9-4ae4-9871-b4abcd756295
+                  id: 650b2df6-c6bd-4eed-9144-a9c0f8bedbd0
                   type: user
                   attributes:
                     first_name: Jan
@@ -4331,7 +4431,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: b8101030-62db-4641-8055-a44401d4b73c
+                  id: 582458fa-43b1-4675-bc61-fda70b1426cb
                   type: user
                   attributes:
                     first_name: Dawna
@@ -4367,19 +4467,19 @@ paths:
           content:
             application/json:
               example:
-                id: be1f9acf-5891-4181-9900-8291d127b61d
-                key: r1y20lwu5yne543ihnx0oxm3ls2x
+                id: 3120e807-1180-4792-b3ca-619d6b19e3f7
+                key: zf68vb84hqq21jx0xk21dpotfj91
                 filename: test.jpg
                 content_type: image/jpeg
                 metadata: {}
                 service_name: test
                 byte_size: 32326
                 checksum: QYeLAwqIj9HrwITqtTYaEw==
-                created_at: '2022-05-06T08:36:06.717Z'
-                signed_id: eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpWlRGbU9XRmpaaTAxT0RreExUUXhPREV0T1Rrd01DMDRNamt4WkRFeU4ySTJNV1FHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--8128fdbf77cf132fe24e1457ae8d0cb54e88f8d9
-                attachable_sgid: BAh7CEkiCGdpZAY6BkVUSSJWZ2lkOi8vYmFja2VuZC9BY3RpdmVTdG9yYWdlOjpCbG9iL2JlMWY5YWNmLTU4OTEtNDE4MS05OTAwLTgyOTFkMTI3YjYxZD9leHBpcmVzX2luBjsAVEkiDHB1cnBvc2UGOwBUSSIPYXR0YWNoYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--4718192c9d43e8666f9ebfadb99849fc8f47f1a6
+                created_at: '2022-05-12T19:09:24.029Z'
+                signed_id: eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TVRJd1pUZ3dOeTB4TVRnd0xUUTNPVEl0WWpOallTMDJNVGxrTm1JeE9XVXpaamNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4f9c84e12b92fa01d5bbf4d7fb87cfbe33ef2de6
+                attachable_sgid: BAh7CEkiCGdpZAY6BkVUSSJWZ2lkOi8vYmFja2VuZC9BY3RpdmVTdG9yYWdlOjpCbG9iLzMxMjBlODA3LTExODAtNDc5Mi1iM2NhLTYxOWQ2YjE5ZTNmNz9leHBpcmVzX2luBjsAVEkiDHB1cnBvc2UGOwBUSSIPYXR0YWNoYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--5a042b9b273e65c44167b738aa7c48e4aefd8b66
                 direct_upload:
-                  url: http://www.example.com/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDam9JYTJWNVNTSWhjakY1TWpCc2QzVTFlVzVsTlRRemFXaHVlREJ2ZUcwemJITXllQVk2QmtWVU9oRmpiMjUwWlc1MFgzUjVjR1ZKSWc5cGJXRm5aUzlxY0dWbkJqc0dWRG9UWTI5dWRHVnVkRjlzWlc1bmRHaHBBa1orT2cxamFHVmphM04xYlVraUhWRlpaVXhCZDNGSmFqbEljbmRKVkhGMFZGbGhSWGM5UFFZN0JsUTZFWE5sY25acFkyVmZibUZ0WlRvSmRHVnpkQT09IiwiZXhwIjoiMjAyMi0wNS0wNlQwODo0MTowNi43MjFaIiwicHVyIjoiYmxvYl90b2tlbiJ9fQ==--edfdad130e932addc8a3def097075948527f990d
+                  url: http://www.example.com/backend/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDam9JYTJWNVNTSWhlbVkyT0haaU9EUm9jWEV5TVdwNE1IaHJNakZrY0c5MFptbzVNUVk2QmtWVU9oRmpiMjUwWlc1MFgzUjVjR1ZKSWc5cGJXRm5aUzlxY0dWbkJqc0dWRG9UWTI5dWRHVnVkRjlzWlc1bmRHaHBBa1orT2cxamFHVmphM04xYlVraUhWRlpaVXhCZDNGSmFqbEljbmRKVkhGMFZGbGhSWGM5UFFZN0JsUTZFWE5sY25acFkyVmZibUZ0WlRvSmRHVnpkQT09IiwiZXhwIjoiMjAyMi0wNS0xMlQxOToxNDoyNC4wMzJaIiwicHVyIjoiYmxvYl90b2tlbiJ9fQ==--585d31483c9a7a42a26f40d9d7e881fc82104c9a
                   headers:
                     Content-Type: image/jpeg
               schema:
@@ -4779,6 +4879,38 @@ components:
       - type
       - attributes
       - relationships
+    background_job_event:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        attributes:
+          type: object
+          properties:
+            status:
+              type: string
+            arguments:
+              type: array
+            queue_name:
+              type: string
+            priority:
+              type: string
+              nullable: true
+            executions:
+              type: integer
+            message:
+              type: object
+              nullable: true
+            created_at:
+              type: string
+            updated_at:
+              type: string
+      required:
+      - id
+      - type
+      - attributes
     enum:
       type: object
       properties:


### PR DESCRIPTION
This PR add new model called `BackgroundJobEvent` which is used to store progress of background jobs. Every job is monitored via `action` hooks and actual status is saved into db. In case of exception, even backtrace is stored. 

There is also new endpoints `GET /api/v1/background_job_events` which is available only for authenticated users (for Admins at future) and which returns data from BackgroundJobEvent table. These data can be filtered (`:status, :created_at_min, :created_at_max`) and are paginated.

## Testing instructions

Start new job and send request to `GET /api/v1/background_job_events`. You should see corresponding information -- if even is enqueued, completed or it crashed, etc.

## Tracking

https://vizzuality.atlassian.net/browse/LET-392
