### PR TITLE
feat: Right policies are applied to API endpoints

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -12,6 +12,7 @@ gem "redis", "~> 4.0"
 gem "rswag"
 gem "active_storage_validations"
 gem "rspec-rails", "~> 5.0.0"
+gem "cancancan"
 
 # BackOffice
 gem "cssbundling-rails"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -90,6 +90,7 @@ GEM
     bundler-audit (0.9.0.1)
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)
+    cancancan (3.3.0)
     capybara (3.37.1)
       addressable
       matrix
@@ -546,6 +547,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   bundler-audit
+  cancancan
   capybara (>= 3.26)
   cloudtasker (~> 0.13.0)
   cssbundling-rails

--- a/backend/app/controllers/api/v1/investors_controller.rb
+++ b/backend/app/controllers/api/v1/investors_controller.rb
@@ -5,7 +5,6 @@ module API
 
       before_action :fetch_investor, only: :show
       load_and_authorize_resource
-      skip_load_resource only: :show
 
       def index
         investors = @investors.includes(account: [:owner, {picture_attachment: :blob}])

--- a/backend/app/controllers/api/v1/open_calls_controller.rb
+++ b/backend/app/controllers/api/v1/open_calls_controller.rb
@@ -4,9 +4,10 @@ module API
       include API::Pagination
 
       before_action :fetch_open_call, only: [:show]
+      load_and_authorize_resource
 
       def index
-        open_calls = OpenCall.all.includes(:investor)
+        open_calls = @open_calls.all.includes(:investor)
         open_calls = API::Filterer.new(open_calls, filter_params.to_h).call
         open_calls = API::Sorter.new(open_calls, sorting_by: params[:sorting]).call
         pagy_object, open_calls = pagy(open_calls, page: current_page, items: per_page)

--- a/backend/app/controllers/api/v1/project_developers_controller.rb
+++ b/backend/app/controllers/api/v1/project_developers_controller.rb
@@ -5,7 +5,6 @@ module API
 
       before_action :fetch_project_developer, only: :show
       load_and_authorize_resource
-      skip_load_resource only: :show
 
       def index
         project_developers = @project_developers.includes(

--- a/backend/app/controllers/api/v1/project_developers_controller.rb
+++ b/backend/app/controllers/api/v1/project_developers_controller.rb
@@ -3,8 +3,12 @@ module API
     class ProjectDevelopersController < BaseController
       include API::Pagination
 
+      before_action :fetch_project_developer, only: :show
+      load_and_authorize_resource
+      skip_load_resource only: :show
+
       def index
-        project_developers = ProjectDeveloper.includes(
+        project_developers = @project_developers.includes(
           :projects, :involved_projects, account: [:owner, {picture_attachment: :blob}]
         )
         project_developers = API::Filterer.new(project_developers, filter_params.to_h).call
@@ -21,10 +25,8 @@ module API
       end
 
       def show
-        project_developer = fetch_project_developer
-
         render json: ProjectDeveloperSerializer.new(
-          project_developer,
+          @project_developer,
           include: included_relationships,
           fields: sparse_fieldset,
           params: {current_user: current_user}
@@ -34,10 +36,10 @@ module API
       private
 
       def fetch_project_developer
-        return ProjectDeveloper.find(params[:id]) if fetching_by_uuid?
+        return @project_developer = ProjectDeveloper.find(params[:id]) if fetching_by_uuid?
 
         account = Account.friendly.find(params[:id])
-        ProjectDeveloper.find_by!(account_id: account.id)
+        @project_developer = ProjectDeveloper.find_by!(account_id: account.id)
       end
 
       def filter_params

--- a/backend/app/controllers/api/v1/projects/maps_controller.rb
+++ b/backend/app/controllers/api/v1/projects/maps_controller.rb
@@ -3,7 +3,8 @@ module API
     module Projects
       class MapsController < BaseController
         def show
-          projects = Project.select(:id, :trusted, :centroid, :category).order(created_at: :desc)
+          projects = Project.accessible_by(current_ability)
+            .select(:id, :trusted, :centroid, :category).order(created_at: :desc)
           projects = API::Filterer.new(projects, filter_params.to_h).call
           render json: ProjectMapSerializer.new(projects).serializable_hash
         end

--- a/backend/app/controllers/api/v1/projects_controller.rb
+++ b/backend/app/controllers/api/v1/projects_controller.rb
@@ -4,9 +4,10 @@ module API
       include API::Pagination
 
       before_action :fetch_project, only: [:show]
+      load_and_authorize_resource
 
       def index
-        projects = Project.all.includes(:project_developer, :involved_project_developers, project_images: {file_attachment: :blob})
+        projects = @projects.includes(:project_developer, :involved_project_developers, project_images: {file_attachment: :blob})
         projects = API::Filterer.new(projects, filter_params.to_h).call
         projects = API::Sorter.new(projects, sorting_by: params[:sorting]).call
         pagy_object, projects = pagy(projects, page: current_page, items: per_page)

--- a/backend/app/controllers/concerns/api/errors.rb
+++ b/backend/app/controllers/concerns/api/errors.rb
@@ -11,6 +11,7 @@ module API
       base.rescue_from ActionController::InvalidAuthenticityToken, with: :render_error
       base.rescue_from API::UnauthorizedError, with: :render_unauthorized_error
       base.rescue_from API::Forbidden, with: :render_forbidden_error
+      base.rescue_from CanCan::AccessDenied, with: :render_forbidden_error
       base.rescue_from API::UnprocessableEntityError, with: :render_unprocessable_entity_error
       base.rescue_from ActiveRecord::RecordNotFound, with: :render_not_found_error
       base.rescue_from ActiveRecord::RecordInvalid, with: :render_validation_errors

--- a/backend/app/models/ability.rb
+++ b/backend/app/models/ability.rb
@@ -13,12 +13,23 @@ class Ability
   private
 
   def default_rights
+    # only data from approved users are visible
     can %i[index show], ProjectDeveloper, account: {review_status: :approved}
     can %i[index show], Investor, account: {review_status: :approved}
+    can %i[index show], Project, project_developer: {account: {review_status: :approved}}
+    can %i[index show], OpenCall, investor: {account: {review_status: :approved}}
   end
 
   def user_rights
+    can %i[create update], Investor, account_id: user.account_id
+    can %i[create update], ProjectDeveloper, account_id: user.account_id
+    can %i[create update], Project, project_developer: {account_id: user.account_id}
+    can %i[create update], OpenCall, investor: {account_id: user.account_id}
+
+    # users can always see their own data
     can %i[show], ProjectDeveloper, account_id: user.account_id
     can %i[show], Investor, account_id: user.account_id
+    can %i[show], Project, project_developer: {account_id: user.account_id}
+    can %i[show], OpenCall, investor: {account_id: user.account_id}
   end
 end

--- a/backend/app/models/ability.rb
+++ b/backend/app/models/ability.rb
@@ -1,0 +1,24 @@
+class Ability
+  include CanCan::Ability
+
+  attr_accessor :user
+
+  def initialize(user)
+    @user = user
+
+    default_rights
+    user_rights if user.present?
+  end
+
+  private
+
+  def default_rights
+    can %i[index show], ProjectDeveloper, account: {review_status: :approved}
+    can %i[index show], Investor, account: {review_status: :approved}
+  end
+
+  def user_rights
+    can %i[show], ProjectDeveloper, account_id: user.account_id
+    can %i[show], Investor, account_id: user.account_id
+  end
+end

--- a/backend/spec/fixtures/snapshots/api/v1/investors-sparse-fieldset.json
+++ b/backend/spec/fixtures/snapshots/api/v1/investors-sparse-fieldset.json
@@ -69,24 +69,14 @@
       },
       "relationships": {
       }
-    },
-    {
-      "id": "7aabac5f-1b20-41e9-80d9-249b81a6ac70",
-      "type": "investor",
-      "attributes": {
-        "instagram": "https://instagram.com/runolfsson-and-sons",
-        "facebook": "https://facebook.com/runolfsson-and-sons"
-      },
-      "relationships": {
-      }
     }
   ],
   "meta": {
     "page": 1,
     "per_page": 10,
     "from": 1,
-    "to": 8,
-    "total": 8,
+    "to": 7,
+    "total": 7,
     "pages": 1
   },
   "links": {

--- a/backend/spec/fixtures/snapshots/api/v1/investors.json
+++ b/backend/spec/fixtures/snapshots/api/v1/investors.json
@@ -391,71 +391,14 @@
           }
         }
       }
-    },
-    {
-      "id": "b996c9e6-0e69-4a0e-bb50-626d781b4049",
-      "type": "investor",
-      "attributes": {
-        "name": "Runolfsson and Sons",
-        "slug": "runolfsson-and-sons",
-        "about": "Est vero minus. Tenetur tempora animi. Aliquid error vitae. Ipsam omnis aut.",
-        "website": "https://runolfsson-and-sons.com",
-        "instagram": "https://instagram.com/runolfsson-and-sons",
-        "facebook": "https://facebook.com/runolfsson-and-sons",
-        "linkedin": "https://linkedin.com/runolfsson-and-sons",
-        "twitter": "https://twitter.com/runolfsson-and-sons",
-        "other_information": "Est vero minus. Tenetur tempora animi. Aliquid error vitae. Ipsam omnis aut.",
-        "investor_type": "angel-investor",
-        "categories": [
-          "forestry-and-agroforestry",
-          "non-timber-forest-production"
-        ],
-        "ticket_sizes": [
-          "validation",
-          "scaling"
-        ],
-        "instrument_types": [
-          "grant",
-          "loan"
-        ],
-        "impacts": [
-          "climate",
-          "water"
-        ],
-        "sdgs": [
-          1,
-          4,
-          5
-        ],
-        "previously_invested": true,
-        "language": "en",
-        "review_status": "unapproved",
-        "contact_email": null,
-        "contact_phone": null,
-        "picture": {
-          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3WXpRNU5qYzRaQzB6T1dKbUxUUXdZbU10WVRCaFlpMWlOMkl3T1RJeE5HWTFOREVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0aa4cb0fefe510b6240e4b607f7d1ff63c972ac0/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg",
-          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3WXpRNU5qYzRaQzB6T1dKbUxUUXdZbU10WVRCaFlpMWlOMkl3T1RJeE5HWTFOREVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0aa4cb0fefe510b6240e4b607f7d1ff63c972ac0/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg",
-          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3WXpRNU5qYzRaQzB6T1dKbUxUUXdZbU10WVRCaFlpMWlOMkl3T1RJeE5HWTFOREVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0aa4cb0fefe510b6240e4b607f7d1ff63c972ac0/picture.jpg"
-        },
-        "mission": "Est vero minus. Tenetur tempora animi. Aliquid error vitae. Ipsam omnis aut.",
-        "prioritized_projects_description": "Est vero minus. Tenetur tempora animi. Aliquid error vitae. Ipsam omnis aut."
-      },
-      "relationships": {
-        "owner": {
-          "data": {
-            "id": "6f8943d0-7ca7-4e92-be98-476836c85685",
-            "type": "user"
-          }
-        }
-      }
     }
   ],
   "meta": {
     "page": 1,
     "per_page": 10,
     "from": 1,
-    "to": 8,
-    "total": 8,
+    "to": 7,
+    "total": 7,
     "pages": 1
   },
   "links": {

--- a/backend/spec/fixtures/snapshots/api/v1/project-developers-include-relationships.json
+++ b/backend/spec/fixtures/snapshots/api/v1/project-developers-include-relationships.json
@@ -1,7 +1,7 @@
 {
   "data": [
     {
-      "id": "f1027c4a-99b3-4137-a135-0fcc66363c90",
+      "id": "0c2552a2-e1ac-4786-9f87-624411c7bbd1",
       "type": "project_developer",
       "attributes": {
         "name": "Bartoletti and Sons"
@@ -15,7 +15,7 @@
       }
     },
     {
-      "id": "e1d12fdf-b557-4c6a-bb5d-18ba60d61e8c",
+      "id": "759984de-17f0-4396-9d6e-40676dd410dd",
       "type": "project_developer",
       "attributes": {
         "name": "Becker LLC"
@@ -29,21 +29,7 @@
       }
     },
     {
-      "id": "30dec4e9-a20a-4aee-93a9-d745415e0fb7",
-      "type": "project_developer",
-      "attributes": {
-        "name": "Gleichner-Bartoletti"
-      },
-      "relationships": {
-        "involved_projects": {
-          "data": [
-
-          ]
-        }
-      }
-    },
-    {
-      "id": "406420f6-491d-4f6f-9ce5-0ff424f37c72",
+      "id": "b93e08e5-ad7b-4783-8e94-b2a45d4f6492",
       "type": "project_developer",
       "attributes": {
         "name": "Hane, Lehner and Goyette"
@@ -57,7 +43,7 @@
       }
     },
     {
-      "id": "58f444e1-2f06-48e3-b88d-8df70d17ef85",
+      "id": "5d5665be-4c2a-403b-965d-cdd5f61be4cf",
       "type": "project_developer",
       "attributes": {
         "name": "Hilpert, Waters and Johnston"
@@ -71,7 +57,7 @@
       }
     },
     {
-      "id": "c978630e-b669-46f5-a6c7-beca7f2b6b64",
+      "id": "5523d507-5a78-4e8a-a8fb-5474db1746d7",
       "type": "project_developer",
       "attributes": {
         "name": "Jacobson, Fritsch and Stanton"
@@ -85,7 +71,7 @@
       }
     },
     {
-      "id": "3cbb2763-5337-4483-95df-b272d13f1a9f",
+      "id": "8b03b1cd-ff98-4ec8-9c5e-6ce24af78b11",
       "type": "project_developer",
       "attributes": {
         "name": "Keebler, Kub and Zemlak"
@@ -99,7 +85,7 @@
       }
     },
     {
-      "id": "0ed788c9-5228-4b3f-8238-32b28785d474",
+      "id": "40625360-65a5-45a7-8867-ee4ed47d244c",
       "type": "project_developer",
       "attributes": {
         "name": "Kutch-Spencer"
@@ -108,11 +94,11 @@
         "involved_projects": {
           "data": [
             {
-              "id": "0cdac0fb-572d-4bef-aa58-eff70c5c830f",
+              "id": "05119ec0-7217-45f6-a26a-7f4debfdf3bf",
               "type": "project"
             },
             {
-              "id": "9019e1d6-6db9-4b00-939e-efd760bd4f3a",
+              "id": "e11e66a4-fa9c-4a65-9100-562cf8056265",
               "type": "project"
             }
           ]
@@ -120,7 +106,7 @@
       }
     },
     {
-      "id": "c9d286a7-e6b4-45fe-8dfa-d7d3bf6e27d5",
+      "id": "656ab0e5-e118-4033-aaa6-73cccabfd5f3",
       "type": "project_developer",
       "attributes": {
         "name": "Ritchie, Glover and Ward"
@@ -134,7 +120,7 @@
       }
     },
     {
-      "id": "f3a3de4f-b40b-4f84-919a-33d5c610c5ae",
+      "id": "5994b3a8-4f98-4585-b02e-ade1859cb1e1",
       "type": "project_developer",
       "attributes": {
         "name": "Runolfsson and Sons"
@@ -150,7 +136,7 @@
   ],
   "included": [
     {
-      "id": "0cdac0fb-572d-4bef-aa58-eff70c5c830f",
+      "id": "05119ec0-7217-45f6-a26a-7f4debfdf3bf",
       "type": "project",
       "attributes": {
         "name": "Project 1",
@@ -182,6 +168,7 @@
           "grant",
           "loan"
         ],
+        "funding_plan": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
         "sustainability": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
         "replicability": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
         "progress_impact_tracking": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
@@ -197,10 +184,6 @@
             2.0
           ]
         },
-        "favourite": null,
-        "latitude": 2.0,
-        "longitude": 1.0,
-        "funding_plan": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
         "trusted": false,
         "municipality_biodiversity_impact": null,
         "municipality_climate_impact": null,
@@ -216,19 +199,43 @@
         "priority_landscape_climate_impact": null,
         "priority_landscape_water_impact": null,
         "priority_landscape_community_impact": null,
-        "priority_landscape_total_impact": null
+        "priority_landscape_total_impact": null,
+        "latitude": 2.0,
+        "longitude": 1.0,
+        "favourite": null
       },
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "f1027c4a-99b3-4137-a135-0fcc66363c90",
+            "id": "0c2552a2-e1ac-4786-9f87-624411c7bbd1",
             "type": "project_developer"
           }
+        },
+        "country": {
+          "data": {
+            "id": "98ca0542-ce3c-47f6-baa9-1aaf1363d358",
+            "type": "location"
+          }
+        },
+        "municipality": {
+          "data": {
+            "id": "3b18cc32-6dec-4635-b250-b3846aedc669",
+            "type": "location"
+          }
+        },
+        "department": {
+          "data": {
+            "id": "0a3eff91-0ff5-4061-bb31-ab6f1ad98566",
+            "type": "location"
+          }
+        },
+        "priority_landscape": {
+          "data": null
         },
         "involved_project_developers": {
           "data": [
             {
-              "id": "0ed788c9-5228-4b3f-8238-32b28785d474",
+              "id": "40625360-65a5-45a7-8867-ee4ed47d244c",
               "type": "project_developer"
             }
           ]
@@ -237,32 +244,11 @@
           "data": [
 
           ]
-        },
-        "country": {
-          "data": {
-            "id": "bd3fc33b-28e0-44ca-90c7-501b06796251",
-            "type": "location"
-          }
-        },
-        "municipality": {
-          "data": {
-            "id": "7312e65c-de64-41b1-ac1d-a59ade3f9bff",
-            "type": "location"
-          }
-        },
-        "department": {
-          "data": {
-            "id": "9bb163fb-33cf-466e-bd05-8eb70c775055",
-            "type": "location"
-          }
-        },
-        "priority_landscape": {
-          "data": null
         }
       }
     },
     {
-      "id": "9019e1d6-6db9-4b00-939e-efd760bd4f3a",
+      "id": "e11e66a4-fa9c-4a65-9100-562cf8056265",
       "type": "project",
       "attributes": {
         "name": "Project 2",
@@ -294,6 +280,7 @@
           "grant",
           "loan"
         ],
+        "funding_plan": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
         "sustainability": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
         "replicability": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
         "progress_impact_tracking": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
@@ -309,10 +296,6 @@
             2.0
           ]
         },
-        "favourite": null,
-        "latitude": 2.0,
-        "longitude": 1.0,
-        "funding_plan": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
         "trusted": false,
         "municipality_biodiversity_impact": null,
         "municipality_climate_impact": null,
@@ -328,19 +311,43 @@
         "priority_landscape_climate_impact": null,
         "priority_landscape_water_impact": null,
         "priority_landscape_community_impact": null,
-        "priority_landscape_total_impact": null
+        "priority_landscape_total_impact": null,
+        "latitude": 2.0,
+        "longitude": 1.0,
+        "favourite": null
       },
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "406420f6-491d-4f6f-9ce5-0ff424f37c72",
+            "id": "b93e08e5-ad7b-4783-8e94-b2a45d4f6492",
             "type": "project_developer"
           }
+        },
+        "country": {
+          "data": {
+            "id": "350c2288-23c7-43a6-9255-e6301404806d",
+            "type": "location"
+          }
+        },
+        "municipality": {
+          "data": {
+            "id": "b4d8a255-eca1-405f-914e-5a5bcaea8b13",
+            "type": "location"
+          }
+        },
+        "department": {
+          "data": {
+            "id": "b1d4ced6-58c8-4377-bdd3-2119a4179f12",
+            "type": "location"
+          }
+        },
+        "priority_landscape": {
+          "data": null
         },
         "involved_project_developers": {
           "data": [
             {
-              "id": "0ed788c9-5228-4b3f-8238-32b28785d474",
+              "id": "40625360-65a5-45a7-8867-ee4ed47d244c",
               "type": "project_developer"
             }
           ]
@@ -349,27 +356,6 @@
           "data": [
 
           ]
-        },
-        "country": {
-          "data": {
-            "id": "e20b6b1c-99d5-42d7-a024-15bff2c0c6f9",
-            "type": "location"
-          }
-        },
-        "municipality": {
-          "data": {
-            "id": "42b10237-ddc0-4c95-9ad8-0d42a8fe2484",
-            "type": "location"
-          }
-        },
-        "department": {
-          "data": {
-            "id": "5d9e5da2-16a5-4365-944a-1b69b61c726e",
-            "type": "location"
-          }
-        },
-        "priority_landscape": {
-          "data": null
         }
       }
     }
@@ -378,8 +364,8 @@
     "page": 1,
     "per_page": 10,
     "from": 1,
-    "to": 10,
-    "total": 10,
+    "to": 9,
+    "total": 9,
     "pages": 1
   },
   "links": {

--- a/backend/spec/fixtures/snapshots/api/v1/project-developers-sparse-fieldset.json
+++ b/backend/spec/fixtures/snapshots/api/v1/project-developers-sparse-fieldset.json
@@ -1,7 +1,7 @@
 {
   "data": [
     {
-      "id": "638a3352-70a7-46fe-9ccd-2a49f5012098",
+      "id": "0c2552a2-e1ac-4786-9f87-624411c7bbd1",
       "type": "project_developer",
       "attributes": {
         "instagram": "https://instagram.com/bartoletti-and-sons",
@@ -11,7 +11,7 @@
       }
     },
     {
-      "id": "482063d9-dcdd-4b85-b1d0-600f52c811ac",
+      "id": "759984de-17f0-4396-9d6e-40676dd410dd",
       "type": "project_developer",
       "attributes": {
         "instagram": "https://instagram.com/becker-llc",
@@ -21,17 +21,7 @@
       }
     },
     {
-      "id": "96ea9b93-1d55-4b70-bc35-c2c1949736b9",
-      "type": "project_developer",
-      "attributes": {
-        "instagram": "https://instagram.com/gleichner-bartoletti",
-        "facebook": "https://facebook.com/gleichner-bartoletti"
-      },
-      "relationships": {
-      }
-    },
-    {
-      "id": "e4be192b-88b1-4625-a91c-fde0128f7200",
+      "id": "b93e08e5-ad7b-4783-8e94-b2a45d4f6492",
       "type": "project_developer",
       "attributes": {
         "instagram": "https://instagram.com/hane-lehner-and-goyette",
@@ -41,7 +31,7 @@
       }
     },
     {
-      "id": "dc22a538-fbd7-46f6-b381-38002d564ed4",
+      "id": "5d5665be-4c2a-403b-965d-cdd5f61be4cf",
       "type": "project_developer",
       "attributes": {
         "instagram": "https://instagram.com/hilpert-waters-and-johnston",
@@ -51,7 +41,7 @@
       }
     },
     {
-      "id": "c13f2e57-445a-4e44-8d89-c895bbece5da",
+      "id": "5523d507-5a78-4e8a-a8fb-5474db1746d7",
       "type": "project_developer",
       "attributes": {
         "instagram": "https://instagram.com/jacobson-fritsch-and-stanton",
@@ -61,7 +51,7 @@
       }
     },
     {
-      "id": "566551b1-2e51-49ed-8727-5e7a6da0cec9",
+      "id": "8b03b1cd-ff98-4ec8-9c5e-6ce24af78b11",
       "type": "project_developer",
       "attributes": {
         "instagram": "https://instagram.com/keebler-kub-and-zemlak",
@@ -71,7 +61,7 @@
       }
     },
     {
-      "id": "52f768fc-f856-4250-b5fd-179a17b4954e",
+      "id": "40625360-65a5-45a7-8867-ee4ed47d244c",
       "type": "project_developer",
       "attributes": {
         "instagram": "https://instagram.com/kutch-spencer",
@@ -81,7 +71,7 @@
       }
     },
     {
-      "id": "011be9a9-7fe7-4c66-b558-b51a98105d7a",
+      "id": "656ab0e5-e118-4033-aaa6-73cccabfd5f3",
       "type": "project_developer",
       "attributes": {
         "instagram": "https://instagram.com/ritchie-glover-and-ward",
@@ -91,7 +81,7 @@
       }
     },
     {
-      "id": "f1029bdf-df59-4c15-a36c-24c81143fe88",
+      "id": "5994b3a8-4f98-4585-b02e-ade1859cb1e1",
       "type": "project_developer",
       "attributes": {
         "instagram": "https://instagram.com/runolfsson-and-sons",
@@ -105,8 +95,8 @@
     "page": 1,
     "per_page": 10,
     "from": 1,
-    "to": 10,
-    "total": 10,
+    "to": 9,
+    "total": 9,
     "pages": 1
   },
   "links": {

--- a/backend/spec/fixtures/snapshots/api/v1/project_developers.json
+++ b/backend/spec/fixtures/snapshots/api/v1/project_developers.json
@@ -1,7 +1,7 @@
 {
   "data": [
     {
-      "id": "f1027c4a-99b3-4137-a135-0fcc66363c90",
+      "id": "0c2552a2-e1ac-4786-9f87-624411c7bbd1",
       "type": "project_developer",
       "attributes": {
         "name": "Bartoletti and Sons",
@@ -32,23 +32,23 @@
         "contact_email": null,
         "contact_phone": null,
         "picture": {
-          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswTURRMFl6RmpaaTA0T1dObExUUXdabVl0WW1FNE15MDFZMlkzWm1KaU1qZGtaRGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2fd708cfaeb354b72494a21bf905067c051ff8dc/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg",
-          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswTURRMFl6RmpaaTA0T1dObExUUXdabVl0WW1FNE15MDFZMlkzWm1KaU1qZGtaRGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2fd708cfaeb354b72494a21bf905067c051ff8dc/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg",
-          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswTURRMFl6RmpaaTA0T1dObExUUXdabVl0WW1FNE15MDFZMlkzWm1KaU1qZGtaRGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2fd708cfaeb354b72494a21bf905067c051ff8dc/picture.jpg"
+          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoT0RVNU5URTBPQzA0WkdZekxUUXlOMlV0T1RBMk1DMWlaVGt4TkRRNFlqRXhZbVFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--80b512862b842a213fad406abbff7eed5666ba4e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg",
+          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoT0RVNU5URTBPQzA0WkdZekxUUXlOMlV0T1RBMk1DMWlaVGt4TkRRNFlqRXhZbVFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--80b512862b842a213fad406abbff7eed5666ba4e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg",
+          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoT0RVNU5URTBPQzA0WkdZekxUUXlOMlV0T1RBMk1DMWlaVGt4TkRRNFlqRXhZbVFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--80b512862b842a213fad406abbff7eed5666ba4e/picture.jpg"
         },
         "favourite": null
       },
       "relationships": {
         "owner": {
           "data": {
-            "id": "313e513e-73aa-4515-8a11-9e7857ddd951",
+            "id": "e12ebb55-af59-4f69-b96b-ee42aa5bdac3",
             "type": "user"
           }
         },
         "projects": {
           "data": [
             {
-              "id": "0cdac0fb-572d-4bef-aa58-eff70c5c830f",
+              "id": "05119ec0-7217-45f6-a26a-7f4debfdf3bf",
               "type": "project"
             }
           ]
@@ -61,7 +61,7 @@
       }
     },
     {
-      "id": "e1d12fdf-b557-4c6a-bb5d-18ba60d61e8c",
+      "id": "759984de-17f0-4396-9d6e-40676dd410dd",
       "type": "project_developer",
       "attributes": {
         "name": "Becker LLC",
@@ -92,16 +92,16 @@
         "contact_email": null,
         "contact_phone": null,
         "picture": {
-          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTW1Vek5EWXhZaTFrT0RKa0xUUmpNek10T1RjeU9TMDFPVGt6TUdNMk1XTXlNakVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--550a084b12c69d1189c6816ef51fcd1506bff3c5/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg",
-          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTW1Vek5EWXhZaTFrT0RKa0xUUmpNek10T1RjeU9TMDFPVGt6TUdNMk1XTXlNakVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--550a084b12c69d1189c6816ef51fcd1506bff3c5/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg",
-          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTW1Vek5EWXhZaTFrT0RKa0xUUmpNek10T1RjeU9TMDFPVGt6TUdNMk1XTXlNakVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--550a084b12c69d1189c6816ef51fcd1506bff3c5/picture.jpg"
+          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TnpBNU1qY3pOaTB3TWpoa0xUUTFZelF0WVdZNFl5MDVZekJoWVRkbE9UVmtNV01HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--1c927aa6f498d8e415ad50e5b23074dc7695b9ab/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg",
+          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TnpBNU1qY3pOaTB3TWpoa0xUUTFZelF0WVdZNFl5MDVZekJoWVRkbE9UVmtNV01HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--1c927aa6f498d8e415ad50e5b23074dc7695b9ab/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg",
+          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TnpBNU1qY3pOaTB3TWpoa0xUUTFZelF0WVdZNFl5MDVZekJoWVRkbE9UVmtNV01HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--1c927aa6f498d8e415ad50e5b23074dc7695b9ab/picture.jpg"
         },
         "favourite": null
       },
       "relationships": {
         "owner": {
           "data": {
-            "id": "c7f37ace-4177-4d70-ac2c-9fdffa92f39d",
+            "id": "11525adc-5775-4d59-8127-f8c7e0f306e7",
             "type": "user"
           }
         },
@@ -118,64 +118,7 @@
       }
     },
     {
-      "id": "30dec4e9-a20a-4aee-93a9-d745415e0fb7",
-      "type": "project_developer",
-      "attributes": {
-        "name": "Gleichner-Bartoletti",
-        "slug": "gleichner-bartoletti",
-        "about": "Tempora excepturi et. Et quia sit. Harum in aut. Aliquid provident suscipit.",
-        "website": "https://gleichner-bartoletti.com",
-        "instagram": "https://instagram.com/gleichner-bartoletti",
-        "facebook": "https://facebook.com/gleichner-bartoletti",
-        "linkedin": "https://linkedin.com/gleichner-bartoletti",
-        "twitter": "https://twitter.com/gleichner-bartoletti",
-        "mission": "Tempora excepturi et. Et quia sit. Harum in aut. Aliquid provident suscipit.",
-        "project_developer_type": "ngo",
-        "categories": [
-          "forestry-and-agroforestry",
-          "non-timber-forest-production"
-        ],
-        "impacts": [
-          "climate",
-          "water"
-        ],
-        "language": "en",
-        "entity_legal_registration_number": "564823570",
-        "review_status": "unapproved",
-        "mosaics": [
-          "amazon-heart",
-          "amazonian-piedmont-massif"
-        ],
-        "contact_email": null,
-        "contact_phone": null,
-        "picture": {
-          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoTnpReVl6Z3pZUzAyTkRabUxUUTNObU10WWpRM01DMHhOV1UwTldWa1lqazJOVEVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--cfdb30c7ebce86b730056563abc9a5b337ad070c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg",
-          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoTnpReVl6Z3pZUzAyTkRabUxUUTNObU10WWpRM01DMHhOV1UwTldWa1lqazJOVEVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--cfdb30c7ebce86b730056563abc9a5b337ad070c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg",
-          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoTnpReVl6Z3pZUzAyTkRabUxUUTNObU10WWpRM01DMHhOV1UwTldWa1lqazJOVEVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--cfdb30c7ebce86b730056563abc9a5b337ad070c/picture.jpg"
-        },
-        "favourite": null
-      },
-      "relationships": {
-        "owner": {
-          "data": {
-            "id": "5ee10141-c010-4db8-9263-562d56f5828a",
-            "type": "user"
-          }
-        },
-        "projects": {
-          "data": [
-
-          ]
-        },
-        "involved_projects": {
-          "data": [
-
-          ]
-        }
-      }
-    },
-    {
-      "id": "406420f6-491d-4f6f-9ce5-0ff424f37c72",
+      "id": "b93e08e5-ad7b-4783-8e94-b2a45d4f6492",
       "type": "project_developer",
       "attributes": {
         "name": "Hane, Lehner and Goyette",
@@ -206,23 +149,23 @@
         "contact_email": null,
         "contact_phone": null,
         "picture": {
-          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTlRSaE5qRXhaUzB5TWpjNUxUUmpZVFl0WWpoa05DMWhZbVpqTmpSak5EWTRaak1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--24d3c371eb3da8cee6414eaf3fbe69dc88965763/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg",
-          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTlRSaE5qRXhaUzB5TWpjNUxUUmpZVFl0WWpoa05DMWhZbVpqTmpSak5EWTRaak1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--24d3c371eb3da8cee6414eaf3fbe69dc88965763/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg",
-          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTlRSaE5qRXhaUzB5TWpjNUxUUmpZVFl0WWpoa05DMWhZbVpqTmpSak5EWTRaak1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--24d3c371eb3da8cee6414eaf3fbe69dc88965763/picture.jpg"
+          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1Tm1ZM05URmhaaTB5T1RFMUxUUTFOamN0T0RnNU5pMDFaR0ZrWmpRM05qVm1NMk1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--29a2fdeda421b8588dcdb160412b739530dae051/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg",
+          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1Tm1ZM05URmhaaTB5T1RFMUxUUTFOamN0T0RnNU5pMDFaR0ZrWmpRM05qVm1NMk1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--29a2fdeda421b8588dcdb160412b739530dae051/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg",
+          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1Tm1ZM05URmhaaTB5T1RFMUxUUTFOamN0T0RnNU5pMDFaR0ZrWmpRM05qVm1NMk1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--29a2fdeda421b8588dcdb160412b739530dae051/picture.jpg"
         },
         "favourite": null
       },
       "relationships": {
         "owner": {
           "data": {
-            "id": "c2a2cd85-d829-4f36-bd1a-ff2f120aeae6",
+            "id": "885191e8-cd65-41b6-b1f0-22c111891417",
             "type": "user"
           }
         },
         "projects": {
           "data": [
             {
-              "id": "9019e1d6-6db9-4b00-939e-efd760bd4f3a",
+              "id": "e11e66a4-fa9c-4a65-9100-562cf8056265",
               "type": "project"
             }
           ]
@@ -235,7 +178,7 @@
       }
     },
     {
-      "id": "58f444e1-2f06-48e3-b88d-8df70d17ef85",
+      "id": "5d5665be-4c2a-403b-965d-cdd5f61be4cf",
       "type": "project_developer",
       "attributes": {
         "name": "Hilpert, Waters and Johnston",
@@ -266,16 +209,16 @@
         "contact_email": null,
         "contact_phone": null,
         "picture": {
-          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyWldJNE16YzVOaTFoTVdNMUxUUTFOVGd0WW1Nek55MDNZVGcyWldJd05qRmhPVGdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--415de6dd8f3dde07e19eb47168f33b9ccb09858e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg",
-          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyWldJNE16YzVOaTFoTVdNMUxUUTFOVGd0WW1Nek55MDNZVGcyWldJd05qRmhPVGdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--415de6dd8f3dde07e19eb47168f33b9ccb09858e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg",
-          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyWldJNE16YzVOaTFoTVdNMUxUUTFOVGd0WW1Nek55MDNZVGcyWldJd05qRmhPVGdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--415de6dd8f3dde07e19eb47168f33b9ccb09858e/picture.jpg"
+          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTldKa05qZ3lPQzFoTVRZMExUUmpNR010T1RFME5DMWpZekV5TlRkaE5HSTRZamdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f2361c193f47205ee21f38ddce33c6b26837642c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg",
+          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTldKa05qZ3lPQzFoTVRZMExUUmpNR010T1RFME5DMWpZekV5TlRkaE5HSTRZamdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f2361c193f47205ee21f38ddce33c6b26837642c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg",
+          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTldKa05qZ3lPQzFoTVRZMExUUmpNR010T1RFME5DMWpZekV5TlRkaE5HSTRZamdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f2361c193f47205ee21f38ddce33c6b26837642c/picture.jpg"
         },
         "favourite": null
       },
       "relationships": {
         "owner": {
           "data": {
-            "id": "79b568f9-b572-45cd-a847-5f03958f9dbb",
+            "id": "7ae33480-aef7-4f55-8730-459c6eccb451",
             "type": "user"
           }
         },
@@ -292,7 +235,7 @@
       }
     },
     {
-      "id": "c978630e-b669-46f5-a6c7-beca7f2b6b64",
+      "id": "5523d507-5a78-4e8a-a8fb-5474db1746d7",
       "type": "project_developer",
       "attributes": {
         "name": "Jacobson, Fritsch and Stanton",
@@ -323,16 +266,16 @@
         "contact_email": null,
         "contact_phone": null,
         "picture": {
-          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTVdZMU5EZGlZaTB3T0dRMExUUmtOV0V0WVRCaE15MHhaRFV4WlRobE9XWXhaR1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5020bbdbe94c7148495a1289752a51af7c4d37de/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg",
-          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTVdZMU5EZGlZaTB3T0dRMExUUmtOV0V0WVRCaE15MHhaRFV4WlRobE9XWXhaR1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5020bbdbe94c7148495a1289752a51af7c4d37de/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg",
-          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTVdZMU5EZGlZaTB3T0dRMExUUmtOV0V0WVRCaE15MHhaRFV4WlRobE9XWXhaR1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5020bbdbe94c7148495a1289752a51af7c4d37de/picture.jpg"
+          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpTVRFd1pHSXlPUzB3T0RZekxUUXpNall0WVRVd1pDMDJabUV5WXprelpqZ3paV0lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6369baae69f9a569d7b4823a1777fde881c79908/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg",
+          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpTVRFd1pHSXlPUzB3T0RZekxUUXpNall0WVRVd1pDMDJabUV5WXprelpqZ3paV0lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6369baae69f9a569d7b4823a1777fde881c79908/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg",
+          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpTVRFd1pHSXlPUzB3T0RZekxUUXpNall0WVRVd1pDMDJabUV5WXprelpqZ3paV0lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6369baae69f9a569d7b4823a1777fde881c79908/picture.jpg"
         },
         "favourite": null
       },
       "relationships": {
         "owner": {
           "data": {
-            "id": "5728f155-d817-41b8-8508-362005e7f10b",
+            "id": "362e3f59-ef1d-4ec1-880a-d2bed86bde73",
             "type": "user"
           }
         },
@@ -349,7 +292,7 @@
       }
     },
     {
-      "id": "3cbb2763-5337-4483-95df-b272d13f1a9f",
+      "id": "8b03b1cd-ff98-4ec8-9c5e-6ce24af78b11",
       "type": "project_developer",
       "attributes": {
         "name": "Keebler, Kub and Zemlak",
@@ -380,16 +323,16 @@
         "contact_email": null,
         "contact_phone": null,
         "picture": {
-          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0WkRsaU56ZGtNaTB3TkdNMkxUUmhabVl0T0dVM09TMDFORFJsTW1RNU1ETm1aVEFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a349bc1846bf74d09b454fee9041848e583a7079/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg",
-          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0WkRsaU56ZGtNaTB3TkdNMkxUUmhabVl0T0dVM09TMDFORFJsTW1RNU1ETm1aVEFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a349bc1846bf74d09b454fee9041848e583a7079/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg",
-          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0WkRsaU56ZGtNaTB3TkdNMkxUUmhabVl0T0dVM09TMDFORFJsTW1RNU1ETm1aVEFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a349bc1846bf74d09b454fee9041848e583a7079/picture.jpg"
+          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5TTJRd05EVmxPUzB3TVdVMExUUXlOVGN0WWpjeU15MHdZMlZpT1RZd09UVTRNamtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a056dde262c3cc977f58e54f042ead046261800e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg",
+          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5TTJRd05EVmxPUzB3TVdVMExUUXlOVGN0WWpjeU15MHdZMlZpT1RZd09UVTRNamtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a056dde262c3cc977f58e54f042ead046261800e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg",
+          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5TTJRd05EVmxPUzB3TVdVMExUUXlOVGN0WWpjeU15MHdZMlZpT1RZd09UVTRNamtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a056dde262c3cc977f58e54f042ead046261800e/picture.jpg"
         },
         "favourite": null
       },
       "relationships": {
         "owner": {
           "data": {
-            "id": "e0e05026-223b-439e-96c6-7d64476a34e0",
+            "id": "84099529-ff88-44c2-b7ec-13a536b804c1",
             "type": "user"
           }
         },
@@ -406,7 +349,7 @@
       }
     },
     {
-      "id": "0ed788c9-5228-4b3f-8238-32b28785d474",
+      "id": "40625360-65a5-45a7-8867-ee4ed47d244c",
       "type": "project_developer",
       "attributes": {
         "name": "Kutch-Spencer",
@@ -436,16 +379,16 @@
         "contact_email": null,
         "contact_phone": null,
         "picture": {
-          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqWVRWaFpqZzNOUzAyTWpoaExUUTBOR010T1RabFl5MWxNVEppTUdNNE9ETm1OeklHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--cb4fb601121ae7cad6f8cb104c93aeed9d2ece2b/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg",
-          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqWVRWaFpqZzNOUzAyTWpoaExUUTBOR010T1RabFl5MWxNVEppTUdNNE9ETm1OeklHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--cb4fb601121ae7cad6f8cb104c93aeed9d2ece2b/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg",
-          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqWVRWaFpqZzNOUzAyTWpoaExUUTBOR010T1RabFl5MWxNVEppTUdNNE9ETm1OeklHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--cb4fb601121ae7cad6f8cb104c93aeed9d2ece2b/picture.jpg"
+          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsWXpobFpXRXpPUzA0WXpFekxUUXpaakF0WVRZek1TMDBNMlZoT0RSbE9USmlZV1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5c829501f7da1f1b0808cb695179ea8a69f25c62/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg",
+          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsWXpobFpXRXpPUzA0WXpFekxUUXpaakF0WVRZek1TMDBNMlZoT0RSbE9USmlZV1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5c829501f7da1f1b0808cb695179ea8a69f25c62/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg",
+          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsWXpobFpXRXpPUzA0WXpFekxUUXpaakF0WVRZek1TMDBNMlZoT0RSbE9USmlZV1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5c829501f7da1f1b0808cb695179ea8a69f25c62/picture.jpg"
         },
         "favourite": null
       },
       "relationships": {
         "owner": {
           "data": {
-            "id": "ea80cee5-de46-4698-bd1f-5ec3eecafb37",
+            "id": "b18d3c4c-526a-4073-9616-43ee71b98ea3",
             "type": "user"
           }
         },
@@ -457,11 +400,11 @@
         "involved_projects": {
           "data": [
             {
-              "id": "0cdac0fb-572d-4bef-aa58-eff70c5c830f",
+              "id": "05119ec0-7217-45f6-a26a-7f4debfdf3bf",
               "type": "project"
             },
             {
-              "id": "9019e1d6-6db9-4b00-939e-efd760bd4f3a",
+              "id": "e11e66a4-fa9c-4a65-9100-562cf8056265",
               "type": "project"
             }
           ]
@@ -469,7 +412,7 @@
       }
     },
     {
-      "id": "c9d286a7-e6b4-45fe-8dfa-d7d3bf6e27d5",
+      "id": "656ab0e5-e118-4033-aaa6-73cccabfd5f3",
       "type": "project_developer",
       "attributes": {
         "name": "Ritchie, Glover and Ward",
@@ -500,16 +443,16 @@
         "contact_email": null,
         "contact_phone": null,
         "picture": {
-          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TUdabE9ERm1ZaTFrTkdReUxUUmtNbUV0T0RNellpMWlObUl5TTJObE1EWXhZemNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4b03cdff0abe8623e927514f0b15cc31184ff87c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg",
-          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TUdabE9ERm1ZaTFrTkdReUxUUmtNbUV0T0RNellpMWlObUl5TTJObE1EWXhZemNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4b03cdff0abe8623e927514f0b15cc31184ff87c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg",
-          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TUdabE9ERm1ZaTFrTkdReUxUUmtNbUV0T0RNellpMWlObUl5TTJObE1EWXhZemNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4b03cdff0abe8623e927514f0b15cc31184ff87c/picture.jpg"
+          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtTkdJM1pEUXlaUzAwTmpnNUxUUmlOR0V0WWpVNU9DMHpaR05sWm1VME56TmpZVElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f44f1cce56ccbcff70d19409ead97cdba4d2f6ee/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg",
+          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtTkdJM1pEUXlaUzAwTmpnNUxUUmlOR0V0WWpVNU9DMHpaR05sWm1VME56TmpZVElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f44f1cce56ccbcff70d19409ead97cdba4d2f6ee/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg",
+          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtTkdJM1pEUXlaUzAwTmpnNUxUUmlOR0V0WWpVNU9DMHpaR05sWm1VME56TmpZVElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f44f1cce56ccbcff70d19409ead97cdba4d2f6ee/picture.jpg"
         },
         "favourite": null
       },
       "relationships": {
         "owner": {
           "data": {
-            "id": "ac927d20-33e1-4970-bb83-1fe468abdc9a",
+            "id": "8178c387-acff-4b3c-b7dc-c8277e3d1032",
             "type": "user"
           }
         },
@@ -526,7 +469,7 @@
       }
     },
     {
-      "id": "f3a3de4f-b40b-4f84-919a-33d5c610c5ae",
+      "id": "5994b3a8-4f98-4585-b02e-ade1859cb1e1",
       "type": "project_developer",
       "attributes": {
         "name": "Runolfsson and Sons",
@@ -557,16 +500,16 @@
         "contact_email": null,
         "contact_phone": null,
         "picture": {
-          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0WkRSalpqSTBZeTB3Wm1JeUxUUTRPRFF0WWpJMFpTMWlabUUwTURCa016VXdNbVVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--315c91c5eed8e31f7b91385ce6a8b45977cdbacb/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg",
-          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0WkRSalpqSTBZeTB3Wm1JeUxUUTRPRFF0WWpJMFpTMWlabUUwTURCa016VXdNbVVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--315c91c5eed8e31f7b91385ce6a8b45977cdbacb/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg",
-          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0WkRSalpqSTBZeTB3Wm1JeUxUUTRPRFF0WWpJMFpTMWlabUUwTURCa016VXdNbVVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--315c91c5eed8e31f7b91385ce6a8b45977cdbacb/picture.jpg"
+          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsWmpJME5XVXpZeTB4TVRCbUxUUmhPVE10WVRnM05DMHdPVE14WldZMFpHVTJZV1VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0c918aa75c60d4ae2c63a07178001a84674aab46/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg",
+          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsWmpJME5XVXpZeTB4TVRCbUxUUmhPVE10WVRnM05DMHdPVE14WldZMFpHVTJZV1VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0c918aa75c60d4ae2c63a07178001a84674aab46/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg",
+          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsWmpJME5XVXpZeTB4TVRCbUxUUmhPVE10WVRnM05DMHdPVE14WldZMFpHVTJZV1VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0c918aa75c60d4ae2c63a07178001a84674aab46/picture.jpg"
         },
         "favourite": null
       },
       "relationships": {
         "owner": {
           "data": {
-            "id": "d33a5d0b-d9c9-4b4a-8200-08989271e48c",
+            "id": "a8f9e66c-fc22-4de5-8fc4-418bf4b60819",
             "type": "user"
           }
         },
@@ -587,8 +530,8 @@
     "page": 1,
     "per_page": 10,
     "from": 1,
-    "to": 10,
-    "total": 10,
+    "to": 9,
+    "total": 9,
     "pages": 1
   },
   "links": {

--- a/backend/spec/requests/api/v1/projects/maps_spec.rb
+++ b/backend/spec/requests/api/v1/projects/maps_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe "API V1 Project Maps", type: :request do
   before_all do
     @project = create(:project, category: "non-timber-forest-production")
     create_list(:project, 6, category: "forestry-and-agroforestry")
+    @unapproved_project = create(:project, project_developer: create(:project_developer, account: create(:account, :unapproved, users: [create(:user)])))
   end
 
   path "/api/v1/projects/map" do
@@ -42,6 +43,10 @@ RSpec.describe "API V1 Project Maps", type: :request do
 
         it "matches snapshot", generate_swagger_example: true do
           expect(response.body).to match_snapshot("api/v1/project-maps")
+        end
+
+        it "ignores unapproved record" do
+          expect(response_json["data"].pluck("id")).not_to include(@unapproved_project.id)
         end
 
         context "when filtering is used" do


### PR DESCRIPTION
I am adding `cancancan` library which is responsible for making sure that:
 - only approved Investors and ProjectDevelopers are visible via public endpoints (`index/show` action)
 - user can always see their own records (even though they are not approved --> `show` action)
 - only Projects and OpenCalls of approved accounts are visible via public endpoints

I have also defined couple other rights for `create` and `update` of records, but `account` API endpoints allow user to manipulate only with its own Investor/ProjectDeveloper data so these policies are a bit extra now. Only endpoint which I have tweaked a bit more is one for `account/projects` which uses cancancan policy to make sure that current_user creates/edits only Projects which he has access to.

I have not touched other already existing endpoints, but they can be always enhanced with cancancan policy if necessary. 

## Testing instructions

We already have Backoffice so it is enough to approve/reject via it some of the records and make sure that approved ones are visible and rejected ones are hidden (with exception if data are your own). Everything is ofc covered with tests so maybe you can also trust them :)

## Tracking

https://vizzuality.atlassian.net/browse/LET-512
https://vizzuality.atlassian.net/browse/LET-513
