### PR TITLE
feat: Update of Project via Backoffice

### DIFF
--- a/backend/app/controllers/backoffice/projects_controller.rb
+++ b/backend/app/controllers/backoffice/projects_controller.rb
@@ -1,5 +1,13 @@
 module Backoffice
   class ProjectsController < BaseController
+    include Sections
+    include ContentLanguage
+
+    before_action :fetch_project, only: [:edit, :update]
+    before_action :set_breadcrumbs, only: [:edit, :update]
+    before_action :set_sections, only: [:edit, :update]
+    before_action :set_content_language_default, only: [:edit, :update]
+
     def index
       @q = Project.ransack params[:q]
       @projects = API::Filterer.new(@q.result, {full_text: params.dig(:q, :filter_full_text)}).call
@@ -15,6 +23,100 @@ module Backoffice
             type: "text/csv; charset=utf-8"
         end
       end
+    end
+
+    def edit
+    end
+
+    def update
+      if @project.update(update_params)
+        redirect_back(
+          fallback_location: edit_backoffice_project_path(@project.friendly_id),
+          notice: t("backoffice.messages.success_update", model: t("backoffice.common.project"))
+        )
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def update_params
+      params.require(:project).permit(
+        :name_en,
+        :name_es,
+        :name_pt,
+        :country_id,
+        :department_id,
+        :municipality_id,
+        # :shapefile # TODO: add support for shapefile
+        :project_developer_id,
+        :development_stage,
+        :estimated_duration_in_months,
+        :category,
+        :problem_en,
+        :problem_es,
+        :problem_pt,
+        :solution_en,
+        :solution_es,
+        :solution_pt,
+        :expected_impact_en,
+        :expected_impact_es,
+        :expected_impact_pt,
+        :looking_for_funding,
+        :ticket_size,
+        :funding_plan_en,
+        :funding_plan_es,
+        :funding_plan_pt,
+        :received_funding,
+        :received_funding_amount_usd,
+        :received_funding_investor,
+        :replicability_en,
+        :replicability_es,
+        :replicability_pt,
+        :sustainability_en,
+        :sustainability_es,
+        :sustainability_pt,
+        :progress_impact_tracking_en,
+        :progress_impact_tracking_es,
+        :progress_impact_tracking_pt,
+        :description_en,
+        :description_es,
+        :description_pt,
+        :relevant_links_en,
+        :relevant_links_es,
+        :relevant_links_pt,
+        :trusted,
+        instrument_types: [],
+        impact_areas: [],
+        sdgs: [],
+        target_groups: [],
+        involved_project_developer_ids: []
+      ).merge(project_images_params_of(@project))
+    end
+
+    def project_images_params_of(project)
+      images = params.dig(:project, :project_images).to_a.reject(&:blank?)
+      return {} if images.blank?
+
+      {project_images_attributes: project.project_images.map { |i| {id: i.id, _destroy: true} } + images.map { |i| {file: i} }}
+    end
+
+    def fetch_project
+      @project = Project.friendly.find(params[:id])
+    end
+
+    def set_breadcrumbs
+      add_breadcrumb(I18n.t("backoffice.layout.projects"), backoffice_projects_path)
+      add_breadcrumb(@project.name)
+    end
+
+    def set_sections
+      sections %w[information status project_developers], default: "information"
+    end
+
+    def set_content_language_default
+      @content_language_default = @project.language
     end
   end
 end

--- a/backend/app/controllers/backoffice/projects_controller.rb
+++ b/backend/app/controllers/backoffice/projects_controller.rb
@@ -31,7 +31,7 @@ module Backoffice
     def update
       if @project.update(update_params)
         redirect_back(
-          fallback_location: edit_backoffice_project_path(@project.friendly_id),
+          fallback_location: edit_backoffice_project_path(@project.id),
           notice: t("backoffice.messages.success_update", model: t("backoffice.common.project"))
         )
       else
@@ -103,7 +103,7 @@ module Backoffice
     end
 
     def fetch_project
-      @project = Project.friendly.find(params[:id])
+      @project = Project.find(params[:id])
     end
 
     def set_breadcrumbs

--- a/backend/app/views/backoffice/projects/_contact_information.html.erb
+++ b/backend/app/views/backoffice/projects/_contact_information.html.erb
@@ -1,0 +1,18 @@
+<table class="m-3 text-left">
+  <tr>
+    <th class="pr-8"><%= t("backoffice.common.name") %></th>
+    <td class="text-green-dark underline"><%= link_to project_developer.name, edit_backoffice_project_developer_path(project_developer.id) %></td>
+  </tr>
+  <tr>
+    <th class="pr-8"><%= t("simple_form.labels.account.type") %></th>
+    <td><%= ProjectDeveloperType.find(project_developer.project_developer_type).name %></td>
+  </tr>
+  <tr>
+    <th class="pr-8"><%= t("simple_form.labels.account.email") %></th>
+    <td class="text-green-dark underline"><%= mail_to project_developer.contact_email %></td>
+  </tr>
+  <tr>
+    <th class="pr-8"><%= t("simple_form.labels.account.phone") %></th>
+    <td class="text-green-dark underline"><%= phone_to project_developer.contact_phone %></td>
+  </tr>
+</table>

--- a/backend/app/views/backoffice/projects/_form.html.erb
+++ b/backend/app/views/backoffice/projects/_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for [:backoffice, project] do |f| %>
+<%= simple_form_for [:backoffice, project], url: backoffice_project_path(project.id) do |f| %>
   <%= f.error_notification %>
 
   <%= f.input localized_attribute(:name), label: t("simple_form.labels.project.name"), as: :string %>

--- a/backend/app/views/backoffice/projects/_form.html.erb
+++ b/backend/app/views/backoffice/projects/_form.html.erb
@@ -1,0 +1,68 @@
+<%= simple_form_for [:backoffice, project] do |f| %>
+  <%= f.error_notification %>
+
+  <%= f.input localized_attribute(:name), label: t("simple_form.labels.project.name"), as: :string %>
+  <%= f.input :project_images, label: t("simple_form.labels.project.project_images"), as: :file, input_html: { multiple: true, accept: "image/*" } %>
+
+  <h2 class="mb-4 mt-6 text-gray-600 font-semibold text-xl">
+    <%= t(".location") %>
+  </h2>
+  <div class="grid grid-cols-3 gap-4">
+    <%= f.input :country_id, collection: Location.country.order(["name", content_language].join("_")), label: t("simple_form.labels.project.country"), include_blank: false %>
+    <%= f.input :department_id, collection: Location.department.order(["name", content_language].join("_")), label: t("simple_form.labels.project.department"), include_blank: false %>
+    <%= f.input :municipality_id, collection: Location.municipality.order(["name", content_language].join("_")), label: t("simple_form.labels.project.municipality"), include_blank: false %>
+  </div>
+  <%= f.input :shapefile, as: :file %>
+
+  <h2 class="mb-4 mt-6 text-gray-600 font-semibold text-xl">
+    <%= t(".project_developers") %>
+  </h2>
+  <%= f.input :project_developer_id, collection: ProjectDeveloper.includes(:account).order("accounts.name"), label: t("simple_form.labels.project.project_developer"), include_blank: false %>
+  <%= f.input :involved_project_developer_ids, collection: ProjectDeveloper.includes(:account).order("accounts.name"), label: t("simple_form.labels.project.involved_project_developers"), input_html: { multiple: true }, include_blank: true, include_hidden: false %>
+
+  <h2 class="mb-4 mt-6 text-gray-600 font-semibold text-xl">
+    <%= t(".description") %>
+  </h2>
+  <div class="grid grid-cols-2 gap-4">
+    <%= f.input :development_stage, collection: ProjectDevelopmentStage.all, label: t("simple_form.labels.project.development_stage"), include_blank: false %>
+    <%= f.input :estimated_duration_in_months, label: t("simple_form.labels.project.estimated_duration_in_months"), placeholder: t("simple_form.labels.project.estimated_duration_in_months_placeholder"), input_html: { max: 36 } %>
+  </div>
+  <%= f.input :category, collection: Category.all, label: t("simple_form.labels.project.category"), include_blank: false %>
+  <%= f.input localized_attribute(:problem), label: t("simple_form.labels.project.problem"), as: :text, input_html: {rows: 5} %>
+  <%= f.input localized_attribute(:solution), label: t("simple_form.labels.project.solution"), as: :text, input_html: {rows: 5} %>
+  <%= f.input :target_groups, collection: ProjectTargetGroup.all, label: t("simple_form.labels.project.target_groups"), as: :check_boxes %>
+  <%= f.input localized_attribute(:expected_impact), label: t("simple_form.labels.project.expected_impact"), as: :text, input_html: {rows: 5} %>
+
+  <h2 class="mb-4 mt-6 text-gray-600 font-semibold text-xl">
+    <%= t(".impact") %>
+  </h2>
+  <%= f.input :impact_areas, collection: ImpactArea.all, label: t("simple_form.labels.project.impact_areas"), as: :check_boxes %>
+  <%= f.input :sdgs, collection: Sdg.all, label: t("simple_form.labels.project.sdgs"), as: :check_boxes %>
+
+  <h2 class="mb-4 mt-6 text-gray-600 font-semibold text-xl">
+    <%= t(".funding_information") %>
+  </h2>
+  <%= f.input :looking_for_funding, label: t("simple_form.labels.project.looking_for_funding"), as: :radio_buttons %>
+  <%= f.input :ticket_size, collection: TicketSize.all.map { |t| [t.description, t.id] }, label: t("simple_form.labels.project.ticket_size") %>
+  <%= f.input :instrument_types, collection: InstrumentType.all, label: t("simple_form.labels.project.instrument_types"), as: :check_boxes %>
+  <%= f.input localized_attribute(:funding_plan), label: t("simple_form.labels.project.funding_plan"), as: :text, input_html: {rows: 5} %>
+  <%= f.input :received_funding, label: t("simple_form.labels.project.received_funding"), as: :radio_buttons %>
+  <div class="grid grid-cols-2 gap-4">
+    <%= f.input :received_funding_amount_usd, label: t("simple_form.labels.project.received_funding_amount_usd") %>
+    <%= f.input :received_funding_investor, label: t("simple_form.labels.project.received_funding_investor"), as: :string %>
+  </div>
+
+  <h2 class="mb-4 mt-6 text-gray-600 font-semibold text-xl">
+    <%= t(".how_will_project_grow") %>
+  </h2>
+  <%= f.input localized_attribute(:replicability), label: t("simple_form.labels.project.replicability"), as: :text, input_html: {rows: 5} %>
+  <%= f.input localized_attribute(:sustainability), label: t("simple_form.labels.project.sustainability"), as: :text, input_html: {rows: 5} %>
+  <%= f.input localized_attribute(:progress_impact_tracking), label: t("simple_form.labels.project.progress_impact_tracking"), as: :text, input_html: {rows: 5} %>
+  <%= f.input localized_attribute(:description), label: t("simple_form.labels.project.description"), as: :text, input_html: {rows: 5} %>
+  <%= f.input localized_attribute(:relevant_links), label: t("simple_form.labels.project.relevant_links"), as: :text, input_html: {rows: 5} %>
+
+  <div class="mt-3 flex justify-end gap-3">
+    <%= link_to t("backoffice.common.cancel"), backoffice_projects_path, class: "button button-secondary-green" %>
+    <%= f.button :submit, t("backoffice.common.save"), class: "button button-primary-green" %>
+  </div>
+<% end %>

--- a/backend/app/views/backoffice/projects/_section_information.html.erb
+++ b/backend/app/views/backoffice/projects/_section_information.html.erb
@@ -1,0 +1,2 @@
+<%= render "content_language_selector" %>
+<%= render "form", project: @project %>

--- a/backend/app/views/backoffice/projects/_section_project_developers.html.erb
+++ b/backend/app/views/backoffice/projects/_section_project_developers.html.erb
@@ -1,0 +1,12 @@
+<h2 class="mb-2 text-gray-900 font-semibold">
+  <%= t("backoffice.projects.project_developers_in_project", count: @project.involved_project_developers.count + 1) %>
+</h2>
+<div class="font-bold my-3"><%= t("simple_form.labels.project.project_developer") %></div>
+<%= render partial: "backoffice/projects/contact_information", locals: { project_developer: @project.project_developer } %>
+
+<% if @project.involved_project_developers.exists? %>
+  <div class="font-bold my-3"><%= t("simple_form.labels.project.partners") %></div>
+  <% @project.involved_project_developers.each do |project_developer| %>
+    <%= render partial: "backoffice/projects/contact_information", locals: { project_developer: project_developer } %>
+  <% end %>
+<% end %>

--- a/backend/app/views/backoffice/projects/_section_status.html.erb
+++ b/backend/app/views/backoffice/projects/_section_status.html.erb
@@ -1,0 +1,17 @@
+<%= simple_form_for [:backoffice, @project] do |f| %>
+  <%= f.error_notification %>
+
+  <h2 class="mb-2 text-gray-900 font-semibold">
+    <%= t("backoffice.projects.status") %>
+  </h2>
+  <p class="mb-8 text-gray-600">
+    <%= t("backoffice.projects.status_description") %>
+  </p>
+
+  <%= f.input :trusted, label: "", collection: [[t("backoffice.common.verified"), true], [t("backoffice.common.unverified"), false]], as: :radio_buttons %>
+
+  <div class="mt-3 flex justify-end gap-3">
+    <%= link_to t("backoffice.common.cancel"), backoffice_projects_path, class: "button button-secondary-green" %>
+    <%= f.button :submit, t("backoffice.common.save"), class: "button button-primary-green" %>
+  </div>
+<% end %>

--- a/backend/app/views/backoffice/projects/_section_status.html.erb
+++ b/backend/app/views/backoffice/projects/_section_status.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for [:backoffice, @project] do |f| %>
+<%= simple_form_for [:backoffice, @project], url: backoffice_project_path(@project.id) do |f| %>
   <%= f.error_notification %>
 
   <h2 class="mb-2 text-gray-900 font-semibold">

--- a/backend/app/views/backoffice/projects/edit.html.erb
+++ b/backend/app/views/backoffice/projects/edit.html.erb
@@ -1,0 +1,16 @@
+<div class="flex">
+  <aside class="w-2/6">
+    <h1 class="font-semibold text-xl text-black mb-8">
+      <%= @project.name %>
+    </h1>
+
+    <ul class="flex flex-col gap-8">
+      <li><%= section_link_to t("backoffice.projects.information"), :information, default: true %></li>
+      <li><%= section_link_to t("backoffice.projects.status"), :status %></li>
+      <li><%= section_link_to t("backoffice.projects.project_developers"), :project_developers %></li>
+    </ul>
+  </aside>
+  <div class="w-full h-full bg-white rounded-xl p-6">
+    <%= render section_partial %>
+  </div>
+</div>

--- a/backend/app/views/backoffice/projects/index.html.erb
+++ b/backend/app/views/backoffice/projects/index.html.erb
@@ -36,7 +36,7 @@
           <%= status_tag :verified, t('backoffice.common.verified') if p.trusted?  %>
           <%= status_tag :unverified, t('backoffice.common.unverified') unless p.trusted?  %>
         </td>
-        <td><%= link_to t("backoffice.common.edit"), edit_backoffice_project_path(p.friendly_id), class: "link-button" %></td>
+        <td><%= link_to t("backoffice.common.edit"), edit_backoffice_project_path(p.id), class: "link-button" %></td>
       </tr>
     <% end %>
   </tbody>

--- a/backend/app/views/backoffice/projects/index.html.erb
+++ b/backend/app/views/backoffice/projects/index.html.erb
@@ -21,6 +21,8 @@
       <th>
         <%= sort_link @q, :trusted, t("backoffice.common.status") %>
       </th>
+      <th>
+      </th>
     </tr>
   </thead>
   <tbody>
@@ -34,6 +36,7 @@
           <%= status_tag :verified, t('backoffice.common.verified') if p.trusted?  %>
           <%= status_tag :unverified, t('backoffice.common.unverified') unless p.trusted?  %>
         </td>
+        <td><%= link_to t("backoffice.common.edit"), edit_backoffice_project_path(p.friendly_id), class: "link-button" %></td>
       </tr>
     <% end %>
   </tbody>

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -16,8 +16,11 @@ zu:
         website: Website
         contact_phone: Contact phone
         contact_email: Contact email
+        phone: Phone
+        email: Email
         language: Language
         review_status: Review status
+        type: Type
       project_developer:
         impacts: Expect to have impact on
         project_developer_type: Project developer type
@@ -29,6 +32,37 @@ zu:
         sdgs: Select the SDG's you are interested in
         prioritized_projects_description: What type of projects are you prioritizing?
         other_information: Other relevant information
+      project:
+        name: Project name
+        project_images: Project gallery (optional)
+        country: Country
+        department: State
+        municipality: Municipality
+        project_developer: Owner
+        involved_project_developers: Partners (optional)
+        partners: Partners
+        development_stage: Stage of development or maturity of the project
+        estimated_duration_in_months: Estimated duration for project in months
+        estimated_duration_in_months_placeholder: Insert number (max 36)
+        category: Which of these topics/sector category better describe your project?
+        problem: Problem you are solving
+        solution: The solution or opportunity proposed
+        expected_impact: Expected impact
+        target_groups: Target group
+        impact_areas: Select which areas your project will have an impact on
+        sdgs: Select in which SDG's your project will have impact
+        looking_for_funding: Are you currently looking for funding?
+        ticket_size: Select the amount of money that you need
+        instrument_types: Select the instrument type(s)
+        funding_plan: How will the money be used?
+        received_funding: Has this project been funded before?
+        received_funding_amount_usd: How much money did the project received or raised?
+        received_funding_investor: From which investor or funder?
+        replicability: Replicability of the project
+        sustainability: Sustainability of the project
+        progress_impact_tracking: Progress and impact tracking
+        description: Short description of the project
+        relevant_links: Relevant links (optional)
       defaults:
         categories: Select the categories that you work on
         mission: What's your mission?
@@ -47,6 +81,7 @@ zu:
       project_name: Project name
       project_developer: Project developer
       investor: Investor
+      project: Project
       category: Category
       mosaic: Mosaic
       verified: Verified
@@ -95,8 +130,21 @@ zu:
         investment_information: Investment information
         impact: Impact
     projects:
+      information: Information
+      status: Verification status
+      status_description: The verification status allow the project to have a verification badge. By default all the projects are set to "Unverified". Please review the information and change it to "Verified".
+      project_developers: Project developers
+      project_developers_in_project: Project developers in the project (%{count})
       index:
         priority_landscape: Priority Landscape
+      edit:
+        location: Location
+        project_developers: Project developers
+        description: Description of the project
+        impact: Impact
+        funding_information: Funding information
+        how_will_project_grow: How the project will grow
+
     layout:
       header: Backoffice
       sign_out: Sign out

--- a/backend/config/routes/backoffice.rb
+++ b/backend/config/routes/backoffice.rb
@@ -12,5 +12,5 @@ namespace :backoffice do
   end
   resources :investors, only: [:index, :edit, :update, :destroy]
   resources :project_developers, only: [:index, :edit, :update, :destroy]
-  resources :projects, only: [:index]
+  resources :projects, only: [:index, :edit, :update]
 end

--- a/backend/spec/system/backoffice/projects_spec.rb
+++ b/backend/spec/system/backoffice/projects_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "Backoffice: Projects", type: :system do
   let!(:project) {
     create(
       :project,
+      :with_involved_project_developers,
       name: "Project ultra name",
       project_developer: create(:project_developer, account: create(:account, name: "Ultra project developer name")),
       geometry: geometry,
@@ -87,6 +88,167 @@ RSpec.describe "Backoffice: Projects", type: :system do
           expect(page).to have_text(project.name)
           projects.each { |p| expect(page).not_to have_text(p.name) }
         end
+      end
+    end
+  end
+
+  describe "Edit" do
+    let!(:country) { create :location, :with_municipalities }
+    let!(:project_developer) { create :project_developer }
+    let!(:extra_project_developer) { create :project_developer }
+
+    before do
+      visit "/backoffice/projects"
+      within_row("Project ultra name") do
+        click_on t("backoffice.common.edit")
+      end
+    end
+
+    context "information section" do
+      context "when content is correct" do
+        it "can update project information" do
+          fill_in t("simple_form.labels.project.name"), with: "New name"
+          attach_file t("simple_form.labels.project.project_images"), [Rails.root.join("spec/fixtures/files/picture.jpg"), Rails.root.join("spec/fixtures/files/picture_2.jpg")]
+          select country.name, from: t("simple_form.labels.project.country")
+          select country.locations.first.name, from: t("simple_form.labels.project.department")
+          select country.locations.first.locations.first.name, from: t("simple_form.labels.project.municipality")
+          select project_developer.name, from: t("simple_form.labels.project.project_developer")
+          select extra_project_developer.name, from: t("simple_form.labels.project.involved_project_developers")
+          select t("enums.project_development_stage.scaling-up.name"), from: t("simple_form.labels.project.development_stage")
+          fill_in t("simple_form.labels.project.estimated_duration_in_months"), with: 15
+          select t("enums.category.human-capital-and-inclusion.name"), from: t("simple_form.labels.project.category")
+          fill_in t("simple_form.labels.project.problem"), with: "New problem"
+          fill_in t("simple_form.labels.project.solution"), with: "New solution"
+          check t("enums.project_target_group.afro-desendant-peoples.name")
+          check t("enums.project_target_group.entrepreneurs-and-innovators-startups.name")
+          uncheck t("enums.project_target_group.urban-populations.name")
+          fill_in t("simple_form.labels.project.expected_impact"), with: "New expected impact"
+          check t("enums.impact_area.carbon-emission-reduction.name")
+          check t("enums.sdg.1.name")
+          check t("enums.sdg.2.name")
+          uncheck t("enums.sdg.4.name")
+          choose "Yes", name: "project[looking_for_funding]"
+          select t("enums.ticket_size.scaling.description"), from: t("simple_form.labels.project.ticket_size")
+          check t("enums.instrument_type.equity.name")
+          fill_in t("simple_form.labels.project.funding_plan"), with: "New funding plan"
+          choose "Yes", name: "project[received_funding]"
+          fill_in t("simple_form.labels.project.received_funding_amount_usd"), with: 10000
+          fill_in t("simple_form.labels.project.received_funding_investor"), with: "Investor"
+          fill_in t("simple_form.labels.project.replicability"), with: "New replicability"
+          fill_in t("simple_form.labels.project.sustainability"), with: "New sustainability"
+          fill_in t("simple_form.labels.project.progress_impact_tracking"), with: "New progress impact tracking"
+          fill_in t("simple_form.labels.project.description"), with: "New description"
+          fill_in t("simple_form.labels.project.relevant_links"), with: "New relevant links"
+          click_on t("backoffice.common.save")
+
+          expect(page).to have_text(t("backoffice.messages.success_update", model: t("backoffice.common.project")))
+          project.reload
+          expect(project.name).to eq("New name")
+          expect(project.project_images.count).to eq(2)
+          expect(project.country).to eq(country)
+          expect(project.department).to eq(country.locations.first)
+          expect(project.municipality).to eq(country.locations.first.locations.first)
+          expect(project.project_developer).to eq(project_developer)
+          expect(project.involved_project_developers).to include(extra_project_developer)
+          expect(project.development_stage).to eq("scaling-up")
+          expect(project.estimated_duration_in_months).to eq(15)
+          expect(project.category).to eq("human-capital-and-inclusion")
+          expect(project.problem).to eq("New problem")
+          expect(project.solution).to eq("New solution")
+          expect(project.target_groups).to include("afro-desendant-peoples")
+          expect(project.target_groups).to include("entrepreneurs-and-innovators-startups")
+          expect(project.target_groups).not_to include("urban-populations")
+          expect(project.expected_impact).to eq("New expected impact")
+          expect(project.impact_areas).to include("carbon-emission-reduction")
+          expect(project.sdgs).to include(1)
+          expect(project.sdgs).to include(2)
+          expect(project.sdgs).not_to include(4)
+          expect(project.looking_for_funding).to be_truthy
+          expect(project.ticket_size).to eq("scaling")
+          expect(project.instrument_types).to include("equity")
+          expect(project.funding_plan).to eq("New funding plan")
+          expect(project.received_funding).to be_truthy
+          expect(project.received_funding_amount_usd).to eq(10000)
+          expect(project.received_funding_investor).to eq("Investor")
+          expect(project.replicability).to eq("New replicability")
+          expect(project.sustainability).to eq("New sustainability")
+          expect(project.progress_impact_tracking).to eq("New progress impact tracking")
+          expect(project.description).to eq("New description")
+          expect(project.relevant_links).to eq("New relevant links")
+        end
+      end
+
+      context "when content is incorrect" do
+        it "shows validation errors" do
+          fill_in t("simple_form.labels.project.estimated_duration_in_months"), with: 80
+          click_on t("backoffice.common.save")
+
+          expect(page).to have_text(t("simple_form.error_notification.default_message"))
+          expect(page).to have_text("Estimated duration in months must be less than 37")
+        end
+      end
+    end
+
+    context "verification status section" do
+      before { within_sidebar { click_on t("backoffice.projects.status") } }
+
+      it "can update verification status" do
+        expect(page).to have_checked_field("project[trusted]")
+        choose t("backoffice.common.unverified"), name: "project[trusted]"
+        click_on t("backoffice.common.save")
+        expect(page).to have_text(t("backoffice.messages.success_update", model: t("backoffice.common.project")))
+        expect(project.reload.trusted).to be_falsey
+      end
+    end
+
+    context "project developers section" do
+      before { within_sidebar { click_on t("backoffice.projects.project_developers") } }
+
+      it "shows owner information" do
+        expect(page).to have_text(project.project_developer.name)
+        expect(page).to have_text(ProjectDeveloperType.find(project.project_developer.project_developer_type).name)
+        expect(page).to have_text(project.project_developer.contact_email)
+        expect(page).to have_text(project.project_developer.contact_phone)
+      end
+
+      it "shows information about partners" do
+        project.involved_project_developers.each do |project_developer|
+          expect(page).to have_text(project_developer.name)
+          expect(page).to have_text(ProjectDeveloperType.find(project_developer.project_developer_type).name)
+          expect(page).to have_text(project_developer.contact_email)
+          expect(page).to have_text(project_developer.contact_phone)
+        end
+      end
+    end
+
+    context "when changing translations" do
+      it "saves translated content" do
+        select "Spanish", from: t("backoffice.common.view_content_in")
+        sleep 1 # have to wait as dunno why it does not wait for turbo to reload page
+        fill_in t("simple_form.labels.project.name"), with: "New name - Spanish"
+        fill_in t("simple_form.labels.project.problem"), with: "New problem - Spanish"
+        fill_in t("simple_form.labels.project.solution"), with: "New solution - Spanish"
+        fill_in t("simple_form.labels.project.expected_impact"), with: "New expected impact - Spanish"
+        fill_in t("simple_form.labels.project.funding_plan"), with: "New funding plan - Spanish"
+        fill_in t("simple_form.labels.project.replicability"), with: "New replicability - Spanish"
+        fill_in t("simple_form.labels.project.sustainability"), with: "New sustainability - Spanish"
+        fill_in t("simple_form.labels.project.progress_impact_tracking"), with: "New progress impact tracking - Spanish"
+        fill_in t("simple_form.labels.project.description"), with: "New description - Spanish"
+        fill_in t("simple_form.labels.project.relevant_links"), with: "New relevant links - Spanish"
+        click_on t("backoffice.common.save")
+
+        expect(page).to have_text(t("backoffice.messages.success_update", model: t("backoffice.common.project")))
+        project.reload
+        expect(project.name_es).to eq("New name - Spanish")
+        expect(project.problem_es).to eq("New problem - Spanish")
+        expect(project.solution_es).to eq("New solution - Spanish")
+        expect(project.expected_impact_es).to eq("New expected impact - Spanish")
+        expect(project.funding_plan_es).to eq("New funding plan - Spanish")
+        expect(project.replicability_es).to eq("New replicability - Spanish")
+        expect(project.sustainability_es).to eq("New sustainability - Spanish")
+        expect(project.progress_impact_tracking_es).to eq("New progress impact tracking - Spanish")
+        expect(project.description_es).to eq("New description - Spanish")
+        expect(project.relevant_links_es).to eq("New relevant links - Spanish")
       end
     end
   end


### PR DESCRIPTION
Adding formular for managing Project to backoffice. There is one Todo and discovered couple bugs, but I would address them as separate PR so this one is not too huge.

![Screenshot 2022-06-20 at 16 48 24](https://user-images.githubusercontent.com/20660167/174629871-6c2e2321-09f9-4719-a291-64b20166337b.png)

There is couple changes when compared to designs:
 - `partner` is multiselect, because of `involved_project_developers` is `has_many` relation
 - `category` is changed to selectbox, because project can have only one
 - `ticket_size` is changed to selectbox, because project can have only one

TODO which will be addresses as separate ticket:
 - I need to find way how to transform shapefile which can be uploaded via backoffice to GeoJson which is provided be FE
 - I am personally not big fan of way how project images are handled now (you always need to change whole set), but it corresponds to current proposal --> would probably require something more fancy at future
 
Discovered also two bugs which are related to all forms and localized fields (we will probably need additional tickets for this):
 - localized fields does not show if field is required or not
 - localized fields does not show erorrs

## Testing instructions

Backoffice ;)

## Tracking

https://vizzuality.atlassian.net/browse/LET-598
https://vizzuality.atlassian.net/browse/LET-599
