### PR TITLE
feat: Filtering by status at Backoffice

### DIFF
--- a/backend/app/controllers/backoffice/investors_controller.rb
+++ b/backend/app/controllers/backoffice/investors_controller.rb
@@ -2,14 +2,8 @@ module Backoffice
   class InvestorsController < BaseController
     def index
       @q = Investor.ransack params[:q]
-      @investors = API::Filterer.new(@q.result, filter_params.to_h).call
+      @investors = API::Filterer.new(@q.result, {full_text: params.dig(:q, :filter_full_text)}).call
       @pagy_object, @investors = pagy @investors.includes(account: [:owner]), pagy_defaults
-    end
-
-    private
-
-    def filter_params
-      params.fetch(:filter, {}).permit :full_text
     end
   end
 end

--- a/backend/app/controllers/backoffice/project_developers_controller.rb
+++ b/backend/app/controllers/backoffice/project_developers_controller.rb
@@ -2,14 +2,8 @@ module Backoffice
   class ProjectDevelopersController < BaseController
     def index
       @q = ProjectDeveloper.ransack params[:q]
-      @project_developers = API::Filterer.new(@q.result, filter_params.to_h).call
+      @project_developers = API::Filterer.new(@q.result, {full_text: params.dig(:q, :filter_full_text)}).call
       @pagy_object, @project_developers = pagy @project_developers.includes(account: [:owner]), pagy_defaults
-    end
-
-    private
-
-    def filter_params
-      params.fetch(:filter, {}).permit :full_text
     end
   end
 end

--- a/backend/app/controllers/backoffice/projects_controller.rb
+++ b/backend/app/controllers/backoffice/projects_controller.rb
@@ -2,8 +2,8 @@ module Backoffice
   class ProjectsController < BaseController
     def index
       @q = Project.ransack params[:q]
-      @projects = @q.result.includes(:priority_landscape, project_developer: [:account])
-      @pagy_object, @projects = pagy @projects, pagy_defaults
+      @projects = API::Filterer.new(@q.result, {full_text: params.dig(:q, :filter_full_text)}).call
+      @pagy_object, @projects = pagy @projects.includes(:priority_landscape, project_developer: [:account]), pagy_defaults
     end
   end
 end

--- a/backend/app/services/api/filterer.rb
+++ b/backend/app/services/api/filterer.rb
@@ -38,7 +38,8 @@ module API
       associated_columns = Array.wrap(FULL_TEXT_EXTRA_TABLES[query.klass]).each_with_object({}) do |relation, res|
         res[relation] = localized_columns_for relation.to_s.classify.constantize
       end
-      self.query = query.where id: query.dynamic_search(localized_columns_for(query.klass), filters[:full_text], associated_columns).pluck(:id)
+      ids = query.klass.dynamic_search(localized_columns_for(query.klass), filters[:full_text], associated_columns).pluck(:id)
+      self.query = query.where id: ids
     end
 
     def apply_numerical_filter

--- a/backend/app/views/backoffice/investors/index.html.erb
+++ b/backend/app/views/backoffice/investors/index.html.erb
@@ -1,4 +1,10 @@
-<%= render partial: "backoffice/shared/full_text_filter", locals: { resource_url: backoffice_investors_path } %>
+<%= render "backoffice/shared/filters", q: @q do |f| %>
+  <%= render partial: "backoffice/shared/full_text_filter", locals: { f: f } %>
+  <div class="w-30 inline-block mx-3">
+    <%= f.input :account_review_status_eq, as: :select, required: false, label: false, prompt: I18n.t("backoffice.common.status"),
+                collection: Account.review_statuses.map { |k, v| [I18n.t("activerecord.attributes.account.review_statuses.#{k}"), v] } %>
+  </div>
+<% end %>
 
 <table class="backoffice-table">
   <thead>

--- a/backend/app/views/backoffice/project_developers/index.html.erb
+++ b/backend/app/views/backoffice/project_developers/index.html.erb
@@ -1,4 +1,10 @@
-<%= render partial: "backoffice/shared/full_text_filter", locals: { resource_url: backoffice_project_developers_path } %>
+<%= render "backoffice/shared/filters", q: @q do |f| %>
+  <%= render partial: "backoffice/shared/full_text_filter", locals: { f: f } %>
+  <div class="w-30 inline-block mx-3">
+    <%= f.input :account_review_status_eq, as: :select, required: false, label: false, prompt: I18n.t("backoffice.common.status"),
+                collection: Account.review_statuses.map { |k, v| [I18n.t("activerecord.attributes.account.review_statuses.#{k}"), v] } %>
+  </div>
+<% end %>
 
 <table class="backoffice-table">
   <thead>

--- a/backend/app/views/backoffice/projects/index.html.erb
+++ b/backend/app/views/backoffice/projects/index.html.erb
@@ -1,3 +1,11 @@
+<%= render "backoffice/shared/filters", q: @q do |f| %>
+  <%= render partial: "backoffice/shared/full_text_filter", locals: { f: f } %>
+  <div class="w-30 inline-block mx-3">
+    <%= f.input :status_eq, as: :select, required: false, label: false, prompt: I18n.t("backoffice.common.status"),
+                collection: Project.statuses.map { |k, v| [I18n.t("activerecord.attributes.project.statuses.#{k}"), v] } %>
+  </div>
+<% end %>
+
 <table class="backoffice-table">
   <thead>
     <tr>

--- a/backend/app/views/backoffice/shared/_filters.html.erb
+++ b/backend/app/views/backoffice/shared/_filters.html.erb
@@ -1,0 +1,8 @@
+<div class="w-full">
+  <%= search_form_for [:backoffice, q], builder: SimpleForm::FormBuilder do |f| %>
+    <%= yield(f) if yield(f).present? %>
+    <div class="inline-block">
+      <%= f.button :submit, value: I18n.t("backoffice.common.apply"), class: "bg-beige text-green-dark border border-solid border-green-dark hover:text-green-dark" %>
+    </div>
+  <% end %>
+</div>

--- a/backend/app/views/backoffice/shared/_full_text_filter.html.erb
+++ b/backend/app/views/backoffice/shared/_full_text_filter.html.erb
@@ -1,12 +1,8 @@
-<div class="w-60">
-  <%= simple_form_for :filter, url: resource_url, method: :get do |f| %>
-    <div class="relative w-full">
-      <%= f.input :full_text, placeholder: I18n.t("backoffice.common.search_placeholder"), required: false, label: false, input_html: { class:"z-20 pr-15", value: params.dig(:filter, :full_text) } %>
-      <%= button_tag type: :submit, class: "absolute top-0 right-0 p-2.5 text-white bg-green-dark rounded-r-lg border border-solid border-beige" do %>
-        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
-        </svg>
-      <% end %>
-    </div>
+<div class="inline-block relative w-60">
+  <%= f.input :filter_full_text, placeholder: I18n.t("backoffice.common.search_placeholder"), required: false, label: false, input_html: { class:"z-20 pr-15", value: params.dig(:q, :filter_full_text) } %>
+  <%= button_tag type: :submit, class: "absolute top-0 right-0 p-2.5 text-white bg-green-dark rounded-r-lg border border-solid border-beige" do %>
+    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+    </svg>
   <% end %>
 </div>

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -1,4 +1,16 @@
 zu:
+  activerecord:
+    attributes:
+      account:
+        review_statuses:
+          unapproved: Unapproved
+          approved: Approved
+          rejected: Rejected
+      project:
+        statuses:
+          draft: Unverified
+          published: Published
+          closed: Closed
   backoffice:
     common:
       account_owner: Account owner
@@ -15,6 +27,7 @@ zu:
       verified: Verified
       unverified: Unverified
       search_placeholder: Search
+      apply: Apply
       navigation:
         prev: "←"
         next: "→"

--- a/backend/spec/system/backoffice/investors_spec.rb
+++ b/backend/spec/system/backoffice/investors_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe "Backoffice: Investors", type: :system do
   let(:admin) { create(:admin, email: "admin@example.com", password: "SuperSecret6", first_name: "Admin", last_name: "Example") }
   let(:approved_investor_owner) { create(:user, :investor, first_name: "Tom", last_name: "Higgs") }
   let(:unapproved_investor_owner) { create(:user, :investor, first_name: "John", last_name: "Levis") }
-  let!(:approved_pd) {
+  let!(:approved_investor) {
     create(:investor, account: build(:account, :approved, name: "Super Investor Enterprise", owner: approved_investor_owner))
   }
-  let!(:unapproved_pd) {
+  let!(:unapproved_investor) {
     create(:investor, account: build(:account, :unapproved, name: "Unapproved Investor Enterprise", owner: unapproved_investor_owner))
   }
 
@@ -63,10 +63,21 @@ RSpec.describe "Backoffice: Investors", type: :system do
       it "shows only found investors" do
         expect(page).to have_text("Super Investor Enterprise")
         expect(page).to have_text("Unapproved Investor Enterprise")
-        fill_in :filter_full_text, with: "Super Investor Enterprise"
-        find("form.simple_form.filter button").click
+        fill_in :q_filter_full_text, with: "Super Investor Enterprise"
+        find("form.investor_search button").click
         expect(page).to have_text("Super Investor Enterprise")
         expect(page).not_to have_text("Unapproved Investor Enterprise")
+      end
+    end
+
+    context "when searching by ransack filter" do
+      it "returns records at correct state" do
+        expect(page).to have_text(approved_investor.name)
+        expect(page).to have_text(unapproved_investor.name)
+        select t("activerecord.attributes.account.review_statuses.approved"), from: :q_account_review_status_eq
+        click_on t("backoffice.common.apply")
+        expect(page).to have_text(approved_investor.name)
+        expect(page).not_to have_text(unapproved_investor.name)
       end
     end
   end

--- a/backend/spec/system/backoffice/project_developers_spec.rb
+++ b/backend/spec/system/backoffice/project_developers_spec.rb
@@ -59,10 +59,21 @@ RSpec.describe "Backoffice: Project Developers", type: :system do
       it "shows only found project developers" do
         expect(page).to have_text("Super PD Enterprise")
         expect(page).to have_text("Unapproved PD Enterprise")
-        fill_in :filter_full_text, with: "Super PD Enterprise"
-        find("form.simple_form.filter button").click
+        fill_in :q_filter_full_text, with: "Super PD Enterprise"
+        find("form.project_developer_search button").click
         expect(page).to have_text("Super PD Enterprise")
         expect(page).not_to have_text("Unapproved PD Enterprise")
+      end
+    end
+
+    context "when searching by ransack filter" do
+      it "returns records at correct state" do
+        expect(page).to have_text(approved_pd.name)
+        expect(page).to have_text(unapproved_pd.name)
+        select t("activerecord.attributes.account.review_statuses.approved"), from: :q_account_review_status_eq
+        click_on t("backoffice.common.apply")
+        expect(page).to have_text(approved_pd.name)
+        expect(page).not_to have_text(unapproved_pd.name)
       end
     end
   end

--- a/backend/spec/system/backoffice/projects_spec.rb
+++ b/backend/spec/system/backoffice/projects_spec.rb
@@ -38,5 +38,29 @@ RSpec.describe "Backoffice: Projects", type: :system do
         expect(page).to have_text(I18n.t("backoffice.common.verified"))
       end
     end
+
+    context "when searching" do
+      it "shows only found projects" do
+        expect(page).to have_text(project.name)
+        projects.each { |p| expect(page).to have_text(p.name) }
+        fill_in :q_filter_full_text, with: project.name
+        find("form.project_search button").click
+        expect(page).to have_text(project.name)
+        projects.each { |p| expect(page).not_to have_text(p.name) }
+      end
+    end
+
+    context "when searching by ransack filter" do
+      before { project.published! }
+
+      it "returns records at correct state" do
+        expect(page).to have_text(project.name)
+        projects.each { |p| expect(page).to have_text(p.name) }
+        select t("activerecord.attributes.project.statuses.published"), from: :q_status_eq
+        click_on t("backoffice.common.apply")
+        expect(page).to have_text(project.name)
+        projects.each { |p| expect(page).not_to have_text(p.name) }
+      end
+    end
   end
 end


### PR DESCRIPTION
Adding possibility to filter Projects, PDs and Investors by Status. I have again taken huge inspiration from Tota project ;) and moved full_text filter inside `search_form_for` formular so searching and filters are part of same form.

Styles are really simplified, for example for dropdown, I have used simple selectbox which should be fine from tech point of view and can be replaced later on by something more fancy...

![Screenshot 2022-06-07 at 12 31 55](https://user-images.githubusercontent.com/20660167/172364218-bd1fb2f6-e411-4468-a4fa-ea7aff1effcd.png)

## Testing instructions

Open Backoffice and try to filter by Status Projects, PDs and Investors one by one.

## Tracking

https://vizzuality.atlassian.net/browse/LET-505
https://vizzuality.atlassian.net/browse/LET-531
https://vizzuality.atlassian.net/browse/LET-532
https://vizzuality.atlassian.net/browse/LET-564
