### PR TITLE
Add project to project page map

### DIFF
--- a/frontend/containers/project-page/overview/component.tsx
+++ b/frontend/containers/project-page/overview/component.tsx
@@ -1,14 +1,31 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 
 import { FormattedMessage } from 'react-intl';
+
+import PluginMapboxGl from '@vizzuality/layer-manager-plugin-mapboxgl';
+import { LayerManager, Layer } from '@vizzuality/layer-manager-react';
 
 import { OverviewProps } from 'containers/project-page/overview/types';
 
 import LayoutContainer from 'components/layout-container';
 import Map from 'components/map';
 
+import { getLayer } from './helpers';
+
 export const Overview: React.FC<OverviewProps> = ({ project }: OverviewProps) => {
-  const { country, municipality } = project;
+  const { country, municipality, geometry, category } = project;
+  const layer = getLayer(geometry, category);
+
+  const [bounds, setBounds] = useState({
+    bbox: [-81.99, -4.35, -65.69, 12.54],
+    options: { padding: 0 },
+  });
+
+  const [viewport, setViewport] = useState({});
+
+  const handleViewportChange = useCallback((vw) => {
+    setViewport(vw);
+  }, []);
 
   return (
     <LayoutContainer className="mb-20 mt-18 space-y-36">
@@ -16,8 +33,16 @@ export const Overview: React.FC<OverviewProps> = ({ project }: OverviewProps) =>
         <div className="relative grid w-full grid-cols-1 gap-12 lg:grid-cols-2">
           <Map
             className="absolute z-10 -mb-32 border-8 border-white drop-shadow-xl h-96 -top-44 lg:overflow-hidden rounded-xl"
-            onMapViewportChange={() => console.log('onMapViewportChange')}
-          />
+            onMapViewportChange={handleViewportChange}
+            bounds={bounds}
+            viewport={viewport}
+          >
+            {(map) => (
+              <LayerManager map={map} plugin={PluginMapboxGl}>
+                <Layer {...layer} />
+              </LayerManager>
+            )}
+          </Map>
           <div className="flex flex-col space-y-4 lg:col-start-2">
             <h2 className="text-2xl lg:text-3xl">
               <FormattedMessage defaultMessage="Country" id="vONi+O" />

--- a/frontend/containers/project-page/overview/helpers.ts
+++ b/frontend/containers/project-page/overview/helpers.ts
@@ -1,0 +1,39 @@
+import { find } from 'lodash-es';
+
+import { ValidGeometryType } from 'containers/forms/geometry/types';
+
+import tw from 'tailwind.config.js';
+
+export const getLayer = (feature: ValidGeometryType, category: string) => {
+  const colors = tw.theme.colors.category;
+  const color = find(colors, (value, key) => category?.includes(key));
+  console.log(color);
+
+  return {
+    id: 'multipolygon',
+    type: 'geojson',
+    source: {
+      type: 'geojson',
+      data: feature,
+    },
+    render: {
+      layers: [
+        {
+          type: 'fill',
+          paint: {
+            'fill-color': color,
+            'fill-opacity': 0.5,
+          },
+        },
+        {
+          type: 'line',
+          paint: {
+            'line-color': color,
+            'line-opacity': 1,
+            'line-width': 1,
+          },
+        },
+      ],
+    },
+  };
+};


### PR DESCRIPTION
This PR adds the project polygon to the project page map

## Testing instructions

The user should be able to see a project’s geometry in the project public’s page map.

[Design](https://www.figma.com/file/KC49uMR9t1YARmFR0Sr6aN/HeCo---Work-in-progress?node-id=2230%3A51861)

## Tracking

[LET-592](https://vizzuality.atlassian.net/browse/LET-592)

## Screenshots

<img width="360" alt="Screenshot 2022-06-10 at 16 08 15" src="https://user-images.githubusercontent.com/48164343/173083899-610a69a9-da28-46fc-9562-107815693120.png">
<img width="360" alt="Screenshot 2022-06-10 at 16 08 24" src="https://user-images.githubusercontent.com/48164343/173083906-235e1910-179e-432b-98c2-1a77a2373e79.png">

