### PR TITLE
fix: Geometry param is permitted even for nested attributes

### DIFF
--- a/backend/app/controllers/api/v1/accounts/projects_controller.rb
+++ b/backend/app/controllers/api/v1/accounts/projects_controller.rb
@@ -57,15 +57,13 @@ module API
             :progress_impact_tracking,
             :description,
             :relevant_links,
-            :geometry,
-            geometry: {},
             involved_project_developer_ids: [],
             target_groups: [],
             impact_areas: [],
             sdgs: [],
             instrument_types: [],
             project_images_attributes: %i[id file cover _destroy]
-          )
+          ).tap { |r| r[:geometry] = params[:geometry].permit! if params[:geometry].present? }
         end
 
         def fetch_project

--- a/backend/config/brakeman.ignore
+++ b/backend/config/brakeman.ignore
@@ -1,0 +1,26 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Mass Assignment",
+      "warning_code": 70,
+      "fingerprint": "38a76f3931f1d8a01c3591d2feee5d17502f144b78bf2123c46d896f800f119b",
+      "check_name": "MassAssignment",
+      "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
+      "file": "app/controllers/api/v1/accounts/projects_controller.rb",
+      "line": 66,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params[:geometry].permit!",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "API::V1::Accounts::ProjectsController",
+        "method": "update_params"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "note": ""
+    }
+  ],
+  "updated": "2022-05-31 16:40:51 +0200",
+  "brakeman_version": "5.2.2"
+}

--- a/backend/spec/fixtures/snapshots/api/v1/accounts-project-create.json
+++ b/backend/spec/fixtures/snapshots/api/v1/accounts-project-create.json
@@ -41,14 +41,44 @@
       "language": "en",
       "favourite": false,
       "geometry": {
-        "type": "Point",
-        "coordinates": [
-          1.0,
-          2.0
+        "type": "FeatureCollection",
+        "features": [
+          {
+            "type": "Feature",
+            "geometry": {
+              "type": "Polygon",
+              "coordinates": [
+                [
+                  [
+                    -77.84036872266269,
+                    1.5274297752414188
+                  ],
+                  [
+                    -77.1591467371437,
+                    0.4940264211830182
+                  ],
+                  [
+                    -76.4661795449776,
+                    0.8933333719051408
+                  ],
+                  [
+                    -77.2531083903186,
+                    1.7974555737018534
+                  ],
+                  [
+                    -77.84036872266269,
+                    1.5274297752414188
+                  ]
+                ]
+              ]
+            },
+            "properties": {
+            }
+          }
         ]
       },
-      "latitude": 2.0,
-      "longitude": 1.0,
+      "latitude": 1.1581373021971106,
+      "longitude": -77.16867902747148,
       "funding_plan": "Funding plan description",
       "trusted": false,
       "municipality_biodiversity_impact": null,

--- a/backend/spec/requests/api/v1/accounts/projects_spec.rb
+++ b/backend/spec/requests/api/v1/accounts/projects_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "API V1 Account Projects", type: :request do
           relevant_links: "Here relevant links",
           involved_project_developer_ids: project_developers.map(&:id),
           involved_project_developer_not_listed: true,
-          geometry: {type: "Point", coordinates: [1, 2]},
+          geometry: {type: "FeatureCollection", features: [{type: "Feature", properties: {}, geometry: {type: "Polygon", coordinates: [[[-77.84036872266269, 1.5274297752414188], [-77.1591467371437, 0.4940264211830182], [-76.4661795449776, 0.8933333719051408], [-77.2531083903186, 1.7974555737018534], [-77.84036872266269, 1.5274297752414188]]]}}]},
           category: "sustainable-agrosystems",
           target_groups: %w[urban-populations indigenous-peoples],
           impact_areas: %w[restoration pollutants-reduction],


### PR DESCRIPTION
GeoJson with Project geometry can be nested json -- instead of permitting every nested attribute of geojson separately, I permit whole geojson by default. 

I am adding security warning to ignore which should be fine, because there are couple of validations on Project model which ensure that GeoJSON has proper format.

## Testing instructions

Try to create or update Project with complex GeoJSON geometry (coordinates are defined inside feature)

## Tracking

BugFix ;)
