### PR TITLE
feat: Notify user when account is removed

### DIFF
--- a/backend/app/controllers/api/v1/accounts/users_controller.rb
+++ b/backend/app/controllers/api/v1/accounts/users_controller.rb
@@ -18,6 +18,7 @@ module API
           # @user cannot be account owner AND
           # either current_user == @user OR current_user is account owner in @user's account
           @user.destroy!
+          UserMailer.destroyed(@user.email, @user.full_name).deliver_later
           head :ok
         end
 

--- a/backend/app/mailers/user_mailer.rb
+++ b/backend/app/mailers/user_mailer.rb
@@ -10,4 +10,10 @@ class UserMailer < ApplicationMailer
 
     mail to: @user.email
   end
+
+  def destroyed(email, full_name)
+    @full_name = full_name
+
+    mail to: email
+  end
 end

--- a/backend/app/views/user_mailer/destroyed.html.erb
+++ b/backend/app/views/user_mailer/destroyed.html.erb
@@ -1,0 +1,3 @@
+<h3><%= t "user_mailer.greetings", full_name: @full_name %></h3>
+<p><%= t "user_mailer.destroyed.content" %></p>
+<p><%= t "user_mailer.farewell_html" %></p>

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -214,6 +214,9 @@ zu:
     rejected:
       subject: Your account was rejected!
       content_html: We would like to inform you that your account at HeCo platform was rejected. One of our platform administrators should reach you shortly, but feel free to contact us at %{contact_url}.
+    destroyed:
+      subject: Your account has been removed!
+      content: We would like to inform you that your account at HeCo platform was removed.
   admin_mailer:
     greetings: Dear %{full_name},
     farewell_html: Best Regards,<br />Your HeCo Team

--- a/backend/spec/mailers/user_mailer_spec.rb
+++ b/backend/spec/mailers/user_mailer_spec.rb
@@ -35,4 +35,19 @@ RSpec.describe UserMailer, type: :mailer do
       expect(mail.body.encoded).to match(I18n.t("user_mailer.farewell_html"))
     end
   end
+
+  describe ".destroyed" do
+    let(:mail) { UserMailer.destroyed user.email, user.full_name }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq(I18n.t("user_mailer.destroyed.subject"))
+      expect(mail.to).to eq([user.email])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match(I18n.t("user_mailer.greetings", full_name: user.full_name))
+      expect(mail.body.encoded).to match(I18n.t("user_mailer.destroyed.content"))
+      expect(mail.body.encoded).to match(I18n.t("user_mailer.farewell_html"))
+    end
+  end
 end

--- a/backend/spec/requests/api/v1/accounts/users_spec.rb
+++ b/backend/spec/requests/api/v1/accounts/users_spec.rb
@@ -119,10 +119,16 @@ RSpec.describe "API V1 Account Users", type: :request do
             sign_in account_owner
           end
 
-          run_test!
-
-          it "user is deleted" do
+          it "user is deleted" do |example|
+            submit_request example.metadata
+            assert_response_matches_metadata example.metadata
             expect { account_user.reload }.to raise_error(ActiveRecord::RecordNotFound)
+          end
+
+          it "send email" do |example|
+            expect {
+              submit_request example.metadata
+            }.to have_enqueued_mail(UserMailer, :destroyed).with(account_user.email, account_user.full_name)
           end
         end
 
@@ -132,10 +138,16 @@ RSpec.describe "API V1 Account Users", type: :request do
             sign_in account_user
           end
 
-          run_test!
-
-          it "user is deleted" do
+          it "user is deleted" do |example|
+            submit_request example.metadata
+            assert_response_matches_metadata example.metadata
             expect { account_user.reload }.to raise_error(ActiveRecord::RecordNotFound)
+          end
+
+          it "send email" do |example|
+            expect {
+              submit_request example.metadata
+            }.to have_enqueued_mail(UserMailer, :destroyed).with(account_user.email, account_user.full_name)
           end
         end
       end


### PR DESCRIPTION
Enhancing `DELETE /api/v1/account/users/{user_id}` endpoint which now also notifies user that his/her account was removed.

## Testing instructions

It is possible to test this enhancement via Rswag documentation --> just delete some existing user account.

## Tracking

https://vizzuality.atlassian.net/browse/LET-680
