### PR TITLE
Fix Project creation form header copy

### DIFF
--- a/frontend/pages/projects/new.tsx
+++ b/frontend/pages/projects/new.tsx
@@ -140,12 +140,10 @@ const Project: PageComponent<ProjectProps, FormPageLayoutProps> = () => {
 
   return (
     <ProtectedPage permissions={[UserRoles.ProjectDeveloper]}>
-      <Head
-        title={formatMessage({ defaultMessage: 'Setup project developer’s account', id: 'bhxvPM' })}
-      />
+      <Head title={formatMessage({ defaultMessage: 'Create project', id: 'VUN1K7' })} />
       <MultiPageLayout
         layout="narrow"
-        title={formatMessage({ defaultMessage: 'Setup project developer’s account', id: 'bhxvPM' })}
+        title={formatMessage({ defaultMessage: 'Create project', id: 'VUN1K7' })}
         autoNavigation={false}
         page={currentPage}
         alert={useGetAlert(createProject.error)}


### PR DESCRIPTION
This PR corrects the copy on the new Project form. 

`Setup project developer’s account` > `Create project`

## Testing instructions

Verify that the new Project form view has the correct copy on the form header & page title. 

## Tracking

[LET-519](https://vizzuality.atlassian.net/browse/LET-519)
