### PR TITLE
recover

### DIFF
--- a/frontend/containers/users/invite-users-modal/component.tsx
+++ b/frontend/containers/users/invite-users-modal/component.tsx
@@ -1,0 +1,217 @@
+import { FC, useCallback, useEffect } from 'react';
+
+import { X as CloseIcon } from 'react-feather';
+import { useForm } from 'react-hook-form';
+import { FormattedMessage, useIntl } from 'react-intl';
+
+import cx from 'classnames';
+
+import Alert from 'components/alert';
+import Button from 'components/button';
+import ErrorMessage from 'components/forms/error-message';
+import Input from 'components/forms/input';
+import Label from 'components/forms/label';
+import Icon from 'components/icon';
+import Modal from 'components/modal';
+import { UsersInvitationForm } from 'types/user';
+import { InviteUsersDto } from 'types/user';
+
+import { useInviteUsers } from 'services/users/userService';
+
+import type { InviteUsersModalProps } from './types';
+
+export const InviteUsersModal: FC<InviteUsersModalProps> = ({
+  openInvitationModal,
+  setOpenInvitationModal,
+}: InviteUsersModalProps) => {
+  const { formatMessage } = useIntl();
+  const inviteUsers = useInviteUsers();
+
+  const {
+    clearErrors,
+    formState,
+    getValues,
+    handleSubmit,
+    register,
+    resetField,
+    setError,
+    setValue,
+    reset,
+  } = useForm<UsersInvitationForm>({
+    shouldFocusError: true,
+    shouldUseNativeValidation: true,
+    reValidateMode: 'onChange',
+    defaultValues: { emails: [] },
+  });
+
+  useEffect(() => {
+    reset();
+    clearErrors();
+  }, [clearErrors, reset, setOpenInvitationModal]);
+
+  const handleSendInvite = useCallback(
+    (data: InviteUsersDto) =>
+      inviteUsers.mutate(data, {
+        onError: (error) => {
+          console.log('error', error);
+        },
+        onSuccess: () => {
+          setOpenInvitationModal(false);
+        },
+      }),
+    [inviteUsers, setOpenInvitationModal]
+  );
+
+  const onSubmit = (values) => {
+    if (values.emails.length) {
+      if (!('email' in formState.errors)) {
+        handleSendInvite({ data: values.emails });
+      } else {
+        setError('email', { message: 'Please, enter valid emails.', type: 'manual' });
+      }
+    }
+  };
+
+  const handleKeyDown = useCallback(
+    (e?, type?: 'submiting') => {
+      const oldEmails = getValues('emails');
+      const newEmail = getValues('email');
+      if (type == 'submiting' || ['Enter', 'Tab'].includes(e.key)) {
+        const isValid = /\S+@\S+\.\S+/.test(newEmail);
+        if (isValid) {
+          setValue('emails', oldEmails.concat(newEmail));
+          resetField('email');
+        } else {
+          console.log('error');
+          setError('email', { message: 'Please, enter a valid email.', type: 'manual' });
+        }
+      }
+    },
+    [getValues, resetField, setError, setValue]
+  );
+
+  const removeEmail = useCallback(
+    (email) => {
+      const oldEmails = getValues('emails');
+      const restEmails = [...oldEmails];
+      restEmails.splice(oldEmails.indexOf(email), 1);
+      setValue('emails', restEmails);
+      resetField('email');
+    },
+    [getValues, resetField, setValue]
+  );
+
+  return (
+    <Modal
+      onDismiss={() => setOpenInvitationModal(false)}
+      title={formatMessage({ defaultMessage: 'Invite users', id: 'R+1DVQ' })}
+      open={openInvitationModal}
+      dismissable={true}
+      size="default"
+      scrollable={false}
+    >
+      <form className="flex flex-col" noValidate>
+        <p className="mb-2 font-serif text-3xl text-green-dark">
+          <FormattedMessage defaultMessage="Invite users" id="R+1DVQ" />
+        </p>
+
+        <p className="mb-4">
+          <FormattedMessage
+            defaultMessage="Users will receive an email to sign up into the platform and join NEEsT’s account."
+            id="hbFTZN"
+          />
+        </p>
+
+        <Label htmlFor="emails-users-invitation" className="mb-2 font-sans text-base text-gray-800">
+          <FormattedMessage defaultMessage="Emails" id="AdAi3x" />
+        </Label>
+        <div className="inline-block p-2 focus-within:border-green-dark min-h-[95px] border border-beige rounded-lg">
+          <div className="flex flex-wrap space-x-1">
+            <div className="flex flex-wrap">
+              {getValues('emails')?.map((email, i) => (
+                <div className="flex px-4 py-1 mb-1 mr-1 bg-beige rounded-2xl" key={i}>
+                  <p className="text-sm text-green-dark">{email}</p>
+                  <button type="button" onClick={() => removeEmail(email)}>
+                    <Icon icon={CloseIcon} className={cx('w-4 ml-3 text-green-dark')} />
+                  </button>
+                </div>
+              ))}
+            </div>
+            <Input
+              type="text"
+              id="email"
+              name="email"
+              aria-describedby="email-error"
+              register={register}
+              placeholder={formatMessage(
+                {
+                  defaultMessage: '{placeholder}',
+                  id: '8SayhS',
+                },
+                {
+                  placeholder: getValues('emails')?.length > 0 ? '' : 'separate emails by enter',
+                }
+              )}
+              className="px-1 py-0 mx-0 max-w-[240px] leading-8 h-7 text-gray-400 border-none focus:shadow-none hover:shadow-none"
+              onKeyDown={handleKeyDown}
+              contentEditable
+            />
+            <Input
+              className="hidden border-none focus:shadow-none hover:shadow-none"
+              name="emails"
+              id="emails"
+              type="text"
+              aria-describedby="emails-error"
+              register={register}
+              registerOptions={{
+                required: formatMessage({
+                  defaultMessage: 'Please, enter valid email.',
+                  id: 'oAIvoH',
+                }),
+                minLength: 1,
+              }}
+            />
+          </div>
+        </div>
+        <div>
+          <ErrorMessage
+            id="email-error"
+            errorText={formState.errors?.emails?.length && formState.errors?.emails[0]?.message}
+          />
+        </div>
+        <div>
+          <ErrorMessage id="email-error" errorText={formState.errors?.email?.message} />
+        </div>
+
+        {inviteUsers.isError && (
+          <Alert className="my-4" withLayoutContainer>
+            {Array.isArray(inviteUsers.error.message)
+              ? inviteUsers.error.message[0].title
+              : inviteUsers.error.message}
+          </Alert>
+        )}
+
+        <div className="flex justify-end mt-8">
+          <Button
+            theme="secondary-green"
+            size="small"
+            className="flex-shrink-0 mr-5"
+            onClick={() => setOpenInvitationModal(false)}
+          >
+            <FormattedMessage defaultMessage="Cancel" id="47FYwb" />
+          </Button>
+          <Button
+            onClick={handleSubmit(onSubmit, console.log)}
+            theme="primary-green"
+            size="small"
+            className="flex-shrink-0 mr-5"
+          >
+            <FormattedMessage defaultMessage="Send invite" id="oBB4L4" />
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
+export default InviteUsersModal;

--- a/frontend/containers/users/invite-users-modal/index.ts
+++ b/frontend/containers/users/invite-users-modal/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { InviteUsersModalProps } from './types';

--- a/frontend/containers/users/invite-users-modal/types.ts
+++ b/frontend/containers/users/invite-users-modal/types.ts
@@ -1,0 +1,4 @@
+export type InviteUsersModalProps = {
+  openInvitationModal: boolean;
+  setOpenInvitationModal: (openInvitationModal: boolean) => void;
+};

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -86,6 +86,9 @@
   "2GBpne": {
     "string": "Impact score"
   },
+  "2JJSDv": {
+    "string": "Edit project developer’s account"
+  },
   "2O2sfp": {
     "string": "Finish"
   },
@@ -227,6 +230,9 @@
   "8R8Or7": {
     "string": "Search community"
   },
+  "8SayhS": {
+    "string": "{placeholder}"
+  },
   "8WtyrD": {
     "string": "Spanish"
   },
@@ -287,8 +293,14 @@
   "APjPYs": {
     "string": "I want to write my content in"
   },
+  "AdAi3x": {
+    "string": "Emails"
+  },
   "AiagLY": {
     "string": "Entity legal registration number (NIT or RUT)"
+  },
+  "AoHRBG": {
+    "string": "Custom search"
   },
   "BAC0rl": {
     "string": "<span>Community:</span> income, sustainable projects;"
@@ -328,9 +340,6 @@
   },
   "CYTiug": {
     "string": "HeCo Invest will benefit poor and vulnerable people living in HeCo priority landscapes."
-  },
-  "CcFPkO": {
-    "string": "This project has {numDevelopers} project developer{noun}"
   },
   "CiBvks": {
     "string": "General information about the the project developer."
@@ -567,6 +576,9 @@
   "MHwpc4": {
     "string": "Draw or upload your location"
   },
+  "MM4RqT": {
+    "string": "This project has {numDevelopers} {numDevelopers, plural, one {project developer} other {project developers}}."
+  },
   "MXykbb": {
     "string": "The problem we are solving"
   },
@@ -590,6 +602,9 @@
   },
   "NjKSap": {
     "string": "Online presence"
+  },
+  "NsIwKY": {
+    "string": "Leave create project develop?"
   },
   "NvzZkI": {
     "string": "Create partnerships"
@@ -662,6 +677,9 @@
   },
   "QqpgJo": {
     "string": "Leave investor creation form"
+  },
+  "R+1DVQ": {
+    "string": "Invite users"
   },
   "RDCAd6": {
     "string": "value {optionName} focused, {pagination}."
@@ -1017,6 +1035,9 @@
   "hWhIuU": {
     "string": "Select the intrument type(s)"
   },
+  "hbFTZN": {
+    "string": "Users will receive an email to sign up into the platform and join NEEsT’s account."
+  },
   "hg7Mex": {
     "string": "Select which areas your project will have an impact on"
   },
@@ -1062,9 +1083,6 @@
   "jKdvln": {
     "string": "Relevant links (optional)"
   },
-  "jQfYef": {
-    "string": "Leave create project develop"
-  },
   "jUgR7w": {
     "string": "Stage of development or maturity of the project"
   },
@@ -1076,6 +1094,9 @@
   },
   "jXqlWP": {
     "string": "{name} project developer"
+  },
+  "jj4ae3": {
+    "string": "Project image {index}."
   },
   "jwimQJ": {
     "string": "Ok"
@@ -1142,6 +1163,12 @@
   },
   "o+Vt3t": {
     "string": "Partnership between:"
+  },
+  "oAIvoH": {
+    "string": "Please, enter valid email."
+  },
+  "oBB4L4": {
+    "string": "Send invite"
   },
   "oMC3r1": {
     "string": "Choose your account type"

--- a/frontend/pages/dashboard/users.tsx
+++ b/frontend/pages/dashboard/users.tsx
@@ -1,9 +1,13 @@
+import { useState } from 'react';
+
 import { Mail as MailIcon } from 'react-feather';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { InferGetStaticPropsType } from 'next';
 
 import { loadI18nMessages } from 'helpers/i18n';
+
+import InviteUsersModal from 'containers/users/invite-users-modal';
 
 import Button from 'components/button';
 import Head from 'components/head';
@@ -25,6 +29,7 @@ export async function getStaticProps(ctx) {
 type UsersPageProps = InferGetStaticPropsType<typeof getStaticProps>;
 
 export const UsersPage: PageComponent<UsersPageProps, DashboardLayoutProps> = () => {
+  const [openInvitationModal, setOpenInvitationModal] = useState(false);
   const intl = useIntl();
 
   return (
@@ -32,14 +37,22 @@ export const UsersPage: PageComponent<UsersPageProps, DashboardLayoutProps> = ()
       <Head title={intl.formatMessage({ defaultMessage: 'My users', id: 'lda5xz' })} />
       <DashboardLayout
         buttons={
-          <Button className="drop-shadow-xl" theme="primary-white">
+          <Button
+            className="drop-shadow-xl"
+            theme="primary-white"
+            onClick={() => setOpenInvitationModal(true)}
+          >
             <Icon icon={MailIcon} className="w-4 h-4 mr-2" aria-hidden />
             <FormattedMessage defaultMessage="Invite user" id="/4GN+O" />
           </Button>
         }
       >
-        <h1>Users page</h1>
+        Users page
       </DashboardLayout>
+      <InviteUsersModal
+        openInvitationModal={openInvitationModal}
+        setOpenInvitationModal={setOpenInvitationModal}
+      />
     </ProtectedPage>
   );
 };

--- a/frontend/services/users/userService.ts
+++ b/frontend/services/users/userService.ts
@@ -1,9 +1,10 @@
-import { useMutation, UseMutationResult } from 'react-query';
+import { useMutation, UseMutationResult, useQueryClient } from 'react-query';
 
 import { AxiosResponse, AxiosError } from 'axios';
 
+import { Queries } from 'enums';
 import { ResetPassword } from 'types/sign-in';
-import { SignupDto, User } from 'types/user';
+import { SignupDto, User, InviteUsersDto } from 'types/user';
 
 import { ErrorResponse, ResponseData } from 'services/types';
 
@@ -32,3 +33,23 @@ export const getCurrentUser = (): Promise<AxiosResponse<ResponseData<User>>> =>
     method: 'GET',
     url: '/api/v1/user',
   });
+
+/** Invite user to project developer account */
+//TODO: Replace endpoint by correct one
+export function useInviteUsers(): UseMutationResult<
+  AxiosResponse<User>,
+  AxiosError<ErrorResponse>,
+  InviteUsersDto
+> {
+  const inviteUsers = async (data: InviteUsersDto): Promise<AxiosResponse<User>> => {
+    return API.post('/api/v1/account/projects', data).then((response) => response.data);
+  };
+
+  const queryClient = useQueryClient();
+
+  return useMutation(inviteUsers, {
+    onSuccess: (result) => {
+      queryClient.setQueryData(Queries.User, result.data);
+    },
+  });
+}

--- a/frontend/types/user.ts
+++ b/frontend/types/user.ts
@@ -33,3 +33,12 @@ export type UserAccount = {
   slug: string;
   type: 'project_developer' | 'investor';
 };
+
+export type UsersInvitationForm = {
+  email: string;
+  emails: string[];
+};
+
+export type InviteUsersDto = {
+  data: string[];
+};


### PR DESCRIPTION
**------> RECOVER <-------**

This PR contains the UI of Invitation Users to a project developer account feature.
The implemented solution has been to wrap an input with a div that resembles a textarea so that the chips can push the input.
_Table with users that has been added is in_ [PR 241](https://github.com/Vizzuality/heco-invest/pull/241)
We still don't have the endpoint so we can think about keeping task in progress by the moment.

## Testing instructions
- Go on `dashboard/users`
- Click Invite users
- Add some email and click Tab, Enter or a comma
- Remove one of them and check that text on input is removed 
- Click Send invite button and check emails logged on console are same as in textarea
- Close modal during the process and check is empty when you re-open.

![Screenshot 2022-06-10 at 21 31 48](https://user-images.githubusercontent.com/51995866/173138139-454a465f-4d35-4253-9043-fe8eb9be8356.png)

## Tracking
[LET-546](https://vizzuality.atlassian.net/browse/LET-546)

