### PR TITLE
fix: increase waiting times at system test helper

### DIFF
--- a/backend/spec/system_helper.rb
+++ b/backend/spec/system_helper.rb
@@ -11,8 +11,9 @@ Capybara.register_driver(:cuprite) do |app|
     browser_options: {
       "no-sandbox": nil
     },
+    timeout: 15,
     # Increase Chrome startup wait time (required for stable CI builds)
-    process_timeout: 15,
+    process_timeout: 30,
     inspector: true,
     headless: ENV["HEADLESS"] != "false"
   )


### PR DESCRIPTION
System tests sometimes crash with:
```
Browser did not produce websocket url within 10 seconds, try to increase `:process_timeout`. See https://github.com/rubycdp/ferrum#customization
Ferrum::TimeoutError
Ferrum::TimeoutError
```
Lets see if increasing waiting times helps :)