### PR TITLE
Remove a hard-coded account name in the front-end code

### DIFF
--- a/frontend/containers/users/invite-users-modal/component.tsx
+++ b/frontend/containers/users/invite-users-modal/component.tsx
@@ -117,8 +117,8 @@ export const InviteUsersModal: FC<InviteUsersModalProps> = ({
 
         <p className="mb-4">
           <FormattedMessage
-            defaultMessage="Users will receive an email to sign up into the platform and join NEEsT’s account."
-            id="hbFTZN"
+            defaultMessage="Users will receive an email to sign up into the platform and join the account."
+            id="j0CZkp"
           />
         </p>
 

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -1077,9 +1077,6 @@
   "hX5PAb": {
     "string": "No results found"
   },
-  "hbFTZN": {
-    "string": "Users will receive an email to sign up into the platform and join NEEsT’s account."
-  },
   "hg7Mex": {
     "string": "Select which areas your project will have an impact on"
   },
@@ -1121,6 +1118,9 @@
   },
   "itfsqC": {
     "string": "Currently you don’t have any <b>Projects</b>."
+  },
+  "j0CZkp": {
+    "string": "Users will receive an email to sign up into the platform and join the account."
   },
   "j4lBL7": {
     "string": "Note: Some filters not apply to all tabs"


### PR DESCRIPTION
This PR only removes a hard-coded account name in the user invitation modal.

If you think the account name is important, then I can modify the PR to use the `useAccount` hook and dynamically insert it.

## Testing instructions

Look at the code 😉.

## Tracking

Not tracked.
