### PR TITLE
feat: Draft projects are not shown at backoffice

### DIFF
--- a/backend/app/controllers/backoffice/projects_controller.rb
+++ b/backend/app/controllers/backoffice/projects_controller.rb
@@ -9,7 +9,7 @@ module Backoffice
     before_action :set_content_language_default, only: [:edit, :update]
 
     def index
-      @q = Project.ransack params[:q]
+      @q = Project.published.ransack params[:q]
       @projects = API::Filterer.new(@q.result, {full_text: params.dig(:q, :filter_full_text)}).call
       @projects = @projects.includes(:priority_landscape, project_developer: [:account])
 

--- a/backend/spec/system/backoffice/projects_spec.rb
+++ b/backend/spec/system/backoffice/projects_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "Backoffice: Projects", type: :system do
     )
   }
   let!(:projects) { create_list(:project, 4) }
+  let!(:draft_project) { create :project, :draft }
 
   before { sign_in admin }
 
@@ -39,6 +40,10 @@ RSpec.describe "Backoffice: Projects", type: :system do
         expect(page).to have_text("Test priority landscape")
         expect(page).to have_text(I18n.t("backoffice.common.verified"))
       end
+    end
+
+    it "ignores draft project" do
+      expect(page).not_to have_text(draft_project.name)
     end
 
     context "when searching" do

--- a/backend/spec/system/backoffice/projects_spec.rb
+++ b/backend/spec/system/backoffice/projects_spec.rb
@@ -112,10 +112,10 @@ RSpec.describe "Backoffice: Projects", type: :system do
     context "information section" do
       context "when content is correct" do
         it "can update project information" do
+          sleep 1 # give form time to load all js libs
           fill_in t("simple_form.labels.project.name"), with: "New name"
           attach_file t("simple_form.labels.project.project_images"), [Rails.root.join("spec/fixtures/files/picture.jpg"), Rails.root.join("spec/fixtures/files/picture_2.jpg")]
           attach_file :shapefile, Rails.root.join("spec/fixtures/files/shapefile.zip")
-          sleep 1 # give js time to process shapefile
           expect(page).to have_text(t("backoffice.projects.form.shapefile_loaded"))
           select country.name, from: t("simple_form.labels.project.country")
           select country.locations.first.name, from: t("simple_form.labels.project.department")

--- a/backend/spec/system/backoffice/projects_spec.rb
+++ b/backend/spec/system/backoffice/projects_spec.rb
@@ -115,6 +115,7 @@ RSpec.describe "Backoffice: Projects", type: :system do
           fill_in t("simple_form.labels.project.name"), with: "New name"
           attach_file t("simple_form.labels.project.project_images"), [Rails.root.join("spec/fixtures/files/picture.jpg"), Rails.root.join("spec/fixtures/files/picture_2.jpg")]
           attach_file :shapefile, Rails.root.join("spec/fixtures/files/shapefile.zip")
+          sleep 1 # give js time to process shapefile
           expect(page).to have_text(t("backoffice.projects.form.shapefile_loaded"))
           select country.name, from: t("simple_form.labels.project.country")
           select country.locations.first.name, from: t("simple_form.labels.project.department")


### PR DESCRIPTION
Just simple tweak which hides draft projects from backoffice.

## Testing instructions

Via backoffice

## Tracking

https://vizzuality.atlassian.net/browse/LET-722
