### PR TITLE
Project details card (search page)

### DIFF
--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -15,6 +15,7 @@ module.exports = {
     '@storybook/addon-essentials',
     'storybook-addon-next',
     'storybook-react-intl',
+    'storybook-addon-mock/register',
     {
       name: '@storybook/addon-postcss',
       options: {

--- a/frontend/components/impact-chart/component.stories.tsx
+++ b/frontend/components/impact-chart/component.stories.tsx
@@ -9,7 +9,7 @@ export default {
 };
 
 const Template: Story<ImpactChartProps> = (args) => (
-  <div className="w-[500px] h-[500px]">
+  <div className="w-96">
     <ImpactChart {...args} />
   </div>
 );

--- a/frontend/components/impact-chart/component.tsx
+++ b/frontend/components/impact-chart/component.tsx
@@ -21,7 +21,7 @@ import { ImpactChartProps } from './types';
 
 ChartJS.register(RadialLinearScale, PointElement, LineElement, Filler, Tooltip);
 
-export const ImpactChart: FC<ImpactChartProps> = ({ category, impact = [] }) => {
+export const ImpactChart: FC<ImpactChartProps> = ({ className, category, impact = [] }) => {
   const {
     data: { impact: impacts, category: categories },
   } = useEnums();
@@ -83,38 +83,48 @@ export const ImpactChart: FC<ImpactChartProps> = ({ category, impact = [] }) => 
     },
   };
 
-  // [470px]
-
   return (
-    <div className="flex justify-between w-[250px] h-[250px] sm:w-[470px] sm:h-[470px]">
-      {/* This is a background and labels for the chart. Since the library doen't allow using elements as labels, this is an alternative way to add labels with incons and tooltips */}
-      {impacts?.length && (
-        <div className="z-1 m-2 absolute w-[232px] h-[232px] sm:w-[453px] sm:h-[453px] flex flex-col justify-between items-center  bg-background-middle rounded-full">
-          {!isPlaceholder && (
-            <div className="absolute w-1/2 rounded-full top-[25%] bg-white h-1/2" />
+    <div className={className}>
+      <div className="flex justify-between w-full">
+        <div className="z-0 flex flex-col w-full h-full gap-2">
+          {impacts?.length && (
+            <span className="flex items-center justify-center w-full">
+              <span className="hidden mr-2 text-sm font-semibold text-gray-800 sm:flex">
+                {impacts[0].name}
+              </span>
+              <FieldInfo infoText={impacts[0].description} />
+            </span>
           )}
-          <div className="translate-y-[-140%]">
-            <span className="mr-2">{impacts[0].name}</span>
-            <FieldInfo infoText={impacts[0].description} />
-          </div>
-          <div className="flex justify-between w-full">
-            <div className="translate-x-[-140%]">
-              <span className="mr-2">{impacts[1].name}</span>
-              <FieldInfo infoText={impacts[1].description} />
-            </div>
-            <div className="translate-x-[140%]">
-              <span className="mr-2">{impacts[2].name}</span>
-              <FieldInfo infoText={impacts[2].description} />
-            </div>
-          </div>
-          <div className="translate-y-[140%]">
-            <span className="mr-2">{impacts[3].name}</span>
-            <FieldInfo infoText={impacts[3].description} />
-          </div>
+          <span className="flex w-full">
+            {impacts?.length && (
+              <span className="flex items-center justify-end mr-2">
+                <span className="hidden mr-2 text-sm font-semibold text-gray-800 sm:flex">
+                  {impacts[2].name}
+                </span>
+                <FieldInfo infoText={impacts[2].description} />
+              </span>
+            )}
+            <span className="flex items-center w-full overflow-x-scroll aspect-square">
+              <Radar data={data} options={options} />
+            </span>
+            {impacts?.length && (
+              <span className="flex items-center justify-start ml-2">
+                <span className="hidden mr-2 text-sm font-semibold text-gray-800 sm:flex">
+                  {impacts[1].name}
+                </span>
+                <FieldInfo infoText={impacts[1].description} />
+              </span>
+            )}
+          </span>
+          {impacts?.length && (
+            <span className="flex items-center justify-center w-full">
+              <span className="hidden mr-2 text-sm font-semibold text-gray-800 sm:flex">
+                {impacts[3].name}
+              </span>
+              <FieldInfo infoText={impacts[3].description} />
+            </span>
+          )}
         </div>
-      )}
-      <div className="z-0 w-full h-full">
-        <Radar width="100%" height="100%" data={data} options={options} />
       </div>
     </div>
   );

--- a/frontend/components/impact-chart/types.ts
+++ b/frontend/components/impact-chart/types.ts
@@ -1,4 +1,6 @@
 export type ImpactChartProps = {
+  /** Classes to apply to the container */
+  className?: string;
   impact?: number[];
   category: string;
 };

--- a/frontend/components/modal/component.tsx
+++ b/frontend/components/modal/component.tsx
@@ -15,7 +15,7 @@ import Icon from 'components/icon';
 
 import XIcon from 'svgs/x.svg';
 
-import { CONTENT_CLASSES, OVERLAY_CLASSES } from './constants';
+import { CONTENT_CLASSES, OVERLAY_CLASSES, THEME_CLASSES } from './constants';
 import type { ModalProps } from './types';
 
 export const Modal: FC<ModalProps> = ({
@@ -23,6 +23,7 @@ export const Modal: FC<ModalProps> = ({
   open,
   dismissable = true,
   size = 'default',
+  theme = 'default',
   children,
   className,
   scrollable = true,
@@ -132,12 +133,16 @@ export const Modal: FC<ModalProps> = ({
                   initial="initial"
                   animate="animate"
                   exit="exit"
-                  className={cx({ [CONTENT_CLASSES[size]]: true, [className]: !!className })}
+                  className={cx({
+                    [CONTENT_CLASSES[size]]: true,
+                    [THEME_CLASSES[theme]]: true,
+                    [className]: !!className,
+                  })}
                   style={{
                     maxHeight: '90%',
                   }}
                 >
-                  {dismissable && (
+                  {dismissable && theme !== 'naked' && (
                     <div className="relative">
                       <Button
                         theme="naked"

--- a/frontend/components/modal/constants.ts
+++ b/frontend/components/modal/constants.ts
@@ -1,9 +1,15 @@
 export const COMMON_CONTENT_CLASSES =
-  'absolute top-1/2 inset-x-4 sm:left-1/2 transform -translate-y-1/2 sm:-translate-x-1/2 outline-none bg-white flex flex-col flex-grow overflow-hidden rounded-lg shadow-2xl pt-12 md:pt-14 pb-8 px-4 md:px-10';
+  'absolute top-1/2 inset-x-4 sm:left-1/2 transform -translate-y-1/2 sm:-translate-x-1/2 outline-none bg-white flex flex-col flex-grow overflow-hidden rounded-lg shadow-2xl';
+
 export const CONTENT_CLASSES = {
   narrow: `sm:w-4/6 md:w-1/2 lg:w-5/12 xl:w-1/3 ${COMMON_CONTENT_CLASSES}`,
   default: `sm:w-4/5 md:w-2/3 lg:1/2 xl:w-5/12 ${COMMON_CONTENT_CLASSES}`,
   wide: `sm:w-10/12 md:w-10/12 lg:w-10/12 xl:w-8/12 ${COMMON_CONTENT_CLASSES}`,
+};
+
+export const THEME_CLASSES = {
+  default: 'pt-12 md:pt-14 pb-8 px-4 md:px-10',
+  naked: '',
 };
 
 export const OVERLAY_CLASSES = 'z-50 fixed inset-0 bg-black bg-blur';

--- a/frontend/components/modal/types.d.ts
+++ b/frontend/components/modal/types.d.ts
@@ -15,6 +15,10 @@ export interface ModalProps {
    */
   dismissable?: boolean;
   /**
+   * Theme of the modal
+   */
+  theme?: 'default' | 'naked';
+  /**
    * Size (width) of the modal
    */
   size?: 'narrow' | 'default' | 'wide';

--- a/frontend/components/tag/component.tsx
+++ b/frontend/components/tag/component.tsx
@@ -4,7 +4,7 @@ import cx from 'classnames';
 
 import type { TagProps } from './types';
 
-export const Tag: FC<TagProps> = ({ children, className }: TagProps) => (
+export const Tag: FC<TagProps> = ({ children, className, size = 'small' }: TagProps) => (
   <div
     className={cx({
       'relative inline-flex border rounded-full': true,
@@ -15,6 +15,8 @@ export const Tag: FC<TagProps> = ({ children, className }: TagProps) => (
     <div
       className={cx({
         'flex items-center px-4 py-2': true,
+        'px-4 py-2': size === 'small',
+        'px-2 py-1': size === 'smallest',
       })}
     >
       {children}

--- a/frontend/components/tag/types.d.ts
+++ b/frontend/components/tag/types.d.ts
@@ -1,4 +1,8 @@
 export interface TagProps {
+  /** Children to pass to the tag */
   children: React.ReactNode;
+  /** Classes to apply to the container */
   className?: string | unknown;
+  /** Size of the tag */
+  size?: 'small' | 'smallest';
 }

--- a/frontend/containers/category-tag/category-tag-dot/component.tsx
+++ b/frontend/containers/category-tag/category-tag-dot/component.tsx
@@ -6,10 +6,15 @@ import { CategoryType } from 'types/category';
 
 import type { CategoryTagDotProps } from './types';
 
-export const CategoryTagDot: FC<CategoryTagDotProps> = ({ category }: CategoryTagDotProps) => (
+export const CategoryTagDot: FC<CategoryTagDotProps> = ({
+  category,
+  size = 'small',
+}: CategoryTagDotProps) => (
   <span
     className={cx({
-      'inline-block w-4 h-4 mr-4 rounded-full': true,
+      'inline-block rounded-full': true,
+      'w-4 h-4 mr-4 ': size === 'small',
+      'w-2 h-2 mr-2': size === 'smallest',
       'bg-category-tourism': category === 'tourism-and-recreation',
       'bg-category-production': category === 'non-timber-forest-production',
       'bg-category-agrosystems': category === 'sustainable-agrosystems',

--- a/frontend/containers/category-tag/category-tag-dot/types.ts
+++ b/frontend/containers/category-tag/category-tag-dot/types.ts
@@ -3,4 +3,6 @@ import { CategoryType } from 'types/category';
 export type CategoryTagDotProps = {
   /** Identifier of the investment type so that the corresponding colored dot is displayed */
   category: CategoryType;
+  /** Size of the dot. Defaults to `small` */
+  size?: 'small' | 'smallest';
 };

--- a/frontend/containers/category-tag/component.tsx
+++ b/frontend/containers/category-tag/component.tsx
@@ -8,10 +8,11 @@ import type { CategoryTagProps } from './types';
 export const CategoryTag: FC<CategoryTagProps> = ({
   className,
   category,
+  size = 'small',
   children,
 }: CategoryTagProps) => (
-  <Tag className={className}>
-    <CategoryTagDot category={category} />
+  <Tag size={size} className={className}>
+    <CategoryTagDot size={size} category={category} />
     {children}
   </Tag>
 );

--- a/frontend/containers/category-tag/types.ts
+++ b/frontend/containers/category-tag/types.ts
@@ -4,5 +4,7 @@ export type CategoryTagProps = React.PropsWithChildren<
   CategoryTagDotProps & {
     /** Classes to apply to the Tag */
     className?: string;
+    /** Size of the tag. Defaults to `small` */
+    size?: 'small' | 'smallest';
   }
 >;

--- a/frontend/containers/project-card/component.tsx
+++ b/frontend/containers/project-card/component.tsx
@@ -21,6 +21,7 @@ import type { ProjectCardProps } from './types';
 
 export const ProjectCard: FC<ProjectCardProps> = ({
   className,
+  active = false,
   project,
   onClick,
 }: ProjectCardProps) => {
@@ -105,8 +106,8 @@ export const ProjectCard: FC<ProjectCardProps> = ({
       className={cx({
         [className]: !!className,
         'cursor-pointer transition rounded-2xl': true,
-        'hover:ring-1 hover:ring-green-dark': true,
-        'ring-2 ring-green-dark': isFocusWithin,
+        'hover:ring-1 hover:ring-green-dark': !active,
+        'ring-2 ring-green-dark': isFocusWithin || active,
       })}
       {...pressProps}
       {...focusWithinProps}

--- a/frontend/containers/project-card/types.ts
+++ b/frontend/containers/project-card/types.ts
@@ -3,6 +3,8 @@ import { Project as ProjectType } from 'types/project';
 export type ProjectCardProps = {
   /** Classnames to apply to the wrapper */
   className?: string;
+  /** Whether the current card is active. Defaults to `false` */
+  active?: boolean;
   /** Projects list */
   project: ProjectType;
   /** onClick callback */

--- a/frontend/containers/project-details/component.stories.tsx
+++ b/frontend/containers/project-details/component.stories.tsx
@@ -24,7 +24,7 @@ export default {
 
 const Template: Story<ProjectDetailsProps> = ({ project }: ProjectDetailsProps) => {
   return (
-    <div className="max-w-md max-h-full overflow-y-scroll bg-white border rounded-2xl lg:mr-10">
+    <div className="relative max-w-md max-h-full overflow-y-scroll bg-white border rounded-2xl">
       <ProjectDetails project={project} />
     </div>
   );

--- a/frontend/containers/project-details/component.stories.tsx
+++ b/frontend/containers/project-details/component.stories.tsx
@@ -1,0 +1,73 @@
+import { Story, Meta } from '@storybook/react/types-6-0';
+import withMock from 'storybook-addon-mock';
+
+import apiEnumsMock from 'mockups/api/v1/enums.json';
+import projectMock from 'mockups/project.json';
+import { Project as ProjectType } from 'types/project';
+
+import ProjectDetails, { ProjectDetailsProps } from '.';
+
+const mockApiData = [
+  {
+    url: '/api/v1/enums',
+    method: 'GET',
+    status: 200,
+    response: apiEnumsMock,
+  },
+];
+
+export default {
+  component: ProjectDetails,
+  title: 'Containers/ProjectDetails',
+  decorators: [withMock],
+} as Meta;
+
+const Template: Story<ProjectDetailsProps> = ({ project }: ProjectDetailsProps) => {
+  return (
+    <div className="max-w-md max-h-full overflow-y-scroll bg-white border rounded-2xl lg:mr-10">
+      <ProjectDetails project={project} />
+    </div>
+  );
+};
+
+export const Default: Story<ProjectDetailsProps> = Template.bind({});
+
+Default.args = {
+  project: {
+    ...(projectMock as ProjectType),
+    trusted: false,
+    looking_for_funding: false,
+  },
+};
+
+Default.parameters = {
+  mockData: mockApiData,
+};
+
+export const Verified: Story<ProjectDetailsProps> = Template.bind({});
+
+Verified.args = {
+  project: {
+    ...(projectMock as ProjectType),
+    trusted: true,
+    looking_for_funding: false,
+  },
+};
+
+Verified.parameters = {
+  mockData: mockApiData,
+};
+
+export const LookingForFunding: Story<ProjectDetailsProps> = Template.bind({});
+
+LookingForFunding.args = {
+  project: {
+    ...(projectMock as ProjectType),
+    trusted: false,
+    looking_for_funding: true,
+  },
+};
+
+LookingForFunding.parameters = {
+  mockData: mockApiData,
+};

--- a/frontend/containers/project-details/component.tsx
+++ b/frontend/containers/project-details/component.tsx
@@ -12,6 +12,7 @@ import CategoryTag from 'containers/category-tag';
 import SDGs from 'containers/sdgs';
 
 import Button from 'components/button';
+import ImpactChart from 'components/impact-chart';
 import Tag from 'components/tag';
 import { Paths } from 'enums';
 import sdgsMock from 'mockups/sdgs.json';
@@ -173,14 +174,30 @@ export const ProjectDetails: FC<ProjectDetailsProps> = ({
           <span>{projectDeveloper.name}</span>
         </div>
         <FavoriteContact className="mt-10 mb-6" project={project} />
-        {/*
+        {/* TODO: Add impact values */}
         <div className="my-2 text-gray-900" aria-describedby="estimated-impact">
           <h2 id="estimated-impact" className="text-xl font-semibold">
             <FormattedMessage defaultMessage="Estimated impact" id="Jl9QMO" />
           </h2>
-          TODO: Show estimated impact
+          <p className="mt-3">
+            <FormattedMessage
+              defaultMessage="In the municipality the project has higher impact on <b>{impactOn}</b> and has an <b>impact score</b>
+            of {score}."
+              values={{
+                impactOn: 'Water',
+                score: 30,
+                b: (chunks) => <span className="font-semibold">{chunks}</span>,
+              }}
+              id="MFPJ9u"
+            />
+          </p>
+          <ImpactChart
+            className="my-4"
+            category="forestry-and-agroforestry"
+            impact={[3, 5, 6, 5]}
+          />
         </div>
-        */}
+        {/* /TODO: Add impact values */}
         <div className="mt-4 text-gray-900" aria-describedby="sdgs">
           <h2 id="sdgs" className="text-xl font-semibold">
             <FormattedMessage defaultMessage="SDGs" id="JQjEP9" />

--- a/frontend/containers/project-details/component.tsx
+++ b/frontend/containers/project-details/component.tsx
@@ -193,11 +193,7 @@ export const ProjectDetails: FC<ProjectDetailsProps> = ({
               id="MFPJ9u"
             />
           </p>
-          <ImpactChart
-            className="my-4"
-            category="forestry-and-agroforestry"
-            impact={[3, 5, 6, 5]}
-          />
+          <ImpactChart className="my-4" category={category.id} impact={[3, 5, 6, 5]} />
         </div>
         {/* /TODO: Add impact values */}
         <div className="mt-4 text-gray-900" aria-describedby="sdgs">

--- a/frontend/containers/project-details/component.tsx
+++ b/frontend/containers/project-details/component.tsx
@@ -72,11 +72,11 @@ export const ProjectDetails: FC<ProjectDetailsProps> = ({
 
   return (
     <div className={className}>
-      <div className="relative p-10">
+      <div className="absolute top-0 right-0 z-10 w-full h-full overflow-hidden pointer-events-none">
         <Button
           size="smallest"
           theme="naked"
-          className="absolute text-gray-400 right-4 top-4 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-dark"
+          className="absolute text-gray-400 pointer-events-auto right-4 top-4 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-dark"
           aria-label={intl.formatMessage({
             defaultMessage: 'Close project details card',
             id: 'hmK5Jb',
@@ -90,6 +90,8 @@ export const ProjectDetails: FC<ProjectDetailsProps> = ({
             <FormattedMessage defaultMessage="Looking for funding" id="Czc5vB" />
           </span>
         )}
+      </div>
+      <div className="relative p-10">
         <div className="flex gap-2 text-sm">
           {project.trusted && (
             <>

--- a/frontend/containers/project-details/component.tsx
+++ b/frontend/containers/project-details/component.tsx
@@ -1,0 +1,196 @@
+import { FC, useMemo, useState, useEffect } from 'react';
+
+import { CheckCircle as CheckCircleIcon, X as XIcon } from 'react-feather';
+import { FormattedMessage, useIntl } from 'react-intl';
+
+import Image from 'next/image';
+import Link from 'next/link';
+
+import { noop } from 'lodash-es';
+
+import CategoryTag from 'containers/category-tag';
+import SDGs from 'containers/sdgs';
+
+import Button from 'components/button';
+import Tag from 'components/tag';
+import { Paths } from 'enums';
+import sdgsMock from 'mockups/sdgs.json';
+import { CategoryType } from 'types/category';
+import { Enum } from 'types/enums';
+
+import { useEnums } from 'services/enums/enumService';
+
+import FavoriteContact from './favorite-contact';
+import type { ProjectDetailsProps } from './types';
+
+export const ProjectDetails: FC<ProjectDetailsProps> = ({
+  className,
+  project,
+  onClose = noop,
+}: ProjectDetailsProps) => {
+  const intl = useIntl();
+
+  const [projectDeveloperImage, setProjectDeveloperImage] = useState<string>(
+    project.project_developer?.picture.small
+  );
+
+  useEffect(() => {
+    setProjectDeveloperImage(project.project_developer?.picture.small);
+  }, [project]);
+
+  const {
+    data: {
+      instrument_type: allInstrumentTypes,
+      ticket_size: allTicketSizes,
+      category: allCategories,
+    },
+  } = useEnums();
+
+  const handleProjectDeveloperImageError = () => {
+    setProjectDeveloperImage('/images/placeholders/profile-logo.png');
+  };
+
+  const ticketSizeStr = useMemo(
+    () => allTicketSizes?.find(({ id }) => project.ticket_size === id)?.description,
+    [allTicketSizes, project.ticket_size]
+  );
+
+  const instrumentTypesStr = useMemo(
+    () =>
+      allInstrumentTypes
+        ?.filter(({ id }) => project.instrument_types?.includes(id))
+        .map(({ name }, idx) => (idx === 0 ? name : name.toLowerCase()))
+        .join(', '),
+    [allInstrumentTypes, project.instrument_types]
+  );
+
+  const projectDeveloper = project?.project_developer;
+  const category = allCategories?.find(({ id }) => id === project.category);
+  const link = `${Paths.Project}/${project.slug}`;
+  const sdgs = sdgsMock.filter(({ id }) => project.sdgs.includes(parseInt(id)));
+
+  return (
+    <div className={className}>
+      <div className="relative p-10">
+        <Button
+          size="smallest"
+          theme="naked"
+          className="absolute text-gray-400 right-4 top-4 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-dark"
+          aria-label={intl.formatMessage({
+            defaultMessage: 'Close project details card',
+            id: 'hmK5Jb',
+          })}
+          onClick={onClose}
+        >
+          <XIcon className="w-6 h-6" aria-hidden={true} />
+        </Button>
+        {project.looking_for_funding && (
+          <span className="absolute px-10 py-2 text-xs text-center origin-top-left rotate-45 w-60 -top-10 -right-28 bg-green-dark text-green-light">
+            <FormattedMessage defaultMessage="Looking for funding" id="Czc5vB" />
+          </span>
+        )}
+        <div className="flex gap-2 text-sm">
+          {project.trusted && (
+            <>
+              <span
+                className="flex items-center text-green-dark"
+                title={intl.formatMessage({
+                  defaultMessage: 'Project verification',
+                  id: 'E1kj21',
+                })}
+              >
+                <Tag className="text-green-dark" size="smallest">
+                  <CheckCircleIcon className="w-4 h-4 mr-1" aria-hidden={true} />
+                  <FormattedMessage defaultMessage="Verified" id="Z8971h" />
+                </Tag>
+              </span>
+            </>
+          )}
+          {category && (
+            <div title={intl.formatMessage({ defaultMessage: 'Project category', id: '/plMvw' })}>
+              <CategoryTag size="smallest" category={category.id as CategoryType}>
+                {category.name}
+              </CategoryTag>
+            </div>
+          )}
+        </div>
+        <h1 className="mt-6 mb-2 font-serif text-3xl">
+          <Link href={link}>
+            <a className="px-2 -mx-2 text-black transition-all rounded-full hover:text-green-light focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-dark">
+              {project.name}
+            </a>
+          </Link>
+        </h1>
+        {instrumentTypesStr && ticketSizeStr && (
+          <div className="flex items-center h-5 my-2 text-gray-800 text-md min-h-fit">
+            {instrumentTypesStr && (
+              <div
+                title={intl.formatMessage({
+                  defaultMessage: 'Project financial instrument',
+                  id: 'hLG9bm',
+                })}
+              >
+                {instrumentTypesStr}
+              </div>
+            )}
+            {instrumentTypesStr && ticketSizeStr && (
+              <span className="mx-2" aria-hidden={true}>
+                &bull;
+              </span>
+            )}
+            {ticketSizeStr && (
+              <div
+                title={intl.formatMessage({
+                  defaultMessage: 'Project ticket size',
+                  id: 'x/AykP',
+                })}
+              >
+                {ticketSizeStr}
+              </div>
+            )}
+          </div>
+        )}
+        <div
+          className="mt-4"
+          aria-label={intl.formatMessage({ defaultMessage: 'Project description', id: 'Hb+Idf' })}
+        >
+          {project.description}
+        </div>
+        <div
+          className="flex items-center mt-4 text-sm text-gray-900"
+          aria-label={intl.formatMessage({ defaultMessage: 'Project developer', id: 'yF82he' })}
+        >
+          <span className="relative w-8 h-8 mr-2 rounded-full" aria-hidden={true}>
+            <Image
+              className="rounded-full"
+              src={projectDeveloperImage}
+              alt={intl.formatMessage({ defaultMessage: 'Project developer photo', id: 'BZkcBV' })}
+              layout="fill"
+              objectFit="cover"
+              onError={handleProjectDeveloperImageError}
+            />
+          </span>
+          <span>{projectDeveloper.name}</span>
+        </div>
+        <FavoriteContact className="mt-10 mb-6" project={project} />
+        {/*
+        <div className="my-2 text-gray-900" aria-describedby="estimated-impact">
+          <h2 id="estimated-impact" className="text-xl font-semibold">
+            <FormattedMessage defaultMessage="Estimated impact" id="Jl9QMO" />
+          </h2>
+          TODO: Show estimated impact
+        </div>
+        */}
+        <div className="mt-4 text-gray-900" aria-describedby="sdgs">
+          <h2 id="sdgs" className="text-xl font-semibold">
+            <FormattedMessage defaultMessage="SDGs" id="JQjEP9" />
+          </h2>
+          <SDGs className="mt-3" size="smallest" sdgs={sdgs as Enum[]} />
+        </div>
+        <FavoriteContact className="mt-4 -mb-4" project={project} />
+      </div>
+    </div>
+  );
+};
+
+export default ProjectDetails;

--- a/frontend/containers/project-details/favorite-contact/component.tsx
+++ b/frontend/containers/project-details/favorite-contact/component.tsx
@@ -1,0 +1,55 @@
+import { FC, useState } from 'react';
+
+import { Heart as HeartIcon } from 'react-feather';
+import { FormattedMessage } from 'react-intl';
+
+import Link from 'next/link';
+
+import Button from 'components/button';
+import { Paths } from 'enums';
+
+import { FavoriteContactProps } from './types';
+
+export const FavoriteContact: FC<FavoriteContactProps> = ({
+  className,
+  project,
+}: FavoriteContactProps) => {
+  const [contactInfoModalOpen, setIsContactInfoModalOpen] = useState<boolean>(false);
+
+  const handleFavoriteClick = () => {};
+
+  // NOTE: This is a placeholder. When adding the contact modal, we need to take into
+  //       account that if there are multiple project developers involved with the project
+  //       we need to display the contact details for all of them.
+  const { contact_email: email, contact_phone: phone } = project?.project_developer;
+
+  return (
+    <div className={className}>
+      <div className="flex flex-col items-start gap-4 mt-5 xl:items-center xl:flex-row">
+        <Button
+          disabled={!phone && !email}
+          className="justify-start"
+          theme="primary-green"
+          onClick={() => setIsContactInfoModalOpen(true)}
+        >
+          <FormattedMessage defaultMessage="Contact" id="zFegDD" />
+        </Button>
+        <Button
+          className="justify-start"
+          theme="secondary-green"
+          icon={HeartIcon}
+          onClick={handleFavoriteClick}
+        >
+          <FormattedMessage defaultMessage="Favorite" id="5Hzwqs" />
+        </Button>
+        <Link href={`${Paths.Project}/${project.id}`}>
+          <a className="px-1 text-sm transition-all text-green-dark hover:text-green-light rounded-2xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-dark">
+            <FormattedMessage defaultMessage="Know more" id="+JVDMC" />
+          </a>
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default FavoriteContact;

--- a/frontend/containers/project-details/favorite-contact/index.ts
+++ b/frontend/containers/project-details/favorite-contact/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { FavoriteContactProps } from './types';

--- a/frontend/containers/project-details/favorite-contact/types.ts
+++ b/frontend/containers/project-details/favorite-contact/types.ts
@@ -1,0 +1,8 @@
+import { Project as ProjectType } from 'types/project';
+
+export type FavoriteContactProps = {
+  /** Classes to apply to the container */
+  className?: string;
+  /** Project object */
+  project: ProjectType;
+};

--- a/frontend/containers/project-details/index.ts
+++ b/frontend/containers/project-details/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { ProjectDetailsProps } from './types';

--- a/frontend/containers/project-details/types.ts
+++ b/frontend/containers/project-details/types.ts
@@ -1,0 +1,10 @@
+import { Project as ProjectType } from 'types/project';
+
+export type ProjectDetailsProps = {
+  /** Classes to apply to the container */
+  className?: string;
+  /** Project to display the details of */
+  project: ProjectType;
+  /** Callback for when the user closes the project details */
+  onClose?: () => void;
+};

--- a/frontend/containers/sdgs/constants.ts
+++ b/frontend/containers/sdgs/constants.ts
@@ -1,4 +1,5 @@
 export const SDGS_SIZES = {
+  smallest: 60,
   small: 88,
   large: 110,
 };

--- a/frontend/hooks/use-breakpoint.ts
+++ b/frontend/hooks/use-breakpoint.ts
@@ -1,0 +1,78 @@
+import { useState, useEffect, useMemo, useCallback } from 'react';
+
+import { debounce } from 'lodash-es';
+import resolveConfig from 'tailwindcss/resolveConfig';
+
+import tailwindConfig from 'tailwind.config.js';
+
+const config = resolveConfig(tailwindConfig);
+
+export const useBreakpoint = () => {
+  const [currentBreakpoint, setCurrentBreakpoint] = useState<string | null>(null);
+  const { screens } = config?.theme;
+
+  const breakpoints = Object.keys(screens);
+
+  // The object coming from tailwindConfig has the breakpoint sizes as strings (and in px);
+  // so here we prepare a similar object with the sizes as integers, to facilitate calculations
+  // later on.
+  const breakpointsObjArr = useMemo(
+    () =>
+      Object.entries(screens).reduce(
+        (acc, [key, value]: [string, string]) => [
+          ...acc,
+          { [key]: parseInt(value.substring(0, value.length - 2)) },
+        ],
+        []
+      ),
+    [screens]
+  );
+
+  // Use the last breakpoint (largest screen) as the default one.
+  const defaultBreakpoint = breakpointsObjArr[breakpointsObjArr.length - 1];
+
+  // Here we compute the current breakpoint based on the window width.
+  const computeBreakpoint = debounce(
+    useCallback(() => {
+      // If no window object we can't get the window width. Return the default breakpoint.
+      if (typeof window !== 'object') return defaultBreakpoint;
+
+      // We try to find the current matching endpoint. Note that if the window matches the largest
+      // one, this will return `undefined`. That's why the default is set as the last one.
+      const matchingBreakpoint = breakpointsObjArr.find((item) => {
+        const [_key, value] = Object.entries(item)[0];
+        return window.innerWidth < value;
+      });
+
+      // If we have a match we'll use it, if not the screen must be larger than the last breakpoint;
+      // We set the default one then.
+      const breakpoint = matchingBreakpoint
+        ? Object.keys(matchingBreakpoint)[0]
+        : Object.keys(defaultBreakpoint)[0];
+
+      setCurrentBreakpoint(breakpoint);
+    }, [breakpointsObjArr, defaultBreakpoint]),
+    250
+  );
+
+  // Adding window listener events to compute the current breakpoint when the window is resized.
+  // We also need to compute it after the component is loaded.
+  useEffect(() => {
+    computeBreakpoint();
+    window.addEventListener('resize', computeBreakpoint);
+
+    return () => {
+      window.removeEventListener('resize', computeBreakpoint);
+    };
+  }, [computeBreakpoint]);
+
+  // Returned function that'll compare the target breakpoint to the current one, and return
+  // whether the target breakpoint is "higher" than the current one.
+  const breakpoint = (targetBreakpoint: string): boolean => {
+    const currentBreakpointIndex = breakpoints.findIndex((bp) => bp === currentBreakpoint);
+    const targetBreakpointIndex = breakpoints.findIndex((bp) => bp === targetBreakpoint);
+    return currentBreakpointIndex > targetBreakpointIndex;
+  };
+
+  return breakpoint;
+};

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -125,9 +125,6 @@
   "5Hzwqs": {
     "string": "Favorite"
   },
-  "5Ueq8c": {
-    "string": "In the municipality the project has higher impact on <b>{impactOn}</b> and has an impact score of <b>{score}</b>."
-  },
   "5c08Qp": {
     "string": "Project information"
   },

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -125,6 +125,9 @@
   "5Hzwqs": {
     "string": "Favorite"
   },
+  "5Ueq8c": {
+    "string": "In the municipality the project has higher impact on <b>{impactOn}</b> and has an impact score of <b>{score}</b>."
+  },
   "5c08Qp": {
     "string": "Project information"
   },
@@ -668,9 +671,6 @@
   },
   "XkF/qg": {
     "string": "Profile picture of {name}"
-  },
-  "XyKb4V": {
-    "string": "In the municipality the the project has higher impact on <b>{impactOn}</b> and has an impact score of <b>{score}</b>."
   },
   "Y7/cBd": {
     "string": "Reach out for what you are looking for, from either <span>Investors</span> or <span>Project Developers</span> and <span>start the conversation</span>. Make sure to update us to help us track your contribution to preserving the Amazon: <span>the future is in your hands too!</span>"

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -173,6 +173,9 @@
   "7eO+k/": {
     "string": "Enter the estimated implementation duration for the project. MAX 24 months."
   },
+  "7gMEKc": {
+    "string": "Project details"
+  },
   "7qgtEX": {
     "string": "Invests in SDG's"
   },
@@ -423,6 +426,9 @@
   "JkLHGw": {
     "string": "Website"
   },
+  "Jl9QMO": {
+    "string": "Estimated impact"
+  },
   "Jwjqn/": {
     "string": "focused"
   },
@@ -449,6 +455,9 @@
   },
   "MF4b8Z": {
     "string": "Use at least 12 characters, one uppercase letter, one lowercase letter and one number."
+  },
+  "MFPJ9u": {
+    "string": "In the municipality the project has higher impact on <b>{impactOn}</b> and has an <b>impact score</b> of {score}."
   },
   "MH3koz": {
     "string": "Previous slide"
@@ -659,6 +668,9 @@
   },
   "XkF/qg": {
     "string": "Profile picture of {name}"
+  },
+  "XyKb4V": {
+    "string": "In the municipality the the project has higher impact on <b>{impactOn}</b> and has an impact score of <b>{score}</b>."
   },
   "Y7/cBd": {
     "string": "Reach out for what you are looking for, from either <span>Investors</span> or <span>Project Developers</span> and <span>start the conversation</span>. Make sure to update us to help us track your contribution to preserving the Amazon: <span>the future is in your hands too!</span>"

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -1,4 +1,7 @@
 {
+  "+JVDMC": {
+    "string": "Know more"
+  },
   "+K9fF0": {
     "string": "Project Developers"
   },
@@ -242,6 +245,9 @@
   "BHrBCl": {
     "string": "PNG, JPG up to 5MB"
   },
+  "BZkcBV": {
+    "string": "Project developer photo"
+  },
   "BcZVZW": {
     "string": "This description should sumarize your project in a few words."
   },
@@ -271,6 +277,9 @@
   },
   "Cra78t": {
     "string": "© {date} HeCo Invest. All rights reserved."
+  },
+  "Czc5vB": {
+    "string": "Looking for funding"
   },
   "D5RCKi": {
     "string": "Project name"
@@ -347,6 +356,9 @@
   "HVQtvr": {
     "string": "BC3's mission is to generate valuable knowledge for policy and decision making, integrating the environmental, socio-economic and ethical dimensions of climate change. Through the production of collaborative and open-source tools such as ARIES, which can track and forecast progress towards sustainable environmental and economic goals, BC3 plays a key role in enhancing regional, national and international economic development."
   },
+  "Hb+Idf": {
+    "string": "Project description"
+  },
   "HmDmU1": {
     "string": "Support the protection of water availability and regulation. These approaches are vital for reducing risks such as floods and droughts, which in the face of climate change can become more frequent and larger in magnitude."
   },
@@ -398,6 +410,9 @@
   },
   "JNTB42": {
     "string": "Phone number (optional)"
+  },
+  "JQjEP9": {
+    "string": "SDGs"
   },
   "JRfERD": {
     "string": "Paulson Institute"
@@ -830,6 +845,9 @@
   },
   "hl9bd4": {
     "string": "Cover"
+  },
+  "hmK5Jb": {
+    "string": "Close project details card"
   },
   "hpOE0K": {
     "string": "<a>Browse</a> or drag and drop"

--- a/frontend/layouts/discover-page/component.tsx
+++ b/frontend/layouts/discover-page/component.tsx
@@ -41,7 +41,7 @@ export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
     data: projects,
     isLoading: isLoadingProjects,
     isFetching: isFetchingProjects,
-  } = useProjectsList(queryParams, queryOptions);
+  } = useProjectsList({ ...queryParams, includes: ['project_developer'] }, queryOptions);
 
   const stats = {
     projects: projects?.meta?.total,

--- a/frontend/mockups/api/v1/enums.json
+++ b/frontend/mockups/api/v1/enums.json
@@ -1,0 +1,567 @@
+{
+  "data": [
+    {
+      "id": "sustainable-agrosystems",
+      "type": "category",
+      "attributes": {
+        "name": "Sustainable Agrosystems",
+        "color": "#E7C343",
+        "description": "Sustainable and regenerative agriculture, fishing, and aquaculture as well as manufacturing of derived subproducts."
+      }
+    },
+    {
+      "id": "tourism-and-recreation",
+      "type": "category",
+      "attributes": {
+        "name": "Tourism and Recreation",
+        "color": "#4492E5",
+        "description": "Accommodation, travel, transportation, hospitality, visitor experiences and eco-tourism projects."
+      }
+    },
+    {
+      "id": "forestry-and-agroforestry",
+      "type": "category",
+      "attributes": {
+        "name": "Forestry and Agroforestry",
+        "color": "#E57D57",
+        "description": "Sustainable timber extraction and forest management practices, including reforestation and restoration."
+      }
+    },
+    {
+      "id": "non-timber-forest-production",
+      "type": "category",
+      "attributes": {
+        "name": "Non Timber Forest Production",
+        "color": "#404B9A",
+        "description": "Production of health, wellness, and cosmetic products; art, clothing, and handcrafted products; production of food and drinks."
+      }
+    },
+    {
+      "id": "human-capital-and-inclusion",
+      "type": "category",
+      "attributes": {
+        "name": "Human capital and inclusion",
+        "color": "#A0616A",
+        "description": "Adequate access to quality education, appropriate health services, and formal employment opportunities that respond to diverse skill profiles and are adapted to regional cultural diversity."
+      }
+    },
+    {
+      "id": "biodiversity",
+      "type": "impact",
+      "attributes": {
+        "name": "Biodiversity",
+        "description": "Impact of projects on biodiversity conservation, calculated from indicators of endemism, land conservation/restoration, connectivity, and development of sustainable social projects."
+      }
+    },
+    {
+      "id": "climate",
+      "type": "impact",
+      "attributes": {
+        "name": "Climate",
+        "description": "Impact of projects that reduce carbon emissions from the land sector (deforestation/degradation), as wood and soil biomass as well as application of sustainable forest measures."
+      }
+    },
+    {
+      "id": "water",
+      "type": "impact",
+      "attributes": {
+        "name": "Water",
+        "description": "Impact of projects managing water cycling, quality and availability as well as the management of associated risks."
+      }
+    },
+    {
+      "id": "community",
+      "type": "impact",
+      "attributes": {
+        "name": "Community",
+        "description": "Impact of projects on ensuring and improving equal and inclusive physical, mental, economic, and spiritual health."
+      }
+    },
+    {
+      "id": "conservation",
+      "type": "impact_area",
+      "attributes": {
+        "name": "Conservation"
+      }
+    },
+    {
+      "id": "restoration",
+      "type": "impact_area",
+      "attributes": {
+        "name": "Restoration"
+      }
+    },
+    {
+      "id": "pollutants-reduction",
+      "type": "impact_area",
+      "attributes": {
+        "name": "Pollutants reduction"
+      }
+    },
+    {
+      "id": "carbon-emission-reduction",
+      "type": "impact_area",
+      "attributes": {
+        "name": "Carbon emission reduction"
+      }
+    },
+    {
+      "id": "energy-efficiency",
+      "type": "impact_area",
+      "attributes": {
+        "name": "Energy efficiency"
+      }
+    },
+    {
+      "id": "renewable-energy",
+      "type": "impact_area",
+      "attributes": {
+        "name": "Renewable energy"
+      }
+    },
+    {
+      "id": "carbon-storage-or-sequestration",
+      "type": "impact_area",
+      "attributes": {
+        "name": "Carbon storage or sequestration"
+      }
+    },
+    {
+      "id": "water-capacity",
+      "type": "impact_area",
+      "attributes": {
+        "name": "Water capacity"
+      }
+    },
+    {
+      "id": "water-efficiency",
+      "type": "impact_area",
+      "attributes": {
+        "name": "Water efficiency"
+      }
+    },
+    {
+      "id": "sustainable-food",
+      "type": "impact_area",
+      "attributes": {
+        "name": "Sustainable food"
+      }
+    },
+    {
+      "id": "gender-equality-jobs",
+      "type": "impact_area",
+      "attributes": {
+        "name": "Gender equality jobs"
+      }
+    },
+    {
+      "id": "indigenous-or-ethic-jobs",
+      "type": "impact_area",
+      "attributes": {
+        "name": "Indigenous or ethic jobs"
+      }
+    },
+    {
+      "id": "community-empowerment",
+      "type": "impact_area",
+      "attributes": {
+        "name": "Community empowerment"
+      }
+    },
+    {
+      "id": "grant",
+      "type": "instrument_type",
+      "attributes": {
+        "name": "Grant",
+        "description": "Technical cooperation grants are resources provided by an entity to fulfill a well-defined purpose or objective. In general, they are non-reimbursable resources that are destined in particular to projects or enterprises in early stages of development."
+      }
+    },
+    {
+      "id": "loan",
+      "type": "instrument_type",
+      "attributes": {
+        "name": "Loan",
+        "description": "A loan is a transaction in which a financial institution grants a predefined amount of money to develop a particular project. The institution or business that receives the loan is obliged to repay it within a certain period of time and to pay the agreed commissions, expenses and interest."
+      }
+    },
+    {
+      "id": "equity",
+      "type": "instrument_type",
+      "attributes": {
+        "name": "Equity",
+        "description": "An equity investment consists of the acquisition, by an entity specialized in private equity, of a package of shares of a company or enterprise. The private equity firm thus becomes one of the owners of the company."
+      }
+    },
+    {
+      "id": "investor",
+      "type": "investor_type",
+      "attributes": {
+        "name": "Investor"
+      }
+    },
+    {
+      "id": "angel-investor",
+      "type": "investor_type",
+      "attributes": {
+        "name": "Angel Investor"
+      }
+    },
+    {
+      "id": "commercial-bank",
+      "type": "investor_type",
+      "attributes": {
+        "name": "Commercial Bank"
+      }
+    },
+    {
+      "id": "family-office",
+      "type": "investor_type",
+      "attributes": {
+        "name": "Family Office"
+      }
+    },
+    {
+      "id": "institutional-investor",
+      "type": "investor_type",
+      "attributes": {
+        "name": "Institutional Investor"
+      }
+    },
+    {
+      "id": "investment-bank",
+      "type": "investor_type",
+      "attributes": {
+        "name": "Investment Bank"
+      }
+    },
+    {
+      "id": "international-financial-institution",
+      "type": "investor_type",
+      "attributes": {
+        "name": "International Financial Institution"
+      }
+    },
+    {
+      "id": "micro-finance",
+      "type": "investor_type",
+      "attributes": {
+        "name": "Micro Finance"
+      }
+    },
+    {
+      "id": "non-VC-investment-vehicle",
+      "type": "investor_type",
+      "attributes": {
+        "name": "Non VC Investment Vehicle"
+      }
+    },
+    {
+      "id": "venture-capital-private-equity",
+      "type": "investor_type",
+      "attributes": {
+        "name": "Venture Capital Private Equity"
+      }
+    },
+    {
+      "id": "carbon-fund",
+      "type": "investor_type",
+      "attributes": {
+        "name": "Carbon Fund"
+      }
+    },
+    {
+      "id": "ngo",
+      "type": "investor_type",
+      "attributes": {
+        "name": "NGO"
+      }
+    },
+    {
+      "id": "foundation",
+      "type": "investor_type",
+      "attributes": {
+        "name": "Foundation"
+      }
+    },
+    {
+      "id": "corporate-foundation",
+      "type": "investor_type",
+      "attributes": {
+        "name": "Corporate Foundation"
+      }
+    },
+    {
+      "id": "philanthropy",
+      "type": "investor_type",
+      "attributes": {
+        "name": "Philanthropy"
+      }
+    },
+    {
+      "id": "hnwi-or-celebrity",
+      "type": "investor_type",
+      "attributes": {
+        "name": "HNWI or Celebrity"
+      }
+    },
+    {
+      "id": "country",
+      "type": "location_type",
+      "attributes": {
+        "name": "Country"
+      }
+    },
+    {
+      "id": "department",
+      "type": "location_type",
+      "attributes": {
+        "name": "Department"
+      }
+    },
+    {
+      "id": "municipality",
+      "type": "location_type",
+      "attributes": {
+        "name": "Municipality"
+      }
+    },
+    {
+      "id": "region",
+      "type": "location_type",
+      "attributes": {
+        "name": "Region"
+      }
+    },
+    {
+      "id": "academic",
+      "type": "project_developer_type",
+      "attributes": {
+        "name": "Academic"
+      }
+    },
+    {
+      "id": "business-cooperative",
+      "type": "project_developer_type",
+      "attributes": {
+        "name": "Business - Cooperative"
+      }
+    },
+    {
+      "id": "business-large-enterprise-corporation",
+      "type": "project_developer_type",
+      "attributes": {
+        "name": "Business - Large enterprise corporation"
+      }
+    },
+    {
+      "id": "business-sme-and-msme",
+      "type": "project_developer_type",
+      "attributes": {
+        "name": "Business - SME and MSME"
+      }
+    },
+    {
+      "id": "business-start-up-entrepreneur",
+      "type": "project_developer_type",
+      "attributes": {
+        "name": "Business - Start-up entrepreneur"
+      }
+    },
+    {
+      "id": "business-trade-or-business-association",
+      "type": "project_developer_type",
+      "attributes": {
+        "name": "Business - Trade or business association"
+      }
+    },
+    {
+      "id": "government-national",
+      "type": "project_developer_type",
+      "attributes": {
+        "name": "Government - National"
+      }
+    },
+    {
+      "id": "government-sub-national",
+      "type": "project_developer_type",
+      "attributes": {
+        "name": "Government - Sub-national"
+      }
+    },
+    {
+      "id": "public-private-organization-or-program",
+      "type": "project_developer_type",
+      "attributes": {
+        "name": "Public-private organization or program"
+      }
+    },
+    {
+      "id": "ngo",
+      "type": "project_developer_type",
+      "attributes": {
+        "name": "NGO"
+      }
+    },
+    {
+      "id": "iplc-organization",
+      "type": "project_developer_type",
+      "attributes": {
+        "name": "IPLC organization"
+      }
+    },
+    {
+      "id": "incipient",
+      "type": "project_development_stage",
+      "attributes": {
+        "name": "Incipient",
+        "description": "idea to be developed from scratch"
+      }
+    },
+    {
+      "id": "consolidaton",
+      "type": "project_development_stage",
+      "attributes": {
+        "name": "Consolidaton",
+        "description": "project or solution already in implementation that seeks to be strengthened and consolidated"
+      }
+    },
+    {
+      "id": "scaling-up",
+      "type": "project_development_stage",
+      "attributes": {
+        "name": "Scaling up",
+        "description": "consolidated, demonstrated project or solution that seeks to be scaled or replicated in other contexts and/or geographies"
+      }
+    },
+    {
+      "id": "entrepreneurs-and-innovators-startups",
+      "type": "project_target_group",
+      "attributes": {
+        "name": "Enterpreneurs and innovators - startups"
+      }
+    },
+    {
+      "id": "small-and-medium-businesses",
+      "type": "project_target_group",
+      "attributes": {
+        "name": "Small and medium businesses"
+      }
+    },
+    {
+      "id": "urban-populations",
+      "type": "project_target_group",
+      "attributes": {
+        "name": "Urban populations"
+      }
+    },
+    {
+      "id": "indigenous-peoples",
+      "type": "project_target_group",
+      "attributes": {
+        "name": "Indigenous peoples"
+      }
+    },
+    {
+      "id": "afro-desendant-peoples",
+      "type": "project_target_group",
+      "attributes": {
+        "name": "Afro-desendant peoples"
+      }
+    },
+    {
+      "id": "peasants-and-traditional-inhabitants",
+      "type": "project_target_group",
+      "attributes": {
+        "name": "Peasants and traditional inhabitants"
+      }
+    },
+    {
+      "id": "migrants-and-displaced-groups",
+      "type": "project_target_group",
+      "attributes": {
+        "name": "Migrants and displaced groups"
+      }
+    },
+    {
+      "id": "groups-with-disabilities",
+      "type": "project_target_group",
+      "attributes": {
+        "name": "Groups with disabilities"
+      }
+    },
+    {
+      "id": "lgtbq-plus-groups",
+      "type": "project_target_group",
+      "attributes": {
+        "name": "LGTBQ+ groups"
+      }
+    },
+    {
+      "id": "other",
+      "type": "project_target_group",
+      "attributes": {
+        "name": "Other"
+      }
+    },
+    {
+      "id": "small-grants",
+      "type": "ticket_size",
+      "attributes": {
+        "name": "Small Grants",
+        "description": "<US$25,000"
+      }
+    },
+    {
+      "id": "prototyping",
+      "type": "ticket_size",
+      "attributes": {
+        "name": "Prototyping",
+        "description": "US$25,000 - 150,000"
+      }
+    },
+    {
+      "id": "validation",
+      "type": "ticket_size",
+      "attributes": {
+        "name": "Validation",
+        "description": "US$150,000 - 750,000"
+      }
+    },
+    {
+      "id": "scaling",
+      "type": "ticket_size",
+      "attributes": {
+        "name": "Scaling",
+        "description": ">US$750,000"
+      }
+    },
+    {
+      "id": "amazon-heart",
+      "type": "mosaic",
+      "attributes": {
+        "name": "Amazon Heart"
+      }
+    },
+    {
+      "id": "amazonian-piedmont-massif",
+      "type": "mosaic",
+      "attributes": {
+        "name": "Amazonian Piedmont Massif"
+      }
+    },
+    {
+      "id": "orinoquia-transition",
+      "type": "mosaic",
+      "attributes": {
+        "name": "Orinoquía Transition"
+      }
+    },
+    {
+      "id": "orinoquia",
+      "type": "mosaic",
+      "attributes": {
+        "name": "Orinoquía"
+      }
+    }
+  ]
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -136,6 +136,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "jest": "^27.5.1",
     "prettier": "^2.3.0",
+    "storybook-addon-mock": "^2.3.2",
     "storybook-addon-next": "^1.6.2",
     "storybook-react-intl": "^1.0.5",
     "typescript": "^4.5.5",

--- a/frontend/pages/discover/projects.tsx
+++ b/frontend/pages/discover/projects.tsx
@@ -129,7 +129,7 @@ const ProjectsPage: PageComponent<ProjectsPageProps, DiscoverPageLayoutProps> = 
                 exit={{ opacity: 0 }}
               >
                 <aside className="absolute top-0 z-10 w-7/12 xl:w-5/12 mt-1 mb-0 -ml-2.5 -bottom-4 left-5/12 rounded-t-2xl">
-                  <div className="max-h-full overflow-y-scroll bg-white border rounded-2xl lg:mr-10">
+                  <div className="max-h-full overflow-y-scroll bg-white border rounded-2xl">
                     <ProjectDetails project={selectedProject} onClose={handleProjectDetailsClose} />
                   </div>
                 </aside>

--- a/frontend/pages/discover/projects.tsx
+++ b/frontend/pages/discover/projects.tsx
@@ -1,18 +1,26 @@
-import { useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import cx from 'classnames';
 
+import { useRouter } from 'next/router';
+
+import { AnimatePresence, motion } from 'framer-motion';
+import { useOutsideClick } from 'rooks';
+
+import { useBreakpoint } from 'hooks/use-breakpoint';
 import { useScrollOnQuery } from 'hooks/use-scroll-on-query';
 import { usePagination } from 'hooks/usePagination';
 
 import { loadI18nMessages } from 'helpers/i18n';
 
 import ProjectCard from 'containers/project-card';
+import ProjectDetails from 'containers/project-details';
 
 import Loading from 'components/loading';
 import Map from 'components/map';
+import Modal from 'components/modal';
 import Pagination from 'components/pagination';
 import DiscoverPageLayout, { DiscoverPageLayoutProps } from 'layouts/discover-page';
 import { PageComponent } from 'types';
@@ -37,41 +45,111 @@ const ProjectsPage: PageComponent<ProjectsPageProps, DiscoverPageLayoutProps> = 
   loading = false,
   meta,
 }) => {
-  const projectsContainerRef = useRef(null);
-  const { props: paginationProps } = usePagination(meta);
+  const projectsListAndDetailsContainerRef = useRef(null);
+  const projectsListContainerRef = useRef(null);
 
-  useScrollOnQuery({ ref: projectsContainerRef });
+  const intl = useIntl();
+  const { query } = useRouter();
+  const { props: paginationProps } = usePagination(meta);
+  const breakpoint = useBreakpoint();
+
+  const [selectedProject, setSelectedProject] = useState<ProjectType | null>(null);
+
+  // Scroll the element to the top when the query changes.
+  useScrollOnQuery({ ref: projectsListContainerRef });
+
+  // Close the project details card when the user clicks outside of the
+  // DetailsCard & Projects list
+  useOutsideClick(projectsListAndDetailsContainerRef, () => {
+    setSelectedProject(null);
+  });
+
+  // Close project details card when query changes; the user either,
+  // changed pages (pagination), searched, or applied filters.
+  useEffect(() => {
+    setSelectedProject(null);
+  }, [query]);
+
+  const handleProjectCardClick = (projectId: string) => {
+    setSelectedProject(projects.find(({ id }) => id === projectId));
+  };
+
+  const handleProjectDetailsClose = () => {
+    setSelectedProject(null);
+  };
 
   const hasProjects = projects?.length > 0 || false;
 
   return (
-    <div className="flex flex-col w-full h-full pb-2 lg:p-1 lg:-m-1 lg:gap-0 lg:overflow-hidden lg:flex-row">
-      <div className="relative flex flex-col w-full lg:overflow-hidden lg:w-5/12">
-        <div
-          ref={projectsContainerRef}
-          className={cx({
-            'relative flex-grow lg:pr-2.5': true,
-            'lg:overflow-y-scroll': !loading,
-            'lg:pointer-events-none lg:overflow-hidden': loading,
-          })}
-        >
-          {loading && (
-            <span className="absolute bottom-0 z-20 flex items-center justify-center bg-gray-600 bg-opacity-20 top-1 left-1 right-3 rounded-2xl">
-              <Loading visible={loading} iconClassName="w-10 h-10" />
-            </span>
-          )}
-          <div className="flex flex-col">
-            {projects.map((project) => (
-              <ProjectCard className="m-1" key={project.id} project={project} />
-            ))}
-            {!loading && !hasProjects && (
-              <FormattedMessage defaultMessage="No projects" id="TfXhCr" />
+    <div className="relative flex flex-col w-full h-full lg:gap-0 lg:overflow-hidden lg:flex-row">
+      <div
+        ref={projectsListAndDetailsContainerRef}
+        className="flex flex-col lg:top-1 lg:bottom-1 lg:absolute lg:w-full"
+      >
+        <div className="relative flex flex-col lg:overflow-hidden lg:w-5/12">
+          <div
+            ref={projectsListContainerRef}
+            className={cx({
+              'relative flex-grow lg:pr-2.5': true,
+              'lg:overflow-y-scroll': !loading,
+              'lg:pointer-events-none lg:overflow-hidden': loading,
+            })}
+          >
+            {loading && (
+              <span className="absolute bottom-0 z-20 flex items-center justify-center bg-gray-600 bg-opacity-20 top-1 left-1 right-3 rounded-2xl">
+                <Loading visible={loading} iconClassName="w-10 h-10" />
+              </span>
             )}
+            <div className="flex flex-col">
+              {projects.map((project) => (
+                <ProjectCard
+                  className="m-1"
+                  key={project.id}
+                  active={project.id === selectedProject?.id}
+                  project={project}
+                  onClick={handleProjectCardClick}
+                />
+              ))}
+              {!loading && !hasProjects && (
+                <FormattedMessage defaultMessage="No projects" id="TfXhCr" />
+              )}
+            </div>
           </div>
+          {hasProjects && <Pagination className="w-full pt-2 -mb-2" {...paginationProps} />}
         </div>
-        {hasProjects && <Pagination className="w-full pt-2 -mb-2" {...paginationProps} />}
+        {breakpoint('lg') ? (
+          <AnimatePresence>
+            {selectedProject && (
+              <motion.div
+                className="z-10"
+                transition={{ duration: 0.15 }}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+              >
+                <aside className="absolute top-0 z-10 w-7/12 xl:w-5/12 mt-1 mb-0 -ml-2.5 -bottom-4 left-5/12 rounded-t-2xl">
+                  <div className="max-h-full overflow-y-scroll bg-white border rounded-2xl lg:mr-10">
+                    <ProjectDetails project={selectedProject} onClose={handleProjectDetailsClose} />
+                  </div>
+                </aside>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        ) : (
+          <Modal
+            theme="naked"
+            title={intl.formatMessage({
+              defaultMessage: 'Project details',
+              id: '7gMEKc',
+            })}
+            open={!!selectedProject}
+            onDismiss={handleProjectDetailsClose}
+          >
+            <ProjectDetails project={selectedProject} onClose={handleProjectDetailsClose} />
+          </Modal>
+        )}
       </div>
-      <aside className="flex-grow min-h-full p-2 m-1 bg-white rounded-2xl lg:min-h-0">
+      <aside className="flex-grow min-h-full p-2 m-1 bg-white rounded-2xl lg:min-h-0 lg:absolute lg:right-0 lg:w-7/12 lg:bottom-1 lg:top-1">
         <Map className="lg:overflow-hidden rounded-xl" onMapViewportChange={() => {}} />
       </aside>
     </div>

--- a/frontend/pages/discover/projects.tsx
+++ b/frontend/pages/discover/projects.tsx
@@ -61,6 +61,7 @@ const ProjectsPage: PageComponent<ProjectsPageProps, DiscoverPageLayoutProps> = 
   // Close the project details card when the user clicks outside of the
   // DetailsCard & Projects list
   useOutsideClick(projectsListAndDetailsContainerRef, () => {
+    if (!breakpoint('lg')) return;
     setSelectedProject(null);
   });
 

--- a/frontend/pages/project/[id]/index.tsx
+++ b/frontend/pages/project/[id]/index.tsx
@@ -68,11 +68,11 @@ const ProjectPage: PageComponent<ProjectPageProps, StaticPageLayoutProps> = ({
         <section>Overview</section>
         <section>
           Impact
-          <div className="lg:justify-between px-2 py-16 sm:px-12 sm:py-20 lg:flex bg-background-greenLight rounded-2xl">
+          <div className="px-2 py-16 lg:justify-between sm:px-12 sm:py-20 lg:flex bg-background-greenLight rounded-2xl">
             <div>
               <h2>Estimated Impact</h2>
             </div>
-            <div className="pl-28 pr-24 py-10">
+            <div className="py-10 pr-24 pl-28">
               <ImpactChart category={project.category} impact={projectImpact} />
             </div>
           </div>

--- a/frontend/services/projects/projectService.ts
+++ b/frontend/services/projects/projectService.ts
@@ -13,17 +13,19 @@ import { PagedResponse, PagedRequest } from 'services/types';
 
 /** Get a paged list of projects */
 const getProjects = async (params?: PagedRequest): Promise<PagedResponse<Project>> => {
-  const { search, page, ...rest } = params;
+  const { search, page, includes, ...rest } = params || {};
+
   const config: AxiosRequestConfig = {
     url: '/api/v1/projects',
     method: 'GET',
     params: {
       ...rest,
-      includes: params.includes.join(','),
-      'filter[full_text]': params.search,
-      'page[number]': params.page,
+      includes: includes?.join(','),
+      'filter[full_text]': search,
+      'page[number]': page,
     },
   };
+
   return await API.request(config).then((result) => result.data);
 };
 

--- a/frontend/services/projects/projectService.ts
+++ b/frontend/services/projects/projectService.ts
@@ -17,7 +17,12 @@ const getProjects = async (params?: PagedRequest): Promise<PagedResponse<Project
   const config: AxiosRequestConfig = {
     url: '/api/v1/projects',
     method: 'GET',
-    params: { ...rest, 'filter[full_text]': params.search, 'page[number]': params.page },
+    params: {
+      ...rest,
+      includes: params.includes.join(','),
+      'filter[full_text]': params.search,
+      'page[number]': params.page,
+    },
   };
   return await API.request(config).then((result) => result.data);
 };

--- a/frontend/services/types.ts
+++ b/frontend/services/types.ts
@@ -2,6 +2,7 @@
 export type PagedRequest = {
   'page[number]'?: number;
   'page[size]'?: number;
+  includes?: string[];
   fields?: string[];
   search?: string;
   page?: number;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -81,6 +81,9 @@ module.exports = {
         'auto-1fr': 'auto 1fr',
         '1fr-auto': '1fr auto',
       },
+      inset: {
+        '5/12': '41.666667%',
+      },
       backgroundImage: {
         'radial-green-dark':
           'radial-gradient(63.59% 95.05% at 42.99% 35.35%, #316146 0%, #073525 100%)',

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1530,7 +1530,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.8.7":
+"@babel/runtime@npm:^7.0.0-rc.0, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.8.7":
   version: 7.17.9
   resolution: "@babel/runtime@npm:7.17.9"
   dependencies:
@@ -5369,6 +5369,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/addons@npm:^6.2.9":
+  version: 6.4.22
+  resolution: "@storybook/addons@npm:6.4.22"
+  dependencies:
+    "@storybook/api": 6.4.22
+    "@storybook/channels": 6.4.22
+    "@storybook/client-logger": 6.4.22
+    "@storybook/core-events": 6.4.22
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    "@storybook/router": 6.4.22
+    "@storybook/theming": 6.4.22
+    "@types/webpack-env": ^1.16.0
+    core-js: ^3.8.2
+    global: ^4.4.0
+    regenerator-runtime: ^0.13.7
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  checksum: c1372cb5e04ebc08b3f2df764630f370b9ccce0c7b47b5126c4964d53971e8a21efb1ef913a376cb6c289e6c492133e5273a36bd6ee4e39e1073acc12be51ee2
+  languageName: node
+  linkType: hard
+
 "@storybook/api@npm:6.4.19":
   version: 6.4.19
   resolution: "@storybook/api@npm:6.4.19"
@@ -5394,6 +5416,34 @@ __metadata:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
   checksum: 305c413ee81f98c0064bbefdd88ee61f4ce0af18465412d7e771ba7af9825c4aa134d827d21f5e7e0dafbb41fafd5a68c65df29525de8bd382b24a960b78e97a
+  languageName: node
+  linkType: hard
+
+"@storybook/api@npm:6.4.22, @storybook/api@npm:^6.2.9":
+  version: 6.4.22
+  resolution: "@storybook/api@npm:6.4.22"
+  dependencies:
+    "@storybook/channels": 6.4.22
+    "@storybook/client-logger": 6.4.22
+    "@storybook/core-events": 6.4.22
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    "@storybook/router": 6.4.22
+    "@storybook/semver": ^7.3.2
+    "@storybook/theming": 6.4.22
+    core-js: ^3.8.2
+    fast-deep-equal: ^3.1.3
+    global: ^4.4.0
+    lodash: ^4.17.21
+    memoizerific: ^1.11.3
+    regenerator-runtime: ^0.13.7
+    store2: ^2.12.0
+    telejson: ^5.3.2
+    ts-dedent: ^2.0.0
+    util-deprecate: ^1.0.2
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  checksum: 3320bc73a892db6a2d0c0448c844084db14c898dd74b79de86df732e73fbe1c274fd8d109da5e8683e9b74c2d7a0f1a365ebc45bd0227a4e7e93db36402a391e
   languageName: node
   linkType: hard
 
@@ -5590,6 +5640,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/channels@npm:6.4.22":
+  version: 6.4.22
+  resolution: "@storybook/channels@npm:6.4.22"
+  dependencies:
+    core-js: ^3.8.2
+    ts-dedent: ^2.0.0
+    util-deprecate: ^1.0.2
+  checksum: cffd2055906e995719b392ccf2928cd244fc0ec278988c290b5d3a8bc8a0d2b2ef679c03e1959fa19134c41bea4f7490ccc9f85ab4211a58c597170c65caa77e
+  languageName: node
+  linkType: hard
+
 "@storybook/client-api@npm:6.4.19":
   version: 6.4.19
   resolution: "@storybook/client-api@npm:6.4.19"
@@ -5631,6 +5692,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/client-logger@npm:6.4.22":
+  version: 6.4.22
+  resolution: "@storybook/client-logger@npm:6.4.22"
+  dependencies:
+    core-js: ^3.8.2
+    global: ^4.4.0
+  checksum: ed615b4f4e022830565b47fe850fa4dc7f75169b84710b5807e95cb75e45b58cba3f514154e039e3fe6ad96519faacaa096e3fd26af5b31322c29946e066c5b2
+  languageName: node
+  linkType: hard
+
 "@storybook/components@npm:6.4.19":
   version: 6.4.19
   resolution: "@storybook/components@npm:6.4.19"
@@ -5663,6 +5734,41 @@ __metadata:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
   checksum: 200ea23620f191b571bbb182109716eb00405eeb7deb16e61fe38434d1c12b8ec3a2edc209ac128ead3dd46c2e03146bf84b63f5f8707b5dd0aa715624b97f52
+  languageName: node
+  linkType: hard
+
+"@storybook/components@npm:^6.2.9":
+  version: 6.4.22
+  resolution: "@storybook/components@npm:6.4.22"
+  dependencies:
+    "@popperjs/core": ^2.6.0
+    "@storybook/client-logger": 6.4.22
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    "@storybook/theming": 6.4.22
+    "@types/color-convert": ^2.0.0
+    "@types/overlayscrollbars": ^1.12.0
+    "@types/react-syntax-highlighter": 11.0.5
+    color-convert: ^2.0.1
+    core-js: ^3.8.2
+    fast-deep-equal: ^3.1.3
+    global: ^4.4.0
+    lodash: ^4.17.21
+    markdown-to-jsx: ^7.1.3
+    memoizerific: ^1.11.3
+    overlayscrollbars: ^1.13.1
+    polished: ^4.0.5
+    prop-types: ^15.7.2
+    react-colorful: ^5.1.2
+    react-popper-tooltip: ^3.1.1
+    react-syntax-highlighter: ^13.5.3
+    react-textarea-autosize: ^8.3.0
+    regenerator-runtime: ^0.13.7
+    ts-dedent: ^2.0.0
+    util-deprecate: ^1.0.2
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  checksum: c558f9148aec6fc8fea746883d183163991c5b0887556abd9a5ffc2561c11f470177e4e83b08b34f11e2a3c344b73b0800c2cf1b3d6b82d1b8dbe0ee9e0ca468
   languageName: node
   linkType: hard
 
@@ -5770,6 +5876,15 @@ __metadata:
   dependencies:
     core-js: ^3.8.2
   checksum: a10620f3f6b6e0dd22951c3c2287482bdb3e53c98b4b482f142aa2e979ae993a9ee626686a7320f97ce2fe82dcb5afec037346abfda4f33c2f612b1cd83c74a2
+  languageName: node
+  linkType: hard
+
+"@storybook/core-events@npm:6.4.22":
+  version: 6.4.22
+  resolution: "@storybook/core-events@npm:6.4.22"
+  dependencies:
+    core-js: ^3.8.2
+  checksum: d114e0ab9e6fbffb232f38cb964eaead5d3fa3752863cafd0be2afb249127b21f833a6f536655cabb41f1748e690e95fc749f5f2956989ea3d9b676f593a3b0b
   languageName: node
   linkType: hard
 
@@ -6120,6 +6235,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/router@npm:6.4.22":
+  version: 6.4.22
+  resolution: "@storybook/router@npm:6.4.22"
+  dependencies:
+    "@storybook/client-logger": 6.4.22
+    core-js: ^3.8.2
+    fast-deep-equal: ^3.1.3
+    global: ^4.4.0
+    history: 5.0.0
+    lodash: ^4.17.21
+    memoizerific: ^1.11.3
+    qs: ^6.10.0
+    react-router: ^6.0.0
+    react-router-dom: ^6.0.0
+    ts-dedent: ^2.0.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  checksum: 107f7e6fa244325f053bbd32a36c891db513d2c6802908964a5fa2f03302256d33c3a85b95e999f36dc8097fb89503999881f56affc8c542874a1dc0468781c7
+  languageName: node
+  linkType: hard
+
 "@storybook/semver@npm:^7.3.2":
   version: 7.3.2
   resolution: "@storybook/semver@npm:7.3.2"
@@ -6199,6 +6336,29 @@ __metadata:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
   checksum: 59e980a602bfff4f7643c9f43fdd09d75b6c08cf8eed59da45f2d9b8a8fc3233057eda953c2de98e5440d29196d0abc7f3d7838f98d66f41b57579e7b2cef5e5
+  languageName: node
+  linkType: hard
+
+"@storybook/theming@npm:6.4.22":
+  version: 6.4.22
+  resolution: "@storybook/theming@npm:6.4.22"
+  dependencies:
+    "@emotion/core": ^10.1.1
+    "@emotion/is-prop-valid": ^0.8.6
+    "@emotion/styled": ^10.0.27
+    "@storybook/client-logger": 6.4.22
+    core-js: ^3.8.2
+    deep-object-diff: ^1.1.0
+    emotion-theming: ^10.0.27
+    global: ^4.4.0
+    memoizerific: ^1.11.3
+    polished: ^4.0.5
+    resolve-from: ^5.0.0
+    ts-dedent: ^2.0.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  checksum: bb95f7fa400f09eb01ac55ebb2ab65b03300033971fe921ab019dc01b9ccd110ed714da8788c0286a6b59ed1b31e6f65296b3319c332835d302cacf0259a0b44
   languageName: node
   linkType: hard
 
@@ -14256,6 +14416,7 @@ __metadata:
     rooks: ^5.10.0
     sharp: ^0.30.1
     slugify: ^1.6.5
+    storybook-addon-mock: ^2.3.2
     storybook-addon-next: ^1.6.2
     storybook-react-intl: ^1.0.5
     tailwindcss: ^3.0.23
@@ -17233,6 +17394,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mock-xmlhttprequest@npm:^7.0.3":
+  version: 7.0.4
+  resolution: "mock-xmlhttprequest@npm:7.0.4"
+  checksum: 64a6fca2094c167a63b387f59d00401f1a804d77a3b257f79f939160f3d3bc0a2a693ec6fcc5502861e7d9ba41d9dab5c052d628adae242efdcf92a675b60c8f
+  languageName: node
+  linkType: hard
+
 "move-concurrently@npm:^1.0.1":
   version: 1.0.1
   resolution: "move-concurrently@npm:1.0.1"
@@ -18237,6 +18405,13 @@ __metadata:
   version: 0.1.7
   resolution: "path-to-regexp@npm:0.1.7"
   checksum: 69a14ea24db543e8b0f4353305c5eac6907917031340e5a8b37df688e52accd09e3cebfe1660b70d76b6bd89152f52183f28c74813dbf454ba1a01c82a38abce
+  languageName: node
+  linkType: hard
+
+"path-to-regexp@npm:^6.2.0":
+  version: 6.2.1
+  resolution: "path-to-regexp@npm:6.2.1"
+  checksum: f0227af8284ea13300f4293ba111e3635142f976d4197f14d5ad1f124aebd9118783dd2e5f1fe16f7273743cc3dbeddfb7493f237bb27c10fdae07020cc9b698
   languageName: node
   linkType: hard
 
@@ -19418,6 +19593,18 @@ __metadata:
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: f7a19ac3496de32ca9ae12aa030f00f14a3d45374f1ceca0af707c831b2a6098ef0d6bdae51bd437b0a306d7f01d4677fcc8de7c0d331eb47ad0f46130e53c5f
+  languageName: node
+  linkType: hard
+
+"react-json-editor-ajrm@npm:^2.5.13":
+  version: 2.5.13
+  resolution: "react-json-editor-ajrm@npm:2.5.13"
+  dependencies:
+    "@babel/runtime": ^7.0.0-rc.0
+  peerDependencies:
+    react: ">=16.2.0"
+    react-dom: ">=16.2.0"
+  checksum: 44fa7557a5b35b96cebfa639083817c9a4fa775e58347daf8a331bf83b15ba64ee5634ea07fdef889b007bd6df9aa878ec007d1e1a1dad8249299abdee302ca5
   languageName: node
   linkType: hard
 
@@ -21000,6 +21187,23 @@ __metadata:
   version: 2.13.1
   resolution: "store2@npm:2.13.1"
   checksum: c5fa1ac7dbf8431d87ad4563d9838311bb421cc6e13696b668c772192942be2e07ef20d36104f7496acab6dc4d569a9b50d6c2299ceaddbcb86628f585323ff4
+  languageName: node
+  linkType: hard
+
+"storybook-addon-mock@npm:^2.3.2":
+  version: 2.3.2
+  resolution: "storybook-addon-mock@npm:2.3.2"
+  dependencies:
+    "@storybook/addons": ^6.2.9
+    "@storybook/api": ^6.2.9
+    "@storybook/components": ^6.2.9
+    mock-xmlhttprequest: ^7.0.3
+    path-to-regexp: ^6.2.0
+    react-json-editor-ajrm: ^2.5.13
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: ea9abe7409b6a878235127686f382353876d28b6240a1351245726b4c20277417f27b9a768b5eadfb93b7a62d0b36108c11327686b84206e6f5c51a21d5d7408
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds a project details card to the discover/search project page. 

**In this PR:**  

- New `ProjectDetails` component:   
  - The project details will be visible in the discover/project page when a `ProjectCard is clicked`:  
    - For large screens, a card with the project details will open next to the list of projects  
      _over the map, as per designs_  
    - For small screens, a modal opens with the project details   
- New `useBreakpoint` hook:  
  - Provides a helpers to allow us to selectively add/remove components from the view, based on Tailwind's breakpoints  
    _This was so that we could switch between displaying a ProjectCard over the map or open it in a modal, depending on screen size._
    _Works virtually the same as Tailwind's own helpers. Eg: `breakpoint('lg')` is equivalent to `'lg:'`_
- `ProjectCard` component changes:  
  - Added an `active` prop  
    _So that when the ProjectDetails card is open for a particular ProjectCard, it is shown in a with a border to indicate it is selected/active_    
- `Modal` component changes:  
  - Added possibility of theming and included a `naked` component, where the modal is shown with no padding nor close button
    _This was necessarily primarily to make the "Looking for funding" ribbon_    
- `Tag` and `CategoryTag` components changes:  
  - Added the possibility to set a `size`
    _Necessary because the ProjectDetails card shows smaller tags_   
- Storybook changes:  
  - Added and configured `storybook-addon-mock`
    _So that we can mock API requests._  
   -  Added `api/v1/enums` mock data  
- `ImpactChart`  component changes:  
  - Made it so it is now responsive  
    _This wasn't strictly necessary for this task, but in order to set proper spacing and test the `ProjectDetails` component I've added an `ImpactChart` with mock data. Needed to know the card wouldn't break with different screen sizes._

**Notes:**

- I believe the ProjectDetails card's accessibility could be improved (with aria-live), but as this task was taking so long and has a huge size I haven't looked much into it. 
- The ribbon/close button have been fixed to the top right, which isn't shown on the screenshots/videos

## Testing instructions

- When clicking one of the projects in the search results list, a “card” will be displayed with the following information
  - Title of the project
  - Instrument type(s)
  - Ticket size
  - Category
  - Verified or not
    _(note that we don't have verified projects yet, but it can be tested in Storybook )_
  - Looking for funding (or not)
  - Description (“About”)
  - Project developer name and picture
  - SDGs

- There will be a way to close the preview
- There will be a way to open the project detail page

## Tracking

[LET-399](https://vizzuality.atlassian.net/browse/LET-399)

## Screenshots 

**Desktop:** 
<img width="1679" alt="Screenshot 2022-05-19 at 12 18 11" src="https://user-images.githubusercontent.com/6273795/169281390-0e1353cb-2d4a-4de7-96cb-c71f1d0fdce3.png">

**Mobile:**
<img width="397" alt="Screenshot 2022-05-19 at 12 18 01" src="https://user-images.githubusercontent.com/6273795/169281430-ee49b20f-a1e7-42fa-b208-5448b7db8453.png">

## Video  

https://user-images.githubusercontent.com/6273795/169281457-048fea5c-51b8-4b17-b1d8-90ccd897e7d0.mp4