### PR TITLE
feat: Total count of Projects/PDs/Investors at backoffice

### DIFF
--- a/backend/app/views/backoffice/base/_full_text_filter.html.erb
+++ b/backend/app/views/backoffice/base/_full_text_filter.html.erb
@@ -1,4 +1,4 @@
-<div class="inline-block relative w-60">
+<div class="inline-block relative w-60 mr-3">
   <%= f.input :filter_full_text, placeholder: I18n.t("backoffice.common.search_placeholder"), required: false, label: false, input_html: { class:"z-20 pr-15", value: params.dig(:q, :filter_full_text) } %>
   <%= button_tag type: :submit, class: "absolute top-0 right-0 p-2.5 text-white bg-green-dark rounded-r-lg border border-solid border-beige" do %>
     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">

--- a/backend/app/views/backoffice/base/_total_records.html.erb
+++ b/backend/app/views/backoffice/base/_total_records.html.erb
@@ -1,0 +1,6 @@
+<div class="min-w-fit flex items-center mb-4 mr-1 font-sans pagination-total-number">
+  <div class="text-gray-800">
+    <span class="mr-1"><%= t("backoffice.common.total") %></span>
+    <span class="font-semibold"><%= @pagy_object.count %></span>
+  </div>
+</div>

--- a/backend/app/views/backoffice/investors/index.html.erb
+++ b/backend/app/views/backoffice/investors/index.html.erb
@@ -1,4 +1,7 @@
-<%= render partial: "filters", locals: {q: @q} %>
+<div class="flex">
+  <%= render partial: "filters", locals: {q: @q} %>
+  <%= render partial: "backoffice/base/total_records" %>
+</div>
 
 <table class="backoffice-table">
   <thead>

--- a/backend/app/views/backoffice/project_developers/index.html.erb
+++ b/backend/app/views/backoffice/project_developers/index.html.erb
@@ -1,4 +1,7 @@
-<%= render partial: "filters", locals: {q: @q} %>
+<div class="flex">
+  <%= render partial: "filters", locals: {q: @q} %>
+  <%= render partial: "backoffice/base/total_records" %>
+</div>
 
 <table class="backoffice-table">
   <thead>

--- a/backend/app/views/backoffice/projects/_filters.html.erb
+++ b/backend/app/views/backoffice/projects/_filters.html.erb
@@ -1,13 +1,13 @@
 <%= render "backoffice/base/filters", q: q do |f| %>
   <%= render partial: "backoffice/base/full_text_filter", locals: { f: f } %>
-  <div class="w-30 inline-block mx-3">
+  <div class="w-30 inline-block mr-3">
     <%= f.input :trusted_eq, as: :select, required: false, label: false, include_blank: I18n.t("backoffice.common.status"),
                 collection: [[t("backoffice.common.verified"), true], [t("backoffice.common.unverified"), false]] %>
   </div>
-  <div class="w-30 inline-block">
+  <div class="w-30 inline-block mr-3">
     <%= f.input :category_eq, as: :select, required: false, label: false, include_blank: I18n.t("backoffice.common.category"), collection: Category.all.sort_by(&:name) %>
   </div>
-  <div class="w-30 inline-block mx-3">
+  <div class="w-30 inline-block mr-3">
     <%= f.input :priority_landscape_id_eq, as: :select, required: false, label: false, include_blank: I18n.t("backoffice.projects.index.priority_landscape"), collection: Location.region.sort_by(&:name) %>
   </div>
 <% end %>

--- a/backend/app/views/backoffice/projects/index.html.erb
+++ b/backend/app/views/backoffice/projects/index.html.erb
@@ -1,4 +1,7 @@
-<%= render partial: "filters", locals: {q: @q} %>
+<div class="flex">
+  <%= render partial: "filters", locals: {q: @q} %>
+  <%= render partial: "backoffice/base/total_records" %>
+</div>
 
 <table class="backoffice-table">
   <thead>

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -22,8 +22,9 @@ zu:
       verified: Verified
       unverified: Unverified
       search_placeholder: Search
-      apply: Apply filters
-      reset: Reset filters
+      apply: Apply
+      reset: Reset
+      total: Total
       navigation:
         prev: "←"
         next: "→"

--- a/backend/spec/support/shared_examples/backoffice/with_table_pagination.rb
+++ b/backend/spec/support/shared_examples/backoffice/with_table_pagination.rb
@@ -1,8 +1,15 @@
-RSpec.shared_examples "with table pagination" do
+RSpec.shared_examples "with table pagination" do |expected_total:|
   describe "Paginated" do
     it "shows page navigation" do
       within ".pagination .active" do
         expect(page).to have_text("1")
+      end
+    end
+
+    it "shows total number of records" do
+      within "div.pagination-total-number" do
+        expect(page).to have_text(t("backoffice.common.total"))
+        expect(page).to have_text(expected_total)
       end
     end
   end

--- a/backend/spec/system/backoffice/investors_spec.rb
+++ b/backend/spec/system/backoffice/investors_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Backoffice: Investors", type: :system do
   describe "Index" do
     before { visit "/backoffice/investors" }
 
-    it_behaves_like "with table pagination"
+    it_behaves_like "with table pagination", expected_total: 2
     it_behaves_like "with table sorting", columns: [
       I18n.t("backoffice.common.name"),
       I18n.t("backoffice.common.account_owner"),

--- a/backend/spec/system/backoffice/project_developers_spec.rb
+++ b/backend/spec/system/backoffice/project_developers_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Backoffice: Project Developers", type: :system do
   describe "Index" do
     before { visit "/backoffice/project_developers" }
 
-    it_behaves_like "with table pagination"
+    it_behaves_like "with table pagination", expected_total: 2
     it_behaves_like "with table sorting", columns: [
       I18n.t("backoffice.common.name"),
       I18n.t("backoffice.common.account_owner"),

--- a/backend/spec/system/backoffice/projects_spec.rb
+++ b/backend/spec/system/backoffice/projects_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Backoffice: Projects", type: :system do
   describe "Index" do
     before { visit "/backoffice/projects" }
 
-    it_behaves_like "with table pagination"
+    it_behaves_like "with table pagination", expected_total: 5
     it_behaves_like "with table sorting", columns: [
       I18n.t("backoffice.common.project_name"),
       I18n.t("backoffice.common.project_developer"),


### PR DESCRIPTION
I am adding partial with Total number of records which is used by Project/PD/Investor pages.

![Screenshot 2022-06-09 at 13 13 13](https://user-images.githubusercontent.com/20660167/172836575-e37061ee-e221-4b33-9930-341cf72aa694.png)

## Testing instructions

Open backoffice and check that number of records correspond to Total number displayed above every table.

## Tracking

https://vizzuality.atlassian.net/browse/LET-537
https://vizzuality.atlassian.net/browse/LET-556
https://vizzuality.atlassian.net/browse/LET-557
