### PR TITLE
Allow sorting of results (search page)

### DIFF
--- a/frontend/components/menu/component.tsx
+++ b/frontend/components/menu/component.tsx
@@ -1,10 +1,11 @@
-import React, { cloneElement } from 'react';
+import React, { cloneElement, useEffect } from 'react';
 
 import cx from 'classnames';
 
 import { useButton } from '@react-aria/button';
 import { useMenuTrigger } from '@react-aria/menu';
 import { useMenuTriggerState } from '@react-stately/menu';
+import { noop } from 'lodash-es';
 
 import Popup from './popup';
 import { MenuProps } from './types';
@@ -18,6 +19,8 @@ export const Menu: React.FC<MenuProps> = ({
   onAction,
   header,
   hiddenSections,
+  onOpen = noop,
+  onClose = noop,
   ...rest
 }: MenuProps) => {
   const triggerRef = React.useRef(null);
@@ -31,6 +34,14 @@ export const Menu: React.FC<MenuProps> = ({
     },
     triggerRef
   );
+
+  useEffect(() => {
+    if (state.isOpen) {
+      onOpen();
+    } else {
+      onClose();
+    }
+  }, [onClose, onOpen, state.isOpen]);
 
   return (
     <div className={cx('relative', className)}>

--- a/frontend/components/menu/types.ts
+++ b/frontend/components/menu/types.ts
@@ -22,4 +22,8 @@ export type MenuProps = MenuTriggerProps & {
   header?: PopupProps['header'];
   /** For each section (if any), breakpoint starting from which it is hidden */
   hiddenSections?: PopupProps['hiddenSections'];
+  /** Callback executed when the menu opens */
+  onOpen?: () => void;
+  /** Callback executed when the menu closes */
+  onClose?: () => void;
 };

--- a/frontend/components/sorting-buttons/component.stories.tsx
+++ b/frontend/components/sorting-buttons/component.stories.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+
+import { Story, Meta } from '@storybook/react/types-6-0';
+
+import SortingButtons, { SortingButtonsProps, SortingOrderType } from '.';
+
+export default {
+  component: SortingButtons,
+  title: 'Components/SortingButtons',
+  argTypes: {},
+} as Meta;
+
+const Template: Story<SortingButtonsProps> = ({ ...props }: SortingButtonsProps) => {
+  const [sortBy, setSortBy] = useState('name');
+  const [sortOrder, setSortOrder] = useState('asc');
+
+  const handleOnChange = ({
+    sortBy,
+    sortOrder,
+  }: {
+    sortBy: string;
+    sortOrder: SortingOrderType;
+  }) => {
+    if (sortOrder) setSortOrder(sortOrder);
+    if (sortBy) setSortBy(sortBy);
+  };
+
+  return (
+    <SortingButtons sortBy={sortBy} sortOrder={sortOrder} onChange={handleOnChange} {...props} />
+  );
+};
+
+export const Default: Story<SortingButtonsProps> = Template.bind({});
+
+Default.args = {
+  options: [
+    { key: 'name', label: 'Name' },
+    { key: 'created_at', label: 'Created at' },
+  ],
+};

--- a/frontend/components/sorting-buttons/component.tsx
+++ b/frontend/components/sorting-buttons/component.tsx
@@ -1,0 +1,108 @@
+import { FC, useState, useMemo } from 'react';
+
+import {
+  ChevronDown as ChevronDownIcon,
+  List as ListIcon,
+  ArrowDown as ArrowDownIcon,
+} from 'react-feather';
+import { useIntl, FormattedMessage } from 'react-intl';
+
+import cx from 'classnames';
+
+import { noop } from 'lodash-es';
+
+import Button from 'components/button';
+import Menu, { MenuItem, MenuSection } from 'components/menu';
+
+import { SortingButtonsProps } from './types';
+
+export const SortingButtons: FC<SortingButtonsProps> = ({
+  className,
+  sortBy,
+  sortOrder,
+  options,
+  onChange = noop,
+}: SortingButtonsProps) => {
+  const intl = useIntl();
+
+  const [sortByMenuOpen, setSortByMenuOpen] = useState<boolean>(false);
+
+  const selectedSortByOption = useMemo(
+    () => options.find(({ key }) => sortBy === key),
+    [options, sortBy]
+  );
+
+  return (
+    <div className={className}>
+      <div className="flex gap-3">
+        <Menu
+          Trigger={
+            <Button
+              className="whitespace-nowrap"
+              size="small"
+              theme="primary-white"
+              aria-label={intl.formatMessage({
+                defaultMessage: 'Choose the field to sort by',
+                id: 'DCAMZh',
+              })}
+              aria-expanded={sortByMenuOpen}
+            >
+              <span className="py-0.5 -mx-2 flex items-center">
+                <span className="text-gray-600">
+                  <FormattedMessage defaultMessage="Sort by" id="hDI+JM" />
+                </span>
+                <span className="ml-2 text-black">{selectedSortByOption.label.toLowerCase()}</span>
+                <ChevronDownIcon
+                  className={cx({
+                    'w-4 h-4 ml-2 text-black transition-transform': true,
+                    '-rotate-180': sortByMenuOpen,
+                  })}
+                />
+              </span>
+            </Button>
+          }
+          align="start"
+          onAction={(key: string) => onChange({ sortBy: key })}
+          onOpen={() => setSortByMenuOpen(true)}
+          onClose={() => setSortByMenuOpen(false)}
+        >
+          <MenuSection>
+            {options.map(({ key, label }) => (
+              <MenuItem key={key}>{label}</MenuItem>
+            ))}
+          </MenuSection>
+        </Menu>
+        <Button
+          theme="primary-white"
+          className="!px-3"
+          size="small"
+          onClick={() => onChange({ sortOrder: sortOrder === 'asc' ? 'desc' : 'asc' })}
+          aria-label={
+            sortOrder === 'asc'
+              ? intl.formatMessage({
+                  defaultMessage: 'Sort in descending order',
+                  id: 'fwSVTQ',
+                })
+              : intl.formatMessage({
+                  defaultMessage: 'Sort in ascending order',
+                  id: 'C23He5',
+                })
+          }
+        >
+          <span className="relative mr-px -ml-px">
+            <ListIcon className="w-4 h-4 text-black -scale-x-100" />
+            <ArrowDownIcon
+              className={cx({
+                'w-4 h-4 text-black -ml-1 absolute -right-1.5': true,
+                '-top-1 -rotate-180': sortOrder === 'asc',
+                '-bottom-1': sortOrder === 'desc',
+              })}
+            />
+          </span>
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default SortingButtons;

--- a/frontend/components/sorting-buttons/index.ts
+++ b/frontend/components/sorting-buttons/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { SortingButtonsProps, SortingOptionType, SortingOrderType } from './types';

--- a/frontend/components/sorting-buttons/types.ts
+++ b/frontend/components/sorting-buttons/types.ts
@@ -1,0 +1,16 @@
+export type SortingOptionType = {
+  /** Option key */
+  key: string;
+  /** Option label */
+  label: string;
+};
+
+export type SortingOrderType = 'asc' | 'desc';
+
+export type SortingButtonsProps = {
+  className?: string;
+  sortBy: string;
+  sortOrder: SortingOrderType;
+  options: SortingOptionType[];
+  onChange?: ({ sortBy, sortOrder }: { sortBy?: string; sortOrder?: SortingOrderType }) => void;
+};

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -356,6 +356,9 @@
   "GdS9Mk": {
     "string": "Has this project been funded before?"
   },
+  "HAlOn1": {
+    "string": "Name"
+  },
   "HK3ph8": {
     "string": "How it works"
   },
@@ -524,6 +527,9 @@
   },
   "P4T4Ib": {
     "string": "Discover projects that have impact in the Amazon region and get connected with investors and project developers."
+  },
+  "P7PLVj": {
+    "string": "Date"
   },
   "PIZ1dD": {
     "string": "Search biodiversity"

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -263,6 +263,9 @@
   "C0sD76": {
     "string": "insert number (max 24)"
   },
+  "C23He5": {
+    "string": "Sort in ascending order"
+  },
   "CEQo2w": {
     "string": "My preferences"
   },
@@ -289,6 +292,9 @@
   },
   "DAJK4J": {
     "string": "<a>Heritage Colombia (HeCo)</a> is a national initiative led by the Colombian Ministry of Environment. The initiative is to secure 20 million hectares of sustainable landscape over the next 20 years, through investments in conservation and sustainable development."
+  },
+  "DCAMZh": {
+    "string": "Choose the field to sort by"
   },
   "DQoGRx": {
     "string": "About the impact"
@@ -825,6 +831,9 @@
   "fnihsY": {
     "string": "Leave"
   },
+  "fwSVTQ": {
+    "string": "Sort in descending order"
+  },
   "g5pX+a": {
     "string": "About"
   },
@@ -833,6 +842,9 @@
   },
   "gpTOIc": {
     "string": "{message} for search term {term}"
+  },
+  "hDI+JM": {
+    "string": "Sort by"
   },
   "hLG9bm": {
     "string": "Project financial instrument"

--- a/frontend/layouts/discover-page/component.tsx
+++ b/frontend/layouts/discover-page/component.tsx
@@ -1,5 +1,7 @@
 import React, { FC, useEffect, useMemo, useState } from 'react';
 
+import { useIntl } from 'react-intl';
+
 import cx from 'classnames';
 
 import { useRouter } from 'next/router';
@@ -7,6 +9,7 @@ import { useRouter } from 'next/router';
 import DiscoverSearch from 'containers/layouts/discover-search';
 
 import LayoutContainer from 'components/layout-container';
+import SortingButtons, { SortingOrderType } from 'components/sorting-buttons';
 import { Paths } from 'enums';
 
 import { useProjectsList } from 'services/projects/projectService';
@@ -19,20 +22,40 @@ export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
   screenHeightLg = false,
   children,
 }: DiscoverPageLayoutProps) => {
+  const intl = useIntl();
   const router = useRouter();
   const { query } = router;
+
+  const sortingOptions = [
+    { key: 'name', label: intl.formatMessage({ defaultMessage: 'Name', id: 'HAlOn1' }) },
+    { key: 'created_at', label: intl.formatMessage({ defaultMessage: 'Date', id: 'P7PLVj' }) },
+  ];
+
+  const defaultSorting = useMemo(
+    () => ({
+      sortBy: 'created_at',
+      sortOrder: 'desc' as SortingOrderType,
+    }),
+    []
+  );
 
   // This shouldn't be needed, but due to CSS positioning / z-index issues we need to have the DiscoverSearch
   // components both in the header and in this layout; which one is visible depends on the screen resolution.
   // These states are here to keep both DiscoverSearch in sync, in case the user resizes their screen.
-  const [searchInputValue, setSearchInputValue] = useState('');
+  const [searchInputValue, setSearchInputValue] = useState<string>('');
+  const [sorting, setSorting] = useState<{ sortBy: string; sortOrder: string }>(defaultSorting);
+
+  // http://localhost:3000/discover/projects?page=2&search=sar&sorting=name+asc
 
   const queryParams = useMemo(
     () => ({
       page: parseInt(query.page as string) || 1,
       search: (query.search as string) || '',
+      sorting:
+        // No need to decode URI component, next/router does it automatically
+        (query.sorting as string) || `${sorting.sortBy} ${sorting.sortOrder}`,
     }),
-    [query]
+    [sorting, query]
   );
 
   const queryOptions = { keepPreviousData: true };
@@ -63,9 +86,29 @@ export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
     setSearchInputValue(queryParams.search);
   }, [queryParams.search]);
 
+  useEffect(() => {
+    const [sortBy, sortOrder] = queryParams.sorting.split(' ');
+    setSorting(sortBy && sortOrder ? { sortBy, sortOrder } : defaultSorting);
+  }, [defaultSorting, queryParams.sorting]);
+
   const handleSearch = (searchText: string) => {
     router.push({ query: { ...queryParams, page: 1, search: searchText } }, undefined, {
       shallow: true,
+    });
+  };
+
+  const handleSorting = ({
+    sortBy,
+    sortOrder,
+  }: {
+    sortBy: string;
+    sortOrder: SortingOrderType;
+  }) => {
+    router.push({
+      query: {
+        ...queryParams,
+        sorting: `${sortBy || sorting.sortBy} ${sortOrder || sorting.sortOrder}`,
+      },
     });
   };
 
@@ -73,6 +116,13 @@ export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
     searchText: searchInputValue,
     onSearch: handleSearch,
     onSearchChange: setSearchInputValue,
+  };
+
+  const sortingButtonsProps = {
+    sortBy: sorting.sortBy,
+    sortOrder: sorting.sortOrder as SortingOrderType,
+    options: sortingOptions,
+    onChange: handleSorting,
   };
 
   const childrenWithProps = React.Children.map(children, (child) => {
@@ -97,10 +147,12 @@ export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
         </div>
         <main className="flex flex-col flex-grow h-screen overflow-y-scroll">
           <LayoutContainer className="xl:mt-28">
-            <div className="flex items-center gap-6 mt-2 mb-4 space-between">
-              {/*<div>Sort</div>*/}
-              <Navigation stats={stats} />
-              {/*<div>Share</div>*/}
+            <div className="flex flex-col items-center gap-2 mt-4 mb-4 lg:mt-2 lg:gap-6 lg:flex-row space-between">
+              <SortingButtons className="flex-1" {...sortingButtonsProps} />
+              <div className="flex justify-center w-full">
+                <Navigation stats={stats} />
+              </div>
+              <div className="flex-1">{/*Share*/}</div>
             </div>
           </LayoutContainer>
           <LayoutContainer


### PR DESCRIPTION
## Description

This PR adds sorting buttons to the search pages. Default sorting is by date of creation, ascending. 

## Testing instructions

At the moment we only have cards in the `Projects` page, so it's the only one that can be tested. However, the solution would work for all of the pages, provided their respective services are updated:  

Visit a search page (Projects), and verify that:  
- User can sort by name  
- User can sort by date of creation  
- Both ascending and descending order sorting work

## Tracking

[LET-408](https://vizzuality.atlassian.net/browse/LET-408)

## Screenshot  

<img width="1680" alt="Screenshot 2022-05-20 at 15 23 55" src="https://user-images.githubusercontent.com/6273795/169548762-2a68d208-7800-450d-9130-12e4dcf95f8c.png">

