### PR TITLE
feat: Adding Phone and Email to Investor/PD table

### DIFF
--- a/backend/app/views/backoffice/investors/index.html.erb
+++ b/backend/app/views/backoffice/investors/index.html.erb
@@ -10,6 +10,12 @@
         <%= sort_link @q, :account_owner_full_name, t("backoffice.common.account_owner") %>
       </th>
       <th>
+        <%= sort_link @q, :account_contact_email, t("backoffice.common.contact_email") %>
+      </th>
+      <th>
+        <%= sort_link @q, :account_contact_phone, t("backoffice.common.contact_phone") %>
+      </th>
+      <th>
         <%= sort_link @q, :account_users_count, t("backoffice.common.account_users") %>
       </th>
       <th>
@@ -30,6 +36,8 @@
       <tr>
         <td><%= investor.name %></td>
         <td><%= investor.account.owner.full_name %></td>
+        <td><%= investor.contact_email %></td>
+        <td><%= investor.contact_phone %></td>
         <td><%= investor.account.users_count %></td>
         <td><%= investor.open_calls_count %></td>
         <td><%= investor.language %></td>

--- a/backend/app/views/backoffice/project_developers/index.html.erb
+++ b/backend/app/views/backoffice/project_developers/index.html.erb
@@ -10,6 +10,12 @@
         <%= sort_link @q, :account_owner_full_name, t("backoffice.common.account_owner") %>
       </th>
       <th>
+        <%= sort_link @q, :account_contact_email, t("backoffice.common.contact_email") %>
+      </th>
+      <th>
+        <%= sort_link @q, :account_contact_phone, t("backoffice.common.contact_phone") %>
+      </th>
+      <th>
         <%= sort_link @q, :account_users_count, t("backoffice.common.account_users") %>
       </th>
       <th>
@@ -30,6 +36,8 @@
       <tr>
         <td><%= pd.name %></td>
         <td><%= pd.account.owner.full_name %></td>
+        <td><%= pd.contact_email %></td>
+        <td><%= pd.contact_phone %></td>
         <td><%= pd.account.users_count %></td>
         <td><%= pd.projects_count %></td>
         <td><%= pd.language %></td>

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -15,6 +15,8 @@ zu:
       status: Status
       approve: Approve
       reject: Reject
+      contact_email: Email
+      contact_phone: Phone
       project_name: Project name
       project_developer: Project developer
       category: Category

--- a/backend/spec/system/backoffice/investors_spec.rb
+++ b/backend/spec/system/backoffice/investors_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe "Backoffice: Investors", type: :system do
     it_behaves_like "with table sorting", columns: [
       I18n.t("backoffice.common.name"),
       I18n.t("backoffice.common.account_owner"),
+      I18n.t("backoffice.common.contact_email"),
+      I18n.t("backoffice.common.contact_phone"),
       I18n.t("backoffice.common.account_users"),
       I18n.t("backoffice.investors.index.open_calls"),
       I18n.t("backoffice.common.language"),
@@ -30,6 +32,8 @@ RSpec.describe "Backoffice: Investors", type: :system do
       within_row("Super Investor Enterprise") do
         expect(page).to have_text("Tom Higgs")
         expect(page).to have_text("approved")
+        expect(page).to have_text(approved_investor.contact_email)
+        expect(page).to have_text(approved_investor.contact_phone)
       end
       within_row("Unapproved Investor Enterprise") do
         expect(page).to have_text("John Levis")

--- a/backend/spec/system/backoffice/project_developers_spec.rb
+++ b/backend/spec/system/backoffice/project_developers_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe "Backoffice: Project Developers", type: :system do
     it_behaves_like "with table sorting", columns: [
       I18n.t("backoffice.common.name"),
       I18n.t("backoffice.common.account_owner"),
+      I18n.t("backoffice.common.contact_email"),
+      I18n.t("backoffice.common.contact_phone"),
       I18n.t("backoffice.common.account_users"),
       I18n.t("backoffice.project_developers.index.projects"),
       I18n.t("backoffice.common.language"),
@@ -26,6 +28,8 @@ RSpec.describe "Backoffice: Project Developers", type: :system do
       within_row("Super PD Enterprise") do
         expect(page).to have_text("Tom Higgs")
         expect(page).to have_text("approved")
+        expect(page).to have_text(approved_pd.contact_email)
+        expect(page).to have_text(approved_pd.contact_phone)
       end
       within_row("Unapproved PD Enterprise") do
         expect(page).to have_text("John Levis")


### PR DESCRIPTION
Simple PR which adds contact email and contact phone to Investor and PD backoffice tables.

![Screenshot 2022-06-09 at 14 15 06](https://user-images.githubusercontent.com/20660167/172844775-3849a973-52d4-4f9b-9ec2-c3a758623b28.png)

## Testing instructions

Just double check that contact email and contact phone is visible at Investor and PD tables. Both new columns should be sortable ;).

## Tracking

https://vizzuality.atlassian.net/browse/LET-568