### PR TITLE
Force Transifex to download the latest translations when deploying

### DIFF
--- a/.github/workflows/frontend-deployment.yml
+++ b/.github/workflows/frontend-deployment.yml
@@ -79,7 +79,7 @@ jobs:
           TX_TOKEN=${{ env.TRANSIFEX_TOKEN }} ./tx push -s
         fi
         echo 'Pulling the translations…'
-        TX_TOKEN=${{ env.TRANSIFEX_TOKEN }} ./tx pull
+        TX_TOKEN=${{ env.TRANSIFEX_TOKEN }} ./tx pull -f
 
     - name: Run tests
       run: yarn test

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 case "$1" in
     start)
         echo "Pulling translations from transifex"
-        ./tx pull -m onlytranslated
+        ./tx pull -m onlytranslated -f
         echo "Running Start"
         RAILS_ENV=production rake db:migrate
         RAILS_ENV=production bin/prod

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -38,7 +38,7 @@ COPY --chown=nextjs:nextjs . .
 RUN yarn install --immutable
 
 RUN curl -o- https://raw.githubusercontent.com/transifex/cli/v1.0.3/install.sh | bash
-RUN ./tx pull
+RUN ./tx pull -f
 
 RUN yarn build
 


### PR DESCRIPTION
At the moment, the static translations are not working on staging. In Cloud Build, for each language, the following warning is displayed when deploying:
> WARNING  Skipping download translation for resource 'o:heco-invest:p:heco-invest:r:front-end-application - en'

According to the [Transifex' CLI's documentation](https://github.com/transifex/cli#pulling-files-from-transifex), the issue may be that because the source file is more recent (on the virtual machine) than the translations, Transifex skips downloading them. To address this, we can force Transifex to always download the translations with the `-f` flag, which is what I've done in this PR.  

## Testing instructions

The changes are not guaranteed to work until we've actually tested the deployment. That said, I tested locally and it seemed to fix the translation issue.

## Tracking

This PR should fix at least parts of:
- [LET-619](https://vizzuality.atlassian.net/browse/LET-619)
- [LET-620](https://vizzuality.atlassian.net/browse/LET-620)
- [LET-621](https://vizzuality.atlassian.net/browse/LET-621)

There may be other issues with the dynamic content translated through Google Translate (not tackled in this PR).
