### PR TITLE
feat: Making backoffice tables sortable

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -27,6 +27,7 @@ gem "friendly_id", "~> 5.4.0"
 gem "devise"
 gem "devise-i18n"
 gem "traco"
+gem "ransack"
 
 # API
 gem "jsonapi-serializer"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -390,6 +390,10 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
+    ransack (3.2.1)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
+      i18n
     redis (4.6.0)
     regexp_parser (2.3.1)
     reline (0.3.1)
@@ -572,6 +576,7 @@ DEPENDENCIES
   pg_search
   puma (~> 5.6)
   rails (~> 7.0.1)
+  ransack
   redis (~> 4.0)
   rgeo
   rgeo-geojson

--- a/backend/app/controllers/backoffice/investors_controller.rb
+++ b/backend/app/controllers/backoffice/investors_controller.rb
@@ -1,8 +1,8 @@
 module Backoffice
   class InvestorsController < BaseController
     def index
-      @investors = Investor.all.includes(account: [:owner])
-      @pagy_object, @investors = pagy @investors
+      @q = Investor.ransack params[:q]
+      @pagy_object, @investors = pagy @q.result.includes(account: [:owner])
     end
   end
 end

--- a/backend/app/controllers/backoffice/project_developers_controller.rb
+++ b/backend/app/controllers/backoffice/project_developers_controller.rb
@@ -1,8 +1,8 @@
 module Backoffice
   class ProjectDevelopersController < BaseController
     def index
-      @project_developers = ProjectDeveloper.all.includes(account: [:owner])
-      @pagy_object, @project_developers = pagy @project_developers
+      @q = ProjectDeveloper.ransack params[:q]
+      @pagy_object, @project_developers = pagy @q.result.includes(account: [:owner])
     end
   end
 end

--- a/backend/app/helpers/application_helper.rb
+++ b/backend/app/helpers/application_helper.rb
@@ -1,5 +1,6 @@
 module ApplicationHelper
   include Pagy::Frontend
+  include Ransack::Helpers::FormHelper
 
   def nav_link_to(text, path)
     is_active = current_page?(path)

--- a/backend/app/models/open_call.rb
+++ b/backend/app/models/open_call.rb
@@ -5,7 +5,7 @@ class OpenCall < ApplicationRecord
 
   friendly_id :investor_prefixed_name, use: :slugged
 
-  belongs_to :investor
+  belongs_to :investor, counter_cache: true
 
   validates :instrument_type, inclusion: {in: InstrumentType::TYPES}
   validates :ticket_size, inclusion: {in: TicketSize::TYPES}

--- a/backend/app/models/project.rb
+++ b/backend/app/models/project.rb
@@ -5,7 +5,7 @@ class Project < ApplicationRecord
 
   friendly_id :project_developer_prefixed_name, use: :slugged
 
-  belongs_to :project_developer
+  belongs_to :project_developer, counter_cache: true
 
   belongs_to :country, class_name: "Location"
   belongs_to :municipality, class_name: "Location"

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   EMAIL_CONFIRMATION_LIMIT_PERIOD = 10.minutes
 
-  belongs_to :account, optional: true
+  belongs_to :account, optional: true, counter_cache: true
 
   has_many :favourite_projects, dependent: :destroy
   has_many :projects, through: :favourite_projects
@@ -21,6 +21,10 @@ class User < ApplicationRecord
   validates_presence_of :first_name, :last_name
 
   delegate :approved?, to: :account, allow_nil: true
+
+  ransacker :full_name do
+    Arel.sql("CONCAT_WS(' ', users.first_name, users.last_name)")
+  end
 
   def send_confirmation_instructions
     return if confirmation_sent_within_limited_period?

--- a/backend/app/views/backoffice/investors/index.html.erb
+++ b/backend/app/views/backoffice/investors/index.html.erb
@@ -2,22 +2,22 @@
   <thead>
     <tr>
       <th>
-        <%= t("backoffice.common.name") %>
+        <%= sort_link @q, :account_name, t("backoffice.common.name") %>
       </th>
       <th>
-        <%= t("backoffice.common.account_owner") %>
+        <%= sort_link @q, :account_owner_full_name, t("backoffice.common.account_owner") %>
       </th>
       <th>
-        <%= t("backoffice.common.account_users") %>
+        <%= sort_link @q, :account_users_count, t("backoffice.common.account_users") %>
       </th>
       <th>
-        <%= t(".open_calls") %>
+        <%= sort_link @q, :open_calls_count, t(".open_calls") %>
       </th>
       <th>
-        <%= t("backoffice.common.language") %>
+        <%= sort_link @q, :language, t("backoffice.common.language") %>
       </th>
       <th>
-        <%= t("backoffice.common.status") %>
+        <%= sort_link @q, :account_review_status, t("backoffice.common.status") %>
       </th>
       <th>
       </th>
@@ -28,8 +28,8 @@
       <tr>
         <td><%= investor.name %></td>
         <td><%= investor.account.owner.full_name %></td>
-        <td><%= investor.account.users.count + 1 %></td>
-        <td><%= investor.open_calls.count %></td>
+        <td><%= investor.account.users_count + 1 %></td>
+        <td><%= investor.open_calls_count %></td>
         <td><%= investor.language %></td>
         <td><%= investor.account.review_status %></td>
         <td>

--- a/backend/app/views/backoffice/project_developers/index.html.erb
+++ b/backend/app/views/backoffice/project_developers/index.html.erb
@@ -2,22 +2,22 @@
   <thead>
     <tr>
       <th>
-        <%= t("backoffice.common.name") %>
+        <%= sort_link @q, :account_name, t("backoffice.common.name") %>
       </th>
       <th>
-        <%= t("backoffice.common.account_owner") %>
+        <%= sort_link @q, :account_owner_full_name, t("backoffice.common.account_owner") %>
       </th>
       <th>
-        <%= t("backoffice.common.account_users") %>
+        <%= sort_link @q, :account_users_count, t("backoffice.common.account_users") %>
       </th>
       <th>
-        <%= t(".projects") %>
+        <%= sort_link @q, :projects_count, t(".projects") %>
       </th>
       <th>
-        <%= t("backoffice.common.language") %>
+        <%= sort_link @q, :language, t("backoffice.common.language") %>
       </th>
       <th>
-        <%= t("backoffice.common.status") %>
+        <%= sort_link @q, :account_review_status, t("backoffice.common.status") %>
       </th>
       <th>
       </th>
@@ -28,8 +28,8 @@
       <tr>
         <td><%= pd.name %></td>
         <td><%= pd.account.owner.full_name %></td>
-        <td><%= pd.account.users.count + 1 %></td>
-        <td><%= pd.projects.count %></td>
+        <td><%= pd.account.users_count + 1 %></td>
+        <td><%= pd.projects_count %></td>
         <td><%= pd.language %></td>
         <td><%= pd.account.review_status %></td>
         <td>

--- a/backend/config/initializers/ransack.rb
+++ b/backend/config/initializers/ransack.rb
@@ -1,0 +1,7 @@
+Ransack.configure do |config|
+  config.custom_arrows = {
+    up_arrow: "↑",
+    down_arrow: "↓",
+    default_arrow: "↕"
+  }
+end

--- a/backend/db/migrate/20220601090659_add_projects_count_to_project_developers.rb
+++ b/backend/db/migrate/20220601090659_add_projects_count_to_project_developers.rb
@@ -1,0 +1,10 @@
+class AddProjectsCountToProjectDevelopers < ActiveRecord::Migration[7.0]
+  def self.up
+    add_column :project_developers, :projects_count, :integer, null: false, default: 0
+    ProjectDeveloper.find_each { |project_developer| ProjectDeveloper.reset_counters(project_developer.id, :projects) }
+  end
+
+  def self.down
+    remove_column :project_developers, :projects_count
+  end
+end

--- a/backend/db/migrate/20220601091618_add_users_count_to_accounts.rb
+++ b/backend/db/migrate/20220601091618_add_users_count_to_accounts.rb
@@ -1,0 +1,10 @@
+class AddUsersCountToAccounts < ActiveRecord::Migration[7.0]
+  def self.up
+    add_column :accounts, :users_count, :integer, null: false, default: 0
+    Account.find_each { |account| Account.reset_counters(account.id, :users) }
+  end
+
+  def self.down
+    remove_column :accounts, :users_count
+  end
+end

--- a/backend/db/migrate/20220601092750_add_open_call_counts_to_investors.rb
+++ b/backend/db/migrate/20220601092750_add_open_call_counts_to_investors.rb
@@ -1,0 +1,10 @@
+class AddOpenCallCountsToInvestors < ActiveRecord::Migration[7.0]
+  def self.up
+    add_column :investors, :open_calls_count, :integer, null: false, default: 0
+    Investor.find_each { |investor| Investor.reset_counters(investor.id, :open_calls) }
+  end
+
+  def self.down
+    remove_column :investors, :open_calls_count
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_26_092240) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_01_092750) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -35,6 +35,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_26_092240) do
     t.integer "review_status", default: 0, null: false
     t.datetime "reviewed_at"
     t.text "review_message"
+    t.integer "users_count", default: 0, null: false
     t.index ["name"], name: "index_accounts_on_name", unique: true
     t.index ["owner_id"], name: "index_accounts_on_owner_id"
     t.index ["slug"], name: "index_accounts_on_slug", unique: true
@@ -146,6 +147,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_26_092240) do
     t.string "prioritized_projects_description_en"
     t.string "prioritized_projects_description_es"
     t.string "prioritized_projects_description_pt"
+    t.integer "open_calls_count", default: 0, null: false
     t.index ["account_id"], name: "index_investors_on_account_id"
   end
 
@@ -226,6 +228,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_26_092240) do
     t.datetime "updated_at", null: false
     t.string "entity_legal_registration_number", null: false
     t.string "mosaics", array: true
+    t.integer "projects_count", default: 0, null: false
     t.index ["account_id"], name: "index_project_developers_on_account_id"
   end
 

--- a/backend/spec/support/shared_examples/backoffice/with_table_sorting.rb
+++ b/backend/spec/support/shared_examples/backoffice/with_table_sorting.rb
@@ -1,0 +1,7 @@
+RSpec.shared_examples "with table sorting" do |columns: []|
+  describe "Sortable" do
+    it "has correct sortable columns" do
+      columns.each { |column| expect(page).to have_css "a.sort_link", text: column }
+    end
+  end
+end

--- a/backend/spec/system/backoffice/investors_spec.rb
+++ b/backend/spec/system/backoffice/investors_spec.rb
@@ -17,6 +17,14 @@ RSpec.describe "Backoffice: Investors", type: :system do
     before { visit "/backoffice/investors" }
 
     it_behaves_like "with table pagination"
+    it_behaves_like "with table sorting", columns: [
+      I18n.t("backoffice.common.name"),
+      I18n.t("backoffice.common.account_owner"),
+      I18n.t("backoffice.common.account_users"),
+      I18n.t("backoffice.investors.index.open_calls"),
+      I18n.t("backoffice.common.language"),
+      I18n.t("backoffice.common.status")
+    ]
 
     it "shows investors list" do
       within_row("Super Investor Enterprise") do

--- a/backend/spec/system/backoffice/project_developers_spec.rb
+++ b/backend/spec/system/backoffice/project_developers_spec.rb
@@ -13,6 +13,14 @@ RSpec.describe "Backoffice: Project Developers", type: :system do
     before { visit "/backoffice/project_developers" }
 
     it_behaves_like "with table pagination"
+    it_behaves_like "with table sorting", columns: [
+      I18n.t("backoffice.common.name"),
+      I18n.t("backoffice.common.account_owner"),
+      I18n.t("backoffice.common.account_users"),
+      I18n.t("backoffice.project_developers.index.projects"),
+      I18n.t("backoffice.common.language"),
+      I18n.t("backoffice.common.status")
+    ]
 
     it "shows project developers list" do
       within_row("Super PD Enterprise") do


### PR DESCRIPTION
This PR adds possibility to sort/order Investor and Project Developer page at Backoffice. All heavy lifting is done by `ransack` -- tbh, I have taken huge inspiration from Tota project. The columns which were using `count` are rewritten to use `counter_cache` instead.

Tests are quite simple, but I am trusting that ransack is doing its job, therefore It should be enough :).

I wasn't able to extract correct `arrow` icons which are visible next to every column name from Figma so I used simpler ones, but they work and can be replaced by correct ones at future.

![Screenshot 2022-06-01 at 13 55 18](https://user-images.githubusercontent.com/20660167/171411841-0d3cc89f-14af-434a-8f91-ebd995e5d3d6.png)

## Testing instructions

Open PDs or Investors table at Backoffice and try to order it by random column values.

## Tracking

https://vizzuality.atlassian.net/browse/LET-504
