### PR TITLE
fix: backoffice localized fields show correct validation errors

### DIFF
--- a/backend/app/controllers/backoffice/investors_controller.rb
+++ b/backend/app/controllers/backoffice/investors_controller.rb
@@ -29,7 +29,7 @@ module Backoffice
     end
 
     def update
-      if @investor.update(update_params)
+      if I18n.with_locale(content_language) { @investor.update(update_params) }
         redirect_back(
           fallback_location: edit_backoffice_investor_path(@investor.id),
           notice: t("backoffice.messages.success_update", model: t("backoffice.common.investor"))
@@ -52,24 +52,16 @@ module Backoffice
       params.require(:investor).permit(
         :investor_type,
         :previously_invested,
-        :mission_en,
-        :mission_es,
-        :mission_pt,
-        :prioritized_projects_description_en,
-        :prioritized_projects_description_es,
-        :prioritized_projects_description_pt,
-        :other_information_en,
-        :other_information_es,
-        :other_information_pt,
+        :mission,
+        :prioritized_projects_description,
+        :other_information,
         account_attributes: [
           :id,
           :picture,
           :name,
           :language,
           :review_status,
-          :about_en,
-          :about_es,
-          :about_pt,
+          :about,
           :website,
           :linkedin,
           :facebook,

--- a/backend/app/controllers/backoffice/project_developers_controller.rb
+++ b/backend/app/controllers/backoffice/project_developers_controller.rb
@@ -29,7 +29,7 @@ module Backoffice
     end
 
     def update
-      if @project_developer.update(update_params)
+      if I18n.with_locale(content_language) { @project_developer.update(update_params) }
         redirect_back(
           fallback_location: edit_backoffice_project_developer_path(@project_developer.id),
           notice: t("backoffice.messages.success_update", model: t("backoffice.common.project_developer"))
@@ -52,18 +52,14 @@ module Backoffice
       params.require(:project_developer).permit(
         :project_developer_type,
         :entity_legal_registration_number,
-        :mission_en,
-        :mission_es,
-        :mission_pt,
+        :mission,
         account_attributes: [
           :id,
           :picture,
           :name,
           :language,
           :review_status,
-          :about_en,
-          :about_es,
-          :about_pt,
+          :about,
           :website,
           :linkedin,
           :facebook,

--- a/backend/app/controllers/backoffice/projects_controller.rb
+++ b/backend/app/controllers/backoffice/projects_controller.rb
@@ -29,7 +29,7 @@ module Backoffice
     end
 
     def update
-      if @project.update(update_params)
+      if I18n.with_locale(content_language) { @project.update(update_params) }
         redirect_back(
           fallback_location: edit_backoffice_project_path(@project.id),
           notice: t("backoffice.messages.success_update", model: t("backoffice.common.project"))
@@ -43,9 +43,7 @@ module Backoffice
 
     def update_params
       params.require(:project).permit(
-        :name_en,
-        :name_es,
-        :name_pt,
+        :name,
         :country_id,
         :department_id,
         :municipality_id,
@@ -54,38 +52,20 @@ module Backoffice
         :development_stage,
         :estimated_duration_in_months,
         :category,
-        :problem_en,
-        :problem_es,
-        :problem_pt,
-        :solution_en,
-        :solution_es,
-        :solution_pt,
-        :expected_impact_en,
-        :expected_impact_es,
-        :expected_impact_pt,
+        :problem,
+        :solution,
+        :expected_impact,
         :looking_for_funding,
         :ticket_size,
-        :funding_plan_en,
-        :funding_plan_es,
-        :funding_plan_pt,
+        :funding_plan,
         :received_funding,
         :received_funding_amount_usd,
         :received_funding_investor,
-        :replicability_en,
-        :replicability_es,
-        :replicability_pt,
-        :sustainability_en,
-        :sustainability_es,
-        :sustainability_pt,
-        :progress_impact_tracking_en,
-        :progress_impact_tracking_es,
-        :progress_impact_tracking_pt,
-        :description_en,
-        :description_es,
-        :description_pt,
-        :relevant_links_en,
-        :relevant_links_es,
-        :relevant_links_pt,
+        :replicability,
+        :sustainability,
+        :progress_impact_tracking,
+        :description,
+        :relevant_links,
         :trusted,
         instrument_types: [],
         impact_areas: [],

--- a/backend/app/controllers/concerns/backoffice/content_language.rb
+++ b/backend/app/controllers/concerns/backoffice/content_language.rb
@@ -4,14 +4,9 @@ module Backoffice
 
     included do
       helper_method :content_language
-      helper_method :localized_attribute
     end
 
     private
-
-    def localized_attribute(attribute)
-      [attribute, content_language].join("_")
-    end
 
     def content_language
       raise "@content_language_default is not set for the controller" unless defined?(@content_language_default)

--- a/backend/app/helpers/application_helper.rb
+++ b/backend/app/helpers/application_helper.rb
@@ -70,4 +70,11 @@ module ApplicationHelper
 
     raw doc
   end
+
+  def localized_input(f, field_name, lang, **options)
+    options[:input_html] ||= {}
+    options[:input_html][:value] ||= params[field_name].presence || f.object.public_send(field_name, locale: lang)
+
+    f.input field_name, options
+  end
 end

--- a/backend/app/views/backoffice/accounts/_common_fields.html.erb
+++ b/backend/app/views/backoffice/accounts/_common_fields.html.erb
@@ -3,8 +3,8 @@
     <%= t("backoffice.account.about") %>
   </h2>
 
-  <%= ff.input localized_attribute(:about), label: t("simple_form.labels.account.about"), as: :text, input_html: {rows: 5} %>
-  <%= f.input localized_attribute(:mission), label: t("simple_form.labels.defaults.mission"), as: :text, input_html: {rows: 5} %>
+  <%= localized_input ff, :about, content_language, label: t("simple_form.labels.account.about"), as: :text, input_html: {rows: 5} %>
+  <%= localized_input f, :mission, content_language, label: t("simple_form.labels.defaults.mission"), as: :text, input_html: {rows: 5} %>
   <%= ff.input :website, as: :string %>
 
   <h2 class="mb-4 mt-6 text-gray-600 font-semibold text-xl">

--- a/backend/app/views/backoffice/investors/_form.html.erb
+++ b/backend/app/views/backoffice/investors/_form.html.erb
@@ -1,5 +1,6 @@
 <%= simple_form_for [:backoffice, investor] do |f| %>
   <%= f.error_notification %>
+  <%= hidden_field_tag :content_lang, params[:content_lang] %>
 
   <h2 class="mb-4 mt-6 text-gray-600 font-semibold text-xl">
     <%= t(".general") %>
@@ -32,8 +33,8 @@
   <%= f.input :previously_invested %>
   <%= f.input :impacts, as: :check_boxes, collection: Impact.all %>
   <%= f.input :sdgs, as: :check_boxes, collection: Sdg.all %>
-  <%= f.input localized_attribute(:prioritized_projects_description), label: t("simple_form.labels.investor.prioritized_projects_description"), as: :text, input_html: {rows: 5} %>
-  <%= f.input localized_attribute(:other_information), label: t("simple_form.labels.investor.other_information"), as: :text, input_html: {rows: 5} %>
+  <%= localized_input f, :prioritized_projects_description, content_language, label: t("simple_form.labels.investor.prioritized_projects_description"), as: :text, input_html: {rows: 5} %>
+  <%= localized_input f, :other_information, content_language, label: t("simple_form.labels.investor.other_information"), as: :text, input_html: {rows: 5} %>
 
   <div class="mt-3 flex justify-end gap-3">
     <%= link_to t("backoffice.common.cancel"), backoffice_investors_path, class: "button button-secondary-green" %>

--- a/backend/app/views/backoffice/project_developers/_form.html.erb
+++ b/backend/app/views/backoffice/project_developers/_form.html.erb
@@ -1,5 +1,6 @@
 <%= simple_form_for [:backoffice, project_developer] do |f| %>
   <%= f.error_notification %>
+  <%= hidden_field_tag :content_lang, params[:content_lang] %>
 
   <h2 class="mb-4 mt-6 text-gray-600 font-semibold text-xl">
     <%= t(".general") %>

--- a/backend/app/views/backoffice/projects/_form.html.erb
+++ b/backend/app/views/backoffice/projects/_form.html.erb
@@ -1,7 +1,8 @@
 <%= simple_form_for [:backoffice, project], url: backoffice_project_path(project.id) do |f| %>
   <%= f.error_notification %>
+  <%= hidden_field_tag :content_lang, params[:content_lang] %>
 
-  <%= f.input localized_attribute(:name), label: t("simple_form.labels.project.name"), as: :string %>
+  <%= localized_input f, :name, content_language, label: t("simple_form.labels.project.name"), as: :string %>
   <%= f.input :project_images, label: t("simple_form.labels.project.project_images"), as: :file, input_html: { multiple: true, accept: "image/*" } %>
 
   <h2 class="mb-4 mt-6 text-gray-600 font-semibold text-xl">
@@ -28,10 +29,10 @@
     <%= f.input :estimated_duration_in_months, label: t("simple_form.labels.project.estimated_duration_in_months"), placeholder: t("simple_form.labels.project.estimated_duration_in_months_placeholder"), input_html: { max: 36 } %>
   </div>
   <%= f.input :category, collection: Category.all, label: t("simple_form.labels.project.category"), include_blank: false %>
-  <%= f.input localized_attribute(:problem), label: t("simple_form.labels.project.problem"), as: :text, input_html: {rows: 5} %>
-  <%= f.input localized_attribute(:solution), label: t("simple_form.labels.project.solution"), as: :text, input_html: {rows: 5} %>
+  <%= localized_input f, :problem, content_language, label: t("simple_form.labels.project.problem"), as: :text, input_html: {rows: 5} %>
+  <%= localized_input f, :solution, content_language, label: t("simple_form.labels.project.solution"), as: :text, input_html: {rows: 5} %>
   <%= f.input :target_groups, collection: ProjectTargetGroup.all, label: t("simple_form.labels.project.target_groups"), as: :check_boxes %>
-  <%= f.input localized_attribute(:expected_impact), label: t("simple_form.labels.project.expected_impact"), as: :text, input_html: {rows: 5} %>
+  <%= localized_input f, :expected_impact, content_language, label: t("simple_form.labels.project.expected_impact"), as: :text, input_html: {rows: 5} %>
 
   <h2 class="mb-4 mt-6 text-gray-600 font-semibold text-xl">
     <%= t(".impact") %>
@@ -45,7 +46,7 @@
   <%= f.input :looking_for_funding, label: t("simple_form.labels.project.looking_for_funding"), as: :radio_buttons %>
   <%= f.input :ticket_size, collection: TicketSize.all.map { |t| [t.description, t.id] }, label: t("simple_form.labels.project.ticket_size") %>
   <%= f.input :instrument_types, collection: InstrumentType.all, label: t("simple_form.labels.project.instrument_types"), as: :check_boxes %>
-  <%= f.input localized_attribute(:funding_plan), label: t("simple_form.labels.project.funding_plan"), as: :text, input_html: {rows: 5} %>
+  <%= localized_input f, :funding_plan, content_language, label: t("simple_form.labels.project.funding_plan"), as: :text, input_html: {rows: 5} %>
   <%= f.input :received_funding, label: t("simple_form.labels.project.received_funding"), as: :radio_buttons %>
   <div class="grid grid-cols-2 gap-4">
     <%= f.input :received_funding_amount_usd, label: t("simple_form.labels.project.received_funding_amount_usd") %>
@@ -55,11 +56,11 @@
   <h2 class="mb-4 mt-6 text-gray-600 font-semibold text-xl">
     <%= t(".how_will_project_grow") %>
   </h2>
-  <%= f.input localized_attribute(:replicability), label: t("simple_form.labels.project.replicability"), as: :text, input_html: {rows: 5} %>
-  <%= f.input localized_attribute(:sustainability), label: t("simple_form.labels.project.sustainability"), as: :text, input_html: {rows: 5} %>
-  <%= f.input localized_attribute(:progress_impact_tracking), label: t("simple_form.labels.project.progress_impact_tracking"), as: :text, input_html: {rows: 5} %>
-  <%= f.input localized_attribute(:description), label: t("simple_form.labels.project.description"), as: :text, input_html: {rows: 5} %>
-  <%= f.input localized_attribute(:relevant_links), label: t("simple_form.labels.project.relevant_links"), as: :text, input_html: {rows: 5} %>
+  <%= localized_input f, :replicability, content_language, label: t("simple_form.labels.project.replicability"), as: :text, input_html: {rows: 5} %>
+  <%= localized_input f, :sustainability, content_language, label: t("simple_form.labels.project.sustainability"), as: :text, input_html: {rows: 5} %>
+  <%= localized_input f, :progress_impact_tracking, content_language, label: t("simple_form.labels.project.progress_impact_tracking"), as: :text, input_html: {rows: 5} %>
+  <%= localized_input f, :description, content_language, label: t("simple_form.labels.project.description"), as: :text, input_html: {rows: 5} %>
+  <%= localized_input f, :relevant_links, content_language, label: t("simple_form.labels.project.relevant_links"), as: :text, input_html: {rows: 5} %>
 
   <div class="mt-3 flex justify-end gap-3">
     <%= link_to t("backoffice.common.cancel"), backoffice_projects_path, class: "button button-secondary-green" %>

--- a/backend/spec/system/backoffice/projects_spec.rb
+++ b/backend/spec/system/backoffice/projects_spec.rb
@@ -186,6 +186,14 @@ RSpec.describe "Backoffice: Projects", type: :system do
           expect(page).to have_text(t("simple_form.error_notification.default_message"))
           expect(page).to have_text("Estimated duration in months must be less than 37")
         end
+
+        it "shows validation errors for localized inputs" do
+          fill_in t("simple_form.labels.project.name"), with: ""
+          click_on t("backoffice.common.save")
+
+          expect(page).to have_text(t("simple_form.error_notification.default_message"))
+          expect(page).to have_text("Name can't be blank")
+        end
       end
     end
 


### PR DESCRIPTION
Fixing bugs with localized attributes at backoffice. These attributes now properly show:
 - if it is required
 - validation error if such error was raised during update

## Testing instructions

Backoffice...

## Tracking

BugFix ;)
