### PR TITLE
feat: Create Admin via backoffice

### DIFF
--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -388,7 +388,7 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.4.2)
+    rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
     railties (7.0.2.4)
       actionpack (= 7.0.2.4)

--- a/backend/app/controllers/backoffice/admins/passwords_controller.rb
+++ b/backend/app/controllers/backoffice/admins/passwords_controller.rb
@@ -1,0 +1,3 @@
+class Backoffice::Admins::PasswordsController < Devise::PasswordsController
+  include Backoffice::Localization
+end

--- a/backend/app/controllers/backoffice/admins_controller.rb
+++ b/backend/app/controllers/backoffice/admins_controller.rb
@@ -24,7 +24,7 @@ module Backoffice
     end
 
     def create
-      if @admin.update admin_params.merge(password: GeneratePassword.new(50).call, ui_language: current_admin.ui_language)
+      if @admin.update admin_params.merge(password: GeneratePassword.new(50).call)
         AdminMailer.first_time_login_instructions(@admin).deliver_later
         redirect_to backoffice_admins_url, notice: t("backoffice.messages.success_create", model: t("backoffice.common.admin"))
       else
@@ -38,6 +38,7 @@ module Backoffice
       params.require(:admin).permit(
         :first_name,
         :last_name,
+        :ui_language,
         :email
       )
     end

--- a/backend/app/controllers/backoffice/admins_controller.rb
+++ b/backend/app/controllers/backoffice/admins_controller.rb
@@ -1,5 +1,8 @@
 module Backoffice
   class AdminsController < BaseController
+    before_action :initialize_admin, only: [:new, :create]
+    before_action :set_breadcrumbs, only: [:new, :create]
+
     def index
       @q = Admin.ransack params[:q]
       @admins = @q.result
@@ -15,6 +18,37 @@ module Backoffice
             type: "text/csv; charset=utf-8"
         end
       end
+    end
+
+    def new
+    end
+
+    def create
+      if @admin.update admin_params.merge(password: GeneratePassword.new(50).call, ui_language: current_admin.ui_language)
+        redirect_to backoffice_admins_url,
+          notice: t("backoffice.messages.success_create", model: t("backoffice.common.admin"))
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def admin_params
+      params.require(:admin).permit(
+        :first_name,
+        :last_name,
+        :email
+      )
+    end
+
+    def initialize_admin
+      @admin = Admin.new
+    end
+
+    def set_breadcrumbs
+      add_breadcrumb(I18n.t("backoffice.layout.admins"), backoffice_admins_path)
+      @admin.new_record? ? add_breadcrumb(I18n.t("backoffice.admins.form.new")) : add_breadcrumb(@admin.full_name)
     end
   end
 end

--- a/backend/app/controllers/backoffice/admins_controller.rb
+++ b/backend/app/controllers/backoffice/admins_controller.rb
@@ -25,8 +25,8 @@ module Backoffice
 
     def create
       if @admin.update admin_params.merge(password: GeneratePassword.new(50).call, ui_language: current_admin.ui_language)
-        redirect_to backoffice_admins_url,
-          notice: t("backoffice.messages.success_create", model: t("backoffice.common.admin"))
+        AdminMailer.first_time_login_instructions(@admin).deliver_later
+        redirect_to backoffice_admins_url, notice: t("backoffice.messages.success_create", model: t("backoffice.common.admin"))
       else
         render :new, status: :unprocessable_entity
       end

--- a/backend/app/mailers/admin_mailer.rb
+++ b/backend/app/mailers/admin_mailer.rb
@@ -1,0 +1,19 @@
+class AdminMailer < ApplicationMailer
+  def first_time_login_instructions(admin)
+    @admin = admin
+    @token = set_reset_password_token admin
+
+    mail to: admin.email
+  end
+
+  private
+
+  def set_reset_password_token(admin)
+    raw, enc = Devise.token_generator.generate(Admin, :reset_password_token)
+
+    admin.reset_password_token = enc
+    admin.reset_password_sent_at = Time.current
+    admin.save validate: false
+    raw
+  end
+end

--- a/backend/app/services/generate_password.rb
+++ b/backend/app/services/generate_password.rb
@@ -1,0 +1,22 @@
+class GeneratePassword
+  attr_accessor :length
+
+  def initialize(length)
+    @length = length
+  end
+
+  def call
+    num_letters = Random.new.rand 2..(length - 1)
+    num_capital_letters = Random.new.rand 1..(num_letters - 1)
+
+    (random(("a".."z").to_a, num_letters - num_capital_letters) +
+      random(("A".."Z").to_a, num_capital_letters) +
+      random((0..9).to_a, length - num_letters)).shuffle.join
+  end
+
+  private
+
+  def random(from, length)
+    length.times.map { from.sample }
+  end
+end

--- a/backend/app/views/admin_mailer/first_time_login_instructions.html.erb
+++ b/backend/app/views/admin_mailer/first_time_login_instructions.html.erb
@@ -1,0 +1,4 @@
+<h3><%= t "admin_mailer.greetings", full_name: @admin.full_name %></h3>
+<p><%= t "admin_mailer.first_time_login_instructions.content_html",
+         reset_password_link: link_to(t(".reset_password_link"), edit_admin_password_url(reset_password_token: @token)) %></p>
+<p><%= t "admin_mailer.farewell_html" %></p>

--- a/backend/app/views/admins/passwords/edit.html.erb
+++ b/backend/app/views/admins/passwords/edit.html.erb
@@ -1,0 +1,20 @@
+<div class="bg-white p-6 rounded-2xl shadow-lg min-w-[600px]">
+  <h2 class="text-green-dark font-bold text-lg"><%= t("backoffice.change_password.title") %></h2>
+
+  <%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, "data-turbo": false }) do |f| %>
+    <%= f.error_notification %>
+
+    <%= f.input :reset_password_token, as: :hidden %>
+    <%= f.full_error :reset_password_token %>
+
+    <%= f.input :password,
+                required: true,
+                autofocus: true,
+                input_html: { autocomplete: "new-password" } %>
+    <%= f.input :password_confirmation,
+                required: true,
+                input_html: { autocomplete: "new-password" } %>
+
+    <%= f.submit t("backoffice.change_password.button"), class: "button button-primary-green mx-auto" %>
+  <% end %>
+</div>

--- a/backend/app/views/admins/passwords/new.html.erb
+++ b/backend/app/views/admins/passwords/new.html.erb
@@ -1,0 +1,11 @@
+<div class="bg-white p-6 rounded-2xl shadow-lg min-w-[600px]">
+  <h2 class="text-green-dark font-bold text-lg"><%= t("backoffice.forgot_password.title") %></h2>
+
+  <%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, "data-turbo": false }) do |f| %>
+    <%= f.error_notification %>
+
+    <%= f.input :email, required: true, autofocus: true, input_html: { autocomplete: "email" } %>
+
+    <%= f.button :submit, t("backoffice.forgot_password.button"), class: "button button-primary-green mx-auto" %>
+  <% end %>
+</div>

--- a/backend/app/views/admins/sessions/new.html.erb
+++ b/backend/app/views/admins/sessions/new.html.erb
@@ -13,9 +13,18 @@
     <%= f.input :email, required: true %>
     <%= f.input :password, required: true %>
 
-    <% if devise_mapping.rememberable? %>
-      <%= f.input :remember_me, as: :boolean %>
-    <% end%>
+
+    <div class="flex">
+      <div class="grow">
+        <% if devise_mapping.rememberable? %>
+          <%= f.input :remember_me, as: :boolean %>
+        <% end%>
+      </div>
+
+      <% if devise_mapping.recoverable? %>
+        <%= link_to t("backoffice.forgot_password.title"), new_admin_password_path, class: "link-button" %>
+      <% end %>
+    </div>
 
     <%= f.submit t("backoffice.sign_in.sign_in"), class: "button button-primary-green mx-auto" %>
   <% end %>

--- a/backend/app/views/backoffice/admins/_form.html.erb
+++ b/backend/app/views/backoffice/admins/_form.html.erb
@@ -7,6 +7,7 @@
 
   <%= f.input :first_name %>
   <%= f.input :last_name %>
+  <%= f.input :ui_language, collection: Language.all %>
   <%= f.input :email, required: true %>
 
   <div class="mt-3 flex justify-end gap-3">

--- a/backend/app/views/backoffice/admins/_form.html.erb
+++ b/backend/app/views/backoffice/admins/_form.html.erb
@@ -1,0 +1,16 @@
+<%= simple_form_for [:backoffice, admin] do |f| %>
+  <%= f.error_notification %>
+
+  <h2 class="mb-4 mt-6 text-gray-600 font-semibold text-xl">
+    <%= t(".information") %>
+  </h2>
+
+  <%= f.input :first_name %>
+  <%= f.input :last_name %>
+  <%= f.input :email, required: true %>
+
+  <div class="mt-3 flex justify-end gap-3">
+    <%= link_to t("backoffice.common.cancel"), backoffice_investors_path, class: "button button-secondary-green" %>
+    <%= f.button :submit, t("backoffice.common.save"), class: "button button-primary-green" %>
+  </div>
+<% end %>

--- a/backend/app/views/backoffice/admins/index.html.erb
+++ b/backend/app/views/backoffice/admins/index.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: "new_record", locals: { text: t("backoffice.admins.index.new"), url: new_backoffice_admin_path } %>
+<%= render "new_record", text: t("backoffice.admins.index.new"), url: new_backoffice_admin_path %>
 <div class="flex">
   <%= render partial: "filters", locals: {q: @q} %>
   <%= render partial: "backoffice/base/total_records" %>

--- a/backend/app/views/backoffice/admins/index.html.erb
+++ b/backend/app/views/backoffice/admins/index.html.erb
@@ -1,3 +1,4 @@
+<%= render partial: "new_record", locals: { text: t("backoffice.admins.index.new"), url: new_backoffice_admin_path } %>
 <div class="flex">
   <%= render partial: "filters", locals: {q: @q} %>
   <%= render partial: "backoffice/base/total_records" %>

--- a/backend/app/views/backoffice/admins/new.html.erb
+++ b/backend/app/views/backoffice/admins/new.html.erb
@@ -1,0 +1,3 @@
+<div class="w-full h-full bg-white rounded-xl p-6">
+  <%= render "form", admin: @admin %>
+</div>

--- a/backend/app/views/backoffice/base/_new_record.html.erb
+++ b/backend/app/views/backoffice/base/_new_record.html.erb
@@ -1,0 +1,8 @@
+<div class="w-full">
+  <%= link_to url do %>
+    <div class="absolute bg-white text-green-dark rounded-full -top-6 right-0 py-2 px-4 flex gap-2">
+      <span class="text-xl leading-none">⊕</span>
+      <span><%= text %></span>
+    </div>
+  <% end %>
+</div>

--- a/backend/app/views/layouts/backoffice.html.erb
+++ b/backend/app/views/layouts/backoffice.html.erb
@@ -22,7 +22,7 @@
     </div>
   </header>
 
-  <main class="container mx-auto py-6">
+  <main class="container mx-auto py-6 mt-1 relative">
     <%= render "flash_messages" %>
     <%= yield %>
     <%== render partial: "pagination", locals: {pagy: @pagy_object} if defined? @pagy_object %>

--- a/backend/config/initializers/devise.rb
+++ b/backend/config/initializers/devise.rb
@@ -283,7 +283,7 @@ Devise.setup do |config|
   # Time interval you can reset your password with a reset password key.
   # Don't put a too small interval or your users won't have the time to
   # change their passwords.
-  config.reset_password_within = 6.hours
+  config.reset_password_within = 2.days
 
   # When set to false, does not sign a user in automatically after their password is
   # reset. Defaults to true, so a user is signed in automatically after a reset.

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -87,6 +87,7 @@ zu:
       project_developer: Project developer
       investor: Investor
       project: Project
+      admin: Administrator
       category: Category
       mosaic: Mosaic
       verified: Verified
@@ -117,6 +118,7 @@ zu:
       delete: Delete account
     messages:
       delete_confirmation: Are you sure you want to delete this %{model}?
+      success_create: "%{model} was successfully created"
       success_update: "%{model} was successfully updated"
       success_delete: "%{model} was successfully deleted"
     sign_in:
@@ -125,7 +127,11 @@ zu:
       sign_in: Sign in
     admins:
       index:
+        new: Add administrator
         last_sign_in_at: Last login
+      form:
+        new: New admin
+        information: Information
     project_developers:
       index:
         projects: Projects
@@ -192,6 +198,12 @@ zu:
     rejected:
       subject: Your account was rejected!
       content_html: We would like to inform you that your account at HeCo platform was rejected. One of our platform administrators should reach you shortly, but feel free to contact us at %{contact_url}.
+  activerecord:
+    attributes:
+      admin:
+        first_name: First name
+        last_name: Last name
+        email: Email
   enums:
     review_status:
       approved:

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -12,6 +12,12 @@ zu:
     error_notification:
       default_message: "Please review the problems below:"
     labels:
+      admin:
+        first_name: First name
+        last_name: Last name
+        email: Email
+        password: New password
+        password_confirmation: Confirm your new password
       account:
         picture: Picture
         name: Profile name
@@ -125,6 +131,12 @@ zu:
       welcome: Welcome to HeCO Invest backoffice.
       enter_details_below: Please enter your details below.
       sign_in: Sign in
+    forgot_password:
+      title: Forgot your password?
+      button: Send me reset password instructions
+    change_password:
+      title: Change your password
+      button: Change my password
     admins:
       index:
         new: Add administrator
@@ -198,12 +210,13 @@ zu:
     rejected:
       subject: Your account was rejected!
       content_html: We would like to inform you that your account at HeCo platform was rejected. One of our platform administrators should reach you shortly, but feel free to contact us at %{contact_url}.
-  activerecord:
-    attributes:
-      admin:
-        first_name: First name
-        last_name: Last name
-        email: Email
+  admin_mailer:
+    greetings: Dear %{full_name},
+    farewell_html: Best Regards,<br />Your HeCo Team
+    first_time_login_instructions:
+      subject: Your HeCo Admin account was created!
+      content_html: "To login for first time, please %{reset_password_link}."
+      reset_password_link: setup your new password
   enums:
     review_status:
       approved:

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -15,6 +15,7 @@ zu:
       admin:
         first_name: First name
         last_name: Last name
+        ui_language: UI language
         email: Email
         password: New password
         password_confirmation: Confirm your new password

--- a/backend/config/routes/backoffice.rb
+++ b/backend/config/routes/backoffice.rb
@@ -1,4 +1,7 @@
-devise_for :admins, path: "backoffice", controllers: {sessions: "backoffice/admins/sessions"}
+devise_for :admins, path: "backoffice", controllers: {
+  sessions: "backoffice/admins/sessions",
+  passwords: "backoffice/admins/passwords"
+}
 devise_scope :admin do
   get "backoffice/admins/sessions/change_locale" => "backoffice/admins/sessions"
 end

--- a/backend/config/routes/backoffice.rb
+++ b/backend/config/routes/backoffice.rb
@@ -16,5 +16,5 @@ namespace :backoffice do
   resources :investors, only: [:index, :edit, :update, :destroy]
   resources :project_developers, only: [:index, :edit, :update, :destroy]
   resources :projects, only: [:index, :edit, :update, :destroy]
-  resources :admins, only: [:index]
+  resources :admins, only: [:index, :new, :create]
 end

--- a/backend/spec/mailers/admin_mailer_spec.rb
+++ b/backend/spec/mailers/admin_mailer_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe AdminMailer, type: :mailer do
+  include ActionView::Helpers::UrlHelper
+
+  let(:admin) { create :admin }
+
+  describe ".first_time_login_instructions" do
+    let(:mail) { AdminMailer.first_time_login_instructions admin }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq(I18n.t("admin_mailer.first_time_login_instructions.subject"))
+      expect(mail.to).to eq([admin.email])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match(I18n.t("admin_mailer.greetings", full_name: admin.full_name))
+      expect(mail.body.encoded).to match(I18n.t("admin_mailer.first_time_login_instructions.content_html", reset_password_link: ""))
+      expect(mail.body.encoded).to match(I18n.t("admin_mailer.first_time_login_instructions.reset_password_link"))
+      expect(mail.body.encoded).to match(I18n.t("admin_mailer.farewell_html"))
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/reset_password_spec.rb
+++ b/backend/spec/requests/api/v1/reset_password_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe "API V1 Reset Password", type: :request do
 
         context "expired token" do
           let(:token) do
-            travel_to 7.hours.ago do
+            travel_to 3.days.ago do
               user.send(:set_reset_password_token) # this is protected method
             end
           end

--- a/backend/spec/services/generate_password_spec.rb
+++ b/backend/spec/services/generate_password_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe GeneratePassword do
+  subject { described_class.new length }
+
+  let(:length) { 150 }
+
+  describe "#call" do
+    it "have correct length" do
+      expect(subject.call.length).to eq(length)
+    end
+
+    it "contains at least one number" do
+      expect(subject.call.count("0-9")).to be_positive
+    end
+
+    it "contains at least one letter" do
+      expect(subject.call.count("a-z")).to be_positive
+    end
+
+    it "contains at least one capital letter" do
+      expect(subject.call.count("A-Z")).to be_positive
+    end
+  end
+end

--- a/backend/spec/system/backoffice/admins_spec.rb
+++ b/backend/spec/system/backoffice/admins_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe "Backoffice: Admins", type: :system do
       it "creates new admin" do
         fill_in t("simple_form.labels.admin.first_name"), with: "First Name"
         fill_in t("simple_form.labels.admin.last_name"), with: "Last Name"
+        select t("enums.language.es.name"), from: t("simple_form.labels.admin.ui_language")
         fill_in t("simple_form.labels.admin.email"), with: "user@example.com"
         expect {
           click_on t("backoffice.common.save")
@@ -65,7 +66,7 @@ RSpec.describe "Backoffice: Admins", type: :system do
         expect(new_admin.last_name).to eq("Last Name")
         expect(new_admin.email).to eq("user@example.com")
         expect(new_admin.encrypted_password).not_to be_blank
-        expect(new_admin.ui_language).to eq(admin.ui_language)
+        expect(new_admin.ui_language).to eq("es")
       end
     end
 

--- a/backend/spec/system/backoffice/admins_spec.rb
+++ b/backend/spec/system/backoffice/admins_spec.rb
@@ -53,10 +53,12 @@ RSpec.describe "Backoffice: Admins", type: :system do
 
     context "when content is correct" do
       it "creates new admin" do
-        fill_in t("activerecord.attributes.admin.first_name"), with: "First Name"
-        fill_in t("activerecord.attributes.admin.last_name"), with: "Last Name"
-        fill_in t("activerecord.attributes.admin.email"), with: "user@example.com"
-        click_on t("backoffice.common.save")
+        fill_in t("simple_form.labels.admin.first_name"), with: "First Name"
+        fill_in t("simple_form.labels.admin.last_name"), with: "Last Name"
+        fill_in t("simple_form.labels.admin.email"), with: "user@example.com"
+        expect {
+          click_on t("backoffice.common.save")
+        }.to have_enqueued_mail(AdminMailer, :first_time_login_instructions).once
 
         expect(page).to have_text(t("backoffice.messages.success_create", model: t("backoffice.common.admin")))
         expect(new_admin.first_name).to eq("First Name")
@@ -69,7 +71,7 @@ RSpec.describe "Backoffice: Admins", type: :system do
 
     context "when content is incorrect" do
       it "shows validation errors" do
-        fill_in t("activerecord.attributes.admin.first_name"), with: ""
+        fill_in t("simple_form.labels.admin.first_name"), with: ""
         click_on t("backoffice.common.save")
 
         expect(page).to have_text(t("simple_form.error_notification.default_message"))

--- a/backend/spec/system/backoffice/admins_spec.rb
+++ b/backend/spec/system/backoffice/admins_spec.rb
@@ -42,4 +42,39 @@ RSpec.describe "Backoffice: Admins", type: :system do
       end
     end
   end
+
+  describe "New" do
+    let(:new_admin) { Admin.last }
+
+    before do
+      visit "/backoffice/admins"
+      click_on t("backoffice.admins.index.new")
+    end
+
+    context "when content is correct" do
+      it "creates new admin" do
+        fill_in t("activerecord.attributes.admin.first_name"), with: "First Name"
+        fill_in t("activerecord.attributes.admin.last_name"), with: "Last Name"
+        fill_in t("activerecord.attributes.admin.email"), with: "user@example.com"
+        click_on t("backoffice.common.save")
+
+        expect(page).to have_text(t("backoffice.messages.success_create", model: t("backoffice.common.admin")))
+        expect(new_admin.first_name).to eq("First Name")
+        expect(new_admin.last_name).to eq("Last Name")
+        expect(new_admin.email).to eq("user@example.com")
+        expect(new_admin.encrypted_password).not_to be_blank
+        expect(new_admin.ui_language).to eq(admin.ui_language)
+      end
+    end
+
+    context "when content is incorrect" do
+      it "shows validation errors" do
+        fill_in t("activerecord.attributes.admin.first_name"), with: ""
+        click_on t("backoffice.common.save")
+
+        expect(page).to have_text(t("simple_form.error_notification.default_message"))
+        expect(page).to have_text("First name can't be blank")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adding formular for Admin creation to backoffice. 

When new Admin is created, email with password reset link is send. Admin can use this link to set up new password -- this part of code uses Forgotten password feature from Devise. When I was implementing this, I have also enabled to trigger Forgotten password flow from sign-in page.

**Note**: We check password complexity and I was not able to find some simple generator which would generate password based on our requirements so I have written simple one just for your needs.

## Testing instructions

Backoffice: list of Admins --> click on `Add administrator` --> fill form and save it

## Tracking

https://vizzuality.atlassian.net/browse/LET-669
