### PR TITLE
Table component w/ existing Pagination (+ theme support)

### DIFF
--- a/frontend/components/table/component.stories.tsx
+++ b/frontend/components/table/component.stories.tsx
@@ -3,17 +3,7 @@ import { Story } from '@storybook/react/types-6-0';
 import Table from './component';
 import { TableProps } from './types';
 
-export default {
-  title: 'Components/Table',
-  component: Table,
-  argTypes: {},
-};
-
-const Template: Story<TableProps> = ({ ...args }: TableProps) => <Table {...args} />;
-
-export const Default = Template.bind({});
-Default.args = {
-  loading: false,
+const mock = {
   columns: [
     {
       Header: 'User',
@@ -44,18 +34,6 @@ Default.args = {
       defaultCanSort: true,
       sortDescFirst: true,
       width: 100,
-    },
-  ],
-  meta: {
-    page: 1,
-    size: 4,
-    totalItems: 8,
-    totalPages: 8,
-  },
-  initialState: [
-    {
-      pageIndex: 0,
-      sortBy: [{ id: 'displayName', desc: false }],
     },
   ],
   data: [
@@ -116,4 +94,39 @@ Default.args = {
       confirmed: 'Accepted',
     },
   ],
+};
+
+export default {
+  title: 'Components/Table',
+  component: Table,
+  argTypes: {},
+};
+
+const Template: Story<TableProps> = ({ ...args }: TableProps) => <Table {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  loading: false,
+  columns: mock.columns,
+  data: mock.data,
+};
+
+export const Loading = Template.bind({});
+Loading.args = {
+  loading: true,
+  columns: mock.columns,
+  data: mock.data,
+};
+
+export const Pagination = Template.bind({});
+Pagination.args = {
+  loading: false,
+  columns: mock.columns,
+  data: mock.data,
+  pagination: {
+    numItems: 10,
+    totalItems: 80,
+    currentPage: 3,
+    totalPages: 8,
+  },
 };


### PR DESCRIPTION
This PR adds a Table component, (reworked version from #241), with pagination built around the existing Pagination component, which has had theming support added to it. 

## Testing instructions

The table can be tested in use in #264, in the dashboard view (`http://localhost:3000/dashboard/projects`)

Verify that: 
- The table displays correctly  
- Sorting works  
- The loading spinner works  
- Pagination works

## Tracking

[LET-550](https://vizzuality.atlassian.net/browse/LET-550)

## Screenshot  
<img width="1123" alt="Screenshot 2022-06-20 at 15 57 03" src="https://user-images.githubusercontent.com/6273795/174629663-34dba092-68fd-4bc9-8b7a-1da4e194fb6e.png">

