### PR TITLE
feat/front/LET-546-invite-users-to-pd-account

### DIFF
--- a/frontend/pages/dashboard/users.tsx
+++ b/frontend/pages/dashboard/users.tsx
@@ -47,7 +47,7 @@ export const UsersPage: PageComponent<UsersPageProps, DashboardLayoutProps> = ()
           </Button>
         }
       >
-        Users page
+        <h1>Users page</h1>
       </DashboardLayout>
       <InviteUsersModal
         openInvitationModal={openInvitationModal}


### PR DESCRIPTION
ANA's PR!!! 

I merged it on develop but then remember that the real API endpoint as missing. I revert the PR and now I'm creating this one to merge later

-----

This PR contains the UI of Invitation Users to a project developer account feature.
The implemented solution has been to wrap an input with a div that resembles a textarea so that the chips can push the input.
_Table with users that has been added is in_ [PR 241](https://github.com/Vizzuality/heco-invest/pull/241)
We still don't have the endpoint so we can think about keeping task in progress by the moment.

## Testing instructions
- Go on `dashboard/users`
- Click Invite users
- Add some email and click Tab, Enter or a comma
- Remove one of them and check that text on input is removed 
- Click Send invite button and check emails logged on console are same as in textarea
- Close modal during the process and check is empty when you re-open.

![Screenshot 2022-06-10 at 21 31 48](https://user-images.githubusercontent.com/51995866/173138139-454a465f-4d35-4253-9043-fe8eb9be8356.png)

## Tracking
[LET-546](https://vizzuality.atlassian.net/browse/LET-546)
