### PR TITLE
test: only approved entities can be favourited

### DIFF
--- a/backend/spec/requests/api/v1/favourite_investors_spec.rb
+++ b/backend/spec/requests/api/v1/favourite_investors_spec.rb
@@ -15,9 +15,12 @@ RSpec.describe "API V1 Favourite Investor", type: :request do
       let(:user) { create :user, account: create(:account, :approved) }
 
       it_behaves_like "with not authorized error", csrf: true
-      it_behaves_like "with forbidden error", csrf: true, user: -> { create(:user, account: create(:account, :unapproved)) }
 
       response "200", :success do
+        schema type: :object, properties: {
+          data: {"$ref" => "#/components/schemas/investor"}
+        }
+
         let("X-CSRF-TOKEN") { get_csrf_token }
 
         before { sign_in user }
@@ -26,6 +29,26 @@ RSpec.describe "API V1 Favourite Investor", type: :request do
 
         it "favourite of investor is truthy" do
           expect(response_json["data"]["attributes"]["favourite"]).to be_truthy
+        end
+      end
+
+      response "403", "Investor or User account are not approved" do
+        schema "$ref" => "#/components/schemas/errors"
+
+        let("X-CSRF-TOKEN") { get_csrf_token }
+
+        before { sign_in user }
+
+        context "when user is not approved" do
+          let(:user) { create :user, account: create(:account, :unapproved) }
+
+          run_test!
+        end
+
+        context "when investor is not approved" do
+          let(:investor) { create :investor, account: create(:account, :unapproved) }
+
+          run_test!
         end
       end
     end
@@ -46,6 +69,10 @@ RSpec.describe "API V1 Favourite Investor", type: :request do
       it_behaves_like "with forbidden error", csrf: true, user: -> { create(:user, account: create(:account, :unapproved)) }
 
       response "200", :success do
+        schema type: :object, properties: {
+          data: {"$ref" => "#/components/schemas/investor"}
+        }
+
         let("X-CSRF-TOKEN") { get_csrf_token }
 
         before do

--- a/backend/spec/requests/api/v1/favourite_project_developers_spec.rb
+++ b/backend/spec/requests/api/v1/favourite_project_developers_spec.rb
@@ -15,9 +15,12 @@ RSpec.describe "API V1 Favourite Project Developer", type: :request do
       let(:user) { create :user, account: create(:account, :approved) }
 
       it_behaves_like "with not authorized error", csrf: true
-      it_behaves_like "with forbidden error", csrf: true, user: -> { create(:user, account: create(:account, :unapproved)) }
 
       response "200", :success do
+        schema type: :object, properties: {
+          data: {"$ref" => "#/components/schemas/project_developer"}
+        }
+
         let("X-CSRF-TOKEN") { get_csrf_token }
 
         before { sign_in user }
@@ -26,6 +29,26 @@ RSpec.describe "API V1 Favourite Project Developer", type: :request do
 
         it "favourite of project developer is truthy" do
           expect(response_json["data"]["attributes"]["favourite"]).to be_truthy
+        end
+      end
+
+      response "403", "Project developer or User account are not approved" do
+        schema "$ref" => "#/components/schemas/errors"
+
+        let("X-CSRF-TOKEN") { get_csrf_token }
+
+        before { sign_in user }
+
+        context "when user is not approved" do
+          let(:user) { create :user, account: create(:account, :unapproved) }
+
+          run_test!
+        end
+
+        context "when project developer is not approved" do
+          let(:project_developer) { create :project_developer, account: create(:account, :unapproved) }
+
+          run_test!
         end
       end
     end
@@ -46,6 +69,10 @@ RSpec.describe "API V1 Favourite Project Developer", type: :request do
       it_behaves_like "with forbidden error", csrf: true, user: -> { create(:user, account: create(:account, :unapproved)) }
 
       response "200", :success do
+        schema type: :object, properties: {
+          data: {"$ref" => "#/components/schemas/project_developer"}
+        }
+
         let("X-CSRF-TOKEN") { get_csrf_token }
 
         before do

--- a/backend/spec/requests/api/v1/favourite_projects_spec.rb
+++ b/backend/spec/requests/api/v1/favourite_projects_spec.rb
@@ -15,9 +15,12 @@ RSpec.describe "API V1 Favourite Project", type: :request do
       let(:user) { create :user, account: create(:account, :approved) }
 
       it_behaves_like "with not authorized error", csrf: true
-      it_behaves_like "with forbidden error", csrf: true, user: -> { create(:user, account: create(:account, :unapproved)) }
 
       response "200", :success do
+        schema type: :object, properties: {
+          data: {"$ref" => "#/components/schemas/project"}
+        }
+
         let("X-CSRF-TOKEN") { get_csrf_token }
 
         before { sign_in user }
@@ -26,6 +29,26 @@ RSpec.describe "API V1 Favourite Project", type: :request do
 
         it "favourite of project is truthy" do
           expect(response_json["data"]["attributes"]["favourite"]).to be_truthy
+        end
+      end
+
+      response "403", "Project or User account are not approved" do
+        schema "$ref" => "#/components/schemas/errors"
+
+        let("X-CSRF-TOKEN") { get_csrf_token }
+
+        before { sign_in user }
+
+        context "when user is not approved" do
+          let(:user) { create :user, account: create(:account, :unapproved) }
+
+          run_test!
+        end
+
+        context "when project is not approved" do
+          let(:project) { create :project, project_developer: create(:project_developer, account: create(:account, :unapproved)) }
+
+          run_test!
         end
       end
     end
@@ -46,6 +69,10 @@ RSpec.describe "API V1 Favourite Project", type: :request do
       it_behaves_like "with forbidden error", csrf: true, user: -> { create(:user, account: create(:account, :unapproved)) }
 
       response "200", :success do
+        schema type: :object, properties: {
+          data: {"$ref" => "#/components/schemas/project"}
+        }
+
         let("X-CSRF-TOKEN") { get_csrf_token }
 
         before do


### PR DESCRIPTION
Unapproved PDs/Projects/Investors cannot be marked as favourite. In reality they are not even publicly visible so it should not be possible to mark them as favourite at all, but I am adding extra tests to make sure that this policy always supported.

## Testing instructions

Not required :))

## Tracking

https://vizzuality.atlassian.net/browse/LET-528
