### PR TITLE
Project Developers card + Project Developers view w/ search/pagination

### DIFF
--- a/frontend/containers/profile-card/component.stories.tsx
+++ b/frontend/containers/profile-card/component.stories.tsx
@@ -1,0 +1,66 @@
+import { Story, Meta } from '@storybook/react/types-6-0';
+import withMock from 'storybook-addon-mock';
+
+import apiEnumsMock from 'mockups/api/v1/enums.json';
+
+import ProfileCard, { ProfileCardProps } from '.';
+
+const mockApiData = [
+  {
+    url: '/api/v1/enums',
+    method: 'GET',
+    status: 200,
+    response: apiEnumsMock,
+  },
+];
+
+export default {
+  component: ProfileCard,
+  title: 'Containers/ProfileCard',
+  decorators: [withMock],
+} as Meta;
+
+const defaultArgs = {
+  picture: 'https://placekitten.com/g/300/300',
+  name: 'John Doe',
+  description:
+    'Morbi varius semper ipsum, sed placerat lacus blandit non. Curabitur ac commodo orci. Sed laoreet feugiat libero, nec tincidunt tortor lacinia',
+  link: '#',
+};
+
+const Template: Story<ProfileCardProps> = (args: ProfileCardProps) => (
+  <ProfileCard className="w-96" {...args} />
+);
+
+export const ProjectDeveloper: Story<ProfileCardProps> = Template.bind({});
+ProjectDeveloper.args = {
+  ...(defaultArgs as ProfileCardProps),
+  profileType: 'project-developer',
+  type: 'academic',
+  impacts: ['climate', 'water'],
+};
+
+export const Investor: Story<ProfileCardProps> = Template.bind({});
+Investor.args = {
+  ...(defaultArgs as ProfileCardProps),
+  profileType: 'investor',
+  type: 'angel-investor',
+  impacts: ['climate', 'community'],
+};
+
+export const WithoutImpacts: Story<ProfileCardProps> = Template.bind({});
+WithoutImpacts.args = {
+  ...(defaultArgs as ProfileCardProps),
+  profileType: 'investor',
+  type: 'angel-investor',
+};
+
+export const TruncatedDescription: Story<ProfileCardProps> = Template.bind({});
+TruncatedDescription.args = {
+  ...(defaultArgs as ProfileCardProps),
+  profileType: 'investor',
+  type: 'angel-investor',
+  description:
+    'Morbi varius semper ipsum, sed placerat lacus blandit non. Curabitur ac commodo orci. Sed laoreet feugiat libero, nec tincidunt tortor lacinia eu. Nulla fringilla auctor nisi, vel accumsan neque bibendum ac. Praesent consequat rhoncus enim. Cras ultricies dolor ante, ac dignissim ex tincidunt ac. Nam placerat elit eget odio interdum pellentesque. Nullam scelerisque, justo ut molestie suscipit, erat elit semper sem, et pharetra mauris nisi scelerisque nisl. Quisque scelerisque risus sit amet sapien pulvinar suscipit. Vestibulum tristique porta augue, vitae convallis quam tincidunt vitae. In sed enim turpis. Praesent placerat eleifend sollicitudin. Morbi sit amet libero scelerisque, lacinia neque luctus, posuere eros. Praesent a turpis ac libero luctus tincidunt. Sed fringilla vehicula dolor. Integer sollicitudin sodales interdum.',
+  impacts: ['climate', 'water'],
+};

--- a/frontend/containers/profile-card/component.tsx
+++ b/frontend/containers/profile-card/component.tsx
@@ -1,0 +1,132 @@
+import { FC, useState, useMemo } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import cx from 'classnames';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+import { usePress, useFocusWithin } from '@react-aria/interactions';
+import { truncate } from 'lodash-es';
+
+import Tag from 'components/tag';
+
+import { useEnums } from 'services/enums/enumService';
+
+import type { ProfileCardProps } from './types';
+
+export const ProfileCard: FC<ProfileCardProps> = ({
+  className,
+  profileType,
+  type,
+  name,
+  description,
+  impacts,
+  link,
+  picture: pictureProp = undefined,
+}: ProfileCardProps) => {
+  const intl = useIntl();
+  const router = useRouter();
+  const [picture, setPicture] = useState<string>(pictureProp);
+
+  const {
+    data: {
+      impact: allImpacts,
+      project_developer_type: allProjectDeveloperTypes,
+      investor_type: allInvestorTypes,
+    },
+  } = useEnums();
+
+  const [isFocusWithin, setIsFocusWithin] = useState<boolean>(false);
+
+  const { pressProps } = usePress({
+    onPress: () => {
+      router.push(link);
+    },
+  });
+
+  const { focusWithinProps } = useFocusWithin({
+    onFocusWithinChange: setIsFocusWithin,
+  });
+
+  const subtitle =
+    profileType === 'project-developer'
+      ? allProjectDeveloperTypes?.find(({ id }) => id === type)?.name
+      : allInvestorTypes?.find(({ id }) => id === type)?.name;
+
+  const truncatedDescription = useMemo(
+    () => truncate(description, { length: 300, omission: ' ...' }),
+    [description]
+  );
+
+  const tags = allImpacts?.filter((impact) => impacts?.includes(impact.id)).map(({ name }) => name);
+
+  return (
+    <div
+      aria-label={intl.formatMessage(
+        { defaultMessage: '{name} project developer', id: 'jXqlWP' },
+        { name }
+      )}
+      role="group"
+      className={cx({
+        [className]: !!className,
+        'cursor-pointer transition rounded-2xl': true,
+        'hover:ring-1 hover:ring-green-dark': true,
+        'ring-2 ring-green-dark': isFocusWithin,
+      })}
+      {...pressProps}
+      {...focusWithinProps}
+    >
+      <div className="relative flex flex-col h-full p-5 bg-white border shadow rounded-2xl gap-y-2 sm:gap-x-4">
+        <div className="flex gap-4">
+          <div className="relative overflow-hidden rounded-full w-18 aspect-square">
+            <Image
+              className="w-18 h-18"
+              src={picture}
+              alt={intl.formatMessage({ defaultMessage: '{name} picture', id: 'rLzWx9' }, { name })}
+              layout="fill"
+              objectFit="cover"
+              onError={() => setPicture('/images/placeholders/profile-logo.png')}
+            />
+          </div>
+          <div className="pt-2">
+            <div className="text-xl font-semibold text-gray-900">
+              <Link href={link}>
+                <a className="text-xl font-semibold leading-tight outline-none pointer-events-none">
+                  {name}
+                </a>
+              </Link>
+            </div>
+            {subtitle && <div className="text-gray-600 text-md">{subtitle}</div>}
+          </div>
+        </div>
+        <div
+          className="flex items-start flex-grow mt-4"
+          aria-label={intl.formatMessage({ defaultMessage: 'Description', id: 'Q8Qw5B' })}
+        >
+          {truncatedDescription}
+        </div>
+        {tags && (
+          <div
+            className="flex flex-wrap gap-2 mt-3"
+            role="group"
+            aria-label={intl.formatMessage({
+              defaultMessage: 'Expects to have impact on',
+              id: 'YYMUK5',
+            })}
+          >
+            {tags.map((tag) => (
+              <Tag key={tag} className="text-sm text-green-dark" size="smallest">
+                {tag}
+              </Tag>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ProfileCard;

--- a/frontend/containers/profile-card/component.tsx
+++ b/frontend/containers/profile-card/component.tsx
@@ -63,12 +63,14 @@ export const ProfileCard: FC<ProfileCardProps> = ({
 
   const tags = allImpacts?.filter((impact) => impacts?.includes(impact.id)).map(({ name }) => name);
 
+  const cardAriaLabel =
+    profileType === 'project-developer'
+      ? intl.formatMessage({ defaultMessage: `{name} project developer`, id: 'jXqlWP' }, { name })
+      : intl.formatMessage({ defaultMessage: `{name} investor`, id: '9WcWke' }, { name });
+
   return (
     <div
-      aria-label={intl.formatMessage(
-        { defaultMessage: '{name} project developer', id: 'jXqlWP' },
-        { name }
-      )}
+      aria-label={cardAriaLabel}
       role="group"
       className={cx({
         [className]: !!className,

--- a/frontend/containers/profile-card/index.ts
+++ b/frontend/containers/profile-card/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { ProfileCardProps } from './types';

--- a/frontend/containers/profile-card/types.ts
+++ b/frontend/containers/profile-card/types.ts
@@ -1,0 +1,18 @@
+export type ProfileCardProps = {
+  /** Classes to apply to the container */
+  className?: string;
+  /** ProjectDeveloper or Investor `type` */
+  type: string;
+  /** Picture to display in the card */
+  picture: string;
+  /** Name to display on the card */
+  name: string;
+  /** Whether the card is for a project-developer or an investor. Will be used as a subtitle */
+  profileType: 'project-developer' | 'investor';
+  /** Description to show on the card */
+  description: string;
+  /** Link to the url the card links to */
+  link: string;
+  /** Impacts to display as tags */
+  impacts?: string[];
+};

--- a/frontend/enums/index.ts
+++ b/frontend/enums/index.ts
@@ -45,6 +45,8 @@ export enum Queries {
   ProjectDeveloper = 'project_developer',
   /** The current user Project Developer */
   CurrentProjectDeveloper = 'current_project_developer',
+  /** List of projects */
+  ProjectList = 'projects',
   /** Single project */
   Project = 'project',
   /** List of investors */

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -672,6 +672,9 @@
   "XkF/qg": {
     "string": "Profile picture of {name}"
   },
+  "Y2zB+b": {
+    "string": "No project developers"
+  },
   "Y7/cBd": {
     "string": "Reach out for what you are looking for, from either <span>Investors</span> or <span>Project Developers</span> and <span>start the conversation</span>. Make sure to update us to help us track your contribution to preserving the Amazon: <span>the future is in your hands too!</span>"
   },

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -531,6 +531,9 @@
   "Q1Q4rT": {
     "string": "Insert your name"
   },
+  "Q8Qw5B": {
+    "string": "Description"
+  },
   "QDj3j7": {
     "string": "Inter-American Development Bank Lab"
   },
@@ -686,6 +689,9 @@
   },
   "YWQkk+": {
     "string": "Short description of the project"
+  },
+  "YYMUK5": {
+    "string": "Expects to have impact on"
   },
   "Z8971h": {
     "string": "Verified"
@@ -888,6 +894,9 @@
   "jWOeHy": {
     "string": "<a>Call on our community</a> of project developers to identify opportunities in your preferred sectors and geographies."
   },
+  "jXqlWP": {
+    "string": "{name} project developer"
+  },
   "jwimQJ": {
     "string": "Ok"
   },
@@ -1001,6 +1010,9 @@
   },
   "qpDURb": {
     "string": "Something went wrong with the file upload"
+  },
+  "rLzWx9": {
+    "string": "{name} picture"
   },
   "rPwaWt": {
     "string": "A great name is short, crisp, and easily understood."

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -218,6 +218,9 @@
   "9VLFbQ": {
     "string": "Landscape photo"
   },
+  "9WcWke": {
+    "string": "{name} investor"
+  },
   "9cE0nR": {
     "string": "How is the impact calculated?"
   },

--- a/frontend/layouts/discover-page/component.tsx
+++ b/frontend/layouts/discover-page/component.tsx
@@ -9,6 +9,7 @@ import DiscoverSearch from 'containers/layouts/discover-search';
 import LayoutContainer from 'components/layout-container';
 import { Paths } from 'enums';
 
+import { useProjectDevelopersList } from 'services/project-developers/projectDevelopersService';
 import { useProjectsList } from 'services/projects/projectService';
 
 import Header from './header';
@@ -35,7 +36,7 @@ export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
     [query]
   );
 
-  const queryOptions = { keepPreviousData: true };
+  const queryOptions = { keepPreviousData: false };
 
   const {
     data: projects,
@@ -43,9 +44,15 @@ export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
     isFetching: isFetchingProjects,
   } = useProjectsList({ ...queryParams, includes: ['project_developer'] }, queryOptions);
 
+  const {
+    data: projectDevelopers,
+    isLoading: isLoadingProjectDevelopers,
+    isFetching: isFetchingProjectDevelopers,
+  } = useProjectDevelopersList({ ...queryParams, perPage: 9 }, queryOptions);
+
   const stats = {
     projects: projects?.meta?.total,
-    projectDevelopers: 0,
+    projectDevelopers: projectDevelopers?.meta?.total,
     investors: 0,
     openCalls: 0,
   };
@@ -54,10 +61,23 @@ export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
     // TODO: Find a way to improve this.
     if (router.pathname.startsWith(Paths.Projects))
       return { ...projects, loading: isLoadingProjects || isFetchingProjects };
-    // if (router.pathname.startsWith(Paths.ProjectDevelopers)) return projectDevelopers;
+    if (router.pathname.startsWith(Paths.ProjectDevelopers)) {
+      return {
+        ...projectDevelopers,
+        loading: isLoadingProjectDevelopers || isFetchingProjectDevelopers,
+      };
+    }
     // if (router.pathname.startsWith(Paths.Investors)) return investors;
     // if (router.pathname.startsWith(Paths.OpenCalls)) return openCalls;
-  }, [isFetchingProjects, isLoadingProjects, projects, router.pathname]) || { data: [], meta: [] };
+  }, [
+    isFetchingProjectDevelopers,
+    isFetchingProjects,
+    isLoadingProjectDevelopers,
+    isLoadingProjects,
+    projectDevelopers,
+    projects,
+    router.pathname,
+  ]) || { data: [], meta: [] };
 
   useEffect(() => {
     setSearchInputValue(queryParams.search);

--- a/frontend/pages/discover/project-developers.tsx
+++ b/frontend/pages/discover/project-developers.tsx
@@ -1,40 +1,96 @@
-import { groupBy } from 'lodash-es';
+import { useRef } from 'react';
+
+import { FormattedMessage } from 'react-intl';
+
+import cx from 'classnames';
+
+import { useScrollOnQuery } from 'hooks/use-scroll-on-query';
+import { usePagination } from 'hooks/usePagination';
 
 import { loadI18nMessages } from 'helpers/i18n';
 
+import ProfileCard from 'containers/profile-card';
+
+import Loading from 'components/loading';
+import Pagination from 'components/pagination';
+import { Paths } from 'enums';
 import DiscoverPageLayout, { DiscoverPageLayoutProps } from 'layouts/discover-page';
 import { PageComponent } from 'types';
-import { GroupedEnums as GroupedEnumsType } from 'types/enums';
-
-import { getEnums } from 'services/enums/enumService';
+import { ProjectDeveloper as ProjectDeveloperType } from 'types/projectDeveloper';
 
 export const getServerSideProps = async ({ locale }) => {
-  const enums = await getEnums();
-
   return {
     props: {
       intlMessages: await loadI18nMessages({ locale }),
-      enums: groupBy(enums, 'type'),
     },
   };
 };
 
 type ProjectDevelopersPageProps = {
-  enums: GroupedEnumsType;
+  data: ProjectDeveloperType[];
+  meta: Record<string, string>;
+  loading: boolean;
 };
 
 const ProjectDevelopersPage: PageComponent<ProjectDevelopersPageProps, DiscoverPageLayoutProps> = ({
-  enums,
+  data: projectDevelopers = [],
+  loading = false,
+  meta,
 }) => {
+  const projectDevelopersContainerRef = useRef(null);
+  const { props: paginationProps } = usePagination(meta);
+
+  useScrollOnQuery({ ref: projectDevelopersContainerRef });
+
+  const hasProjectDevelopers = projectDevelopers?.length > 0 || false;
+
   return (
-    <div className="flex w-full gap-5">
-      <span>Page: Project Developers</span>
+    <div className="flex flex-col w-full h-full pb-2 lg:p-1 lg:-m-1 lg:gap-0 lg:overflow-hidden lg:flex-row">
+      <div className="relative flex flex-col w-full lg:overflow-hidden ">
+        <div
+          ref={projectDevelopersContainerRef}
+          className={cx({
+            'relative flex-grow lg:pr-2.5': true,
+            'lg:overflow-y-scroll': !loading,
+            'lg:pointer-events-none lg:overflow-hidden': loading,
+          })}
+        >
+          {loading && (
+            <span className="absolute bottom-0 z-20 flex items-center justify-center bg-gray-600 bg-opacity-20 top-1 left-1 right-3 rounded-2xl">
+              <Loading visible={loading} iconClassName="w-10 h-10" />
+            </span>
+          )}
+          <div className="grid grid-cols-1 gap-6 p-1 md:grid-cols-2 xl:grid-cols-3">
+            {projectDevelopers.map(
+              ({ project_developer_type, name, about, slug, picture, impacts }) => (
+                <ProfileCard
+                  profileType="project-developer"
+                  key={slug}
+                  name={name}
+                  type={project_developer_type}
+                  description={about}
+                  link={`${Paths.ProjectDeveloper}/${slug}`}
+                  picture={picture?.small}
+                  impacts={impacts}
+                />
+              )
+            )}
+            {!loading && !hasProjectDevelopers && (
+              <FormattedMessage defaultMessage="No project developers" id="Y2zB+b" />
+            )}
+          </div>
+        </div>
+        {hasProjectDevelopers && <Pagination className="w-full pt-2 -mb-2" {...paginationProps} />}
+      </div>
     </div>
   );
 };
 
 ProjectDevelopersPage.layout = {
   Component: DiscoverPageLayout,
+  props: {
+    screenHeightLg: true,
+  },
 };
 
 export default ProjectDevelopersPage;

--- a/frontend/services/project-developers/projectDevelopersService.ts
+++ b/frontend/services/project-developers/projectDevelopersService.ts
@@ -17,18 +17,20 @@ import { PagedResponse, PagedRequest, ResponseData } from 'services/types';
 const getProjectDevelopers = async (
   params?: PagedRequest
 ): Promise<PagedResponse<ProjectDeveloper>> => {
-  const { fields, search, page, ...rest } = params;
+  const { fields, search, page, perPage, ...rest } = params || {};
+
   const config: AxiosRequestConfig = {
     url: '/api/v1/project_developers',
     method: 'GET',
     params: {
       ...rest,
-      'fields[project_developer]': params.fields?.join(','),
-      'filter[full_text]': params.search,
-      'page[number]': params.page,
-      'page[size]': params.perPage,
+      'fields[project_developer]': fields?.join(','),
+      'filter[full_text]': search,
+      'page[number]': page,
+      'page[size]': perPage,
     },
   };
+
   return await API.request(config).then((result) => result.data);
 };
 

--- a/frontend/services/project-developers/projectDevelopersService.ts
+++ b/frontend/services/project-developers/projectDevelopersService.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { UseQueryResult, useQuery, useMutation, QueryClient } from 'react-query';
+import { UseQueryResult, useQuery, useMutation, QueryClient, UseQueryOptions } from 'react-query';
 
 import { AxiosResponse, AxiosRequestConfig } from 'axios';
 import { decycle } from 'cycle';
@@ -17,23 +17,33 @@ import { PagedResponse, PagedRequest, ResponseData } from 'services/types';
 const getProjectDevelopers = async (
   params?: PagedRequest
 ): Promise<PagedResponse<ProjectDeveloper>> => {
-  const { fields, ...rest } = params;
+  const { fields, search, page, ...rest } = params;
   const config: AxiosRequestConfig = {
     url: '/api/v1/project_developers',
     method: 'GET',
-    params: { ...rest, 'fields[project_developer]': params.fields.join(',') },
+    params: {
+      ...rest,
+      'fields[project_developer]': params.fields?.join(','),
+      'filter[full_text]': params.search,
+      'page[number]': params.page,
+      'page[size]': params.perPage,
+    },
   };
   return await API.request(config).then((result) => result.data);
 };
 
 /** Hook to use the the Project Developers list */
 export function useProjectDevelopersList(
-  params?: PagedRequest
+  params?: PagedRequest,
+  options?: UseQueryOptions<PagedResponse<ProjectDeveloper>>
 ): UseQueryResult<PagedResponse<ProjectDeveloper>> & { projectDevelopers: ProjectDeveloper[] } {
   const query = useQuery(
     [Queries.ProjectDeveloperList, params],
     () => getProjectDevelopers(params),
-    staticDataQueryOptions
+    {
+      ...staticDataQueryOptions,
+      ...options,
+    }
   );
 
   return useMemo(

--- a/frontend/services/projects/projectService.ts
+++ b/frontend/services/projects/projectService.ts
@@ -34,7 +34,7 @@ export function useProjectsList(
   params?: PagedRequest,
   options?: UseQueryOptions<PagedResponse<Project>>
 ): UseQueryResult<PagedResponse<Project>> & { projects: Project[] } {
-  const query = useQuery([Queries.ProjectDeveloperList, params], () => getProjects(params), {
+  const query = useQuery([Queries.ProjectList, params], () => getProjects(params), {
     ...staticDataQueryOptions,
     ...options,
   });

--- a/frontend/services/types.ts
+++ b/frontend/services/types.ts
@@ -6,6 +6,7 @@ export type PagedRequest = {
   fields?: string[];
   search?: string;
   page?: number;
+  perPage?: number;
 };
 
 /** Default API single item response structure */

--- a/frontend/types/projectDeveloper.ts
+++ b/frontend/types/projectDeveloper.ts
@@ -11,6 +11,7 @@ export type ProjectDeveloperPicture = {
 
 export type ProjectDeveloper = {
   id: string;
+  slug: string;
   type: 'project_developer';
   name: string;
   about: string;


### PR DESCRIPTION
## Note

~Includes commits from #177 (`Tag` `size` prop addition, api mocks, storybook set up for mocking API requests).~

## Description

**In this PR:**  
- `ProfileCard`, meant to be used by both ProjectDevelopers and Investors discover/search views, as well as in the Project public view page (project developers section). 
  - Card made with a base on the `ProjectCard` (so that accessibility is on par)  
- Project developers discover/search page:  
  - List of project developers, paginated, searchable   
- Fixed an issue with the `projectService` having a wrong `useQuery` set up  

## Testing instructions

Verify that: 

- `discover/project-developers` displays a paginated view of project developer cards  
  - Cards display the name, project developer type, description (truncated if too long, may need to be tested via storybook), impact category tags as per designs, as well as the project developer picture  
- Clicking on a card takes the user to the respective project developer page  
- Pagination works  
- Search works (searching by the name won't work; BE)  
- It is responsive

## Tracking

[LET-415 (FE - PD card (search page))](https://vizzuality.atlassian.net/browse/LET-415)  
[LET-416 (FE - Allow users to search PDs (search page))](https://vizzuality.atlassian.net/browse/LET-416)

## Screenshot  
<img width="1680" alt="Screenshot 2022-05-19 at 15 55 34" src="https://user-images.githubusercontent.com/6273795/169326806-1211d285-4b85-4ed2-aed4-976e8dd2ffba.png">

