### PR TITLE
Send a locale param in API requests

### DIFF
--- a/frontend/containers/layouts/language-selector/component.tsx
+++ b/frontend/containers/layouts/language-selector/component.tsx
@@ -4,6 +4,8 @@ import { useIntl } from 'react-intl';
 
 import { useRouter } from 'next/router';
 
+import { setCookie } from 'helpers/cookies';
+
 import Button from 'components/button';
 import Icon from 'components/icon';
 import Menu, { MenuItem } from 'components/menu';
@@ -31,7 +33,7 @@ export const LanguageSelector: React.FC<LanguageSelectorProps> = () => {
       router.push({ pathname, query }, asPath, { locale: newLanguageCode });
 
       // Set a cookie for 1 year so that the user preference is kept
-      document.cookie = `NEXT_LOCALE=${newLanguageCode}; path=/; max-age=31536000; secure`;
+      setCookie('NEXT_LOCALE', `${newLanguageCode}; path=/; max-age=31536000; secure`);
     },
     [router]
   );

--- a/frontend/helpers/cookies.ts
+++ b/frontend/helpers/cookies.ts
@@ -1,0 +1,24 @@
+/**
+ * Get a cookie value by key
+ * @param key Cookie to retrieve
+ */
+export const getCookie = function (key: string): string {
+  if (!key) return null;
+  try {
+    return document.cookie
+      .split('; ')
+      .find((row) => row.startsWith(`${key}=`))
+      ?.split('=')[1];
+  } catch (err) {
+    return null;
+  }
+};
+
+/**
+ * Set a cookie value by key
+ * @param key Cookie key to set
+ * @param value Cookie value to set
+ */
+export const setCookie = function (key: string, value: string): void {
+  document.cookie = `${key}=${value}`;
+};

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -1,7 +1,11 @@
 import axios from 'axios';
 import Jsona from 'jsona';
 
+import { getCookie } from 'helpers/cookies';
+
 import { ErrorResponse } from './types';
+
+const { locales } = require('locales.config.json');
 
 const dataFormatter = new Jsona();
 
@@ -18,6 +22,16 @@ const API = axios.create({
   xsrfCookieName: 'csrf_token',
   xsrfHeaderName: 'X-CSRF-TOKEN',
 });
+
+const onRequest = (config) => {
+  return {
+    ...config,
+    params: {
+      ...config?.params,
+      locale: getCookie('NEXT_LOCALE') || locales.find((locale) => locale.default).locale,
+    },
+  };
+};
 
 const onResponseSuccess = (response) => {
   try {
@@ -45,6 +59,7 @@ const onResponseError = (error) => {
   return Promise.reject(error);
 };
 
+API.interceptors.request.use(onRequest);
 API.interceptors.response.use(onResponseSuccess, onResponseError);
 
 export default API;


### PR DESCRIPTION
With this PR, API requests will include a `locale` param, set to the user's current locale. 

## Testing instructions

In the developer tools, verify that requests have a `locale=` appended. This is most important for the discover pages search, which is what prompted this task. 

## Tracking

[LET-425](https://vizzuality.atlassian.net/browse/LET-425)
