### PR TITLE
Adds cloudtranslate.generalModels.batchPredict permission to service account

### DIFF
--- a/infrastructure/base/.terraform.lock.hcl
+++ b/infrastructure/base/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/google" {
   constraints = "~> 4.20"
   hashes = [
     "h1:CrNR/pzPm6Z4NQzyb3rlU79RQ+NRXJ3xgrhy1ap4JiM=",
+    "h1:jQ0CdHlnQDCogTR8o4wYV7twTiYPOR+si9Ph/UIhpPk=",
     "zh:0ccae031531ee3d412681b93f2f6941e0e2c43c294d0ea7851a027aa99a32c8a",
     "zh:1a84e894bf56aa4a7a663a198fd0576cf5a37407e65d2b46bf0c351eb626f7eb",
     "zh:1c3708268482ad172b08adfc98aa11df5d4cd663d6be4b0ce4bb12c997c5bd49",
@@ -24,6 +25,7 @@ provider "registry.terraform.io/hashicorp/google-beta" {
   version     = "4.20.0"
   constraints = "~> 4.20"
   hashes = [
+    "h1:5X/EO0XrjeTXhdF20n2+I5lgz/qutG2rNMd0WmXm7IM=",
     "h1:leuD3b+U9BkO8sh5YlBOiDrhWrjvtyqQBTwrqxhW2hI=",
     "zh:4d14d5695bbc30564e042f689fbbd22f214e71a7f6cfc181c0c4a654123c008b",
     "zh:74f676b14d826d12022d0fb64c1051619dd4b7fcc7eb69a6a37f7e08cbcd8873",

--- a/infrastructure/base/modules/cloudrun/main.tf
+++ b/infrastructure/base/modules/cloudrun/main.tf
@@ -105,12 +105,3 @@ resource "google_service_account_iam_binding" "admin-account-iam" {
     "serviceAccount:${google_service_account.service_account.email}",
   ]
 }
-
-resource "google_service_account_iam_binding" "translation-user" {
-  service_account_id = google_service_account.service_account.name
-  role               = "roles/cloudtranslate.generalModels.batchPredict"
-
-  members = [
-    "serviceAccount:${google_service_account.service_account.email}",
-  ]
-}

--- a/infrastructure/base/modules/cloudrun/main.tf
+++ b/infrastructure/base/modules/cloudrun/main.tf
@@ -105,3 +105,12 @@ resource "google_service_account_iam_binding" "admin-account-iam" {
     "serviceAccount:${google_service_account.service_account.email}",
   ]
 }
+
+resource "google_service_account_iam_binding" "translation-user" {
+  service_account_id = google_service_account.service_account.name
+  role               = "roles/cloudtranslate.generalModels.batchPredict"
+
+  members = [
+    "serviceAccount:${google_service_account.service_account.email}",
+  ]
+}

--- a/infrastructure/base/modules/env/main.tf
+++ b/infrastructure/base/modules/env/main.tf
@@ -273,6 +273,8 @@ module "load_balancer" {
 
 module "translation" {
   source = "../translation"
+  project_id            = var.gcp_project_id
+  service_account_email = module.backend_cloudrun.service_account_email
 }
 
 module "error_reporting" {

--- a/infrastructure/base/modules/translation/main.tf
+++ b/infrastructure/base/modules/translation/main.tf
@@ -2,3 +2,9 @@ resource "google_project_service" "translation_api" {
   service    = "translate.googleapis.com"
   disable_on_destroy = false
 }
+
+resource "google_project_iam_member" "cloudtranslate_user" {
+  project = var.project_id
+  role    = "roles/cloudtranslate.user"
+  member = "serviceAccount:${var.service_account_email}"
+}

--- a/infrastructure/base/modules/translation/variables.tf
+++ b/infrastructure/base/modules/translation/variables.tf
@@ -1,0 +1,9 @@
+variable "project_id" {
+  type        = string
+  description = "GCP project id"
+}
+
+variable "service_account_email" {
+  type        = string
+  description = "Email address of the service account to grant translation access to"
+}


### PR DESCRIPTION
https://vizzuality.atlassian.net/browse/LET-472

I used this https://cloud.google.com/iam/docs/permissions-reference

To search for roles which include the `cloudtranslate.generalModels.batchPredict` permission, about which we're getting an error. It seems that the lowest priority role with that permission is `Cloud Translation API User (roles/cloudtranslate.user)`, so I added that to the service account.