### PR TITLE
feat: Possibility to edit Admins via backoffice

### DIFF
--- a/backend/app/controllers/backoffice/admins_controller.rb
+++ b/backend/app/controllers/backoffice/admins_controller.rb
@@ -4,7 +4,7 @@ module Backoffice
 
     before_action :initialize_admin, only: [:new, :create]
     before_action :fetch_admin, only: [:edit, :update, :destroy]
-    before_action :set_breadcrumbs, only: [:new, :create]
+    before_action :set_breadcrumbs, only: [:new, :create, :edit, :update]
     before_action :set_sections, only: [:edit, :update]
 
     def index

--- a/backend/app/controllers/backoffice/admins_controller.rb
+++ b/backend/app/controllers/backoffice/admins_controller.rb
@@ -1,7 +1,11 @@
 module Backoffice
   class AdminsController < BaseController
+    include Sections
+
     before_action :initialize_admin, only: [:new, :create]
+    before_action :fetch_admin, only: [:edit, :update, :destroy]
     before_action :set_breadcrumbs, only: [:new, :create]
+    before_action :set_sections, only: [:edit, :update]
 
     def index
       @q = Admin.ransack params[:q]
@@ -32,6 +36,27 @@ module Backoffice
       end
     end
 
+    def edit
+    end
+
+    def update
+      if @admin.update(admin_params) && update_password_for(@admin)
+        redirect_back(
+          fallback_location: edit_backoffice_admin_path(@admin.id),
+          notice: t("backoffice.messages.success_update", model: t("backoffice.common.admin"))
+        )
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    def destroy
+      @admin.destroy!
+
+      redirect_to backoffice_admins_path, status: :see_other,
+        notice: t("backoffice.messages.success_delete", model: t("backoffice.common.admin"))
+    end
+
     private
 
     def admin_params
@@ -43,13 +68,29 @@ module Backoffice
       )
     end
 
+    def update_password_for(admin)
+      return true if admin != current_admin || params.dig(:admin, :password).blank?
+
+      admin.password = params.dig(:admin, :password)
+      admin.password_confirmation = params.dig(:admin, :password_confirmation)
+      admin.save.tap { |res| bypass_sign_in admin if res } # keep current admin logged in
+    end
+
     def initialize_admin
       @admin = Admin.new
+    end
+
+    def fetch_admin
+      @admin = Admin.find(params[:id])
     end
 
     def set_breadcrumbs
       add_breadcrumb(I18n.t("backoffice.layout.admins"), backoffice_admins_path)
       @admin.new_record? ? add_breadcrumb(I18n.t("backoffice.admins.form.new")) : add_breadcrumb(@admin.full_name)
+    end
+
+    def set_sections
+      sections %w[information password], default: "information"
     end
   end
 end

--- a/backend/app/helpers/application_helper.rb
+++ b/backend/app/helpers/application_helper.rb
@@ -32,14 +32,14 @@ module ApplicationHelper
     link_to text, path, class: classnames
   end
 
-  def section_link_to(text, section, default: false)
+  def section_link_to(text, url, section, default: false)
     is_active = (params[:section].blank? && default) || params[:section] == section.to_s
     classnames = {
       "text-black hover:text-gray-600": true,
       "text-green-dark": is_active
     }.reject { |_k, v| v == false }.keys
 
-    link_to text, url_for(section: section), class: classnames
+    link_to text, "#{url}?section=#{section}", class: classnames
   end
 
   def localized_sort_link(q, key, *args, &block)

--- a/backend/app/views/backoffice/accounts/_content_language_form.html.erb
+++ b/backend/app/views/backoffice/accounts/_content_language_form.html.erb
@@ -1,5 +1,6 @@
 <%= simple_form_for [:backoffice, form_object] do |f| %>
   <%= f.error_notification %>
+  <%= hidden_field_tag :section, params[:section] %>
 
   <h2 class="mb-2 text-gray-900 font-semibold">
     <%= t("backoffice.account.account_language") %>

--- a/backend/app/views/backoffice/accounts/_status_form.html.erb
+++ b/backend/app/views/backoffice/accounts/_status_form.html.erb
@@ -1,5 +1,6 @@
 <%= simple_form_for [:backoffice, form_object] do |f| %>
   <%= f.error_notification %>
+  <%= hidden_field_tag :section, params[:section] %>
 
   <h2 class="mb-2 text-gray-900 font-semibold">
     <%= t("backoffice.account.approval_status") %>

--- a/backend/app/views/backoffice/admins/_form.html.erb
+++ b/backend/app/views/backoffice/admins/_form.html.erb
@@ -1,5 +1,6 @@
 <%= simple_form_for [:backoffice, admin] do |f| %>
   <%= f.error_notification %>
+  <%= hidden_field_tag :section, params[:section] %>
 
   <h2 class="mb-4 mt-6 text-gray-600 font-semibold text-xl">
     <%= t(".information") %>

--- a/backend/app/views/backoffice/admins/_section_information.html.erb
+++ b/backend/app/views/backoffice/admins/_section_information.html.erb
@@ -1,0 +1,1 @@
+<%= render "form", admin: @admin %>

--- a/backend/app/views/backoffice/admins/_section_password.html.erb
+++ b/backend/app/views/backoffice/admins/_section_password.html.erb
@@ -1,0 +1,16 @@
+<%= simple_form_for [:backoffice, @admin] do |f| %>
+  <%= f.error_notification %>
+  <%= hidden_field_tag :section, params[:section] %>
+
+  <h2 class="mb-4 mt-6 text-gray-600 font-semibold text-xl">
+    <%= t("backoffice.admins.password") %>
+  </h2>
+
+  <%= f.input :password, required: true, input_html: { autocomplete: "new-password" } %>
+  <%= f.input :password_confirmation, required: true, input_html: { autocomplete: "new-password" } %>
+
+  <div class="mt-3 flex justify-end gap-3">
+    <%= link_to t("backoffice.common.cancel"), backoffice_admins_path, class: "button button-secondary-green" %>
+    <%= f.button :submit, t("backoffice.common.save"), class: "button button-primary-green" %>
+  </div>
+<% end %>

--- a/backend/app/views/backoffice/admins/edit.html.erb
+++ b/backend/app/views/backoffice/admins/edit.html.erb
@@ -1,0 +1,26 @@
+<div class="flex">
+  <aside class="w-2/6">
+    <h1 class="font-semibold text-xl text-black mb-8">
+      <%= @admin.full_name %>
+    </h1>
+
+    <ul class="flex flex-col gap-8 mb-8">
+      <li><%= section_link_to t("backoffice.admins.information"), edit_backoffice_admin_path, :information, default: true %></li>
+      <% if @admin == current_admin %>
+        <li><%= section_link_to t("backoffice.admins.password"), edit_backoffice_admin_path, :password %></li>
+      <% end %>
+    </ul>
+    <%= link_to backoffice_admin_path(@admin.id),
+       data: {
+         turbo_method: :delete,
+         turbo_confirm: t("backoffice.messages.delete_confirmation", model: t("backoffice.common.admin").downcase)
+       },
+       class: "button button-secondary-green button-with-icon" do %>
+      <%= svg "trash" %>
+      <%= t("backoffice.admins.delete") %>
+    <% end %>
+  </aside>
+  <div class="w-full h-full bg-white rounded-xl p-6">
+    <%= render section_partial %>
+  </div>
+</div>

--- a/backend/app/views/backoffice/admins/index.html.erb
+++ b/backend/app/views/backoffice/admins/index.html.erb
@@ -19,6 +19,8 @@
       <th>
         <%= sort_link @q, :last_sign_in_at, t("backoffice.admins.index.last_sign_in_at") %>
       </th>
+      <th>
+      </th>
     </tr>
   </thead>
   <tbody>
@@ -28,6 +30,7 @@
         <td><%= admin.email %></td>
         <td><%= I18n.l admin.created_at.to_date %></td>
         <td><%= I18n.l admin.last_sign_in_at&.to_date, default: '' %></td>
+        <td><%= link_to t("backoffice.common.edit"), edit_backoffice_admin_path(admin.id), class: "link-button" %></td>
       </tr>
     <% end %>
   </tbody>

--- a/backend/app/views/backoffice/investors/_form.html.erb
+++ b/backend/app/views/backoffice/investors/_form.html.erb
@@ -1,6 +1,7 @@
 <%= simple_form_for [:backoffice, investor] do |f| %>
   <%= f.error_notification %>
   <%= hidden_field_tag :content_lang, params[:content_lang] %>
+  <%= hidden_field_tag :section, params[:section] %>
 
   <h2 class="mb-4 mt-6 text-gray-600 font-semibold text-xl">
     <%= t(".general") %>

--- a/backend/app/views/backoffice/investors/edit.html.erb
+++ b/backend/app/views/backoffice/investors/edit.html.erb
@@ -5,9 +5,9 @@
     </h1>
 
     <ul class="flex flex-col gap-8 mb-8">
-      <li><%= section_link_to t("backoffice.account.account_language"), :language %></li>
-      <li><%= section_link_to t("backoffice.account.profile"), :profile, default: true %></li>
-      <li><%= section_link_to t("backoffice.account.approval_status"), :status %></li>
+      <li><%= section_link_to t("backoffice.account.account_language"), edit_backoffice_investor_path, :language %></li>
+      <li><%= section_link_to t("backoffice.account.profile"), edit_backoffice_investor_path, :profile, default: true %></li>
+      <li><%= section_link_to t("backoffice.account.approval_status"), edit_backoffice_investor_path, :status %></li>
     </ul>
     <%= link_to backoffice_investor_path(@investor.id),
        data: {

--- a/backend/app/views/backoffice/project_developers/_form.html.erb
+++ b/backend/app/views/backoffice/project_developers/_form.html.erb
@@ -1,6 +1,7 @@
 <%= simple_form_for [:backoffice, project_developer] do |f| %>
   <%= f.error_notification %>
   <%= hidden_field_tag :content_lang, params[:content_lang] %>
+  <%= hidden_field_tag :section, params[:section] %>
 
   <h2 class="mb-4 mt-6 text-gray-600 font-semibold text-xl">
     <%= t(".general") %>

--- a/backend/app/views/backoffice/project_developers/edit.html.erb
+++ b/backend/app/views/backoffice/project_developers/edit.html.erb
@@ -5,9 +5,9 @@
     </h1>
 
     <ul class="flex flex-col gap-8 mb-8">
-      <li><%= section_link_to t("backoffice.account.account_language"), :language %></li>
-      <li><%= section_link_to t("backoffice.account.profile"), :profile, default: true %></li>
-      <li><%= section_link_to t("backoffice.account.approval_status"), :status %></li>
+      <li><%= section_link_to t("backoffice.account.account_language"), edit_backoffice_project_developer_path, :language %></li>
+      <li><%= section_link_to t("backoffice.account.profile"), edit_backoffice_project_developer_path, :profile, default: true %></li>
+      <li><%= section_link_to t("backoffice.account.approval_status"), edit_backoffice_project_developer_path, :status %></li>
     </ul>
     <%= link_to backoffice_project_developer_path(@project_developer.id),
        data: {

--- a/backend/app/views/backoffice/projects/_form.html.erb
+++ b/backend/app/views/backoffice/projects/_form.html.erb
@@ -1,6 +1,7 @@
 <%= simple_form_for [:backoffice, project], url: backoffice_project_path(project.id) do |f| %>
   <%= f.error_notification %>
   <%= hidden_field_tag :content_lang, params[:content_lang] %>
+  <%= hidden_field_tag :section, params[:section] %>
 
   <%= localized_input f, :name, content_language, label: t("simple_form.labels.project.name"), as: :string %>
   <%= f.input :project_images, label: t("simple_form.labels.project.project_images"), as: :file, input_html: { multiple: true, accept: "image/*" } %>

--- a/backend/app/views/backoffice/projects/_section_status.html.erb
+++ b/backend/app/views/backoffice/projects/_section_status.html.erb
@@ -1,5 +1,6 @@
 <%= simple_form_for [:backoffice, @project], url: backoffice_project_path(@project.id) do |f| %>
   <%= f.error_notification %>
+  <%= hidden_field_tag :section, params[:section] %>
 
   <h2 class="mb-2 text-gray-900 font-semibold">
     <%= t("backoffice.projects.status") %>

--- a/backend/app/views/backoffice/projects/edit.html.erb
+++ b/backend/app/views/backoffice/projects/edit.html.erb
@@ -5,9 +5,9 @@
     </h1>
 
     <ul class="flex flex-col gap-8 mb-8">
-      <li><%= section_link_to t("backoffice.projects.information"), :information, default: true %></li>
-      <li><%= section_link_to t("backoffice.projects.status"), :status %></li>
-      <li><%= section_link_to t("backoffice.projects.project_developers"), :project_developers %></li>
+      <li><%= section_link_to t("backoffice.projects.information"), edit_backoffice_project_path, :information, default: true %></li>
+      <li><%= section_link_to t("backoffice.projects.status"), edit_backoffice_project_path, :status %></li>
+      <li><%= section_link_to t("backoffice.projects.project_developers"), edit_backoffice_project_path, :project_developers %></li>
     </ul>
     <%= link_to backoffice_project_path(@project.id),
        data: {

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -139,6 +139,9 @@ zu:
       title: Change your password
       button: Change my password
     admins:
+      information: User information
+      password: Password
+      delete: Delete admin
       index:
         new: Add administrator
         last_sign_in_at: Last login

--- a/backend/config/routes/backoffice.rb
+++ b/backend/config/routes/backoffice.rb
@@ -19,5 +19,5 @@ namespace :backoffice do
   resources :investors, only: [:index, :edit, :update, :destroy]
   resources :project_developers, only: [:index, :edit, :update, :destroy]
   resources :projects, only: [:index, :edit, :update, :destroy]
-  resources :admins, only: [:index, :new, :create]
+  resources :admins
 end


### PR DESCRIPTION
I am adding possibility to edit already existing Admins. It is possible to edit all attributes of user, even email --> there is no email confirmation for Admin for now (not sure if this will change at future) so changing email is simple.

Password can be changed only if you are editing admin which is one currently logged in. After password is changed, user stays logged in (default behaviour of Devise is logout user).

Btw. I guess this is clear, but be super careful when you register new Admins and use only emails which you own :). If by any chance we would create Admin with wrong email (typo, etc.), owner of such email could login as Admin and take over whole system.

## Testing instructions

Via Bakoffice -- create new Admin and try to edit it ;). You should be able to edit password only if you are editing yourself. You should be also able to delete this newly created record.

## Tracking

https://vizzuality.atlassian.net/browse/LET-672
https://vizzuality.atlassian.net/browse/LET-673
https://vizzuality.atlassian.net/browse/LET-674
