### PR TITLE
Let 287 fe prevent non signed in users and investors to access the project creation form

### DIFF
--- a/frontend/enums/index.ts
+++ b/frontend/enums/index.ts
@@ -20,10 +20,12 @@ export enum Paths {
   Projects = '/discover/projects',
   ProjectCreation = '/projects/new',
   ProjectDeveloper = '/project-developer',
+  NewProjectDeveloper = '/project-developers/new',
   ProjectDevelopers = '/discover/project-developers',
   OpenCall = '/open-call',
   OpenCalls = '/discover/open-calls',
   Investor = '/investor',
+  NewInvestor = '/investors/new',
   Investors = '/discover/investors',
 }
 

--- a/frontend/helpers/user.ts
+++ b/frontend/helpers/user.ts
@@ -6,7 +6,7 @@ import { User } from 'types/user';
 export const getUserInitials = (user: User) => {
   if (user) {
     const { first_name, last_name } = user;
-    return `${first_name.substring(0, 1)}${last_name.substring(0, 1)}`.toUpperCase();
+    return `${first_name?.substring(0, 1)}${last_name?.substring(0, 1)}`.toUpperCase();
   }
   return '';
 };

--- a/frontend/hooks/me/index.ts
+++ b/frontend/hooks/me/index.ts
@@ -2,15 +2,20 @@ import { useMemo } from 'react';
 
 import { useQuery } from 'react-query';
 
+import { useRouter } from 'next/router';
+
 import { AxiosError } from 'axios';
 
-import { Queries } from 'enums';
+import { Paths, Queries, UserRoles } from 'enums';
 import { User } from 'types/user';
 
 import API from 'services/api';
 import { ErrorResponse } from 'services/types';
 
-export default function useMe() {
+const NOT_SIGNED_USER_ERROR_CODE = '401';
+
+export default function useMe(withProtection?: { protectedPage?: boolean; roles?: UserRoles[] }) {
+  const { replace, back } = useRouter();
   const query = useQuery<User, AxiosError<ErrorResponse>>(
     Queries.User,
     () =>
@@ -20,11 +25,23 @@ export default function useMe() {
       }).then((response) => response.data.data),
     {
       // If the user is not signed in, it will no retry, else (other error causes), it will retry 2 times.
-      retry: (count, error) => error.code !== '401' && count < 3,
+      retry: (count, error) => error.code !== NOT_SIGNED_USER_ERROR_CODE && count < 3,
       staleTime: Infinity,
       refetchOnMount: false,
       refetchOnWindowFocus: false,
       // Changing the defaults to those configurations will reduce the fetchings and prevent the unecessary retries
+      onError: (error) => {
+        if (withProtection?.protectedPage && error.code === NOT_SIGNED_USER_ERROR_CODE) {
+          // User is not signed in
+          replace(Paths.SignIn);
+        }
+      },
+      onSuccess: (user) => {
+        if (withProtection?.protectedPage && !withProtection?.roles.includes(user.role)) {
+          // User is signed in but doesn't have permission
+          back();
+        }
+      },
     }
   );
 

--- a/frontend/hooks/me/index.ts
+++ b/frontend/hooks/me/index.ts
@@ -2,20 +2,15 @@ import { useMemo } from 'react';
 
 import { useQuery } from 'react-query';
 
-import { useRouter } from 'next/router';
-
 import { AxiosError } from 'axios';
 
-import { Paths, Queries, UserRoles } from 'enums';
+import { Queries } from 'enums';
 import { User } from 'types/user';
 
 import API from 'services/api';
 import { ErrorResponse } from 'services/types';
 
-const NOT_SIGNED_USER_ERROR_CODE = '401';
-
-export default function useMe(withProtection?: { protectedPage?: boolean; roles?: UserRoles[] }) {
-  const { replace, back } = useRouter();
+export default function useMe() {
   const query = useQuery<User, AxiosError<ErrorResponse>>(
     Queries.User,
     () =>
@@ -25,23 +20,11 @@ export default function useMe(withProtection?: { protectedPage?: boolean; roles?
       }).then((response) => response.data.data),
     {
       // If the user is not signed in, it will no retry, else (other error causes), it will retry 2 times.
-      retry: (count, error) => error.code !== NOT_SIGNED_USER_ERROR_CODE && count < 3,
+      retry: (count, error) => error.code !== '401' && count < 3,
       staleTime: Infinity,
       refetchOnMount: false,
       refetchOnWindowFocus: false,
       // Changing the defaults to those configurations will reduce the fetchings and prevent the unecessary retries
-      onError: (error) => {
-        if (withProtection?.protectedPage && error.code === NOT_SIGNED_USER_ERROR_CODE) {
-          // User is not signed in
-          replace(Paths.SignIn);
-        }
-      },
-      onSuccess: (user) => {
-        if (withProtection?.protectedPage && !withProtection?.roles.includes(user.role)) {
-          // User is signed in but doesn't have permission
-          back();
-        }
-      },
     }
   );
 

--- a/frontend/hooks/me/index.ts
+++ b/frontend/hooks/me/index.ts
@@ -2,25 +2,20 @@ import { useMemo } from 'react';
 
 import { useQuery } from 'react-query';
 
-import { AxiosError } from 'axios';
+import { AxiosError, AxiosResponse } from 'axios';
 
 import { Queries } from 'enums';
 import { User } from 'types/user';
 
-import API from 'services/api';
-import { ErrorResponse } from 'services/types';
+import { ErrorResponse, ResponseData } from 'services/types';
+import { getCurrentUser } from 'services/users/userService';
 
 export default function useMe() {
-  const query = useQuery<User, AxiosError<ErrorResponse>>(
+  const query = useQuery<AxiosResponse<ResponseData<User>>, AxiosError<ErrorResponse>>(
     Queries.User,
-    () =>
-      API.request({
-        method: 'GET',
-        url: '/api/v1/user',
-      }).then((response) => response.data.data),
+    getCurrentUser,
     {
-      // If the user is not signed in, it will no retry, else (other error causes), it will retry 2 times.
-      retry: (count, error) => error.code !== '401' && count < 3,
+      retry: 1,
       staleTime: Infinity,
       refetchOnMount: false,
       refetchOnWindowFocus: false,
@@ -33,7 +28,7 @@ export default function useMe() {
   return useMemo(
     () => ({
       ...query,
-      user: data,
+      user: data?.data?.data,
     }),
     [query, data]
   );

--- a/frontend/layouts/protected-page/component.tsx
+++ b/frontend/layouts/protected-page/component.tsx
@@ -9,20 +9,22 @@ import { ProtectedProps } from 'layouts/protected-page/types';
 
 const Protected: React.FC<ProtectedProps> = ({ permissions, children, ...rest }) => {
   const router = useRouter();
-  const { user, isLoading } = useMe();
+  const { user, isLoading, isError } = useMe();
 
   // Not display anything when me request is on progress
   if (isLoading) return null;
 
-  // Redirect when session doesn't exist
-  if (!user) {
+  // Redirect to sign-in when session doesn't exist
+  if (isError) {
     router.push(Paths.SignIn);
     return null;
   }
+
   if (!permissions.includes(user.role)) {
     if (user.role === UserRoles.Light) {
       // Redirect to choose account type if the user have a Light account
       router.push(Paths.AccountType);
+      return null;
     }
     // Redirect to the last route (go back) if the user have a different kind of account
     router.back();

--- a/frontend/layouts/protected-page/component.tsx
+++ b/frontend/layouts/protected-page/component.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/router';
 
 import useMe from 'hooks/me';
 
-import { Paths } from 'enums';
+import { Paths, UserRoles } from 'enums';
 import { ProtectedProps } from 'layouts/protected-page/types';
 
 const Protected: React.FC<ProtectedProps> = ({ permissions, children, ...rest }) => {
@@ -19,8 +19,12 @@ const Protected: React.FC<ProtectedProps> = ({ permissions, children, ...rest })
     router.push(Paths.SignIn);
     return null;
   }
-
   if (!permissions.includes(user.role)) {
+    if (user.role === UserRoles.Light) {
+      // Redirect to choose account type if the user have a Light account
+      router.push(Paths.AccountType);
+    }
+    // Redirect to the last route (go back) if the user have a different kind of account
     router.back();
     return null;
   }

--- a/frontend/layouts/protected-page/component.tsx
+++ b/frontend/layouts/protected-page/component.tsx
@@ -4,9 +4,10 @@ import { useRouter } from 'next/router';
 
 import useMe from 'hooks/me';
 
+import { Paths } from 'enums';
 import { ProtectedProps } from 'layouts/protected-page/types';
 
-const Protected: React.FC<ProtectedProps> = ({ children, ...rest }) => {
+const Protected: React.FC<ProtectedProps> = ({ permissions, children, ...rest }) => {
   const router = useRouter();
   const { user, isLoading } = useMe();
 
@@ -14,8 +15,13 @@ const Protected: React.FC<ProtectedProps> = ({ children, ...rest }) => {
   if (isLoading) return null;
 
   // Redirect when session doesn't exist
-  if (!isLoading && !user) {
-    router.push(`/sign-in?callbackUrl=${window.location.origin}${router.asPath}`);
+  if (!user) {
+    router.push(Paths.SignIn);
+    return null;
+  }
+
+  if (!permissions.includes(user.role)) {
+    router.back();
     return null;
   }
 

--- a/frontend/layouts/protected-page/types.ts
+++ b/frontend/layouts/protected-page/types.ts
@@ -1,1 +1,7 @@
-export type ProtectedProps = React.PropsWithChildren<React.ComponentProps<'div'> & {}>;
+import { UserRoles } from 'enums';
+
+export type ProtectedProps = React.PropsWithChildren<
+  React.ComponentProps<'div'> & {
+    permissions: UserRoles[];
+  }
+>;

--- a/frontend/pages/investors/new.tsx
+++ b/frontend/pages/investors/new.tsx
@@ -9,7 +9,9 @@ import { loadI18nMessages } from 'helpers/i18n';
 import MultiPageLayout, { Page, OutroPage } from 'containers/multi-page-layout';
 
 import Head from 'components/head';
+import { UserRoles } from 'enums';
 import FormPageLayout, { FormPageLayoutProps } from 'layouts/form-page';
+import ProtectedPage from 'layouts/protected-page';
 import { PageComponent } from 'types';
 
 export async function getServerSideProps(ctx) {
@@ -53,7 +55,7 @@ const NewInvestorPage: PageComponent<{}, FormPageLayoutProps> = (props) => {
   };
 
   return (
-    <>
+    <ProtectedPage permissions={[UserRoles.Light]}>
       <Head
         title={intl.formatMessage({ defaultMessage: 'Setup investor profile', id: '7Rh11y' })}
       />
@@ -186,7 +188,7 @@ const NewInvestorPage: PageComponent<{}, FormPageLayoutProps> = (props) => {
           </h1>
         </OutroPage>
       </MultiPageLayout>
-    </>
+    </ProtectedPage>
   );
 };
 

--- a/frontend/pages/projects/new.tsx
+++ b/frontend/pages/projects/new.tsx
@@ -8,8 +8,6 @@ import { useRouter } from 'next/router';
 
 import { InferGetStaticPropsType } from 'next';
 
-import useMe from 'hooks/me';
-
 import { loadI18nMessages } from 'helpers/i18n';
 import { getServiceErrors, useGetAlert } from 'helpers/pages';
 
@@ -27,6 +25,7 @@ import {
 import Head from 'components/head';
 import { Paths, Queries, UserRoles } from 'enums';
 import FormPageLayout, { FormPageLayoutProps } from 'layouts/form-page';
+import ProtectedPage from 'layouts/protected-page';
 import { PageComponent } from 'types';
 import { ProjectCreationPayload, ProjectForm } from 'types/project';
 import useProjectValidation from 'validations/project';
@@ -52,9 +51,6 @@ export async function getStaticProps(ctx) {
 type ProjectProps = InferGetStaticPropsType<typeof getStaticProps>;
 
 const Project: PageComponent<ProjectProps, FormPageLayoutProps> = () => {
-  // Get the user and redirect if it it's not signed in or doesn't have the permissions
-  useMe({ protectedPage: true, roles: [UserRoles.ProjectDeveloper] });
-
   const [currentPage, setCurrentPage] = useState(0);
   const [showLeave, setShowLeave] = useState(false);
   const { formatMessage } = useIntl();
@@ -143,7 +139,7 @@ const Project: PageComponent<ProjectProps, FormPageLayoutProps> = () => {
   };
 
   return (
-    <>
+    <ProtectedPage permissions={[UserRoles.ProjectDeveloper]}>
       <Head
         title={formatMessage({ defaultMessage: 'Setup project developer’s account', id: 'bhxvPM' })}
       />
@@ -235,7 +231,7 @@ const Project: PageComponent<ProjectProps, FormPageLayoutProps> = () => {
         handleLeave={() => push(Paths.Dashboard)}
         title={formatMessage({ defaultMessage: 'Leave project creation form', id: 'vygPIS' })}
       />
-    </>
+    </ProtectedPage>
   );
 };
 

--- a/frontend/pages/projects/new.tsx
+++ b/frontend/pages/projects/new.tsx
@@ -8,6 +8,8 @@ import { useRouter } from 'next/router';
 
 import { InferGetStaticPropsType } from 'next';
 
+import useMe from 'hooks/me';
+
 import { loadI18nMessages } from 'helpers/i18n';
 import { getServiceErrors, useGetAlert } from 'helpers/pages';
 
@@ -23,7 +25,7 @@ import {
 } from 'containers/project-form-pages';
 
 import Head from 'components/head';
-import { Paths, Queries } from 'enums';
+import { Paths, Queries, UserRoles } from 'enums';
 import FormPageLayout, { FormPageLayoutProps } from 'layouts/form-page';
 import { PageComponent } from 'types';
 import { ProjectCreationPayload, ProjectForm } from 'types/project';
@@ -50,6 +52,9 @@ export async function getStaticProps(ctx) {
 type ProjectProps = InferGetStaticPropsType<typeof getStaticProps>;
 
 const Project: PageComponent<ProjectProps, FormPageLayoutProps> = () => {
+  // Get the user and redirect if it it's not signed in or doesn't have the permissions
+  useMe({ protectedPage: true, roles: [UserRoles.ProjectDeveloper] });
+
   const [currentPage, setCurrentPage] = useState(0);
   const [showLeave, setShowLeave] = useState(false);
   const { formatMessage } = useIntl();

--- a/frontend/pages/sign-in/index.tsx
+++ b/frontend/pages/sign-in/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
@@ -37,7 +37,7 @@ export async function getStaticProps(ctx) {
 type SignInPageProps = InferGetStaticPropsType<typeof getStaticProps>;
 
 const SignIn: PageComponent<SignInPageProps, AuthPageLayoutProps> = () => {
-  const { push } = useRouter();
+  const { push, query } = useRouter();
   const intl = useIntl();
   const signIn = useSignIn();
   const resolver = useSignInResolver();
@@ -48,19 +48,17 @@ const SignIn: PageComponent<SignInPageProps, AuthPageLayoutProps> = () => {
   } = useForm<SignIn>({ resolver, shouldUseNativeValidation: true });
   const { user } = useMe();
 
-  const handleSignIn = useCallback(
-    (data: SignIn) =>
-      signIn.mutate(data, {
-        onSuccess: () => {
-          if (user?.role === UserRoles.Light) {
-            push(Paths.AccountType);
-          } else {
-            push(Paths.Dashboard);
-          }
-        },
-      }),
-    [signIn, push, user]
-  );
+  useEffect(() => {
+    if (user) {
+      if (user?.role === UserRoles.Light) {
+        push(Paths.AccountType);
+      } else {
+        push(Paths.Dashboard);
+      }
+    }
+  }, [push, query.callbackUrl, user]);
+
+  const handleSignIn = useCallback((data: SignIn) => signIn.mutate(data), [signIn]);
 
   const onSubmit: SubmitHandler<SignIn> = handleSignIn;
 

--- a/frontend/pages/sign-up/account-type.tsx
+++ b/frontend/pages/sign-up/account-type.tsx
@@ -26,8 +26,8 @@ const SignUpAccountTypePage: PageComponent<{}, StaticPageLayoutProps> = () => {
   const { push } = useRouter();
 
   const handleAccountTypeSelected = (accountType: AccountType) => {
-    // TODO: Handle account type selected
-    if (accountType === 'project-developer') push('/project-developers/new');
+    if (accountType === 'project-developer') push(Paths.NewProjectDeveloper);
+    if (accountType === 'investor') push(Paths.NewInvestor);
   };
 
   return (

--- a/frontend/services/users/userService.ts
+++ b/frontend/services/users/userService.ts
@@ -3,9 +3,9 @@ import { useMutation, UseMutationResult } from 'react-query';
 import { AxiosResponse, AxiosError } from 'axios';
 
 import { ResetPassword } from 'types/sign-in';
-import { SignupDto } from 'types/user';
+import { SignupDto, User } from 'types/user';
 
-import { ErrorResponse } from 'services/types';
+import { ErrorResponse, ResponseData } from 'services/types';
 
 import API from '../api';
 
@@ -25,3 +25,10 @@ export function useResetPassword(): UseMutationResult<AxiosResponse, AxiosError,
   const resetPassword = async (dto: ResetPassword) => await API.post('/api/v1/reset_password', dto);
   return useMutation(resetPassword);
 }
+
+/** Get the logged user */
+export const getCurrentUser = (): Promise<AxiosResponse<ResponseData<User>>> =>
+  API.request({
+    method: 'GET',
+    url: '/api/v1/user',
+  });


### PR DESCRIPTION
This PR changes the ProtectedPage layout and adds it to the project creation page and investor account creation page

## Testing instructions

When trying to go to projects/new:

* A non signed in user should be redirected from projects/new to sign in page
* An investor user should be redirected to the last page (back)
* A light user should be redirected to sign-up/account-type

## Tracking

[LET-287](https://vizzuality.atlassian.net/browse/LET-287) 
[LET-420](https://vizzuality.atlassian.net/browse/LET-420)