### PR TITLE
Front/improvement/dashboard projects

### DIFF
--- a/frontend/components/table/component.tsx
+++ b/frontend/components/table/component.tsx
@@ -19,6 +19,7 @@ export const Table: FC<TableProps> = ({
   columns,
   initialState,
   loading,
+  sortingEnabled = false,
   pagination: paginationProps,
   onSortChange = noop,
 }: TableProps) => {
@@ -50,6 +51,7 @@ export const Table: FC<TableProps> = ({
       // sorting
       manualSortBy: true,
       disableMultiSort: true,
+      disableSortBy: !sortingEnabled,
 
       initialState: {
         ...initialState,
@@ -85,9 +87,15 @@ export const Table: FC<TableProps> = ({
               return (
                 <tr key={headerGroupKey} {...restHeaderGroupProps} className="sticky top-0 px-10">
                   {headerGroup.headers.map((column) => {
-                    const { id, canSort, sortDescFirst, toggleSortBy } = column;
-
+                    const { id, sortDescFirst, toggleSortBy } = column;
                     const { key: headerKey, ...restHeaderProps } = column.getHeaderProps();
+
+                    // canSort is always true when manualSortBy is true
+                    // See: https://github.com/TanStack/table/issues/2599
+                    const canSort =
+                      (sortingEnabled &&
+                        columns.find(({ accessor }) => accessor === id)?.canSort) ??
+                      true;
 
                     return (
                       <th
@@ -113,10 +121,12 @@ export const Table: FC<TableProps> = ({
                         {column.hideHeader ? null : (
                           <>
                             <span>{column.render('Header')}</span>
-                            <div className="flex flex-col">
-                              <Icon icon={SORT_SVG} className="w-2 h-2 text-black" />
-                              <Icon icon={SORT_SVG} className="w-2 h-2 text-black rotate-180" />
-                            </div>
+                            {canSort && (
+                              <div className="flex flex-col">
+                                <Icon icon={SORT_SVG} className="w-2 h-2 text-black" />
+                                <Icon icon={SORT_SVG} className="w-2 h-2 text-black rotate-180" />
+                              </div>
+                            )}
                           </>
                         )}
                       </th>

--- a/frontend/components/table/types.d.ts
+++ b/frontend/components/table/types.d.ts
@@ -6,5 +6,6 @@ export interface TableProps {
   initialState?: Record<string, any>;
   loading?: boolean;
   pagination?: PaginationProps;
+  sortingEnabled?: boolean;
   onSortChange?: ({ sortBy, sortOrder }: { sortBy?: string; sortOrder?: 'asc' | 'desc' }) => void;
 }

--- a/frontend/pages/dashboard/projects.tsx
+++ b/frontend/pages/dashboard/projects.tsx
@@ -81,7 +81,10 @@ export const ProjectsPage: PageComponent<ProjectsPageProps, DashboardLayoutProps
   const handleRowMenuItemClick = ({ key, slug }: { key: string; slug: string }) => {
     switch (key) {
       case 'edit':
-        router.push(`${Paths.Project}/${slug}/edit`);
+        router.push(
+          `${Paths.Project}/${slug}/edit?returnPath=${encodeURIComponent(router.asPath)}`,
+          `${Paths.Project}/${slug}/edit`
+        );
         return;
       case 'open':
         router.push(`${Paths.Project}/${slug}`);
@@ -122,7 +125,12 @@ export const ProjectsPage: PageComponent<ProjectsPageProps, DashboardLayoutProps
         Cell: ({ cell }) => {
           return (
             <div className="flex items-center justify-center gap-3">
-              <Link href={`${Paths.Project}/${cell.row.original.slug}/edit`}>
+              <Link
+                href={`${Paths.Project}/${
+                  cell.row.original.slug
+                }/edit?returnPath=${encodeURIComponent(router.asPath)}`}
+                as={`${Paths.Project}/${cell.row.original.slug}/edit`}
+              >
                 <a className="px-2 py-1 text-sm transition-all text-green-dark focus-visible:outline-green-dark rounded-2xl">
                   <FormattedMessage defaultMessage="Edit" id="wEQDC6" />
                 </a>

--- a/frontend/pages/dashboard/projects.tsx
+++ b/frontend/pages/dashboard/projects.tsx
@@ -120,6 +120,7 @@ export const ProjectsPage: PageComponent<ProjectsPageProps, DashboardLayoutProps
       },
       {
         accessor: 'actions',
+        canSort: false,
         hideHeader: true,
         width: 0,
         Cell: ({ cell }) => {
@@ -168,6 +169,7 @@ export const ProjectsPage: PageComponent<ProjectsPageProps, DashboardLayoutProps
     })),
     loading: isLoadingProjects || isFetchingProjects,
     pagination: paginationProps,
+    sortingEnabled: false, // Enable when endpoints can handle sorting
     onSortChange: sortChangeHandler,
   };
 

--- a/frontend/pages/project-developers/edit.tsx
+++ b/frontend/pages/project-developers/edit.tsx
@@ -38,7 +38,7 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, FormPageLayoutProps
   const { projectDeveloper } = useCurrentProjectDeveloper();
 
   const handleOnComplete = () => {
-    router.push((router.query?.returnPath as string) || Paths.Dashboard);
+    router.push(decodeURIComponent(router.query?.returnPath as string) || Paths.Dashboard);
   };
 
   return (

--- a/frontend/pages/project/[id]/edit.tsx
+++ b/frontend/pages/project/[id]/edit.tsx
@@ -78,7 +78,7 @@ const EditProject: PageComponent<EditProjectProps, FormPageLayoutProps> = ({ pro
   const { formatMessage } = useIntl();
   const resolver = useProjectValidation(currentPage);
   const updateProject = useUpdateProject();
-  const { push } = useRouter();
+  const router = useRouter();
   const { data } = useEnums();
   const {
     category,
@@ -146,14 +146,16 @@ const EditProject: PageComponent<EditProjectProps, FormPageLayoutProps> = ({ pro
           errorPages.length && setCurrentPage(errorPages[0]);
         },
         onSuccess: (result) => {
-          push({
-            pathname: `${Paths.Project}/${project?.slug}`,
-            search: `project=${result.data.slug}`,
-          });
+          router.push(
+            decodeURIComponent(router.query?.returnPath as string) || {
+              pathname: `${Paths.Project}/${project?.slug}`,
+              search: `project=${result.data.slug}`,
+            }
+          );
         },
       });
     },
-    [updateProject, setError, push, project?.slug]
+    [updateProject, setError, router, project?.slug]
   );
 
   const onSubmit: SubmitHandler<ProjectForm> = (values: ProjectForm) => {
@@ -304,7 +306,9 @@ const EditProject: PageComponent<EditProjectProps, FormPageLayoutProps> = ({ pro
       <LeaveFormModal
         isOpen={showLeave}
         close={() => setShowLeave(false)}
-        handleLeave={() => push(Paths.Dashboard)}
+        handleLeave={() =>
+          router.push(decodeURIComponent(router.query?.returnPath as string) || Paths.Dashboard)
+        }
         title={formatMessage({ defaultMessage: 'Leave project creation form', id: 'vygPIS' })}
       />
     </ProtectedPage>


### PR DESCRIPTION
This PR adds a couple enhancements to the dashboard/projects section (but does not complete it): 

- It makes it so that when the user clicks on the "Edit" button on a project, when edition is fixed the user is returned to the same dashboard page. 
  _Virtually the same implementation as in #290_  
- Adds an option to disable table sorting entirely  
  _In case that doesn't get implemented in the API right away_

## Tracking

Continues [LET-551](https://vizzuality.atlassian.net/browse/LET-551) but does not complete it. 
