### PR TITLE
User can favorite project developer from search project details card

### DIFF
--- a/frontend/containers/project-details/favorite-contact/component.tsx
+++ b/frontend/containers/project-details/favorite-contact/component.tsx
@@ -1,4 +1,4 @@
-import { FC, useState, useEffect } from 'react';
+import { FC, useState } from 'react';
 
 import { Heart as HeartIcon } from 'react-feather';
 import { FormattedMessage } from 'react-intl';
@@ -6,6 +6,8 @@ import { FormattedMessage } from 'react-intl';
 import cx from 'classnames';
 
 import Link from 'next/link';
+
+import useMe from 'hooks/me';
 
 import ContactInformationModal from 'containers/social-contact/contact-information-modal';
 
@@ -23,6 +25,7 @@ export const FavoriteContact: FC<FavoriteContactProps> = ({
 }: FavoriteContactProps) => {
   const [contactInfoModalOpen, setIsContactInfoModalOpen] = useState<boolean>(false);
 
+  const { user } = useMe();
   const favoriteProjectDeveloper = useFavoriteProjectDeveloper();
 
   const handleFavoriteClick = () => {
@@ -53,29 +56,33 @@ export const FavoriteContact: FC<FavoriteContactProps> = ({
     })
     .filter((developer) => !!developer);
 
+  const hasContacts = !contacts.length;
+
   return (
     <div className={className}>
       <div className="flex flex-col items-start gap-4 mt-5 xl:items-center xl:flex-row">
         <Button
-          disabled={!contacts.length}
+          disabled={!user || hasContacts}
           className="justify-start"
           theme="primary-green"
           onClick={() => setIsContactInfoModalOpen(true)}
         >
           <FormattedMessage defaultMessage="Contact" id="zFegDD" />
         </Button>
-        <Button
-          className="justify-start"
-          disabled={favoriteProjectDeveloper.isLoading}
-          theme="secondary-green"
-          onClick={handleFavoriteClick}
-        >
-          <Icon
-            icon={HeartIcon}
-            className={cx('w-4 mr-3', { 'fill-green-dark': project.project_developer.favourite })}
-          />
-          <FormattedMessage defaultMessage="Favorite" id="5Hzwqs" />
-        </Button>
+        {!!user && (
+          <Button
+            className="justify-start"
+            disabled={favoriteProjectDeveloper.isLoading}
+            theme="secondary-green"
+            onClick={handleFavoriteClick}
+          >
+            <Icon
+              icon={HeartIcon}
+              className={cx('w-4 mr-3', { 'fill-green-dark': project.project_developer.favourite })}
+            />
+            <FormattedMessage defaultMessage="Favorite" id="5Hzwqs" />
+          </Button>
+        )}
         <Link href={`${Paths.Project}/${project.slug}`}>
           <a className="px-1 text-sm transition-all text-green-dark hover:text-green-light rounded-2xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-dark">
             <FormattedMessage defaultMessage="Know more" id="+JVDMC" />

--- a/frontend/containers/project-details/favorite-contact/component.tsx
+++ b/frontend/containers/project-details/favorite-contact/component.tsx
@@ -1,14 +1,19 @@
-import { FC, useState } from 'react';
+import { FC, useState, useEffect } from 'react';
 
 import { Heart as HeartIcon } from 'react-feather';
 import { FormattedMessage } from 'react-intl';
+
+import cx from 'classnames';
 
 import Link from 'next/link';
 
 import ContactInformationModal from 'containers/social-contact/contact-information-modal';
 
 import Button from 'components/button';
+import Icon from 'components/icon';
 import { Paths } from 'enums';
+
+import { useFavoriteProjectDeveloper } from 'services/project-developers/projectDevelopersService';
 
 import { FavoriteContactProps } from './types';
 
@@ -18,7 +23,22 @@ export const FavoriteContact: FC<FavoriteContactProps> = ({
 }: FavoriteContactProps) => {
   const [contactInfoModalOpen, setIsContactInfoModalOpen] = useState<boolean>(false);
 
-  const handleFavoriteClick = () => {};
+  const favoriteProjectDeveloper = useFavoriteProjectDeveloper();
+
+  const handleFavoriteClick = () => {
+    // This mutation uses a 'DELETE' request when the isFavorite is true, and a 'POST' request when is false.
+    favoriteProjectDeveloper.mutate(
+      {
+        id: project.project_developer.id,
+        isFavourite: project.project_developer.favourite,
+      },
+      {
+        onSuccess: (data) => {
+          project.project_developer = data;
+        },
+      }
+    );
+  };
 
   const contacts = [project?.project_developer, ...project?.involved_project_developers]
     .map((developer) => {
@@ -46,10 +66,14 @@ export const FavoriteContact: FC<FavoriteContactProps> = ({
         </Button>
         <Button
           className="justify-start"
+          disabled={favoriteProjectDeveloper.isLoading}
           theme="secondary-green"
-          icon={HeartIcon}
           onClick={handleFavoriteClick}
         >
+          <Icon
+            icon={HeartIcon}
+            className={cx('w-4 mr-3', { 'fill-green-dark': project.project_developer.favourite })}
+          />
           <FormattedMessage defaultMessage="Favorite" id="5Hzwqs" />
         </Button>
         <Link href={`${Paths.Project}/${project.slug}`}>


### PR DESCRIPTION
## Description

This PR makes it so that the user can favourite a project developer from a project's details card, in the discover/search projects view. 

Behaviour was implemented to be identical to the one on the project profile header buttons.  

## Testing instructions

Navigate to the `discover/projects` view and:  
- Select a project to open the details card:  
  - Verify that clicking the "Favourite" button works  
    _Icon should be filled when the project developer is favourited_  
- Close the details card and re-open it  
  - Verify that the project developer still shows as favourited  
- Unfavourite the project developer  
  - Verify that the button displays as unfavourited  

## Tracking

[LET-398](https://vizzuality.atlassian.net/browse/LET-398)

## Screenshot  
<img width="1247" alt="Screenshot 2022-05-24 at 09 58 56" src="https://user-images.githubusercontent.com/6273795/169993956-82f6fa47-9cac-4862-9e58-709ad64ee4b1.png">

## Video

https://user-images.githubusercontent.com/6273795/169994403-0e92304b-d4c5-4919-9a93-1274b5feba7a.mp4


