### PR TITLE
Fix image exception when creating project

### DIFF
--- a/frontend/containers/project-form-pages/pages/general-information.tsx
+++ b/frontend/containers/project-form-pages/pages/general-information.tsx
@@ -197,11 +197,9 @@ const GeneralInformation = ({
                 clearErrors={clearErrors}
                 register={register}
                 registerOptions={{ disabled: false }}
-                fileTypes={{
-                  'image/png': ['.png'],
-                  'image/jpeg': ['.jpeg'],
-                  'image/jpg': ['.jpg'],
-                }}
+                // See: Browser limitations section
+                // https://react-dropzone.org/#section-accepting-specific-file-types
+                fileTypes={{ 'image/*': ['.png', '.jpg', '.jpeg'] }}
                 maxFiles={6}
                 maxSize={5 * 1024 * 1025}
                 onUpload={handleUploadImages}

--- a/frontend/pages/projects/new.tsx
+++ b/frontend/pages/projects/new.tsx
@@ -86,8 +86,19 @@ const Project: PageComponent<ProjectProps, FormPageLayoutProps> = () => {
   });
 
   const handleCreate = useCallback(
-    (data: ProjectCreationPayload) =>
-      createProject.mutate(data, {
+    (formData: ProjectCreationPayload) => {
+      const data = {
+        ...formData,
+        // Endpoint only expects `file` and `cover`. If for instance an `id` is passed, it'll
+        // return an error. However, the frontend needs extra properties such as the `id` during
+        // the form creation, so we're cleaning up the form data before POST'ing it to the endpoint.
+        project_images_attributes: formData.project_images_attributes?.map(({ file, cover }) => ({
+          file,
+          cover,
+        })),
+      } as ProjectCreationPayload;
+
+      return createProject.mutate(data, {
         onError: (error) => {
           const { errorPages, fieldErrors } = getServiceErrors<ProjectForm>(error, formPageInputs);
           fieldErrors.forEach(({ fieldName, message }) => setError(fieldName, { message }));
@@ -96,7 +107,8 @@ const Project: PageComponent<ProjectProps, FormPageLayoutProps> = () => {
         onSuccess: (result) => {
           push({ pathname: '/projects/pending/', search: `project=${result.data.slug}` });
         },
-      }),
+      });
+    },
     [createProject, push, setError]
   );
 


### PR DESCRIPTION
## Description

This PR fixes 2 bugs:  

1. **Image exception when creating project**  
  The endpoint only expects `file` and `cover`. We use other properties such as `id` in the forms which crashes the backend. This PR implements a quick fix (that doesn't require refactoring) in which it cleans up the project images data of all properties except for the ones the endpoint can deal with, on form submit. 

2. **In the Project form, using Google Chrome on MacOS, the Image uploader does not accept JPEG images when clicking on the uploader**  
  I noticed this when clicking on the uploader to select files using the native file selector window. The only file type it would accept was `png`; but drag 'n drop worked correctly. 
  See https://react-dropzone.org/#section-accepting-specific-file-types, _"Browser limitations"_ section. 

## Testing instructions

Verify that:  
- When creating a project, there is no longer a `ProjectImage` error  
  (note that there still may be one about `GeoJSON`)  
- When using Chrome, at least on MacOS, the user can click on the uploader box and is able to select `png`, `jpg` and `jpeg` images. 

## Tracking

[LET-510](https://vizzuality.atlassian.net/browse/LET-510)
[LET-517](https://vizzuality.atlassian.net/browse/LET-517)