### PR TITLE
fix: Full text searching takes into account attributes at different tables (Account)

### DIFF
--- a/backend/app/models/account.rb
+++ b/backend/app/models/account.rb
@@ -1,6 +1,7 @@
 class Account < ApplicationRecord
   extend FriendlyId
   include Translatable
+  include Searchable
 
   friendly_id :name, use: :slugged
 

--- a/backend/spec/models/account_spec.rb
+++ b/backend/spec/models/account_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe Account, type: :model do
   subject { build(:account) }
 
+  it_behaves_like :searchable
   it_behaves_like :translatable
 
   it { is_expected.to be_valid }

--- a/backend/spec/services/api/filterer_spec.rb
+++ b/backend/spec/services/api/filterer_spec.rb
@@ -77,6 +77,16 @@ RSpec.describe API::Filterer do
           expect(subject.call).to eq([correct_project_developer])
         end
       end
+
+      context "when filtered by full_text param which is at different table" do
+        let(:filters) { {full_text: "TEST", language: :en} }
+        let!(:correct_project_developer) { create :project_developer, account: (create :account, name: "TEST") }
+        let!(:different_text_project_developer) { create :project_developer, account: (create :account, name: "DIFFERENT") }
+
+        it "returns only correct project developers" do
+          expect(subject.call).to eq([correct_project_developer])
+        end
+      end
     end
 
     describe "used with Open Call query" do
@@ -144,6 +154,16 @@ RSpec.describe API::Filterer do
         let!(:different_text_investor) { create :investor, mission_en: "DIFFERENT" }
 
         it "returns only records with correct text at correct language" do
+          expect(subject.call).to eq([correct_investor])
+        end
+      end
+
+      context "when filtered by full_text param which is at different table" do
+        let(:filters) { {full_text: "TEST", language: :en} }
+        let!(:correct_investor) { create :investor, account: (create :account, name: "TEST") }
+        let!(:different_text_project_developer) { create :investor, account: (create :account, name: "DIFFERENT") }
+
+        it "returns only correct project developers" do
           expect(subject.call).to eq([correct_investor])
         end
       end


### PR DESCRIPTION
Full text searching needs to take into account some attributes which are stored at different table -- for example `Account` table keeps `name` of `Investor` or `ProjectDeveloper`. 

I have slightly tweaked logic behind filtering so you can specify which extra tables (relations) should be taken into account during full text searching. In the end, searching is run on top of all defined tables and final result is union of these subqueries. I have split queries to small ones and pass `ids` between them instead of constructing one huge and slow query. It causes that 1 (for queries with Account relation it is 3) extra db hits are done which is quite insignificant from my point of view.

Following tweak also fixes problems with localization, so it takes into account also columns which are not localized such as `name` of ProjectDeveloper.

And one last bug was related to full text searching interfering with sorting --> full text searching query ordered results by weight, which was naturally fixed by using individual subqueries and passing just `ids`.

## Testing instructions

Prepare two Investor/Project Developer records and try to run full text search based on their `name` value.

## Tracking

https://vizzuality.atlassian.net/browse/LET-325 (bug fix ;))
