### PR TITLE
Fixes to cloudtasker & active job config

### DIFF
--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -41,7 +41,6 @@ Rails.application.configure do
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :google
-  config.active_storage.queue = ENV["CLOUD_TASKS_TEST_QUEUE_NAME"].to_sym
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil
@@ -65,6 +64,7 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "backend_production"
   config.active_job.queue_adapter = :cloudtasker
+  config.active_job.default_queue_name = ENV["CLOUD_TASKS_TEST_QUEUE_NAME"].to_sym
 
   config.action_mailer.perform_caching = false
   config.action_mailer.delivery_method = :smtp

--- a/backend/config/initializers/cloudtasker.rb
+++ b/backend/config/initializers/cloudtasker.rb
@@ -53,7 +53,7 @@ Cloudtasker.configure do |config|
   # Defaults to :development unless CLOUDTASKER_ENV or RAILS_ENV or RACK_ENV is set to something else.
   #
   # config.mode = Rails.env.production? || Rails.env.my_other_env? ? :production : :development
-  config.mode = config.mode = Rails.env.production? ? :production : :development
+  config.mode = Rails.env.production? ? :production : :development
 
   #
   # Specify the logger to use


### PR DESCRIPTION
This is another attempt to fix `Failed enqueuing ActiveStorage::AnalyzeJob to Cloudtasker(default): Google::Cloud::FailedPreconditionError (9:Queue does not exist`

also, there was a mysterious occurrence of redis connection failure in the log, redis connections shouldn't be made - not sure what that was about, but correcting the cloudtasker config mode setting cannot do harm
