### PR TITLE
feat: Allow to export data as csv at backoffice

### DIFF
--- a/backend/app/controllers/backoffice/investors_controller.rb
+++ b/backend/app/controllers/backoffice/investors_controller.rb
@@ -10,7 +10,7 @@ module Backoffice
           @pagy_object, @investors = pagy @investors, pagy_defaults
         end
         format.csv do
-          send_data Backoffice::Csv::InvestorExporter.new(@investors).call,
+          send_data Backoffice::CSV::InvestorExporter.new(@investors).call,
             filename: "investors.csv",
             type: "text/csv; charset=utf-8"
         end

--- a/backend/app/controllers/backoffice/investors_controller.rb
+++ b/backend/app/controllers/backoffice/investors_controller.rb
@@ -3,7 +3,18 @@ module Backoffice
     def index
       @q = Investor.ransack params[:q]
       @investors = API::Filterer.new(@q.result, {full_text: params.dig(:q, :filter_full_text)}).call
-      @pagy_object, @investors = pagy @investors.includes(account: [:owner]), pagy_defaults
+      @investors = @investors.includes(account: [:owner])
+
+      respond_to do |format|
+        format.html do
+          @pagy_object, @investors = pagy @investors, pagy_defaults
+        end
+        format.csv do
+          send_data Backoffice::Csv::InvestorExporter.new(@investors).call,
+            filename: "investors.csv",
+            type: "text/csv; charset=utf-8"
+        end
+      end
     end
   end
 end

--- a/backend/app/controllers/backoffice/project_developers_controller.rb
+++ b/backend/app/controllers/backoffice/project_developers_controller.rb
@@ -18,7 +18,7 @@ module Backoffice
           @pagy_object, @project_developers = pagy @project_developers, pagy_defaults
         end
         format.csv do
-          send_data Backoffice::Csv::ProjectDeveloperExporter.new(@project_developers).call,
+          send_data Backoffice::CSV::ProjectDeveloperExporter.new(@project_developers).call,
             filename: "project_developers.csv",
             type: "text/csv; charset=utf-8"
         end

--- a/backend/app/controllers/backoffice/project_developers_controller.rb
+++ b/backend/app/controllers/backoffice/project_developers_controller.rb
@@ -11,7 +11,18 @@ module Backoffice
     def index
       @q = ProjectDeveloper.ransack params[:q]
       @project_developers = API::Filterer.new(@q.result, {full_text: params.dig(:q, :filter_full_text)}).call
-      @pagy_object, @project_developers = pagy @project_developers.includes(account: [:owner]), pagy_defaults
+      @project_developers = @project_developers.includes(account: [:owner])
+
+      respond_to do |format|
+        format.html do
+          @pagy_object, @project_developers = pagy @project_developers, pagy_defaults
+        end
+        format.csv do
+          send_data Backoffice::Csv::ProjectDeveloperExporter.new(@project_developers).call,
+            filename: "project_developers.csv",
+            type: "text/csv; charset=utf-8"
+        end
+      end
     end
 
     def edit

--- a/backend/app/controllers/backoffice/projects_controller.rb
+++ b/backend/app/controllers/backoffice/projects_controller.rb
@@ -10,7 +10,7 @@ module Backoffice
           @pagy_object, @projects = pagy @projects, pagy_defaults
         end
         format.csv do
-          send_data Backoffice::Csv::ProjectExporter.new(@projects).call,
+          send_data Backoffice::CSV::ProjectExporter.new(@projects).call,
             filename: "projects.csv",
             type: "text/csv; charset=utf-8"
         end

--- a/backend/app/controllers/backoffice/projects_controller.rb
+++ b/backend/app/controllers/backoffice/projects_controller.rb
@@ -3,7 +3,18 @@ module Backoffice
     def index
       @q = Project.ransack params[:q]
       @projects = API::Filterer.new(@q.result, {full_text: params.dig(:q, :filter_full_text)}).call
-      @pagy_object, @projects = pagy @projects.includes(:priority_landscape, project_developer: [:account]), pagy_defaults
+      @projects = @projects.includes(:priority_landscape, project_developer: [:account])
+
+      respond_to do |format|
+        format.html do
+          @pagy_object, @projects = pagy @projects, pagy_defaults
+        end
+        format.csv do
+          send_data Backoffice::Csv::ProjectExporter.new(@projects).call,
+            filename: "projects.csv",
+            type: "text/csv; charset=utf-8"
+        end
+      end
     end
   end
 end

--- a/backend/app/services/backoffice/csv/base_exporter.rb
+++ b/backend/app/services/backoffice/csv/base_exporter.rb
@@ -1,7 +1,7 @@
 require "csv"
 
 module Backoffice
-  module Csv
+  module CSV
     class BaseExporter
       attr_accessor :query, :columns
 
@@ -19,7 +19,7 @@ module Backoffice
         self.columns = []
         yield
 
-        CSV.generate do |csv|
+        ::CSV.generate do |csv|
           csv << columns.map { |column| column[:name] }
           query.each do |record|
             csv << columns.map { |column| column[:block].call record }

--- a/backend/app/services/backoffice/csv/base_exporter.rb
+++ b/backend/app/services/backoffice/csv/base_exporter.rb
@@ -1,0 +1,35 @@
+require "csv"
+
+module Backoffice
+  module Csv
+    class BaseExporter
+      attr_accessor :query, :columns
+
+      def initialize(query)
+        @query = query
+      end
+
+      def call
+        raise NotImplementedError
+      end
+
+      private
+
+      def generate_csv
+        self.columns = []
+        yield
+
+        CSV.generate do |csv|
+          csv << columns.map { |column| column[:name] }
+          query.each do |record|
+            csv << columns.map { |column| column[:block].call record }
+          end
+        end
+      end
+
+      def column(name, &block)
+        columns << {name: name, block: block}
+      end
+    end
+  end
+end

--- a/backend/app/services/backoffice/csv/investor_exporter.rb
+++ b/backend/app/services/backoffice/csv/investor_exporter.rb
@@ -1,5 +1,5 @@
 module Backoffice
-  module Csv
+  module CSV
     class InvestorExporter < BaseExporter
       def call
         generate_csv do

--- a/backend/app/services/backoffice/csv/investor_exporter.rb
+++ b/backend/app/services/backoffice/csv/investor_exporter.rb
@@ -1,0 +1,18 @@
+module Backoffice
+  module Csv
+    class InvestorExporter < BaseExporter
+      def call
+        generate_csv do
+          column(I18n.t("backoffice.common.name")) { |r| r.name }
+          column(I18n.t("backoffice.common.account_owner")) { |r| r.account.owner.full_name }
+          column(I18n.t("backoffice.common.contact_email")) { |r| r.contact_email }
+          column(I18n.t("backoffice.common.contact_phone")) { |r| r.contact_phone }
+          column(I18n.t("backoffice.common.account_users")) { |r| r.account.users_count }
+          column(I18n.t("backoffice.investors.index.open_calls")) { |r| r.open_calls_count }
+          column(I18n.t("backoffice.common.language")) { |r| r.language }
+          column(I18n.t("backoffice.common.status")) { |r| ReviewStatus.find(r.account.review_status).name }
+        end
+      end
+    end
+  end
+end

--- a/backend/app/services/backoffice/csv/project_developer_exporter.rb
+++ b/backend/app/services/backoffice/csv/project_developer_exporter.rb
@@ -1,0 +1,18 @@
+module Backoffice
+  module Csv
+    class ProjectDeveloperExporter < BaseExporter
+      def call
+        generate_csv do
+          column(I18n.t("backoffice.common.name")) { |r| r.name }
+          column(I18n.t("backoffice.common.account_owner")) { |r| r.account.owner.full_name }
+          column(I18n.t("backoffice.common.contact_email")) { |r| r.contact_email }
+          column(I18n.t("backoffice.common.contact_phone")) { |r| r.contact_phone }
+          column(I18n.t("backoffice.common.account_users")) { |r| r.account.users_count }
+          column(I18n.t("backoffice.project_developers.index.projects")) { |r| r.projects_count }
+          column(I18n.t("backoffice.common.language")) { |r| r.language }
+          column(I18n.t("backoffice.common.status")) { |r| ReviewStatus.find(r.account.review_status).name }
+        end
+      end
+    end
+  end
+end

--- a/backend/app/services/backoffice/csv/project_developer_exporter.rb
+++ b/backend/app/services/backoffice/csv/project_developer_exporter.rb
@@ -1,5 +1,5 @@
 module Backoffice
-  module Csv
+  module CSV
     class ProjectDeveloperExporter < BaseExporter
       def call
         generate_csv do

--- a/backend/app/services/backoffice/csv/project_exporter.rb
+++ b/backend/app/services/backoffice/csv/project_exporter.rb
@@ -1,0 +1,17 @@
+module Backoffice
+  module Csv
+    class ProjectExporter < BaseExporter
+      def call
+        generate_csv do
+          column(I18n.t("backoffice.common.project_name")) { |r| r.name }
+          column(I18n.t("backoffice.common.project_developer")) { |r| r.project_developer.name }
+          column(I18n.t("backoffice.common.category")) { |r| Category.find(r.category).name }
+          column(I18n.t("backoffice.projects.index.priority_landscape")) { |r| r.priority_landscape&.name }
+          column(I18n.t("backoffice.common.status")) { |r|
+            r.trusted? ? I18n.t("backoffice.common.verified") : I18n.t("backoffice.common.unverified")
+          }
+        end
+      end
+    end
+  end
+end

--- a/backend/app/services/backoffice/csv/project_exporter.rb
+++ b/backend/app/services/backoffice/csv/project_exporter.rb
@@ -1,5 +1,5 @@
 module Backoffice
-  module Csv
+  module CSV
     class ProjectExporter < BaseExporter
       def call
         generate_csv do

--- a/backend/app/views/backoffice/base/_total_records.html.erb
+++ b/backend/app/views/backoffice/base/_total_records.html.erb
@@ -2,5 +2,6 @@
   <div class="text-gray-800">
     <span class="mr-1"><%= t("backoffice.common.total") %></span>
     <span class="font-semibold"><%= @pagy_object.count %></span>
+    <div class="text-xs text-center"><%= link_to t("backoffice.common.export_csv"), request.query_parameters.merge(format: :csv) %></div>
   </div>
 </div>

--- a/backend/config/initializers/inflections.rb
+++ b/backend/config/initializers/inflections.rb
@@ -1,3 +1,4 @@
 ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym "API"
+  inflect.acronym "CSV"
 end

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -51,6 +51,7 @@ zu:
       apply: Apply
       reset: Reset
       total: Total
+      export_csv: export csv
       navigation:
         prev: "←"
         next: "→"

--- a/backend/spec/services/backoffice/csv/investor_exporter_spec.rb
+++ b/backend/spec/services/backoffice/csv/investor_exporter_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe Backoffice::Csv::InvestorExporter do
+  subject { described_class.new(query) }
+
+  let(:query) { create_list :investor, 4 }
+  let(:parsed_csv) { CSV.parse(subject.call) }
+
+  describe "#call" do
+    it "has correct headers at csv" do
+      expect(parsed_csv.first).to eq([
+        I18n.t("backoffice.common.name"),
+        I18n.t("backoffice.common.account_owner"),
+        I18n.t("backoffice.common.contact_email"),
+        I18n.t("backoffice.common.contact_phone"),
+        I18n.t("backoffice.common.account_users"),
+        I18n.t("backoffice.investors.index.open_calls"),
+        I18n.t("backoffice.common.language"),
+        I18n.t("backoffice.common.status")
+      ])
+    end
+
+    it "has correct data at csv" do
+      expect(parsed_csv.size).to eq(query.count + 1)
+      expect(parsed_csv.second).to eq([
+        query.first.name,
+        query.first.account.owner.full_name,
+        query.first.contact_email,
+        query.first.contact_phone,
+        query.first.account.users_count.to_s,
+        query.first.open_calls_count.to_s,
+        query.first.language,
+        ReviewStatus.find(query.first.account.review_status).name
+      ])
+    end
+  end
+end

--- a/backend/spec/services/backoffice/csv/investor_exporter_spec.rb
+++ b/backend/spec/services/backoffice/csv/investor_exporter_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Backoffice::Csv::InvestorExporter do
+RSpec.describe Backoffice::CSV::InvestorExporter do
   subject { described_class.new(query) }
 
   let(:query) { create_list :investor, 4 }

--- a/backend/spec/services/backoffice/csv/project_developer_exporter_spec.rb
+++ b/backend/spec/services/backoffice/csv/project_developer_exporter_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe Backoffice::Csv::ProjectDeveloperExporter do
+  subject { described_class.new(query) }
+
+  let(:query) { create_list :project_developer, 4 }
+  let(:parsed_csv) { CSV.parse(subject.call) }
+
+  describe "#call" do
+    it "has correct headers at csv" do
+      expect(parsed_csv.first).to eq([
+        I18n.t("backoffice.common.name"),
+        I18n.t("backoffice.common.account_owner"),
+        I18n.t("backoffice.common.contact_email"),
+        I18n.t("backoffice.common.contact_phone"),
+        I18n.t("backoffice.common.account_users"),
+        I18n.t("backoffice.project_developers.index.projects"),
+        I18n.t("backoffice.common.language"),
+        I18n.t("backoffice.common.status")
+      ])
+    end
+
+    it "has correct data at csv" do
+      expect(parsed_csv.size).to eq(query.count + 1)
+      expect(parsed_csv.second).to eq([
+        query.first.name,
+        query.first.account.owner.full_name,
+        query.first.contact_email,
+        query.first.contact_phone,
+        query.first.account.users_count.to_s,
+        query.first.projects_count.to_s,
+        query.first.language,
+        ReviewStatus.find(query.first.account.review_status).name
+      ])
+    end
+  end
+end

--- a/backend/spec/services/backoffice/csv/project_developer_exporter_spec.rb
+++ b/backend/spec/services/backoffice/csv/project_developer_exporter_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Backoffice::Csv::ProjectDeveloperExporter do
+RSpec.describe Backoffice::CSV::ProjectDeveloperExporter do
   subject { described_class.new(query) }
 
   let(:query) { create_list :project_developer, 4 }

--- a/backend/spec/services/backoffice/csv/project_exporter_spec.rb
+++ b/backend/spec/services/backoffice/csv/project_exporter_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe Backoffice::Csv::ProjectExporter do
+  subject { described_class.new(query) }
+
+  let(:query) { create_list :project, 4, trusted: true }
+  let(:parsed_csv) { CSV.parse(subject.call) }
+
+  describe "#call" do
+    it "has correct headers at csv" do
+      expect(parsed_csv.first).to eq([
+        I18n.t("backoffice.common.project_name"),
+        I18n.t("backoffice.common.project_developer"),
+        I18n.t("backoffice.common.category"),
+        I18n.t("backoffice.projects.index.priority_landscape"),
+        I18n.t("backoffice.common.status")
+      ])
+    end
+
+    it "has correct data at csv" do
+      expect(parsed_csv.size).to eq(query.count + 1)
+      expect(parsed_csv.second).to eq([
+        query.first.name,
+        query.first.project_developer.name,
+        Category.find(query.first.category).name,
+        query.first.priority_landscape&.name,
+        I18n.t("backoffice.common.verified")
+      ])
+    end
+  end
+end

--- a/backend/spec/services/backoffice/csv/project_exporter_spec.rb
+++ b/backend/spec/services/backoffice/csv/project_exporter_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Backoffice::Csv::ProjectExporter do
+RSpec.describe Backoffice::CSV::ProjectExporter do
   subject { described_class.new(query) }
 
   let(:query) { create_list :project, 4, trusted: true }

--- a/backend/spec/support/shared_examples/backoffice/with_csv_export.rb
+++ b/backend/spec/support/shared_examples/backoffice/with_csv_export.rb
@@ -1,0 +1,12 @@
+RSpec.shared_examples "with csv export" do |file_name:|
+  downloaded_file = File.join(Capybara.save_path, file_name)
+
+  describe "CSV Export" do
+    it "allows to export csv" do
+      click_on t("backoffice.common.export_csv")
+      sleep 1
+      expect(File).to exist(downloaded_file)
+      FileUtils.rm_rf downloaded_file
+    end
+  end
+end

--- a/backend/spec/system/backoffice/investors_spec.rb
+++ b/backend/spec/system/backoffice/investors_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe "Backoffice: Investors", type: :system do
       I18n.t("backoffice.common.language"),
       I18n.t("backoffice.common.status")
     ]
+    it_behaves_like "with csv export", file_name: "investors.csv"
 
     it "shows investors list" do
       within_row("Super Investor Enterprise") do

--- a/backend/spec/system/backoffice/project_developers_spec.rb
+++ b/backend/spec/system/backoffice/project_developers_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe "Backoffice: Project Developers", type: :system do
       I18n.t("backoffice.common.language"),
       I18n.t("backoffice.common.status")
     ]
+    it_behaves_like "with csv export", file_name: "project_developers.csv"
 
     it "shows project developers list" do
       within_row("Super PD Enterprise") do

--- a/backend/spec/system/backoffice/projects_spec.rb
+++ b/backend/spec/system/backoffice/projects_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe "Backoffice: Projects", type: :system do
       I18n.t("backoffice.projects.index.priority_landscape"),
       I18n.t("backoffice.common.status")
     ]
+    it_behaves_like "with csv export", file_name: "projects.csv"
 
     it "shows projects list" do
       expect(page).to have_xpath(".//tbody/tr", count: 5)


### PR DESCRIPTION
I am adding ability to export data for Project, PD and Investors as CSV. All functionality for csv files is done via appropriate exporter services (even though they are quite simple and maybe could be part of controller). I have used logic similar to ActiveAdmin for defining csv output.

Data which are exported take into account active filters ;).
 
![Screenshot 2022-06-10 at 13 24 13](https://user-images.githubusercontent.com/20660167/173056567-ad210078-3974-41e3-8d47-6ff6305cc529.png)

## Testing instructions

Open backoffice and try to export data as csv for Projects, PDs and Investors.

## Tracking

https://vizzuality.atlassian.net/browse/LET-569
https://vizzuality.atlassian.net/browse/LET-570
