### PR TITLE
feat: Notify PD on changes related to project involvement

### DIFF
--- a/backend/app/mailers/project_developer_mailer.rb
+++ b/backend/app/mailers/project_developer_mailer.rb
@@ -1,0 +1,15 @@
+class ProjectDeveloperMailer < ApplicationMailer
+  def added_to_project(project_developer, project)
+    @user = project_developer.owner
+    @project = project
+
+    mail to: @user.email
+  end
+
+  def removed_from_project(project_developer, project)
+    @user = project_developer.owner
+    @project = project
+
+    mail to: @user.email
+  end
+end

--- a/backend/app/models/project.rb
+++ b/backend/app/models/project.rb
@@ -12,10 +12,10 @@ class Project < ApplicationRecord
   belongs_to :department, class_name: "Location"
   belongs_to :priority_landscape, class_name: "Location", optional: true
 
-  has_and_belongs_to_many :involved_project_developers, join_table: "project_involvements", class_name: "ProjectDeveloper"
-
   has_many :project_images, dependent: :destroy
   has_many :favourite_projects, dependent: :destroy
+  has_many :project_involvements, dependent: :destroy
+  has_many :involved_project_developers, through: :project_involvements, source: :project_developer
 
   translates :name,
     :description,

--- a/backend/app/models/project_developer.rb
+++ b/backend/app/models/project_developer.rb
@@ -5,8 +5,8 @@ class ProjectDeveloper < ApplicationRecord
 
   has_many :projects, dependent: :destroy
   has_many :favourite_project_developers, dependent: :destroy
-
-  has_and_belongs_to_many :involved_projects, join_table: "project_involvements", class_name: "Project"
+  has_many :project_involvements, dependent: :destroy
+  has_many :involved_projects, through: :project_involvements, source: :project
 
   validates :categories, array_inclusion: {in: Category::TYPES}, presence: true
   validates :impacts, array_inclusion: {in: Impact::TYPES}

--- a/backend/app/models/project_involvement.rb
+++ b/backend/app/models/project_involvement.rb
@@ -5,10 +5,10 @@ class ProjectInvolvement < ApplicationRecord
   validates_uniqueness_of :project_id, scope: :project_developer_id
 
   after_create do
-    ProjectDeveloperMailer.added_to_project(project_developer, project).deliver_later
+    ProjectDeveloperMailer.added_to_project(project_developer, project).deliver_later if project.published?
   end
 
   after_destroy do
-    ProjectDeveloperMailer.removed_from_project(project_developer, project).deliver_later
+    ProjectDeveloperMailer.removed_from_project(project_developer, project).deliver_later if project.published?
   end
 end

--- a/backend/app/models/project_involvement.rb
+++ b/backend/app/models/project_involvement.rb
@@ -1,0 +1,14 @@
+class ProjectInvolvement < ApplicationRecord
+  belongs_to :project
+  belongs_to :project_developer
+
+  validates_uniqueness_of :project_id, scope: :project_developer_id
+
+  after_create do
+    ProjectDeveloperMailer.added_to_project(project_developer, project).deliver_later
+  end
+
+  after_destroy do
+    ProjectDeveloperMailer.removed_from_project(project_developer, project).deliver_later
+  end
+end

--- a/backend/app/views/project_developer_mailer/added_to_project.html.erb
+++ b/backend/app/views/project_developer_mailer/added_to_project.html.erb
@@ -1,0 +1,3 @@
+<h3><%= t "project_developer_mailer.greetings", full_name: @user.full_name %></h3>
+<p><%= t "project_developer_mailer.added_to_project.content", project_name: @project.name %></p>
+<p><%= t "project_developer_mailer.farewell_html" %></p>

--- a/backend/app/views/project_developer_mailer/removed_from_project.html.erb
+++ b/backend/app/views/project_developer_mailer/removed_from_project.html.erb
@@ -1,0 +1,3 @@
+<h3><%= t "project_developer_mailer.greetings", full_name: @user.full_name %></h3>
+<p><%= t "project_developer_mailer.removed_from_project.content", project_name: @project.name %></p>
+<p><%= t "project_developer_mailer.farewell_html" %></p>

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -221,6 +221,15 @@ zu:
       subject: Your HeCo Admin account was created!
       content_html: "To login for first time, please %{reset_password_link}."
       reset_password_link: setup your new password
+  project_developer_mailer:
+    greetings: Dear %{full_name},
+    farewell_html: Best Regards,<br />Your HeCo Team
+    added_to_project:
+      subject: You have been added as new collaborator.
+      content: We would like to inform you that you have been added as new collaborator to project %{project_name}.
+    removed_from_project:
+      subject: Your collaboration has ended.
+      content: We would like to inform you that your collaboration with project %{project_name} has ended.
   enums:
     review_status:
       approved:

--- a/backend/spec/factories/project_involvements.rb
+++ b/backend/spec/factories/project_involvements.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :project_involvement do
+    project
+    project_developer
+  end
+end

--- a/backend/spec/mailers/project_developer_mailer_spec.rb
+++ b/backend/spec/mailers/project_developer_mailer_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe ProjectDeveloperMailer, type: :mailer do
+  include ActionView::Helpers::UrlHelper
+
+  let(:project_developer) { create :project_developer }
+  let(:project) { create :project }
+
+  describe ".added_to_project" do
+    let(:mail) { ProjectDeveloperMailer.added_to_project project_developer, project }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq(I18n.t("project_developer_mailer.added_to_project.subject"))
+      expect(mail.to).to eq([project_developer.owner.email])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match(I18n.t("project_developer_mailer.greetings", full_name: project_developer.owner.full_name))
+      expect(mail.body.encoded).to match(I18n.t("project_developer_mailer.added_to_project.content", project_name: project.name))
+      expect(mail.body.encoded).to match(I18n.t("project_developer_mailer.farewell_html"))
+    end
+  end
+
+  describe ".removed_from_project" do
+    let(:mail) { ProjectDeveloperMailer.removed_from_project project_developer, project }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq(I18n.t("project_developer_mailer.removed_from_project.subject"))
+      expect(mail.to).to eq([project_developer.owner.email])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match(I18n.t("project_developer_mailer.greetings", full_name: project_developer.owner.full_name))
+      expect(mail.body.encoded).to match(I18n.t("project_developer_mailer.removed_from_project.content", project_name: project.name))
+      expect(mail.body.encoded).to match(I18n.t("project_developer_mailer.farewell_html"))
+    end
+  end
+end

--- a/backend/spec/models/project_involvement_spec.rb
+++ b/backend/spec/models/project_involvement_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe ProjectInvolvement, type: :model do
+  subject { build(:project_involvement) }
+
+  it { is_expected.to be_valid }
+
+  it "should not be valid without project" do
+    subject.project = nil
+    expect(subject).to have(1).errors_on(:project)
+  end
+
+  it "should not be valid without project_developer" do
+    subject.project_developer = nil
+    expect(subject).to have(1).errors_on(:project_developer)
+  end
+
+  it "notifies project developer owner when involvement is created" do
+    expect {
+      subject.save!
+    }.to have_enqueued_mail(ProjectDeveloperMailer, :added_to_project).with(subject.project_developer, subject.project)
+  end
+
+  it "notifies project developer owner when involvement is destroyed" do
+    subject.save!
+    expect {
+      subject.destroy!
+    }.to have_enqueued_mail(ProjectDeveloperMailer, :removed_from_project).with(subject.project_developer, subject.project)
+  end
+end

--- a/backend/spec/models/project_involvement_spec.rb
+++ b/backend/spec/models/project_involvement_spec.rb
@@ -15,16 +15,45 @@ RSpec.describe ProjectInvolvement, type: :model do
     expect(subject).to have(1).errors_on(:project_developer)
   end
 
-  it "notifies project developer owner when involvement is created" do
-    expect {
-      subject.save!
-    }.to have_enqueued_mail(ProjectDeveloperMailer, :added_to_project).with(subject.project_developer, subject.project)
+  describe "added_to_project notification" do
+    context "when project is published" do
+      it "notifies project developer owner" do
+        expect {
+          subject.save!
+        }.to have_enqueued_mail(ProjectDeveloperMailer, :added_to_project).with(subject.project_developer, subject.project)
+      end
+    end
+
+    context "when project is draft" do
+      before { subject.project.update! status: :draft }
+
+      it "does not notifies project developer owner" do
+        expect {
+          subject.save!
+        }.not_to have_enqueued_mail(ProjectDeveloperMailer, :added_to_project)
+      end
+    end
   end
 
-  it "notifies project developer owner when involvement is destroyed" do
-    subject.save!
-    expect {
-      subject.destroy!
-    }.to have_enqueued_mail(ProjectDeveloperMailer, :removed_from_project).with(subject.project_developer, subject.project)
+  describe "removed_from_project notification" do
+    before { subject.save! }
+
+    context "when project is published" do
+      it "notifies project developer owner" do
+        expect {
+          subject.destroy!
+        }.to have_enqueued_mail(ProjectDeveloperMailer, :removed_from_project).with(subject.project_developer, subject.project)
+      end
+    end
+
+    context "when project is draft" do
+      before { subject.project.update! status: :draft }
+
+      it "does not notifies project developer owner" do
+        expect {
+          subject.destroy!
+        }.not_to have_enqueued_mail(ProjectDeveloperMailer, :removed_from_project)
+      end
+    end
   end
 end


### PR DESCRIPTION
I am adding `ProjectInvolvement` model which covers already existing table called `project_involvements`. I have decided to add class for this, because I have needed `after_create`/`after_destroy` hooks which are used to send notifications to PDs.

Mails for PD are handled by new mailer called `ProjectDeveloperMailer` <-- I have found it more transparent to move it to special mailer, but It can be theoretically also part of `UserMailer`.

## Testing instructions

Everything should be testable via Rswag documentation --> find some project and update `involved_project_developer_ids` param. Added/removed PDs should receive appropriate email.

## Tracking

https://vizzuality.atlassian.net/browse/LET-525
https://vizzuality.atlassian.net/browse/LET-524
