### PR TITLE
Add impact on sorter options for projects

### DIFF
--- a/frontend/components/sorting-buttons/component.tsx
+++ b/frontend/components/sorting-buttons/component.tsx
@@ -4,6 +4,7 @@ import {
   ChevronDown as ChevronDownIcon,
   List as ListIcon,
   ArrowDown as ArrowDownIcon,
+  Check,
 } from 'react-feather';
 import { useIntl, FormattedMessage } from 'react-intl';
 
@@ -12,6 +13,7 @@ import cx from 'classnames';
 import { noop } from 'lodash-es';
 
 import Button from 'components/button';
+import Icon from 'components/icon';
 import Menu, { MenuItem, MenuSection } from 'components/menu';
 
 import { SortingButtonsProps } from './types';
@@ -65,11 +67,24 @@ export const SortingButtons: FC<SortingButtonsProps> = ({
           onAction={(key: string) => onChange({ sortBy: key })}
           onOpen={() => setSortByMenuOpen(true)}
           onClose={() => setSortByMenuOpen(false)}
+          className="min-w-fit"
         >
           <MenuSection>
-            {options.map(({ key, label }) => (
-              <MenuItem key={key}>{label}</MenuItem>
-            ))}
+            {options.map(({ key, label }) => {
+              const isSelected = selectedSortByOption.key === key;
+              return (
+                <MenuItem key={key}>
+                  <span
+                    className={cx({
+                      'text-green-dark': isSelected,
+                    })}
+                  >
+                    {label}
+                    {isSelected && <Icon width={18} className="inline ml-2" icon={Check} />}
+                  </span>
+                </MenuItem>
+              );
+            })}
           </MenuSection>
         </Menu>
         <Button

--- a/frontend/components/sorting-buttons/types.ts
+++ b/frontend/components/sorting-buttons/types.ts
@@ -1,6 +1,15 @@
+export type SortingOptionKey =
+  | 'name'
+  | 'created_at'
+  | 'total_impact'
+  | 'biodiversity_impact'
+  | 'climate_impact'
+  | 'water_impact'
+  | 'community_impact';
+
 export type SortingOptionType = {
   /** Option key */
-  key: string;
+  key: SortingOptionKey;
   /** Option label */
   label: string;
 };

--- a/frontend/layouts/discover-page/helpers.ts
+++ b/frontend/layouts/discover-page/helpers.ts
@@ -1,0 +1,32 @@
+import { useIntl } from 'react-intl';
+
+import { SortingOptionType } from 'components/sorting-buttons';
+
+/** Returns the sorting-by types array with translated labels  */
+export const useSortingByOptions = (): SortingOptionType[] => {
+  const { formatMessage } = useIntl();
+  return [
+    { key: 'name', label: formatMessage({ defaultMessage: 'Name', id: 'HAlOn1' }) },
+    { key: 'created_at', label: formatMessage({ defaultMessage: 'Date', id: 'P7PLVj' }) },
+    {
+      key: 'total_impact',
+      label: formatMessage({ defaultMessage: 'Impact score', id: '2GBpne' }),
+    },
+    {
+      key: 'biodiversity_impact',
+      label: formatMessage({ defaultMessage: 'Biodiversity impact', id: 'BvO1iK' }),
+    },
+    {
+      key: 'climate_impact',
+      label: formatMessage({ defaultMessage: 'Climate impact', id: 'TUFmRM' }),
+    },
+    {
+      key: 'water_impact',
+      label: formatMessage({ defaultMessage: 'Water impact', id: 'W5x0GV' }),
+    },
+    {
+      key: 'community_impact',
+      label: formatMessage({ defaultMessage: 'Community impact', id: 'PGlFh/' }),
+    },
+  ];
+};


### PR DESCRIPTION
This PR adds the impact scores on the sorting options for discover/projects page

## Testing instructions

There will a way to sort projects by
* General impact (ascending, descending)
* 4 Impact dimensions (ascending, descending)

This is an addition to the sorting options defined at [LET-368: Visitors can sort Projects search results by date and alphabeticallyDONE](https://vizzuality.atlassian.net/browse/LET-368) 

Default sorting as defined in the previously mentioned ticket

## Tracking

[LET-410](https://vizzuality.atlassian.net/browse/LET-410)
