### PR TITLE
Feature/Backoffice project list

### DIFF
--- a/backend/app/controllers/backoffice/base_controller.rb
+++ b/backend/app/controllers/backoffice/base_controller.rb
@@ -5,5 +5,9 @@ module Backoffice
     layout "backoffice"
 
     before_action :authenticate_admin!
+
+    def pagy_defaults
+      {items: 10}
+    end
   end
 end

--- a/backend/app/controllers/backoffice/investors_controller.rb
+++ b/backend/app/controllers/backoffice/investors_controller.rb
@@ -2,7 +2,7 @@ module Backoffice
   class InvestorsController < BaseController
     def index
       @q = Investor.ransack params[:q]
-      @pagy_object, @investors = pagy @q.result.includes(account: [:owner])
+      @pagy_object, @investors = pagy @q.result.includes(account: [:owner]), pagy_defaults
     end
   end
 end

--- a/backend/app/controllers/backoffice/project_developers_controller.rb
+++ b/backend/app/controllers/backoffice/project_developers_controller.rb
@@ -2,7 +2,7 @@ module Backoffice
   class ProjectDevelopersController < BaseController
     def index
       @q = ProjectDeveloper.ransack params[:q]
-      @pagy_object, @project_developers = pagy @q.result.includes(account: [:owner])
+      @pagy_object, @project_developers = pagy @q.result.includes(account: [:owner]), pagy_defaults
     end
   end
 end

--- a/backend/app/controllers/backoffice/projects_controller.rb
+++ b/backend/app/controllers/backoffice/projects_controller.rb
@@ -1,0 +1,9 @@
+module Backoffice
+  class ProjectsController < BaseController
+    def index
+      @q = Project.ransack params[:q]
+      @projects = @q.result.includes(:priority_landscape, project_developer: [:account])
+      @pagy_object, @projects = pagy @projects, pagy_defaults
+    end
+  end
+end

--- a/backend/app/helpers/application_helper.rb
+++ b/backend/app/helpers/application_helper.rb
@@ -17,6 +17,10 @@ module ApplicationHelper
     link_to text, path, class: classnames
   end
 
+  def localized_sort_link(q, key, *args, &block)
+    sort_link q, "#{key}_#{I18n.locale}", *args, &block
+  end
+
   def status_tag(key, text)
     return if text.blank?
 

--- a/backend/app/helpers/application_helper.rb
+++ b/backend/app/helpers/application_helper.rb
@@ -2,6 +2,11 @@ module ApplicationHelper
   include Pagy::Frontend
   include Ransack::Helpers::FormHelper
 
+  STATUS_TAG_CLASSES = {
+    "unverified" => "text-gray-800 bg-gray-800/20",
+    "verified" => "text-green-dark bg-green-light/20"
+  }
+
   def nav_link_to(text, path)
     is_active = current_page?(path)
     classnames = {
@@ -10,5 +15,15 @@ module ApplicationHelper
     }.reject { |_k, v| v == false }.keys
 
     link_to text, path, class: classnames
+  end
+
+  def status_tag(key, text)
+    return if text.blank?
+
+    content_tag(
+      :span,
+      text,
+      class: "text-sm font-sans px-2 py-0.5 rounded-full #{STATUS_TAG_CLASSES[key.to_s]}"
+    )
   end
 end

--- a/backend/app/models/concerns/enum_model.rb
+++ b/backend/app/models/concerns/enum_model.rb
@@ -31,7 +31,7 @@ module EnumModel
     end
 
     def find(slug)
-      all.find { |o| o.slug == slug }
+      new(slug: slug)
     end
   end
 end

--- a/backend/app/models/concerns/enum_model.rb
+++ b/backend/app/models/concerns/enum_model.rb
@@ -33,5 +33,14 @@ module EnumModel
     def find(slug)
       new(slug: slug)
     end
+
+    def select_index_sql(column_name = name.underscore)
+      sql = ["CASE"]
+      all.sort_by(&:name).each_with_index do |enum, index|
+        sql << "WHEN #{column_name} ='#{enum.slug}' THEN #{index}"
+      end
+      sql << "END"
+      sql.join(" ")
+    end
   end
 end

--- a/backend/app/models/project.rb
+++ b/backend/app/models/project.rb
@@ -70,6 +70,10 @@ class Project < ApplicationRecord
 
   accepts_nested_attributes_for :project_images, reject_if: :all_blank, allow_destroy: true
 
+  ransacker :category_index do
+    Arel.sql(Category.select_index_sql)
+  end
+
   def project_developer_prefixed_name
     "#{project_developer&.name} #{original_name}"
   end
@@ -79,10 +83,6 @@ class Project < ApplicationRecord
     # to prevent crashing validations because of setting slug, fallback just to current locale name
   rescue I18n::InvalidLocale
     name
-  end
-
-  ransacker :category_index do
-    Arel.sql(Category.select_index_sql)
   end
 
   private

--- a/backend/app/models/project.rb
+++ b/backend/app/models/project.rb
@@ -81,6 +81,10 @@ class Project < ApplicationRecord
     name
   end
 
+  ransacker :category_index do
+    Arel.sql(Category.select_index_sql)
+  end
+
   private
 
   def clear_funding_fields

--- a/backend/app/views/admins/sessions/new.html.erb
+++ b/backend/app/views/admins/sessions/new.html.erb
@@ -3,7 +3,7 @@
 
   <p class="my-6 text-gray-600"><%= t("backoffice.sign_in.enter_details_below") %></p>
 
-  <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+  <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name), html: {"data-turbo": false}) do |f| %>
     <% flash.each do |type, message| %>
       <div class="mb-4 bg-red-50 text-black text-sm px-4 py-4">
         <%= message %>

--- a/backend/app/views/backoffice/projects/index.html.erb
+++ b/backend/app/views/backoffice/projects/index.html.erb
@@ -14,7 +14,7 @@
         <%= sort_link @q, :priority_landscape_name, t("backoffice.common.mosaic") %>
       </th>
       <th>
-        <%= t("backoffice.common.status") %>
+        <%= sort_link @q, :trusted, t("backoffice.common.status") %>
       </th>
     </tr>
   </thead>
@@ -25,7 +25,10 @@
         <td><%= p.project_developer.name %></td>
         <td><%= Category.find(p.category).name %></td>
         <td><%= p.priority_landscape&.name %></td>
-        <td><%= p.status %></td>
+        <td>
+          <%= status_tag :verified, t('backoffice.common.verified') if p.trusted?  %>
+          <%= status_tag :unverified, t('backoffice.common.unverified') unless p.trusted?  %>
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/backend/app/views/backoffice/projects/index.html.erb
+++ b/backend/app/views/backoffice/projects/index.html.erb
@@ -1,0 +1,32 @@
+<table class="backoffice-table">
+  <thead>
+    <tr>
+      <th>
+        <%= sort_link @q, "name_#{I18n.locale}", t("backoffice.common.project_name") %>
+      </th>
+      <th>
+        <%= sort_link @q, :project_developer_account_name, t("backoffice.common.project_developer") %>
+      </th>
+      <th>
+        <%= sort_link @q, :category, t("backoffice.common.category") %>
+      </th>
+      <th>
+        <%= sort_link @q, :priority_landscape_name, t("backoffice.common.mosaic") %>
+      </th>
+      <th>
+        <%= sort_link @q, :status, t("backoffice.common.status") %>
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @projects.each do |p| %>
+      <tr>
+        <td><%= p.name %></td>
+        <td><%= p.project_developer.name %></td>
+        <td><%= Category.find(p.category).name %></td>
+        <td><%= p.priority_landscape&.name %></td>
+        <td><%= p.status %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/backend/app/views/backoffice/projects/index.html.erb
+++ b/backend/app/views/backoffice/projects/index.html.erb
@@ -14,7 +14,7 @@
         <%= sort_link @q, :priority_landscape_name, t("backoffice.common.mosaic") %>
       </th>
       <th>
-        <%= sort_link @q, :status, t("backoffice.common.status") %>
+        <%= t("backoffice.common.status") %>
       </th>
     </tr>
   </thead>

--- a/backend/app/views/backoffice/projects/index.html.erb
+++ b/backend/app/views/backoffice/projects/index.html.erb
@@ -2,7 +2,7 @@
   <thead>
     <tr>
       <th>
-        <%= sort_link @q, "name_#{I18n.locale}", t("backoffice.common.project_name") %>
+        <%= localized_sort_link @q, :name, t("backoffice.common.project_name") %>
       </th>
       <th>
         <%= sort_link @q, :project_developer_account_name, t("backoffice.common.project_developer") %>

--- a/backend/app/views/backoffice/projects/index.html.erb
+++ b/backend/app/views/backoffice/projects/index.html.erb
@@ -8,7 +8,7 @@
         <%= sort_link @q, :project_developer_account_name, t("backoffice.common.project_developer") %>
       </th>
       <th>
-        <%= sort_link @q, :category, t("backoffice.common.category") %>
+        <%= sort_link @q, :category_index, t("backoffice.common.category") %>
       </th>
       <th>
         <%= sort_link @q, :priority_landscape_name, t("backoffice.common.mosaic") %>

--- a/backend/app/views/layouts/application.html.erb
+++ b/backend/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
   </head>
 
-  <body data-turbo="false" class="bg-beige">
+  <body class="bg-beige">
     <%= content_for?(:content) ? yield(:content) : yield %>
   </body>
 </html>

--- a/backend/app/views/layouts/backoffice.html.erb
+++ b/backend/app/views/layouts/backoffice.html.erb
@@ -8,7 +8,7 @@
         </div>
         <div class="flex items-center justify-end flex-1">
           <%= current_admin.email %>
-          <%= button_to t("backoffice.layout.sign_out"), destroy_admin_session_path, class: "ml-2", method: :delete %>
+          <%= button_to t("backoffice.layout.sign_out"), destroy_admin_session_path, data: {turbo: false}, class: "ml-2", method: :delete %>
         </div>
       </div>
     </div>

--- a/backend/app/views/layouts/backoffice.html.erb
+++ b/backend/app/views/layouts/backoffice.html.erb
@@ -14,6 +14,7 @@
     </div>
     <div class="container mx-auto">
       <nav class="flex gap-4.5 py-3">
+        <%= nav_link_to t("backoffice.layout.projects"), backoffice_projects_path %>
         <%= nav_link_to t("backoffice.layout.investors"), backoffice_investors_path %>
         <%= nav_link_to t("backoffice.layout.project_developers"), backoffice_project_developers_path %>
       </nav>

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -8,6 +8,10 @@ zu:
       status: Status
       approve: Approve
       reject: Reject
+      project_name: Project name
+      project_developer: Project developer
+      category: Category
+      mosaic: Mosaic
       navigation:
         prev: "←"
         next: "→"
@@ -27,6 +31,7 @@ zu:
       sign_out: Sign out
       project_developers: Project developers
       investors: Investors
+      projects: Projects
   errors:
     messages:
       password_length: must be at least %{count} characters long

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -12,6 +12,8 @@ zu:
       project_developer: Project developer
       category: Category
       mosaic: Mosaic
+      verified: Verified
+      unverified: Unverified
       navigation:
         prev: "←"
         next: "→"

--- a/backend/config/routes/backoffice.rb
+++ b/backend/config/routes/backoffice.rb
@@ -12,4 +12,5 @@ namespace :backoffice do
   end
   resources :investors, only: [:index]
   resources :project_developers, only: [:index]
+  resources :projects, only: [:index]
 end

--- a/backend/config/routes/backoffice.rb
+++ b/backend/config/routes/backoffice.rb
@@ -1,7 +1,7 @@
 devise_for :admins, path: "backoffice"
 
 # admin_root_path is useful for devise
-get "/backoffice", to: redirect("backoffice/investors"), as: :admin_root
+get "/backoffice", to: redirect("backoffice/projects"), as: :admin_root
 
 namespace :backoffice do
   resources :accounts, only: [] do

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -50,6 +50,7 @@ if Rails.env.development?
         FactoryBot.create(:municipality, parent: FactoryBot.create(:department, parent: FactoryBot.create(:location)))
       FactoryBot.create(
         :project,
+        trusted: [true, false].sample,
         name: "#{Faker::Lorem.sentence} #{SecureRandom.hex(4)}",
         category: Category::TYPES.sample,
         project_developer: project_developer,

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -12,7 +12,7 @@ if Rails.env.development?
 
   Rake::Task["import_geojsons:colombia"].invoke
 
-  5.times do
+  15.times do
     investor_account = FactoryBot.create(:account)
     investor_account.owner.update!(role: "investor")
     investor = Investor.create!(
@@ -29,7 +29,7 @@ if Rails.env.development?
       other_information: Faker::Lorem.paragraph(sentence_count: 4),
       language: investor_account.language
     )
-    (0..3).to_a.sample.times do
+    (0..5).to_a.sample.times do
       FactoryBot.create(:open_call, investor: investor)
     end
 
@@ -45,11 +45,13 @@ if Rails.env.development?
       entity_legal_registration_number: "564823570"
     )
 
-    (0..3).to_a.sample.times do
+    (0..5).to_a.sample.times do
       municipality = Location.where(location_type: :municipality).order("RANDOM()").first ||
         FactoryBot.create(:municipality, parent: FactoryBot.create(:department, parent: FactoryBot.create(:location)))
       FactoryBot.create(
         :project,
+        name: "#{Faker::Lorem.sentence} #{SecureRandom.hex(4)}",
+        category: Category::TYPES.sample,
         project_developer: project_developer,
         municipality: municipality,
         department: municipality.parent,

--- a/backend/spec/models/project_spec.rb
+++ b/backend/spec/models/project_spec.rb
@@ -290,4 +290,28 @@ RSpec.describe Project, type: :model do
       end
     end
   end
+
+  describe "ransacker" do
+    describe "#category_index" do
+      before do
+        create(:project, category: "sustainable-agrosystems")
+        create(:project, category: "tourism-and-recreation")
+        create(:project, category: "forestry-and-agroforestry")
+      end
+
+      context "sort" do
+        it "correctly by category name asc" do
+          q = Project.ransack
+          q.sorts = "category_index asc"
+          expect(q.result.pluck(:category)).to eq(["forestry-and-agroforestry", "sustainable-agrosystems", "tourism-and-recreation"])
+        end
+
+        it "correctly by category name desc" do
+          q = Project.ransack
+          q.sorts = "category_index desc"
+          expect(q.result.pluck(:category)).to eq(["tourism-and-recreation", "sustainable-agrosystems", "forestry-and-agroforestry"])
+        end
+      end
+    end
+  end
 end

--- a/backend/spec/system/backoffice/projects_spec.rb
+++ b/backend/spec/system/backoffice/projects_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe "Backoffice: Projects", type: :system do
     ]
 
     it "shows projects list" do
+      expect(page).to have_xpath(".//tbody/tr", count: 5)
       within_row("Project ultra name") do
         expect(page).to have_text("Ultra project developer name")
         expect(page).to have_text(Category.find(project.category).name)

--- a/backend/spec/system/backoffice/projects_spec.rb
+++ b/backend/spec/system/backoffice/projects_spec.rb
@@ -2,15 +2,16 @@ require "system_helper"
 
 RSpec.describe "Backoffice: Projects", type: :system do
   let(:admin) { create(:admin, email: "admin@example.com", password: "SuperSecret6", first_name: "Admin", last_name: "Example") }
+  let(:geometry) { {type: "Polygon", coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1]]]} }
+  let!(:mosaic) { create(:location, :with_geometry, geometry: RGeo::GeoJSON.decode(geometry.to_json), location_type: "region", name: "Test mosaic") }
   let!(:project) {
-    project = create(
+    create(
       :project,
       name: "Project ultra name",
       project_developer: create(:project_developer, account: create(:account, name: "Ultra project developer name")),
+      geometry: geometry,
       trusted: true
     )
-    project.update(priority_landscape: create(:location, location_type: "region", name: "Test mosaic"))
-    project
   }
   let!(:projects) { create_list(:project, 4) }
 

--- a/backend/spec/system/backoffice/projects_spec.rb
+++ b/backend/spec/system/backoffice/projects_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe "Backoffice: Projects", type: :system do
     project = create(
       :project,
       name: "Project ultra name",
-      project_developer: create(:project_developer, account: create(:account, name: "Ultra project developer name"))
+      project_developer: create(:project_developer, account: create(:account, name: "Ultra project developer name")),
+      trusted: true
     )
     project.update(priority_landscape: create(:location, location_type: "region", name: "Test mosaic"))
     project
@@ -23,7 +24,8 @@ RSpec.describe "Backoffice: Projects", type: :system do
       I18n.t("backoffice.common.project_name"),
       I18n.t("backoffice.common.project_developer"),
       I18n.t("backoffice.common.category"),
-      I18n.t("backoffice.common.mosaic")
+      I18n.t("backoffice.common.mosaic"),
+      I18n.t("backoffice.common.status")
     ]
 
     it "shows projects list" do
@@ -32,7 +34,7 @@ RSpec.describe "Backoffice: Projects", type: :system do
         expect(page).to have_text("Ultra project developer name")
         expect(page).to have_text(Category.find(project.category).name)
         expect(page).to have_text("Test mosaic")
-        expect(page).to have_text("draft")
+        expect(page).to have_text(I18n.t("backoffice.common.verified"))
       end
     end
   end

--- a/backend/spec/system/backoffice/projects_spec.rb
+++ b/backend/spec/system/backoffice/projects_spec.rb
@@ -3,11 +3,13 @@ require "system_helper"
 RSpec.describe "Backoffice: Projects", type: :system do
   let(:admin) { create(:admin, email: "admin@example.com", password: "SuperSecret6", first_name: "Admin", last_name: "Example") }
   let!(:project) {
-    create(
+    project = create(
       :project,
       name: "Project ultra name",
       project_developer: create(:project_developer, account: create(:account, name: "Ultra project developer name"))
     )
+    project.update(priority_landscape: create(:location, location_type: "region", name: "Test mosaic"))
+    project
   }
   let!(:projects) { create_list(:project, 4) }
 
@@ -29,6 +31,7 @@ RSpec.describe "Backoffice: Projects", type: :system do
       within_row("Project ultra name") do
         expect(page).to have_text("Ultra project developer name")
         expect(page).to have_text(Category.find(project.category).name)
+        expect(page).to have_text("Test mosaic")
         expect(page).to have_text("draft")
       end
     end

--- a/backend/spec/system/backoffice/projects_spec.rb
+++ b/backend/spec/system/backoffice/projects_spec.rb
@@ -21,8 +21,7 @@ RSpec.describe "Backoffice: Projects", type: :system do
       I18n.t("backoffice.common.project_name"),
       I18n.t("backoffice.common.project_developer"),
       I18n.t("backoffice.common.category"),
-      I18n.t("backoffice.common.mosaic"),
-      I18n.t("backoffice.common.status")
+      I18n.t("backoffice.common.mosaic")
     ]
 
     it "shows projects list" do

--- a/backend/spec/system/backoffice/projects_spec.rb
+++ b/backend/spec/system/backoffice/projects_spec.rb
@@ -1,0 +1,36 @@
+require "system_helper"
+
+RSpec.describe "Backoffice: Projects", type: :system do
+  let(:admin) { create(:admin, email: "admin@example.com", password: "SuperSecret6", first_name: "Admin", last_name: "Example") }
+  let!(:project) {
+    create(
+      :project,
+      name: "Project ultra name",
+      project_developer: create(:project_developer, account: create(:account, name: "Ultra project developer name"))
+    )
+  }
+  let!(:projects) { create_list(:project, 4) }
+
+  before { sign_in admin }
+
+  describe "Index" do
+    before { visit "/backoffice/projects" }
+
+    it_behaves_like "with table pagination"
+    it_behaves_like "with table sorting", columns: [
+      I18n.t("backoffice.common.project_name"),
+      I18n.t("backoffice.common.project_developer"),
+      I18n.t("backoffice.common.category"),
+      I18n.t("backoffice.common.mosaic"),
+      I18n.t("backoffice.common.status")
+    ]
+
+    it "shows projects list" do
+      within_row("Project ultra name") do
+        expect(page).to have_text("Ultra project developer name")
+        expect(page).to have_text(Category.find(project.category).name)
+        expect(page).to have_text("draft")
+      end
+    end
+  end
+end


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1286444/171848323-9fa5db43-9404-481a-bca8-fd722fa3caba.png)

1. Category search is kinda workaround as we have translated names in Rails locale files, so I needed to use `ransacker` stuff and change names to numeric indexes and then sorting on that.
2. Sorting by `verified` slash `trusted` is right now done just like sorting by boolean column. I'm not sure if we want to spend more time and complicate, and does it like the category search is done? I'm lazy :P
3. Added a `status_tag` helper.
4. Seeds are updated to return more stuff, and with better properties.
5. Changed default pagination to 10 items as per design.
6. Enabled Turbo, but disabled it for devise as it's not supported. I have managed to enable it for devise in other project, but I have not copied that solution here as there could be some problems with it and resolving them could take more time.

I have not added total count as I think @martintomas is working on this right now, so don't want to duplicate work.

## Testing instructions

Run seeds and click through.

## Tracking

https://vizzuality.atlassian.net/browse/LET-530
https://vizzuality.atlassian.net/browse/LET-535
https://vizzuality.atlassian.net/browse/LET-536