### PR TITLE
Add forms/switch component

### DIFF
--- a/frontend/components/forms/switch/component.stories.tsx
+++ b/frontend/components/forms/switch/component.stories.tsx
@@ -1,0 +1,168 @@
+import React from 'react';
+
+import { SubmitHandler, useForm } from 'react-hook-form';
+
+import { action } from '@storybook/addon-actions';
+import { Story, Meta } from '@storybook/react/types-6-0';
+
+import Button from 'components/button';
+
+import { SwitchProps } from './types';
+
+import Switch from '.';
+
+export default {
+  component: Switch,
+  title: 'Components/Forms/Switch',
+  argTypes: {
+    register: { control: { disable: true } },
+  },
+} as Meta;
+
+interface FormValues {
+  accept: string;
+}
+
+const Template: Story<SwitchProps<FormValues>> = (args: SwitchProps<FormValues>) => {
+  const { register } = useForm<FormValues>();
+
+  return (
+    <div className="p-4">
+      <Switch register={register} {...args} />
+      <p className="mt-2 text-xs text-gray-50">
+        This input is not accessible. Either define <code>aria-label</code> or associate a label
+        (see the “With Label” story).
+      </p>
+    </div>
+  );
+};
+
+export const Default: Story<SwitchProps<FormValues>> = Template.bind({});
+Default.args = {
+  id: 'form-accept',
+  name: 'accept',
+  registerOptions: {
+    disabled: false,
+  },
+};
+
+const TemplateWithLabel: Story<SwitchProps<FormValues>> = (args: SwitchProps<FormValues>) => {
+  const { register } = useForm<FormValues>();
+
+  return (
+    <div className="p-3">
+      <label htmlFor="story-check" className="flex items-center gap-2 cursor-pointer">
+        <Switch id="story-check" name="checkbox" register={register} {...args} />I accept the Terms
+        and Privacy Policy
+      </label>
+    </div>
+  );
+};
+
+export const WithLabel: Story<SwitchProps<FormValues>> = TemplateWithLabel.bind({});
+WithLabel.args = {
+  id: 'story-check',
+  name: 'accept',
+  registerOptions: {
+    disabled: false,
+  },
+};
+
+const TemplateWithForm: Story<SwitchProps<FormValues>> = (args: SwitchProps<FormValues>) => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>({
+    // Using the native validation, we're able to style the inputs using the `valid` and `invalid`
+    // pseudo class
+    shouldUseNativeValidation: true,
+  });
+  const onSubmit: SubmitHandler<FormValues> = (data) => action('onSubmit')(data);
+
+  return (
+    <div className="p-4">
+      <form
+        // `noValidate` here prevents the browser from not submitting the form if there's a validation
+        // error. We absolutely want the form to be submitted so that React Hook Form is made aware of
+        // the validation errors and we can display errors below inputs.
+        noValidate
+        onSubmit={handleSubmit(onSubmit)}
+      >
+        <label htmlFor="story-check" className="flex items-center gap-2 cursor-pointer">
+          <Switch
+            id="story-check"
+            name="accept"
+            register={register}
+            aria-describedby="form-error"
+            {...args}
+          />
+          I accept the Terms and Privacy Policy
+        </label>
+        {errors.accept?.message && (
+          <p id="form-error" className="pl-2 mt-1 text-xs text-red-700">
+            {errors.accept?.message}
+          </p>
+        )}
+
+        <Button type="submit" className="mt-2">
+          Submit
+        </Button>
+        <p className="mt-2 text-xs text-gray-50">
+          Submit the form to see the {"input's"} error state (the input is required).
+        </p>
+      </form>
+    </div>
+  );
+};
+
+export const ErrorState: Story<SwitchProps<FormValues>> = TemplateWithForm.bind({});
+ErrorState.args = {
+  id: 'story-check',
+  name: 'accept',
+  registerOptions: {
+    disabled: false,
+    required: 'Accept Terms and Privacy Policy is required.',
+  },
+};
+
+const TemplateDisabled: Story<SwitchProps<FormValues>> = (args: SwitchProps<FormValues>) => {
+  const {
+    register,
+    formState: { errors },
+  } = useForm<FormValues>({
+    // Using the native validation, we're able to style the inputs using the `valid` and `invalid`
+    // pseudo class
+    shouldUseNativeValidation: true,
+  });
+
+  return (
+    <div className="p-4">
+      <label htmlFor="story-check" className="flex items-center gap-2">
+        <Switch
+          id="story-check"
+          name="accept"
+          register={register}
+          aria-describedby="form-error"
+          {...args}
+        />
+        I accept the Terms and Privacy Policy
+      </label>
+      {errors.accept?.message && (
+        <p id="form-error" className="pl-2 mt-1 text-xs text-red-700">
+          {errors.accept?.message}
+        </p>
+      )}
+    </div>
+  );
+};
+
+export const Disabled: Story<SwitchProps<FormValues>> = TemplateDisabled.bind({});
+Disabled.args = {
+  id: 'story-check',
+  name: 'accept',
+  registerOptions: {
+    disabled: true,
+    required: false,
+  },
+};

--- a/frontend/components/forms/switch/component.tsx
+++ b/frontend/components/forms/switch/component.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+
+import { FieldValues } from 'react-hook-form';
+
+import cx from 'classnames';
+
+import { SwitchProps } from './types';
+
+export const Switch = <FormValues extends FieldValues>(props: SwitchProps<FormValues>) => {
+  const { register, registerOptions, ...rest } = props;
+  const { name, id, 'aria-label': ariaLabel, switchSize = 'small' } = rest;
+
+  const [invalid, setInvalid] = useState(false);
+
+  return (
+    <input
+      type="checkbox"
+      className={cx({
+        'peer relative appearance-none cursor-pointer inline-flex items-center transition-all':
+          true,
+        'rounded-full border border-green-dark bg-transparent': true,
+        'checked:bg-green-dark checked:after:bg-white': true,
+        'focus-visible:outline focus-visible:outline-green-dark focus-visible:outline-2': true,
+        'after:content after:absolute after:rounded-full after:bg-green-dark after:transition-all':
+          true,
+        'disabled:opacity-60 disabled:border-beige disabled:after:bg-gray-400 disabled:bg-background-middle':
+          true,
+        'w-5 h-3 focus-visible:outline-offset-1 after:h-2 after:w-2 after:translate-x-px checked:after:translate-x-[9px]':
+          switchSize === 'smallest',
+        'w-8 h-4 focus-visible:outline-offset-2 after:h-2.5 after:w-2.5 after:translate-x-0.5 checked:after:translate-x-[18px]':
+          switchSize === 'small',
+      })}
+      id={id}
+      aria-label={ariaLabel}
+      {...rest}
+      {...register(name, {
+        ...registerOptions,
+      })}
+      onInvalid={() => setInvalid(true)}
+    />
+  );
+};
+
+export default Switch;

--- a/frontend/components/forms/switch/index.ts
+++ b/frontend/components/forms/switch/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { SwitchProps } from './types';

--- a/frontend/components/forms/switch/types.ts
+++ b/frontend/components/forms/switch/types.ts
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { Path, UseFormRegister, RegisterOptions, FieldPath } from 'react-hook-form';
+
+export type SwitchProps<FormValues> = {
+  /** ID of the element. Required if `aria-label` is not provided. */
+  id?: string;
+  /** Label of the element. Required `id` is not provided. */
+  'aria-label'?: string;
+  /** Name of the switch */
+  name: Path<FormValues>;
+  /** Value of the switch */
+  value: any;
+  /** React Hook Form's `register` function */
+  register: UseFormRegister<FormValues>;
+  /** Options for React Hook Form's `register` function */
+  registerOptions?: RegisterOptions<FormValues, FieldPath<FormValues>>;
+  /** Size of the switch. Defaults to 'small' */
+  switchSize?: 'small' | 'smallest';
+  /** Whether the switch is disabled. Defaults to false */
+  disabled?: boolean;
+} & Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  keyof RegisterOptions<FormValues, FieldPath<FormValues>>
+>;


### PR DESCRIPTION
## Description

This PR adds a forms/Switch component, built in a similar fashion to the existing checkbox component. 

This switch will be needed for the (in progress) Map layers list: https://www.figma.com/file/KC49uMR9t1YARmFR0Sr6aN/HeCo---Work-in-progress?node-id=2%3A4787  

And later on Open calls: 
https://www.figma.com/file/KC49uMR9t1YARmFR0Sr6aN/HeCo---Work-in-progress?node-id=2681%3A33130

## Testing instructions

Verify that the Switch component works correctly (in Storybook). 

## Tracking

[LET-655](https://vizzuality.atlassian.net/browse/LET-655)

## Screenshots  

<img width="199" alt="Screenshot 2022-06-23 at 13 00 54" src="https://user-images.githubusercontent.com/6273795/175293862-d40aecfc-83d9-48ed-97e5-10e644a5fd86.png">

<img width="394" alt="Screenshot 2022-06-23 at 13 01 20" src="https://user-images.githubusercontent.com/6273795/175293938-1b182315-3130-404b-84e1-44c0152aa402.png">

