### PR TITLE
refactoring: Only changed attributes are translated

### DIFF
--- a/backend/app/jobs/translate_job.rb
+++ b/backend/app/jobs/translate_job.rb
@@ -1,7 +1,7 @@
 class TranslateJob < ApplicationJob
   queue_as ENV["CLOUD_TASKS_TEST_QUEUE_NAME"].to_sym
 
-  def perform(resource)
-    Translations::Translate.new(resource).call
+  def perform(resource, changed_attrs: nil)
+    Translations::Translate.new(resource, changed_attrs: changed_attrs).call
   end
 end

--- a/backend/app/models/concerns/translatable.rb
+++ b/backend/app/models/concerns/translatable.rb
@@ -8,8 +8,10 @@ module Translatable
   end
 
   def translate_attributes
-    return unless translatable_attributes.any? { |attr| public_send "saved_change_to_#{attr}_#{language}?" }
+    changed_attrs = translatable_attributes.each_with_object([]) do |attr, res|
+      res << attr if public_send "saved_change_to_#{attr}_#{language}?"
+    end
 
-    TranslateJob.perform_later self
+    TranslateJob.perform_later self, changed_attrs: changed_attrs if changed_attrs.present?
   end
 end

--- a/backend/app/services/translations/translate.rb
+++ b/backend/app/services/translations/translate.rb
@@ -1,9 +1,10 @@
 module Translations
   class Translate
-    attr_accessor :resource
+    attr_accessor :resource, :changed_attrs
 
-    def initialize(resource)
+    def initialize(resource, changed_attrs: nil)
       @resource = resource
+      @changed_attrs = changed_attrs
       # try to obtain project id automatically
       @project_id = ENV["GCP_PROJECT_ID"]
     end
@@ -35,7 +36,7 @@ module Translations
     end
 
     def present_translatable_attributes
-      @present_translatable_attributes ||= resource.translatable_attributes.select do |col|
+      @present_translatable_attributes ||= (changed_attrs.presence || resource.translatable_attributes).select do |col|
         resource.public_send(:"#{col}?", locale: source_language_code)
       end
     end

--- a/backend/spec/services/translations/translate_spec.rb
+++ b/backend/spec/services/translations/translate_spec.rb
@@ -6,10 +6,11 @@ RSpec.describe Translations::Translate do
     allow(credentials).to receive(:quota_project_id).and_return("heco")
     allow(Google::Auth).to receive(:get_application_default).and_return(credentials)
   end
-  subject { described_class.new resource }
 
   describe "#call" do
     [Project, ProjectDeveloper, OpenCall, Investor, Account].each do |klass|
+      subject { described_class.new resource, changed_attrs: [attribute] }
+
       let(:attribute) { klass.translatable_attributes.first }
       let(:resource) { create klass.table_name.singularize, "#{attribute}_en" => "TEXT_EN" }
       let(:translated_text) { "TEXT_ES" }

--- a/backend/spec/support/shared_examples/models/translatable.rb
+++ b/backend/spec/support/shared_examples/models/translatable.rb
@@ -14,7 +14,7 @@ RSpec.shared_examples :translatable do
       end
 
       it "queues translation job" do
-        assert_enqueued_with job: TranslateJob, args: [resource] do
+        assert_enqueued_with job: TranslateJob, args: [resource, changed_attrs: [attribute]] do
           resource.save!
         end
       end


### PR DESCRIPTION
Only attributes changed should be auto-translated ;)

## Testing instructions

Pick some model, for example Investor and change `mission_es` and `prioritized_projects_description_es`. After changes are saved, change `mission_en` and save stuff. The `mission_es` should be overwritten by `mission_en` by auto-translate, but changes at `prioritized_projects_description_es` should not be touched ;).

## Tracking

https://vizzuality.atlassian.net/browse/LET-558
