### PR TITLE
feat: Allow to delete projects via Backoffice

### DIFF
--- a/backend/app/controllers/backoffice/projects_controller.rb
+++ b/backend/app/controllers/backoffice/projects_controller.rb
@@ -3,7 +3,7 @@ module Backoffice
     include Sections
     include ContentLanguage
 
-    before_action :fetch_project, only: [:edit, :update]
+    before_action :fetch_project, only: [:edit, :update, :destroy]
     before_action :set_breadcrumbs, only: [:edit, :update]
     before_action :set_sections, only: [:edit, :update]
     before_action :set_content_language_default, only: [:edit, :update]
@@ -37,6 +37,13 @@ module Backoffice
       else
         render :edit, status: :unprocessable_entity
       end
+    end
+
+    def destroy
+      @project.destroy!
+
+      redirect_to backoffice_projects_path, status: :see_other,
+        notice: t("backoffice.messages.success_delete", model: t("backoffice.common.project"))
     end
 
     private

--- a/backend/app/helpers/application_helper.rb
+++ b/backend/app/helpers/application_helper.rb
@@ -73,7 +73,7 @@ module ApplicationHelper
 
   def localized_input(f, field_name, lang, **options)
     options[:input_html] ||= {}
-    options[:input_html][:value] ||= params[field_name].presence || f.object.public_send(field_name, locale: lang)
+    options[:input_html][:value] ||= f.object.public_send(field_name, locale: lang)
 
     f.input field_name, options
   end

--- a/backend/app/views/backoffice/projects/edit.html.erb
+++ b/backend/app/views/backoffice/projects/edit.html.erb
@@ -4,11 +4,20 @@
       <%= @project.name %>
     </h1>
 
-    <ul class="flex flex-col gap-8">
+    <ul class="flex flex-col gap-8 mb-8">
       <li><%= section_link_to t("backoffice.projects.information"), :information, default: true %></li>
       <li><%= section_link_to t("backoffice.projects.status"), :status %></li>
       <li><%= section_link_to t("backoffice.projects.project_developers"), :project_developers %></li>
     </ul>
+    <%= link_to backoffice_project_path(@project.id),
+       data: {
+         turbo_method: :delete,
+         turbo_confirm: t("backoffice.messages.delete_confirmation", model: t("backoffice.common.project").downcase)
+       },
+       class: "button button-secondary-green button-with-icon" do %>
+      <%= svg "trash" %>
+      <%= t("backoffice.projects.delete") %>
+    <% end %>
   </aside>
   <div class="w-full h-full bg-white rounded-xl p-6">
     <%= render section_partial %>

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -135,6 +135,7 @@ zu:
       status_description: The verification status allow the project to have a verification badge. By default all the projects are set to "Unverified". Please review the information and change it to "Verified".
       project_developers: Project developers
       project_developers_in_project: Project developers in the project (%{count})
+      delete: Delete project
       index:
         priority_landscape: Priority Landscape
       edit:

--- a/backend/config/routes/backoffice.rb
+++ b/backend/config/routes/backoffice.rb
@@ -12,5 +12,5 @@ namespace :backoffice do
   end
   resources :investors, only: [:index, :edit, :update, :destroy]
   resources :project_developers, only: [:index, :edit, :update, :destroy]
-  resources :projects, only: [:index, :edit, :update]
+  resources :projects, only: [:index, :edit, :update, :destroy]
 end

--- a/backend/spec/system/backoffice/projects_spec.rb
+++ b/backend/spec/system/backoffice/projects_spec.rb
@@ -259,5 +259,16 @@ RSpec.describe "Backoffice: Projects", type: :system do
         expect(project.relevant_links_es).to eq("New relevant links - Spanish")
       end
     end
+
+    context "when removing project" do
+      it "removes project" do
+        accept_confirm do
+          click_on t("backoffice.projects.delete")
+        end
+        expect(page).to have_text(t("backoffice.messages.success_delete", model: t("backoffice.common.project")))
+        expect(current_path).to eql(backoffice_projects_path)
+        expect(page).not_to have_text(project.name)
+      end
+    end
   end
 end


### PR DESCRIPTION
Simple enhancement of Project page at Backoffice which allows to delete existing Projects.

## Testing instructions

Via backoffice ;)

## Tracking

https://vizzuality.atlassian.net/browse/LET-597
