### PR TITLE
bug: fix project page bug.

### DIFF
--- a/frontend/containers/project-page/developers/component.tsx
+++ b/frontend/containers/project-page/developers/component.tsx
@@ -11,8 +11,15 @@ import { Paths } from 'enums';
 export const ProjectDevelopers: React.FC<ProjectDevelopersProps> = ({
   project,
 }: ProjectDevelopersProps) => {
-  const { project_developer: mainDeveloper, involved_project_developers: developers } = project;
-  const NUMBER_DEVELOPERS = developers.length;
+  const { project_developer: mainDeveloper, involved_project_developers } = project;
+  // If the involved_project_developers have just the project_developer (same id), the JSONA parsing returns a reference of the project_developer, so it doesn't have propoerties.
+  //   involved_project_developers: [{
+  //     "$ref": "$[\"project_developer\"]"
+  // }]
+  // So  we have to filter the involved_project_developers that have properties to have the ones that are not the main project developer.
+  const developers = involved_project_developers?.filter(({ id }) => id);
+  // The involved_projectDevelpers + the  project_developer
+  const NUMBER_DEVELOPERS = developers.length + 1;
 
   return (
     <section className="bg-background-middle py-18">
@@ -46,14 +53,14 @@ export const ProjectDevelopers: React.FC<ProjectDevelopersProps> = ({
             />
           )}
           {!!NUMBER_DEVELOPERS &&
-            developers.map((developer) => {
+            developers?.map((developer) => {
               const { about, name, picture, project_developer_type, id, slug } = developer;
               return (
                 <ProfileCard
                   className="w-full"
                   key={id}
                   link={`${Paths.ProjectDeveloper}/${slug}`}
-                  picture={picture.small}
+                  picture={picture?.small || ''}
                   name={name}
                   description={about}
                   type={project_developer_type}

--- a/frontend/containers/project-page/developers/component.tsx
+++ b/frontend/containers/project-page/developers/component.tsx
@@ -11,67 +11,46 @@ import { Paths } from 'enums';
 export const ProjectDevelopers: React.FC<ProjectDevelopersProps> = ({
   project,
 }: ProjectDevelopersProps) => {
-  const { project_developer: mainDeveloper, involved_project_developers } = project;
-  // If the involved_project_developers have just the project_developer (same id), the JSONA parsing returns a reference of the project_developer, so it doesn't have propoerties.
-  //   involved_project_developers: [{
-  //     "$ref": "$[\"project_developer\"]"
-  // }]
-  // So  we have to filter the involved_project_developers that have properties to have the ones that are not the main project developer.
-  const developers = involved_project_developers?.filter(({ id }) => id);
-  // The involved_projectDevelpers + the  project_developer
-  const NUMBER_DEVELOPERS = developers.length + 1;
+  const allDevelopers = [project.project_developer, ...project.involved_project_developers].filter(
+    // Occasionally, the (involved_project_developers) relationship is not returned correctly, causing
+    // the frontend to crash. In order to make it more resilient, we're making this check to ensure
+    // that we do have the relationship before attempting to use its data to show the PD cards.
+    ({ type }) => type === 'project_developer'
+  );
 
   return (
     <section className="bg-background-middle py-18">
       <LayoutContainer className="flex flex-col lg:flex-row space-y-28 lg:space-y-0 lg:space-x-28">
         <div className="flex flex-col pl-6 space-y-1 lg:pl-16">
-          <h2 className="font-serif text-2xl text-black lg:text-3xl">
+          <h2 className="font-serif text-2xl text-black lg:text-4xl lg:mb-4">
             <FormattedMessage defaultMessage="Project Developers" id="+K9fF0" />
           </h2>
           <p className="text-gray-800">
             <FormattedMessage
-              defaultMessage="This project has {numDevelopers} project developer{noun}"
-              id="CcFPkO"
+              defaultMessage="This project has {numDevelopers} {numDevelopers, plural, one {project developer} other {project developers}}."
+              id="MM4RqT"
               values={{
-                numDevelopers: NUMBER_DEVELOPERS,
-                noun: NUMBER_DEVELOPERS === 1 ? '' : 's',
+                numDevelopers: allDevelopers.length,
               }}
             />
           </p>
         </div>
         <div className="flex flex-col space-y-6">
-          {!!mainDeveloper && (
+          {allDevelopers.map(({ about, name, picture, project_developer_type, id, slug }) => (
             <ProfileCard
               className="w-full"
-              key={mainDeveloper.id}
-              link={`${Paths.ProjectDeveloper}/${mainDeveloper.slug}`}
-              picture={mainDeveloper.picture.small}
-              name={mainDeveloper.name}
-              description={mainDeveloper.about}
-              type={mainDeveloper.project_developer_type}
+              key={id}
+              link={`${Paths.ProjectDeveloper}/${slug}`}
+              picture={picture?.small}
+              name={name}
+              description={about}
+              type={project_developer_type}
               profileType="project-developer"
             />
-          )}
-          {!!NUMBER_DEVELOPERS &&
-            developers?.map((developer) => {
-              const { about, name, picture, project_developer_type, id, slug } = developer;
-              return (
-                <ProfileCard
-                  className="w-full"
-                  key={id}
-                  link={`${Paths.ProjectDeveloper}/${slug}`}
-                  picture={picture?.small || ''}
-                  name={name}
-                  description={about}
-                  type={project_developer_type}
-                  profileType="project-developer"
-                />
-              );
-            })}
+          ))}
         </div>
       </LayoutContainer>
     </section>
   );
 };
-
 export default ProjectDevelopers;


### PR DESCRIPTION
This PR fixes a bug on the project public page

The page was crashing because the jsona parsing on axios requests.
If the involved_project_developers was just the project_developer, the jsona creates a reference for the project_developer:
`involved_project_developers: [{
     "$ref": "$[\"project_developer\"]"
}]`
Because of that, it is not possible to access the involved_project_developers item id.


The endpoint returns it correctly 
`involved_project_developers: {data: [{id: "0139a6a2-a864-49a0-8f13-1065f929583b", type: "project_developer"}]}`

SOLUTION COPIED FROM https://github.com/Vizzuality/heco-invest/pull/249/files


## Testing instructions

The project pages do not crash
The project page displays a list of the project developers

## Tracking

[LET-356](https://vizzuality.atlassian.net/browse/LET-356)
