### PR TITLE
Fix flaky backend tests - snapshots ignore included array

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -75,7 +75,7 @@ group :test do
   gem "cuprite"
   gem "rspec-collection_matchers"
   gem "rspec-retry"
-  gem "rspec-request_snapshot"
+  gem "rspec-request_snapshot", github: "tsubik/rspec-request_snapshot", branch: "fix/ignore-order"
   gem "rswag-specs"
   gem "simplecov", require: false
   gem "super_diff"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/tsubik/rspec-request_snapshot.git
+  revision: 86775ed811110a71df75605440ca41deae07cf26
+  branch: fix/ignore-order
+  specs:
+    rspec-request_snapshot (0.7.3)
+      rspec (~> 3.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -435,8 +443,6 @@ GEM
       rspec-expectations (~> 3.10)
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
-    rspec-request_snapshot (0.7.3)
-      rspec (~> 3.0)
     rspec-retry (0.6.2)
       rspec-core (> 3.3)
     rspec-support (3.11.0)
@@ -582,7 +588,7 @@ DEPENDENCIES
   rgeo-geojson
   rspec-collection_matchers
   rspec-rails (~> 5.0.0)
-  rspec-request_snapshot
+  rspec-request_snapshot!
   rspec-retry
   rswag
   rswag-specs

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -24,6 +24,7 @@ RSpec.configure do |config|
   config.request_snapshots_dir = "spec/fixtures/snapshots"
   # adding dynamic attributes for snapshots, small medium original are for active storage links
   config.request_snapshots_dynamic_attributes = %w[id created_at updated_at small medium original]
+  config.request_snapshots_ignore_order = %w[included]
 
   config.include ActiveSupport::Testing::TimeHelpers
   config.include FactoryBot::Syntax::Methods


### PR DESCRIPTION
Using fork of snaphost gem, until I make a PR to main gem and it's merged.

## Testing instructions

I was no longer able to get any failing specs when running specs multiple times this way 
```
for i in `seq 20`; bundle exec rspec spec/requests; done
```

## Tracking

Link to the task(s), if any
