### PR TITLE
Improve the error messages when uploading a geometry

### DIFF
--- a/frontend/containers/forms/geometry/component.tsx
+++ b/frontend/containers/forms/geometry/component.tsx
@@ -147,7 +147,9 @@ export const GeometryInput = <FormValues extends FieldValues>({
           <Icon icon={UploadIcon} className="inline-block w-5 h-5 mr-3" aria-hidden={true} />
           <FormattedMessage defaultMessage="Shapefile / KML" id="cqoaMq" />
         </Button>
-        <ErrorMessage id={`${name}-internal-error`} errorText={internalError} />
+        <span className="max-w-lg text-right">
+          <ErrorMessage id={`${name}-internal-error`} errorText={internalError} />
+        </span>
       </div>
       <div
         className={cx({

--- a/frontend/containers/forms/geometry/helpers.ts
+++ b/frontend/containers/forms/geometry/helpers.ts
@@ -109,6 +109,23 @@ export async function convertFilesToGeojson(
 
   let loader: Loader;
 
+  // We check that we have all the mandatory files to process a ShapeFile
+  if (
+    (fileToParse.name.endsWith('.shp') ||
+      fileToParse.name.endsWith('.shx') ||
+      fileToParse.name.endsWith('.dbf') ||
+      fileToParse.name.endsWith('.prj')) &&
+    files.length < 3
+  ) {
+    return Promise.reject(
+      intl.formatMessage({
+        defaultMessage:
+          'To upload a Shapefile geometry, you must upload the .shp, .shx, .dbf and eventually .prj files all at once.',
+        id: 'ejuZC0',
+      })
+    );
+  }
+
   if (fileToParse.name.endsWith('.kmz')) {
     // In most of the cases, a .kmz file is just a zipped .kml file, but it can still contains
     // multiple files
@@ -120,7 +137,16 @@ export async function convertFilesToGeojson(
 
     loader = KMLLoader;
   } else {
-    loader = await selectLoader(fileToParse, [ShapefileLoader, KMLLoader]);
+    try {
+      loader = await selectLoader(fileToParse, [ShapefileLoader, KMLLoader]);
+    } catch (e) {
+      return Promise.reject(
+        intl.formatMessage({
+          defaultMessage: 'This file is not supported. Please try uploading a different format.',
+          id: 'XO0Kon',
+        })
+      );
+    }
   }
 
   if (!loader) {

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -999,6 +999,9 @@
   "efZTBX": {
     "string": "Use this space to share links to documents, videos and websites that support your pitch."
   },
+  "ejuZC0": {
+    "string": "To upload a Shapefile geometry, you must upload the .shp, .shx, .dbf and eventually .prj files all at once."
+  },
   "et2m37": {
     "string": "insert URL"
   },


### PR DESCRIPTION
This PR improves the error messages when uploading incomplete Shapefile geometries.

![Error below the input says: To upload a Shapefile geometry, you must upload the .shp, .shx, .dbf and eventually .prj files all at once.](https://user-images.githubusercontent.com/6073968/174757182-b442a1ad-5efc-459d-8981-e8aa830b6211.png)

## Testing instructions

Upload only some of the files of the zip found in the [task](https://vizzuality.atlassian.net/browse/LET-595). You should see this error. If you upload all the files, the geometry should be displayed on the map.

This was tested on the project creation's first step.

## Tracking

[LET-595](https://vizzuality.atlassian.net/browse/LET-595).
