### PR TITLE
refactoring: Only Admins can access background job events API

### DIFF
--- a/backend/app/controllers/api/v1/background_job_events_controller.rb
+++ b/backend/app/controllers/api/v1/background_job_events_controller.rb
@@ -3,7 +3,7 @@ module API
     class BackgroundJobEventsController < BaseController
       include API::Pagination
 
-      before_action :authenticate_user! # TODO: Only Admin can access!
+      before_action :authenticate_admin!
 
       def index
         events = apply_filter_to(BackgroundJobEvent.all).order :created_at

--- a/backend/spec/requests/api/v1/background_job_events_spec.rb
+++ b/backend/spec/requests/api/v1/background_job_events_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "API V1 Background Job Events", type: :request do
       parameter name: "filter[created_at_min]", in: :query, type: :string, description: "Filter records", required: false
       parameter name: "filter[created_at_max]", in: :query, type: :string, description: "Filter records", required: false
 
-      let(:user) { create :user }
+      let(:admin) { create :admin }
 
       it_behaves_like "with not authorized error", csrf: true
 
@@ -29,7 +29,7 @@ RSpec.describe "API V1 Background Job Events", type: :request do
         }
         let("X-CSRF-TOKEN") { get_csrf_token }
 
-        before { sign_in user }
+        before { sign_in admin }
 
         run_test!
 


### PR DESCRIPTION
Just minor tweak of `BackgroundJobEvents` API which ensures that only Admins can access it <-- it can contain some sensitive information so that is why I am putting there this restriction.