### PR TITLE
feat: Searching at Backoffice

### DIFF
--- a/backend/app/controllers/backoffice/investors_controller.rb
+++ b/backend/app/controllers/backoffice/investors_controller.rb
@@ -2,7 +2,14 @@ module Backoffice
   class InvestorsController < BaseController
     def index
       @q = Investor.ransack params[:q]
-      @pagy_object, @investors = pagy @q.result.includes(account: [:owner]), pagy_defaults
+      @investors = API::Filterer.new(@q.result, filter_params.to_h).call
+      @pagy_object, @investors = pagy @investors.includes(account: [:owner]), pagy_defaults
+    end
+
+    private
+
+    def filter_params
+      params.fetch(:filter, {}).permit :full_text
     end
   end
 end

--- a/backend/app/controllers/backoffice/project_developers_controller.rb
+++ b/backend/app/controllers/backoffice/project_developers_controller.rb
@@ -2,7 +2,14 @@ module Backoffice
   class ProjectDevelopersController < BaseController
     def index
       @q = ProjectDeveloper.ransack params[:q]
-      @pagy_object, @project_developers = pagy @q.result.includes(account: [:owner]), pagy_defaults
+      @project_developers = API::Filterer.new(@q.result, filter_params.to_h).call
+      @pagy_object, @project_developers = pagy @project_developers.includes(account: [:owner]), pagy_defaults
+    end
+
+    private
+
+    def filter_params
+      params.fetch(:filter, {}).permit :full_text
     end
   end
 end

--- a/backend/app/models/concerns/searchable.rb
+++ b/backend/app/models/concerns/searchable.rb
@@ -3,6 +3,12 @@ module Searchable
   include PgSearch::Model
 
   included do
-    pg_search_scope :dynamic_search, ->(columns, query) { {against: columns, query: query} }
+    pg_search_scope :dynamic_search, ->(columns, query, associated_against) do
+      {
+        against: columns,
+        query: query,
+        associated_against: associated_against
+      }
+    end
   end
 end

--- a/backend/app/services/api/filterer.rb
+++ b/backend/app/services/api/filterer.rb
@@ -35,10 +35,10 @@ module API
     def apply_full_text_filter
       return query if filters[:full_text].blank?
 
-      extra_ids = Array.wrap(FULL_TEXT_EXTRA_TABLES[query.klass]).map do |relation|
-        full_text_record_ids_for relation.to_s.classify.constantize, attr: "#{relation}_id"
-      end.flatten
-      self.query = query.where(id: extra_ids + full_text_record_ids_for(query.klass))
+      associated_columns = Array.wrap(FULL_TEXT_EXTRA_TABLES[query.klass]).each_with_object({}) do |relation, res|
+        res[relation] = localized_columns_for relation.to_s.classify.constantize
+      end
+      self.query = query.where id: query.dynamic_search(localized_columns_for(query.klass), filters[:full_text], associated_columns).pluck(:id)
     end
 
     def apply_numerical_filter
@@ -61,12 +61,9 @@ module API
       self.query = query.where trusted: true
     end
 
-    def full_text_record_ids_for(klass, attr: "id")
+    def localized_columns_for(klass)
       columns = (klass.translatable_attributes & FULL_TEXT_FILTERS).map { |key| "#{key}_#{language}" }
-      columns = (columns + FULL_TEXT_FILTERS.map(&:to_s)) & klass.column_names
-      return [] if columns.blank?
-
-      query.klass.where(attr => klass.dynamic_search(columns, filters[:full_text]).pluck(:id)).pluck(:id)
+      (columns + FULL_TEXT_FILTERS.map(&:to_s)) & klass.column_names
     end
 
     def pluralize(hash)

--- a/backend/app/views/backoffice/investors/index.html.erb
+++ b/backend/app/views/backoffice/investors/index.html.erb
@@ -1,3 +1,5 @@
+<%= render partial: "backoffice/shared/full_text_filter", locals: { resource_url: backoffice_investors_path } %>
+
 <table class="backoffice-table">
   <thead>
     <tr>

--- a/backend/app/views/backoffice/project_developers/index.html.erb
+++ b/backend/app/views/backoffice/project_developers/index.html.erb
@@ -1,3 +1,5 @@
+<%= render partial: "backoffice/shared/full_text_filter", locals: { resource_url: backoffice_project_developers_path } %>
+
 <table class="backoffice-table">
   <thead>
     <tr>

--- a/backend/app/views/backoffice/shared/_full_text_filter.html.erb
+++ b/backend/app/views/backoffice/shared/_full_text_filter.html.erb
@@ -1,0 +1,12 @@
+<div class="w-60">
+  <%= simple_form_for :filter, url: resource_url, method: :get do |f| %>
+    <div class="relative w-full">
+      <%= f.input :full_text, placeholder: I18n.t("backoffice.common.search_placeholder"), required: false, label: false, input_html: { class:"z-20 pr-15", value: params.dig(:filter, :full_text) } %>
+      <%= button_tag type: :submit, class: "absolute top-0 right-0 p-2.5 text-white bg-green-dark rounded-r-lg border border-solid border-beige" do %>
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+        </svg>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -14,6 +14,7 @@ zu:
       mosaic: Mosaic
       verified: Verified
       unverified: Unverified
+      search_placeholder: Search
       navigation:
         prev: "←"
         next: "→"

--- a/backend/spec/support/shared_examples/models/searchable.rb
+++ b/backend/spec/support/shared_examples/models/searchable.rb
@@ -7,7 +7,7 @@ RSpec.shared_examples :searchable do
     let!(:searched_record_wrong) { create factory, attribute => "WRONG" }
 
     it "finds correct records" do
-      expect(described_class.dynamic_search([attribute], "CORRECT")).to eq([searched_record_correct])
+      expect(described_class.dynamic_search([attribute], "CORRECT", {})).to eq([searched_record_correct])
     end
   end
 end

--- a/backend/spec/system/backoffice/investors_spec.rb
+++ b/backend/spec/system/backoffice/investors_spec.rb
@@ -58,5 +58,16 @@ RSpec.describe "Backoffice: Investors", type: :system do
         end
       end
     end
+
+    context "when searching" do
+      it "shows only found investors" do
+        expect(page).to have_text("Super Investor Enterprise")
+        expect(page).to have_text("Unapproved Investor Enterprise")
+        fill_in :filter_full_text, with: "Super Investor Enterprise"
+        find("form.simple_form.filter button").click
+        expect(page).to have_text("Super Investor Enterprise")
+        expect(page).not_to have_text("Unapproved Investor Enterprise")
+      end
+    end
   end
 end

--- a/backend/spec/system/backoffice/project_developers_spec.rb
+++ b/backend/spec/system/backoffice/project_developers_spec.rb
@@ -54,5 +54,16 @@ RSpec.describe "Backoffice: Project Developers", type: :system do
         end
       end
     end
+
+    context "when searching" do
+      it "shows only found project developers" do
+        expect(page).to have_text("Super PD Enterprise")
+        expect(page).to have_text("Unapproved PD Enterprise")
+        fill_in :filter_full_text, with: "Super PD Enterprise"
+        find("form.simple_form.filter button").click
+        expect(page).to have_text("Super PD Enterprise")
+        expect(page).not_to have_text("Unapproved PD Enterprise")
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR adds searching input to Investor and PD page at Backoffice. For searching itself, I have reused same service used by FE at our API.

Note: I have discovered that pg_search gem supports `associated_against` param, which makes easier to do full text search at other associated tables. I have slightly tweaked backend/app/services/api/filterer.rb to reflect this, so it is much easier to add other extra tables to full text searching at future.

![Screenshot 2022-06-06 at 14 41 41](https://user-images.githubusercontent.com/20660167/172166725-d048ffab-c2e3-489b-844d-8a62aaca6ef4.png)

## Testing instructions

This one should be simple, just open Backoffice and try to search some Investors or PDs. Searching should work same way as it works for FE.

## Tracking

https://vizzuality.atlassian.net/browse/LET-506
https://vizzuality.atlassian.net/browse/LET-563
