### PR TITLE
Fixing account users count in backoffice

### DIFF
--- a/backend/app/views/backoffice/investors/index.html.erb
+++ b/backend/app/views/backoffice/investors/index.html.erb
@@ -28,7 +28,7 @@
       <tr>
         <td><%= investor.name %></td>
         <td><%= investor.account.owner.full_name %></td>
-        <td><%= investor.account.users_count + 1 %></td>
+        <td><%= investor.account.users_count %></td>
         <td><%= investor.open_calls_count %></td>
         <td><%= investor.language %></td>
         <td><%= investor.account.review_status %></td>

--- a/backend/app/views/backoffice/project_developers/index.html.erb
+++ b/backend/app/views/backoffice/project_developers/index.html.erb
@@ -28,7 +28,7 @@
       <tr>
         <td><%= pd.name %></td>
         <td><%= pd.account.owner.full_name %></td>
-        <td><%= pd.account.users_count + 1 %></td>
+        <td><%= pd.account.users_count %></td>
         <td><%= pd.projects_count %></td>
         <td><%= pd.language %></td>
         <td><%= pd.account.review_status %></td>

--- a/backend/spec/factories/account.rb
+++ b/backend/spec/factories/account.rb
@@ -35,5 +35,9 @@ FactoryBot.define do
     trait :rejected do
       review_status { "rejected" }
     end
+
+    after :create do |account|
+      account.users << account.owner
+    end
   end
 end


### PR DESCRIPTION
There was a problem with seeds, and account owners did not have `account_id` applied. When I was adding user count + 1, I somehow thought we are not counting owners in `users` relationship :), because I had `0` and it was because of the bug in seeds. Just realized that when entering back office on staging when I saw that all accounts somehow have 2 users which is wrong.

## Testing instructions

What to test? How to do it?

## Tracking

Link to the task(s), if any
