### PR TITLE
feat: Allow to change language at Backoffice

### DIFF
--- a/backend/app/controllers/backoffice/admins/sessions_controller.rb
+++ b/backend/app/controllers/backoffice/admins/sessions_controller.rb
@@ -1,0 +1,9 @@
+class Backoffice::Admins::SessionsController < Devise::SessionsController
+  include Backoffice::Localization
+
+  # GET
+  def change_locale
+    session[:locale] = params[:locale]
+    redirect_back fallback_location: admin_root_path
+  end
+end

--- a/backend/app/controllers/backoffice/base_controller.rb
+++ b/backend/app/controllers/backoffice/base_controller.rb
@@ -2,6 +2,7 @@ module Backoffice
   class BaseController < ApplicationController
     include Pagy::Backend
     include Breadcrumbs
+    include Localization
 
     layout "backoffice"
 

--- a/backend/app/controllers/concerns/backoffice/localization.rb
+++ b/backend/app/controllers/concerns/backoffice/localization.rb
@@ -1,0 +1,13 @@
+module Backoffice
+  module Localization
+    def self.included(base)
+      base.around_action :set_locale
+    end
+
+    def set_locale(&action)
+      locale = session[:locale].presence || current_admin&.ui_language
+      locale = I18n.default_locale.to_s unless Language::TYPES.include?(locale)
+      I18n.with_locale(locale, &action)
+    end
+  end
+end

--- a/backend/app/views/layouts/_language_selector.html.erb
+++ b/backend/app/views/layouts/_language_selector.html.erb
@@ -1,0 +1,8 @@
+<%= select_tag :locale, options_for_select(Language.all.map { |l| [l.id.upcase, l.id] }, I18n.locale),
+   class: "bg-green-dark", data: {url: backoffice_admins_sessions_change_locale_url},
+   onchange: "
+     url = new window.URL(event.target.dataset.url);
+     url.searchParams.set('locale', event.target.value);
+     location.assign(url.toString());
+   "
+%>

--- a/backend/app/views/layouts/backoffice.html.erb
+++ b/backend/app/views/layouts/backoffice.html.erb
@@ -6,9 +6,10 @@
           <a class="font-semibold" href="/">HeCo Invest</a>
           <span class="font-light"><%= t("backoffice.layout.header") %></span>
         </div>
-        <div class="flex items-center justify-end flex-1">
+        <div class="flex items-center justify-end flex-1 gap-2">
           <%= current_admin.email %>
-          <%= button_to t("backoffice.layout.sign_out"), destroy_admin_session_path, data: {turbo: false}, class: "ml-2", method: :delete %>
+          <%= render partial: "layouts/language_selector" %>
+          <%= button_to t("backoffice.layout.sign_out"), destroy_admin_session_path, data: {turbo: false}, method: :delete %>
         </div>
       </div>
     </div>

--- a/backend/app/views/layouts/devise.html.erb
+++ b/backend/app/views/layouts/devise.html.erb
@@ -1,8 +1,13 @@
 <% content_for :content do %>
   <header class="fixed top-0 w-full h-16 lg:h-20 z-10 py-4 bg-green-dark">
-    <div class="container mx-auto text-beige">
-      <a class="font-semibold" href="/">HeCo Invest</a>
-      <span class="font-light">Backoffice</span>
+    <div class="text-beige flex items-center">
+      <div class="container mx-auto">
+        <a class="font-semibold" href="/">HeCo Invest</a>
+        <span class="font-light">Backoffice</span>
+      </div>
+      <div class="mx-auto">
+        <%= render partial: "layouts/language_selector" %>
+      </div>
     </div>
   </header>
 

--- a/backend/config/routes/backoffice.rb
+++ b/backend/config/routes/backoffice.rb
@@ -1,4 +1,7 @@
-devise_for :admins, path: "backoffice"
+devise_for :admins, path: "backoffice", controllers: {sessions: "backoffice/admins/sessions"}
+devise_scope :admin do
+  get "backoffice/admins/sessions/change_locale" => "backoffice/admins/sessions"
+end
 
 # admin_root_path is useful for devise
 get "/backoffice", to: redirect("backoffice/projects"), as: :admin_root

--- a/backend/spec/system/backoffice/localization_spec.rb
+++ b/backend/spec/system/backoffice/localization_spec.rb
@@ -1,0 +1,32 @@
+require "system_helper"
+
+RSpec.describe "Backoffice: Localization", type: :system do
+  let_it_be(:admin) { create(:admin, email: "admin@example.com", password: "SuperSecret6", first_name: "Admin", last_name: "Example", ui_language: "en") }
+
+  shared_context "localizable" do
+    it "allows to switch localization" do
+      expect(page).to have_select(:locale, selected: "EN")
+      select "ES", from: :locale
+      sleep 1
+      visit "/backoffice"
+      expect(page).to have_select(:locale, selected: "ES")
+    end
+  end
+
+  context "when user is logged in" do
+    before do
+      sign_in admin
+      visit "/backoffice"
+    end
+
+    include_context "localizable"
+  end
+
+  context "when user is not logged in" do
+    before do
+      visit "/backoffice"
+    end
+
+    include_context "localizable"
+  end
+end


### PR DESCRIPTION
I am adding simple selectbox next to user name which allows to switch between currently supported languages. Selected language is stored at session --> not sure if we have some attribute at admin table that I could use for it so I have decided to put it into session.

## Testing instructions

Open Backoffice and try to change language as logged and not-logged user. All text localized with I18n or even with traco should react to this change.

## Tracking

https://vizzuality.atlassian.net/browse/LET-659
