### PR TITLE
Fe allow users to search investors search page

### DIFF
--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -963,6 +963,9 @@
   "jWOeHy": {
     "string": "<a>Call on our community</a> of project developers to identify opportunities in your preferred sectors and geographies."
   },
+  "jX0V8C": {
+    "string": "No investors"
+  },
   "jXqlWP": {
     "string": "{name} project developer"
   },

--- a/frontend/layouts/discover-page/component.tsx
+++ b/frontend/layouts/discover-page/component.tsx
@@ -12,6 +12,7 @@ import LayoutContainer from 'components/layout-container';
 import SortingButtons, { SortingOrderType } from 'components/sorting-buttons';
 import { Paths } from 'enums';
 
+import { useInvestorsList } from 'services/investors/investorsService';
 import { useProjectDevelopersList } from 'services/project-developers/projectDevelopersService';
 import { useProjectsList } from 'services/projects/projectService';
 
@@ -73,10 +74,16 @@ export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
     isFetching: isFetchingProjectDevelopers,
   } = useProjectDevelopersList({ ...queryParams, perPage: 9 }, queryOptions);
 
+  const {
+    data: investors,
+    isLoading: isLoadingInvestors,
+    isFetching: isFetchingInvestors,
+  } = useInvestorsList({ ...queryParams, perPage: 9 }, queryOptions);
+
   const stats = {
     projects: projects?.meta?.total,
     projectDevelopers: projectDevelopers?.meta?.total,
-    investors: 0,
+    investors: investors?.meta?.total,
     openCalls: 0,
   };
 
@@ -84,17 +91,28 @@ export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
     // TODO: Find a way to improve this.
     if (router.pathname.startsWith(Paths.Projects))
       return { ...projects, loading: isLoadingProjects || isFetchingProjects };
+
     if (router.pathname.startsWith(Paths.ProjectDevelopers)) {
       return {
         ...projectDevelopers,
         loading: isLoadingProjectDevelopers || isFetchingProjectDevelopers,
       };
     }
-    // if (router.pathname.startsWith(Paths.Investors)) return investors;
+
+    if (router.pathname.startsWith(Paths.Investors)) {
+      return {
+        ...investors,
+        loading: isLoadingInvestors || isFetchingInvestors,
+      };
+    }
+
     // if (router.pathname.startsWith(Paths.OpenCalls)) return openCalls;
   }, [
+    investors,
+    isFetchingInvestors,
     isFetchingProjectDevelopers,
     isFetchingProjects,
+    isLoadingInvestors,
     isLoadingProjectDevelopers,
     isLoadingProjects,
     projectDevelopers,

--- a/frontend/pages/discover/investors.tsx
+++ b/frontend/pages/discover/investors.tsx
@@ -1,38 +1,94 @@
-import { groupBy } from 'lodash-es';
+import { useRef } from 'react';
+
+import { FormattedMessage } from 'react-intl';
+
+import cx from 'classnames';
+
+import { useScrollOnQuery } from 'hooks/use-scroll-on-query';
+import { usePagination } from 'hooks/usePagination';
 
 import { loadI18nMessages } from 'helpers/i18n';
 
+import ProfileCard from 'containers/profile-card';
+
+import Loading from 'components/loading';
+import Pagination from 'components/pagination';
+import { Paths } from 'enums';
 import DiscoverPageLayout, { DiscoverPageLayoutProps } from 'layouts/discover-page';
 import { PageComponent } from 'types';
-import { GroupedEnums as GroupedEnumsType } from 'types/enums';
-
-import { getEnums } from 'services/enums/enumService';
+import { Investor as InvestorType } from 'types/investor';
 
 export const getServerSideProps = async ({ locale }) => {
-  const enums = await getEnums();
-
   return {
     props: {
       intlMessages: await loadI18nMessages({ locale }),
-      enums: groupBy(enums, 'type'),
     },
   };
 };
 
 type InvestorsPageProps = {
-  enums: GroupedEnumsType;
+  data: InvestorType[];
+  meta: Record<string, string>;
+  loading: boolean;
 };
 
-const InvestorsPage: PageComponent<InvestorsPageProps, DiscoverPageLayoutProps> = ({ enums }) => {
+const InvestorsPage: PageComponent<InvestorsPageProps, DiscoverPageLayoutProps> = ({
+  data: investors = [],
+  loading = false,
+  meta,
+}) => {
+  const investorsContainerRef = useRef(null);
+  const { props: paginationProps } = usePagination(meta);
+
+  useScrollOnQuery({ ref: investorsContainerRef });
+
+  const hasInvestors = investors?.length > 0 || false;
+
   return (
-    <div className="flex w-full gap-5">
-      <span>Page: Investors</span>
+    <div className="flex flex-col w-full h-full pb-2 lg:p-1 lg:-m-1 lg:gap-0 lg:overflow-hidden lg:flex-row">
+      <div className="relative flex flex-col w-full lg:overflow-hidden ">
+        <div
+          ref={investorsContainerRef}
+          className={cx({
+            'relative flex-grow lg:pr-2.5': true,
+            'lg:overflow-y-scroll': !loading,
+            'lg:pointer-events-none lg:overflow-hidden': loading,
+          })}
+        >
+          {loading && (
+            <span className="absolute bottom-0 z-20 flex items-center justify-center bg-gray-600 bg-opacity-20 top-1 left-1 right-3 rounded-2xl">
+              <Loading visible={loading} iconClassName="w-10 h-10" />
+            </span>
+          )}
+          <div className="grid grid-cols-1 gap-6 p-1 md:grid-cols-2 xl:grid-cols-3">
+            {investors.map(({ investor_type, name, about, slug, picture, impacts }) => (
+              <ProfileCard
+                profileType="investor"
+                key={slug}
+                name={name}
+                type={investor_type}
+                description={about}
+                link={`${Paths.Investor}/${slug}`}
+                picture={picture?.small}
+                impacts={impacts}
+              />
+            ))}
+            {!loading && !hasInvestors && (
+              <FormattedMessage defaultMessage="No investors" id="jX0V8C" />
+            )}
+          </div>
+        </div>
+        {hasInvestors && <Pagination className="w-full pt-2 -mb-2" {...paginationProps} />}
+      </div>
     </div>
   );
 };
 
 InvestorsPage.layout = {
   Component: DiscoverPageLayout,
+  props: {
+    screenHeightLg: true,
+  },
 };
 
 export default InvestorsPage;

--- a/frontend/services/investors/investorsService.ts
+++ b/frontend/services/investors/investorsService.ts
@@ -1,28 +1,51 @@
 import { useMemo } from 'react';
 
-import { UseQueryResult, useQuery } from 'react-query';
+import { UseQueryResult, useQuery, UseQueryOptions } from 'react-query';
 
 import { AxiosResponse, AxiosError, AxiosRequestConfig } from 'axios';
 
 import { Queries } from 'enums';
+import { Investor } from 'types/investor';
 
 import API from 'services/api';
-import { PagedResponse, ErrorResponse, PagedRequest } from 'services/types';
+import { staticDataQueryOptions } from 'services/helpers';
+import { PagedResponse, PagedRequest } from 'services/types';
+
+const getInvestors = async (params?: PagedRequest) => {
+  const { fields, search, page, perPage, ...rest } = params || {};
+
+  const config: AxiosRequestConfig = {
+    url: '/api/v1/investors',
+    method: 'GET',
+    params: {
+      ...rest,
+      'fields[investor]': fields?.join(','),
+      'filter[full_text]': search,
+      'page[number]': page,
+      'page[size]': perPage,
+    },
+  };
+
+  return await API.request(config).then((result) => result.data);
+};
 
 /** Use query for the Investors list */
 export function useInvestorsList(
-  params: PagedRequest
-): UseQueryResult<AxiosResponse<PagedResponse<any>>, AxiosError<ErrorResponse>> {
-  const getInvestors = async (params: PagedRequest) => {
-    const config: AxiosRequestConfig = {
-      url: '/api/v1/investors',
-      method: 'GET',
-      params,
-    };
-    return await API.request(config).then((response) => response.data.data);
-  };
+  params?: PagedRequest,
+  options?: UseQueryOptions<PagedResponse<Investor>>
+): UseQueryResult<PagedResponse<Investor>> & { investors: Investor[] } {
+  const query = useQuery([Queries.InvestorList, params], () => getInvestors(params), {
+    ...staticDataQueryOptions,
+    ...options,
+  });
 
-  return useQuery([Queries.InvestorList, params], () => getInvestors(params));
+  return useMemo(
+    () => ({
+      ...query,
+      investors: query?.data?.data || [],
+    }),
+    [query]
+  );
 }
 
 /** Get a Investor using an id and, optionally, the wanted fields */


### PR DESCRIPTION
## Description

This PR adds the search page for Investors.  

- Project card in is shared with the PD's one (built to be and added on #192)  
- Badge navigation shows the number of Investors  
- Includes search (~*Note:** not yet available on the endpoint~) It's implemented now    
- Includes pagination  
- Includes sorting  

## Testing instructions

Navigate to `(discover/investors)` and verify that:  
- A list of investors is displayed with the correct information  
- Clicking on an investor takes the user to the investor public page  
- Sorting works  
- Pagination works
  _(may be a tad difficult to test since we only have 3 test investors as of now, but locally it can be tested by changing `perPage` in `useInvestorsList` in `layouts/discover/component` to `1`)_  
- Searching works (??)
  _~Although implemented in the frontend, it is not implemented in the endpoint. The share functionality is shared between all search page views though, and we can verify in the browser's developer tools that the query is sent~_ It's implemented now. 

## Tracking

[LET-452 (FE - Add Discover/search/investors page)](https://vizzuality.atlassian.net/browse/LET-452)
[LET-451 (FE - Create Investor card component)](https://vizzuality.atlassian.net/browse/LET-451)

## Screenshot  
<img width="1680" alt="Screenshot 2022-05-23 at 12 30 51" src="https://user-images.githubusercontent.com/6273795/169810033-bf895138-1330-4828-bd8c-5a9bc79382b4.png">

