### PR TITLE
Fix DirectUpload - swcminify

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -8,7 +8,7 @@ module.exports = {
   images: {
     domains: ['heco.vizzuality.com', 'staging.heco.vizzuality.com'],
   },
-  swcMinify: true,
+  swcMinify: false,
   eslint: {
     dirs: [
       'components',


### PR DESCRIPTION
Do not use swcminify as it breaks something with directupload, md5 probably. I think some other webpack plugin is used instead of that, and the output size seems even smaller.