### PR TITLE
Display message in PD & Investor forms informing the users of the account language

### DIFF
--- a/frontend/components/alert/component.stories.tsx
+++ b/frontend/components/alert/component.stories.tsx
@@ -15,11 +15,6 @@ const Template: Story<AlertProps> = ({ children, ...rest }: AlertProps) => (
 export const Default: Story<AlertProps> = Template.bind({});
 Default.args = {};
 
-export const withLayoutContainer: Story<AlertProps> = Template.bind({});
-withLayoutContainer.args = {
-  withLayoutContainer: true,
-};
-
 export const Warning: Story<AlertProps> = Template.bind({});
 Warning.args = {
   type: 'warning',
@@ -28,4 +23,9 @@ Warning.args = {
 export const Success: Story<AlertProps> = Template.bind({});
 Success.args = {
   type: 'success',
+};
+
+export const withLayoutContainer: Story<AlertProps> = Template.bind({});
+withLayoutContainer.args = {
+  withLayoutContainer: true,
 };

--- a/frontend/components/alert/component.tsx
+++ b/frontend/components/alert/component.tsx
@@ -14,7 +14,7 @@ import type { AlertProps } from './types';
 export const Alert: FC<AlertProps> = ({
   className,
   withLayoutContainer = false,
-  type = 'warning',
+  type = 'default',
   children,
 }: AlertProps) => {
   const variants = {
@@ -29,8 +29,10 @@ export const Alert: FC<AlertProps> = ({
     switch (type) {
       case 'success':
         return 'text-green-dark';
-      default:
+      case 'warning':
         return 'text-red-700';
+      default:
+        return 'text-black';
     }
   }, [type]);
 
@@ -38,20 +40,24 @@ export const Alert: FC<AlertProps> = ({
     switch (type) {
       case 'success':
         return CheckCircleIcon;
-      default:
+      case 'warning':
         return AlertTriangleIcon;
+      default:
+        return null;
     }
   }, [type]);
 
   const alertContent = () => (
     <>
-      <Icon
-        className={cx({
-          'w-5 h-5 mr-2': true,
-          [alertIconColor]: true,
-        })}
-        icon={alertIcon}
-      />
+      {alertIcon && (
+        <Icon
+          className={cx({
+            'w-5 h-5 mr-2': true,
+            [alertIconColor]: true,
+          })}
+          icon={alertIcon}
+        />
+      )}
       {children}
     </>
   );
@@ -68,6 +74,7 @@ export const Alert: FC<AlertProps> = ({
         <div
           className={cx({
             'rounded-lg': !withLayoutContainer,
+            'bg-beige': type === 'default',
             'bg-red-50': type === 'warning',
             'bg-green-light': type === 'success',
           })}

--- a/frontend/components/alert/types.ts
+++ b/frontend/components/alert/types.ts
@@ -3,8 +3,8 @@ import { PropsWithChildren } from 'react';
 export type AlertProps = PropsWithChildren<{
   /** Classnames to apply to container */
   className?: string;
-  /** Alert type. Defaults to `warning` */
-  type?: 'warning' | 'success';
+  /** Alert type. Defaults to `default` */
+  type?: 'default' | 'warning' | 'success';
   /** Whether to wrap the alert in a LayoutContainer. Defaults to `false` */
   withLayoutContainer?: boolean;
 }>;

--- a/frontend/containers/forms/content-language-alert/component.stories.tsx
+++ b/frontend/containers/forms/content-language-alert/component.stories.tsx
@@ -13,9 +13,4 @@ const Template: Story<ContentLanguageAlertProps> = ({ ...props }: ContentLanguag
 );
 
 export const Default: Story<ContentLanguageAlertProps> = Template.bind({});
-Default.args = {
-  locale: 'en',
-};
-
-export const NoLocale: Story<ContentLanguageAlertProps> = Template.bind({});
-NoLocale.args = {};
+Default.args = {};

--- a/frontend/containers/forms/content-language-alert/component.stories.tsx
+++ b/frontend/containers/forms/content-language-alert/component.stories.tsx
@@ -1,0 +1,21 @@
+import { Story, Meta } from '@storybook/react/types-6-0';
+
+import ContentLanguageAlert, { ContentLanguageAlertProps } from '.';
+
+export default {
+  component: ContentLanguageAlert,
+  title: 'Containers/Forms/ContentLanguageAlert',
+  argTypes: {},
+} as Meta;
+
+const Template: Story<ContentLanguageAlertProps> = ({ ...props }: ContentLanguageAlertProps) => (
+  <ContentLanguageAlert {...props}>This an alert message</ContentLanguageAlert>
+);
+
+export const Default: Story<ContentLanguageAlertProps> = Template.bind({});
+Default.args = {
+  locale: 'en',
+};
+
+export const NoLocale: Story<ContentLanguageAlertProps> = Template.bind({});
+NoLocale.args = {};

--- a/frontend/containers/forms/content-language-alert/component.tsx
+++ b/frontend/containers/forms/content-language-alert/component.tsx
@@ -1,8 +1,10 @@
 import { FC, useState } from 'react';
 
 import { X as XIcon } from 'react-feather';
+import { FormattedMessage } from 'react-intl';
 
 import Alert from 'components/alert';
+import Button from 'components/button';
 import Icon from 'components/icon';
 
 import type { ContentLanguageAlertProps } from './types';
@@ -19,11 +21,17 @@ export const ContentLanguageAlert: FC<ContentLanguageAlertProps> = ({
     <Alert className={className}>
       <div className="flex items-center w-full">
         <span className="flex-1">{children}</span>
-        <Icon
-          className="w-5 h-5 ml-2 cursor-pointer"
-          icon={XIcon}
+        <Button
+          className="ml-2 focus-visible:outline-green-dark"
+          theme="naked"
+          size="smallest"
           onClick={() => setIsOpen(false)}
-        />
+        >
+          <span className="sr-only">
+            <FormattedMessage defaultMessage="Dismiss" id="TDaF6J" />
+          </span>
+          <Icon className="w-5 h-5" icon={XIcon} />
+        </Button>
       </div>
     </Alert>
   );

--- a/frontend/containers/forms/content-language-alert/component.tsx
+++ b/frontend/containers/forms/content-language-alert/component.tsx
@@ -2,8 +2,6 @@ import { FC, useState } from 'react';
 
 import { X as XIcon } from 'react-feather';
 
-import { useLanguageNames } from 'helpers/pages';
-
 import Alert from 'components/alert';
 import Icon from 'components/icon';
 
@@ -11,21 +9,16 @@ import type { ContentLanguageAlertProps } from './types';
 
 export const ContentLanguageAlert: FC<ContentLanguageAlertProps> = ({
   className,
-  locale,
+  children,
 }: ContentLanguageAlertProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(true);
 
-  const languageNames = useLanguageNames();
-
-  if (!isOpen || !locale) return null;
+  if (!isOpen) return null;
 
   return (
     <Alert className={className}>
       <div className="flex items-center w-full">
-        <span className="flex-1">
-          <span className="mr-2 font-semibold">Note:</span>The content of this project should be
-          written in {languageNames[locale]}
-        </span>
+        <span className="flex-1">{children}</span>
         <Icon
           className="w-5 h-5 ml-2 cursor-pointer"
           icon={XIcon}

--- a/frontend/containers/forms/content-language-alert/component.tsx
+++ b/frontend/containers/forms/content-language-alert/component.tsx
@@ -1,0 +1,39 @@
+import { FC, useState } from 'react';
+
+import { X as XIcon } from 'react-feather';
+
+import { useLanguageNames } from 'helpers/pages';
+
+import Alert from 'components/alert';
+import Icon from 'components/icon';
+
+import type { ContentLanguageAlertProps } from './types';
+
+export const ContentLanguageAlert: FC<ContentLanguageAlertProps> = ({
+  className,
+  locale,
+}: ContentLanguageAlertProps) => {
+  const [isOpen, setIsOpen] = useState<boolean>(true);
+
+  const languageNames = useLanguageNames();
+
+  if (!isOpen || !locale) return null;
+
+  return (
+    <Alert className={className}>
+      <div className="flex items-center w-full">
+        <span className="flex-1">
+          <span className="mr-2 font-semibold">Note:</span>The content of this project should be
+          written in {languageNames[locale]}
+        </span>
+        <Icon
+          className="w-5 h-5 ml-2 cursor-pointer"
+          icon={XIcon}
+          onClick={() => setIsOpen(false)}
+        />
+      </div>
+    </Alert>
+  );
+};
+
+export default ContentLanguageAlert;

--- a/frontend/containers/forms/content-language-alert/index.ts
+++ b/frontend/containers/forms/content-language-alert/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { ContentLanguageAlertProps } from './types';

--- a/frontend/containers/forms/content-language-alert/types.ts
+++ b/frontend/containers/forms/content-language-alert/types.ts
@@ -1,0 +1,8 @@
+import { LanguageType } from 'types';
+
+export type ContentLanguageAlertProps = {
+  /** Classes to apply to the container */
+  className?: string;
+  /** Locale code to display a translated string of */
+  locale?: LanguageType;
+};

--- a/frontend/containers/forms/content-language-alert/types.ts
+++ b/frontend/containers/forms/content-language-alert/types.ts
@@ -1,8 +1,8 @@
+import { PropsWithChildren } from 'react';
+
 import { LanguageType } from 'types';
 
-export type ContentLanguageAlertProps = {
+export type ContentLanguageAlertProps = PropsWithChildren<{
   /** Classes to apply to the container */
   className?: string;
-  /** Locale code to display a translated string of */
-  locale?: LanguageType;
-};
+}>;

--- a/frontend/containers/investor-form/component.tsx
+++ b/frontend/containers/investor-form/component.tsx
@@ -1,13 +1,14 @@
 import { FC, useCallback, useEffect, useState } from 'react';
 
 import { Path, SubmitHandler, useForm } from 'react-hook-form';
+import { FormattedMessage } from 'react-intl';
 
 import { useRouter } from 'next/router';
 
 import { AxiosError } from 'axios';
 import { entries, pick } from 'lodash-es';
 
-import { getServiceErrors, useGetAlert } from 'helpers/pages';
+import { getServiceErrors, useGetAlert, useLanguageNames } from 'helpers/pages';
 
 import ContentLanguageAlert from 'containers/forms/content-language-alert';
 import SelectLanguageForm from 'containers/forms/select-language-form';
@@ -41,6 +42,7 @@ const InvestorForm: FC<InvestorFormProps> = ({
   const [totalPages, setTotalPages] = useState(0);
   const resolver = useValidation(isCreateForm ? currentPage : currentPage + 1);
   const { back } = useRouter();
+  const languageNames = useLanguageNames();
 
   const {
     register,
@@ -135,8 +137,17 @@ const InvestorForm: FC<InvestorFormProps> = ({
           </Page>
         )}
         <Page hasErrors={getPageErrors(1)}>
-          {!isCreateForm && (
-            <ContentLanguageAlert className="mb-6" locale={initialValues?.language} />
+          {!isCreateForm && initialValues?.language && (
+            <ContentLanguageAlert className="mb-6">
+              <FormattedMessage
+                defaultMessage="<span>Note:</span>The content of this profile should be written in {language}"
+                id="zINRAT"
+                values={{
+                  language: languageNames[initialValues?.language],
+                  span: (chunks: string) => <span className="mr-2 font-semibold">{chunks}</span>,
+                }}
+              />
+            </ContentLanguageAlert>
           )}
           <Profile
             register={register}

--- a/frontend/containers/investor-form/component.tsx
+++ b/frontend/containers/investor-form/component.tsx
@@ -9,6 +9,7 @@ import { entries, pick } from 'lodash-es';
 
 import { getServiceErrors, useGetAlert } from 'helpers/pages';
 
+import ContentLanguageAlert from 'containers/forms/content-language-alert';
 import SelectLanguageForm from 'containers/forms/select-language-form';
 import {
   Profile,
@@ -132,6 +133,9 @@ const InvestorForm: FC<InvestorFormProps> = ({
           </Page>
         )}
         <Page hasErrors={getPageErrors(1)}>
+          {!isCreateForm && (
+            <ContentLanguageAlert className="mb-6" locale={initialValues?.language} />
+          )}
           <Profile
             register={register}
             control={control}

--- a/frontend/containers/investor-form/component.tsx
+++ b/frontend/containers/investor-form/component.tsx
@@ -49,6 +49,7 @@ const InvestorForm: FC<InvestorFormProps> = ({
     control,
     setError,
     setValue,
+    getValues,
     clearErrors,
   } = useForm<InvestorFormType>({
     resolver,
@@ -116,6 +117,7 @@ const InvestorForm: FC<InvestorFormProps> = ({
         getTotalPages={(pages) => setTotalPages(pages)}
         layout="narrow"
         title={title}
+        locale={initialValues?.language || (currentPage !== 0 ? getValues('language') : null)}
         autoNavigation={false}
         page={currentPage}
         alert={alert}

--- a/frontend/containers/multi-page-layout/component.tsx
+++ b/frontend/containers/multi-page-layout/component.tsx
@@ -17,6 +17,7 @@ export const MultiPageLayout: FC<MultiPageLayoutProps> = ({
   className,
   layout,
   title,
+  locale,
   showProgressBar = true,
   isSubmitting = false,
   showOutro = false,
@@ -106,6 +107,7 @@ export const MultiPageLayout: FC<MultiPageLayoutProps> = ({
       />
       <MultiPageLayoutHeader
         title={title}
+        locale={locale}
         leaveButtonText={leaveButtonText}
         onCloseClick={onCloseClick}
       />

--- a/frontend/containers/multi-page-layout/footer/component.tsx
+++ b/frontend/containers/multi-page-layout/footer/component.tsx
@@ -57,12 +57,16 @@ export const MultiPageLayoutFooter: FC<MultiPageLayoutFooterProps> = ({
             <ul>
               {alert.map((a: string) => (
                 <li key={a}>
-                  <Alert withLayoutContainer={true}>{a}</Alert>
+                  <Alert type="warning" withLayoutContainer={true}>
+                    {a}
+                  </Alert>
                 </li>
               ))}
             </ul>
           ) : (
-            <Alert withLayoutContainer={true}>{alert}</Alert>
+            <Alert type="warning" withLayoutContainer={true}>
+              {alert}
+            </Alert>
           )}
         </div>
       )}

--- a/frontend/containers/multi-page-layout/header/component.tsx
+++ b/frontend/containers/multi-page-layout/header/component.tsx
@@ -5,8 +5,6 @@ import { useIntl, FormattedMessage } from 'react-intl';
 
 import cx from 'classnames';
 
-import Link from 'next/link';
-
 import { noop } from 'lodash-es';
 
 import Button from 'components/button';
@@ -17,6 +15,7 @@ import { MultiPageLayoutHeaderProps } from './types';
 export const MultiPageLayoutHeader: React.FC<MultiPageLayoutHeaderProps> = ({
   className,
   title,
+  locale,
   leaveButtonText,
   onCloseClick = noop,
 }: MultiPageLayoutHeaderProps) => {
@@ -31,11 +30,23 @@ export const MultiPageLayoutHeader: React.FC<MultiPageLayoutHeaderProps> = ({
     >
       <LayoutContainer>
         <div className="flex items-center justify-between h-20 gap-x-8 md:gap-x-16">
-          <div className="flex justify-start flex-1 md:flex-none">
+          <div className="flex justify-start flex-1">
             <span className="font-semibold">HeCo Invest</span>
           </div>
-          <div className="md:flex-1">{title}</div>
-          <div className="flex justify-end flex-1 md:flex-none">
+          <LayoutContainer
+            layout="narrow"
+            className="flex flex-col items-center justify-between lg:flex-row"
+          >
+            <span>{title}</span>
+            {locale && (
+              <span className="px-2 py-1 text-sm text-black rounded-lg lg:py-2 bg-background-dark">
+                <FormattedMessage defaultMessage="Content language" id="zetZX8" />
+                <span className="mr-1">:</span>
+                {locale.toUpperCase()}
+              </span>
+            )}
+          </LayoutContainer>
+          <div className="flex justify-end flex-1 whitespace-nowrap">
             <Button
               theme="naked"
               className="px-0 text-gray-400 md:px-6"

--- a/frontend/containers/multi-page-layout/header/types.ts
+++ b/frontend/containers/multi-page-layout/header/types.ts
@@ -1,8 +1,12 @@
+import { LanguageType } from 'types';
+
 export interface MultiPageLayoutHeaderProps {
   /** Classnames to apply to container */
   className?: string;
   /** Title to display at the top of the page */
   title: string;
+  /** Locale of the layout to display in a tag */
+  locale?: LanguageType;
   /** Text to display on top right "Leave" button. Defaults to +Leave` */
   leaveButtonText?: string;
   /** Callback when the close button is pressed */

--- a/frontend/containers/multi-page-layout/types.ts
+++ b/frontend/containers/multi-page-layout/types.ts
@@ -1,6 +1,7 @@
 import { PropsWithChildren } from 'react';
 
 import { LayoutContainerProps } from 'components/layout-container';
+import { LanguageType } from 'types';
 
 import { MultiPageLayoutFooterProps } from './footer';
 import { MultiPageLayoutHeaderProps } from './header';
@@ -9,6 +10,8 @@ export type MultiPageLayoutProps = PropsWithChildren<
   {
     /** Classnames to apply to the container */
     className?: string;
+    /** Locale of the layout to display in a tag in the header */
+    locale?: LanguageType;
     /** Whether to show the outro page */
     showOutro?: boolean;
     /** Whether to show the footer on the outro page. Defaults to `false` */

--- a/frontend/containers/project-developer-form/component.tsx
+++ b/frontend/containers/project-developer-form/component.tsx
@@ -2,7 +2,6 @@ import { FC, useEffect } from 'react';
 import { useState, useCallback } from 'react';
 
 import { SubmitHandler, useForm, Path } from 'react-hook-form';
-import { useIntl } from 'react-intl';
 
 import { useRouter } from 'next/router';
 
@@ -13,6 +12,7 @@ import useInterests from 'hooks/useInterests';
 
 import { getServiceErrors, useGetAlert } from 'helpers/pages';
 
+import ContentLanguageAlert from 'containers/forms/content-language-alert';
 import SelectLanguageForm from 'containers/forms/select-language-form';
 import LeaveFormModal from 'containers/leave-form-modal';
 import MultiPageLayout, { Page, OutroPage } from 'containers/multi-page-layout';
@@ -139,7 +139,10 @@ export const ProjectDeveloperForm: FC<ProjectDeveloperFormProps> = ({
             <SelectLanguageForm register={register} errors={errors} fieldName="language" />
           </Page>
         )}
-        <Page hasErrors={getPageErrors(1)}>
+        <Page hasErrors={getPageErrors(1)} className="relative">
+          {!isCreateForm && (
+            <ContentLanguageAlert className="mb-6" locale={initialValues?.language} />
+          )}
           <Profile
             setError={setError}
             setValue={setValue}

--- a/frontend/containers/project-developer-form/component.tsx
+++ b/frontend/containers/project-developer-form/component.tsx
@@ -2,6 +2,7 @@ import { FC, useEffect } from 'react';
 import { useState, useCallback } from 'react';
 
 import { SubmitHandler, useForm, Path } from 'react-hook-form';
+import { FormattedMessage } from 'react-intl';
 
 import { useRouter } from 'next/router';
 
@@ -10,7 +11,7 @@ import { entries, pick } from 'lodash-es';
 
 import useInterests from 'hooks/useInterests';
 
-import { getServiceErrors, useGetAlert } from 'helpers/pages';
+import { getServiceErrors, useGetAlert, useLanguageNames } from 'helpers/pages';
 
 import ContentLanguageAlert from 'containers/forms/content-language-alert';
 import SelectLanguageForm from 'containers/forms/select-language-form';
@@ -41,6 +42,7 @@ export const ProjectDeveloperForm: FC<ProjectDeveloperFormProps> = ({
   const [totalPages, setTotalPages] = useState(0);
   const resolver = useProjectDeveloperValidation(isCreateForm ? currentPage : currentPage + 1);
   const { back } = useRouter();
+  const languageNames = useLanguageNames();
 
   const enums = useEnums();
   const {
@@ -142,8 +144,17 @@ export const ProjectDeveloperForm: FC<ProjectDeveloperFormProps> = ({
           </Page>
         )}
         <Page hasErrors={getPageErrors(1)} className="relative">
-          {!isCreateForm && (
-            <ContentLanguageAlert className="mb-6" locale={initialValues?.language} />
+          {!isCreateForm && initialValues?.language && (
+            <ContentLanguageAlert className="mb-6">
+              <FormattedMessage
+                defaultMessage="<span>Note:</span>The content of this profile should be written in {language}"
+                id="zINRAT"
+                values={{
+                  language: languageNames[initialValues?.language],
+                  span: (chunks: string) => <span className="mr-2 font-semibold">{chunks}</span>,
+                }}
+              />
+            </ContentLanguageAlert>
           )}
           <Profile
             setError={setError}

--- a/frontend/containers/project-developer-form/component.tsx
+++ b/frontend/containers/project-developer-form/component.tsx
@@ -57,6 +57,7 @@ export const ProjectDeveloperForm: FC<ProjectDeveloperFormProps> = ({
     control,
     setError,
     setValue,
+    getValues,
     clearErrors,
   } = useForm<ProjectDeveloperSetupForm>({
     resolver,
@@ -123,6 +124,7 @@ export const ProjectDeveloperForm: FC<ProjectDeveloperFormProps> = ({
         getTotalPages={(pages) => setTotalPages(pages)}
         layout="narrow"
         title={title}
+        locale={initialValues?.language || (currentPage !== 0 ? getValues('language') : null)}
         autoNavigation={false}
         page={currentPage}
         alert={alert}

--- a/frontend/containers/project-form/component.tsx
+++ b/frontend/containers/project-form/component.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/router';
 
 import { getServiceErrors, useGetAlert, useQueryReturnPath } from 'helpers/pages';
 
+import ContentLanguageAlert from 'containers/forms/content-language-alert';
 import LeaveFormModal from 'containers/leave-form-modal';
 import MultiPageLayout, { OutroPage, Page } from 'containers/multi-page-layout';
 
@@ -184,6 +185,8 @@ export const ProjectForm: FC<ProjectFormProps> = ({
     await handleSubmit(onSubmit)();
   };
 
+  const contentLocale = defaultValues?.language || userAccount?.language;
+
   return (
     <>
       <Head title={title} />
@@ -191,7 +194,7 @@ export const ProjectForm: FC<ProjectFormProps> = ({
         layout="narrow"
         getTotalPages={(pages) => setTotalPages(pages)}
         title={title}
-        locale={defaultValues?.language || userAccount?.language}
+        locale={contentLocale}
         autoNavigation={false}
         page={currentPage}
         alert={useGetAlert(updateProject.error)}
@@ -204,6 +207,7 @@ export const ProjectForm: FC<ProjectFormProps> = ({
         onSubmitClick={handleSubmit(onSubmit)}
       >
         <Page key="general-information">
+          <ContentLanguageAlert className="mb-6" locale={contentLocale} />
           <GeneralInformation
             register={register}
             control={control}

--- a/frontend/containers/project-form/component.tsx
+++ b/frontend/containers/project-form/component.tsx
@@ -18,6 +18,7 @@ import {
 } from 'types/project';
 import useProjectValidation, { formPageInputs } from 'validations/project';
 
+import { useAccount } from 'services/account';
 import { useUpdateProject } from 'services/account';
 
 import { useDefaultValues } from './helpers';
@@ -50,6 +51,7 @@ export const ProjectForm: FC<ProjectFormProps> = ({
   const updateProject = useUpdateProject();
   const queryReturnPath = useQueryReturnPath();
   const router = useRouter();
+  const { userAccount } = useAccount();
   const {
     category,
     project_development_stage,
@@ -189,6 +191,7 @@ export const ProjectForm: FC<ProjectFormProps> = ({
         layout="narrow"
         getTotalPages={(pages) => setTotalPages(pages)}
         title={title}
+        locale={defaultValues?.language || userAccount?.language}
         autoNavigation={false}
         page={currentPage}
         alert={useGetAlert(updateProject.error)}

--- a/frontend/containers/project-form/component.tsx
+++ b/frontend/containers/project-form/component.tsx
@@ -1,10 +1,11 @@
 import { FC, useCallback, useState } from 'react';
 
 import { useForm, SubmitHandler } from 'react-hook-form';
+import { FormattedMessage } from 'react-intl';
 
 import { useRouter } from 'next/router';
 
-import { getServiceErrors, useGetAlert, useQueryReturnPath } from 'helpers/pages';
+import { getServiceErrors, useGetAlert, useQueryReturnPath, useLanguageNames } from 'helpers/pages';
 
 import ContentLanguageAlert from 'containers/forms/content-language-alert';
 import LeaveFormModal from 'containers/leave-form-modal';
@@ -61,7 +62,9 @@ export const ProjectForm: FC<ProjectFormProps> = ({
     ticket_size,
     instrument_type,
   } = enums;
+
   const defaultValues = useDefaultValues(project);
+  const languageNames = useLanguageNames();
 
   const {
     register,
@@ -207,7 +210,16 @@ export const ProjectForm: FC<ProjectFormProps> = ({
         onSubmitClick={handleSubmit(onSubmit)}
       >
         <Page key="general-information">
-          <ContentLanguageAlert className="mb-6" locale={contentLocale} />
+          <ContentLanguageAlert className="mb-6">
+            <FormattedMessage
+              defaultMessage="<span>Note:</span>The content of this project should be written in {language}"
+              id="S27Bu1"
+              values={{
+                language: languageNames[contentLocale],
+                span: (chunks: string) => <span className="mr-2 font-semibold">{chunks}</span>,
+              }}
+            />
+          </ContentLanguageAlert>
           <GeneralInformation
             register={register}
             control={control}

--- a/frontend/containers/project-form/component.tsx
+++ b/frontend/containers/project-form/component.tsx
@@ -4,7 +4,7 @@ import { useForm, SubmitHandler } from 'react-hook-form';
 
 import { useRouter } from 'next/router';
 
-import { getServiceErrors, useGetAlert } from 'helpers/pages';
+import { getServiceErrors, useGetAlert, useQueryReturnPath } from 'helpers/pages';
 
 import LeaveFormModal from 'containers/leave-form-modal';
 import MultiPageLayout, { OutroPage, Page } from 'containers/multi-page-layout';
@@ -48,6 +48,7 @@ export const ProjectForm: FC<ProjectFormProps> = ({
   const [projectSlug, setProjectSlug] = useState<string>();
   const resolver = useProjectValidation(currentPage);
   const updateProject = useUpdateProject();
+  const queryReturnPath = useQueryReturnPath();
   const router = useRouter();
   const {
     category,
@@ -273,9 +274,7 @@ export const ProjectForm: FC<ProjectFormProps> = ({
       <LeaveFormModal
         isOpen={showLeave}
         close={() => setShowLeave(false)}
-        handleLeave={() =>
-          router.push(decodeURIComponent(router.query?.returnPath as string) || Paths.Dashboard)
-        }
+        handleLeave={() => router.push(queryReturnPath || Paths.Dashboard)}
         title={leaveMessage}
       />
     </>

--- a/frontend/containers/project-form/helpers.ts
+++ b/frontend/containers/project-form/helpers.ts
@@ -16,6 +16,7 @@ export const useDefaultValues = (project: Project): Partial<ProjectForm> => {
     const general = pickBy(project, (value, key: any) => projectFormKeys.includes(key));
     return {
       ...general,
+      language: project.language,
       municipality_id: project.municipality?.id,
       department_id: project.municipality.parent.id,
       country_id: project.country?.id,

--- a/frontend/containers/users/invite-users-modal/component.tsx
+++ b/frontend/containers/users/invite-users-modal/component.tsx
@@ -198,7 +198,7 @@ export const InviteUsersModal: FC<InviteUsersModalProps> = ({
         </div>
 
         {inviteUsers.isError && (
-          <Alert className="my-4" withLayoutContainer>
+          <Alert type="warning" className="my-4" withLayoutContainer>
             {Array.isArray(inviteUsers.error.message)
               ? inviteUsers.error.message[0].title
               : inviteUsers.error.message}

--- a/frontend/helpers/pages.ts
+++ b/frontend/helpers/pages.ts
@@ -115,6 +115,14 @@ export const useQueryString = () => {
   return '';
 };
 
+/** Hook that returns the query returnPath, if any */
+export const useQueryReturnPath = () => {
+  const { query } = useRouter();
+  return typeof query?.returnPath === 'string'
+    ? decodeURIComponent(query.returnPath as string)
+    : undefined;
+};
+
 export const getSocialMediaLinksRegex = () => {
   const getRegex = (media: string) => new RegExp(`^https?:\/\/(www.)?${media}.com\/.*$`);
   return {

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -828,6 +828,9 @@
   "Swj4mJ": {
     "string": "Select the {name} account"
   },
+  "TDaF6J": {
+    "string": "Dismiss"
+  },
   "TJo5E6": {
     "string": "Preview"
   },

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -1701,6 +1701,9 @@
   "zdIaHp": {
     "string": "Investors"
   },
+  "zetZX8": {
+    "string": "Content language"
+  },
   "zkonnO": {
     "string": "World Wildlife Fund (WWF) is the largest international conservation organization in the world, with more than 50 offices implementing conservation projects across more than 100 countries and has a membership of almost five million people. WWF has extensive experience working in the Amazon region, with offices in all seven signatory countries of the Leticia Pact. In Colombia, WWF has been working in partnership with the government and a consortium of civil society organizations on Heritage Colombia since 2015."
   },

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -1461,6 +1461,9 @@
   "qpDURb": {
     "string": "Something went wrong with the file upload"
   },
+  "qwCflo": {
+    "string": "Edit project"
+  },
   "r/AN6W": {
     "string": "select investor/funder type"
   },

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -798,6 +798,9 @@
   "RXoqkD": {
     "string": "Mission"
   },
+  "S27Bu1": {
+    "string": "<span>Note:</span>The content of this project should be written in {language}"
+  },
   "SHw9Ht": {
     "string": "Start connecting with people to create impact. You can find investors, opportunities to invest open calls and much more."
   },
@@ -1691,6 +1694,9 @@
   },
   "zFegDD": {
     "string": "Contact"
+  },
+  "zINRAT": {
+    "string": "<span>Note:</span>The content of this profile should be written in {language}"
   },
   "zINlao": {
     "string": "Owner"

--- a/frontend/pages/investors/edit.tsx
+++ b/frontend/pages/investors/edit.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router';
 import { groupBy } from 'lodash-es';
 
 import { loadI18nMessages } from 'helpers/i18n';
+import { useQueryReturnPath } from 'helpers/pages';
 
 import InvestorForm from 'containers/investor-form';
 
@@ -39,9 +40,10 @@ const EditInvestorPage: PageComponent<EditInvestorServerSideProps, FormPageLayou
   const { formatMessage } = useIntl();
 
   const updateInvestor = useUpdateInvestor();
+  const queryReturnPath = useQueryReturnPath();
 
   const handleOnComplete = () => {
-    router.push((router.query?.returnPath as string) || Paths.Dashboard);
+    router.push(queryReturnPath || Paths.Dashboard);
   };
 
   const { investor } = useInvestor({});

--- a/frontend/pages/investors/new.tsx
+++ b/frontend/pages/investors/new.tsx
@@ -7,6 +7,7 @@ import { withLocalizedRequests } from 'hoc/locale';
 import { groupBy } from 'lodash-es';
 
 import { loadI18nMessages } from 'helpers/i18n';
+import { useQueryReturnPath } from 'helpers/pages';
 
 import InvestorForm from 'containers/investor-form';
 
@@ -41,9 +42,10 @@ const NewInvestorPage: PageComponent<NewInvestorServerSideProps, FormPageLayoutP
   const { formatMessage } = useIntl();
 
   const createInvestor = useCreateInvestor();
+  const queryReturnPath = useQueryReturnPath();
 
   const handleOnComplete = () => {
-    router.push((router.query?.returnPath as string) || Paths.Dashboard);
+    router.push(queryReturnPath || Paths.Dashboard);
   };
 
   return (

--- a/frontend/pages/project-developers/edit.tsx
+++ b/frontend/pages/project-developers/edit.tsx
@@ -8,6 +8,7 @@ import { withLocalizedRequests } from 'hoc/locale';
 import { InferGetStaticPropsType } from 'next';
 
 import { loadI18nMessages } from 'helpers/i18n';
+import { useQueryReturnPath } from 'helpers/pages';
 
 import ProjectDeveloperForm from 'containers/project-developer-form';
 
@@ -36,11 +37,13 @@ type ProjectDeveloperProps = InferGetStaticPropsType<typeof getStaticProps>;
 const ProjectDeveloper: PageComponent<ProjectDeveloperProps, FormPageLayoutProps> = () => {
   const router = useRouter();
   const { formatMessage } = useIntl();
+
   const updateProjectDeveloper = useUpdateProjectDeveloper();
   const { projectDeveloper } = useCurrentProjectDeveloper();
+  const queryReturnPath = useQueryReturnPath();
 
   const handleOnComplete = () => {
-    router.push(decodeURIComponent(router.query?.returnPath as string) || Paths.Dashboard);
+    router.push(queryReturnPath || Paths.Dashboard);
   };
 
   return (

--- a/frontend/pages/project-developers/new.tsx
+++ b/frontend/pages/project-developers/new.tsx
@@ -8,6 +8,7 @@ import { withLocalizedRequests } from 'hoc/locale';
 import { InferGetStaticPropsType } from 'next';
 
 import { loadI18nMessages } from 'helpers/i18n';
+import { useQueryReturnPath } from 'helpers/pages';
 
 import ProjectDeveloperForm from 'containers/project-developer-form';
 
@@ -37,9 +38,10 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, FormPageLayoutProps
   const { formatMessage } = useIntl();
 
   const createProjectDeveloper = useCreateProjectDeveloper();
+  const queryReturnPath = useQueryReturnPath();
 
   const handleOnComplete = () => {
-    router.push(Paths.Dashboard);
+    router.push(queryReturnPath || Paths.Dashboard);
   };
 
   return (

--- a/frontend/pages/project/[id]/edit.tsx
+++ b/frontend/pages/project/[id]/edit.tsx
@@ -90,7 +90,7 @@ const EditProject: PageComponent<EditProjectProps, FormPageLayoutProps> = ({ pro
       permissions={[UserRoles.ProjectDeveloper]}
     >
       <ProjectForm
-        title={formatMessage({ defaultMessage: 'Create project', id: 'VUN1K7' })}
+        title={formatMessage({ defaultMessage: 'Edit project', id: 'qwCflo' })}
         leaveMessage={formatMessage({
           defaultMessage: 'Leave project creation form',
           id: 'vygPIS',

--- a/frontend/pages/project/[id]/edit.tsx
+++ b/frontend/pages/project/[id]/edit.tsx
@@ -8,6 +8,7 @@ import { decycle } from 'cycle';
 import { groupBy } from 'lodash-es';
 
 import { loadI18nMessages } from 'helpers/i18n';
+import { useQueryReturnPath } from 'helpers/pages';
 
 import ProjectForm from 'containers/project-form';
 
@@ -61,8 +62,10 @@ type EditProjectProps = {
 
 const EditProject: PageComponent<EditProjectProps, FormPageLayoutProps> = ({ project, enums }) => {
   const { formatMessage } = useIntl();
-  const updateProject = useUpdateProject();
   const router = useRouter();
+
+  const updateProject = useUpdateProject();
+  const queryReturnPath = useQueryReturnPath();
 
   const getIsOwner = (user: User, userAccount: ProjectDeveloper | Investor) => {
     // The user must be a the creator of the project to be allowed to edit it.
@@ -74,11 +77,7 @@ const EditProject: PageComponent<EditProjectProps, FormPageLayoutProps> = ({ pro
   };
 
   const onComplete = () => {
-    router.push(
-      router.query?.returnPath
-        ? decodeURIComponent(router.query?.returnPath as string)
-        : Paths.DashboardProjects
-    );
+    router.push(queryReturnPath || Paths.DashboardProjects);
   };
 
   return (

--- a/frontend/pages/sign-in/forgot-password.tsx
+++ b/frontend/pages/sign-in/forgot-password.tsx
@@ -70,7 +70,7 @@ const ForgotPassword: PageComponent<ForgotPasswordPageProps, AuthPageLayoutProps
       </p>
       <form onSubmit={handleSubmit(onSubmit)} noValidate>
         {resetPassword.isError && (
-          <Alert className="mb-4.5" withLayoutContainer>
+          <Alert type="warning" className="mb-4.5" withLayoutContainer>
             {Array.isArray(resetPassword.error.message)
               ? resetPassword.error.message[0].title
               : resetPassword.error.message}

--- a/frontend/pages/sign-in/index.tsx
+++ b/frontend/pages/sign-in/index.tsx
@@ -93,7 +93,7 @@ const SignIn: PageComponent<SignInPageProps, AuthPageLayoutProps> = () => {
       </p>
       <form onSubmit={handleSubmit(onSubmit)} noValidate>
         {signIn.error?.message && (
-          <Alert className="mb-4.5" withLayoutContainer>
+          <Alert type="warning" className="mb-4.5" withLayoutContainer>
             {Array.isArray(signIn.error?.message)
               ? signIn.error.message[0].title
               : signIn.error.message}

--- a/frontend/pages/sign-up/index.tsx
+++ b/frontend/pages/sign-up/index.tsx
@@ -82,13 +82,13 @@ const SignUp: PageComponent<SignUpPageProps, AuthPageLayoutProps> = () => {
           Array.isArray(signUp.error.message) ? (
             <ul>
               {signUp.error.message.map((err: any) => (
-                <Alert key={err.title} withLayoutContainer className="mt-6">
+                <Alert type="warning" key={err.title} withLayoutContainer className="mt-6">
                   <li key={err.title}>{err.title}</li>
                 </Alert>
               ))}
             </ul>
           ) : (
-            <Alert withLayoutContainer className="mt-6">
+            <Alert type="warning" withLayoutContainer className="mt-6">
               {signUp.error.message}
             </Alert>
           )


### PR DESCRIPTION
## Description

**In this PR:**

- Fixed the logic that handles returning an user to the previous page after editing a form  
  _The logic was also extracted into a helper to ensure it is consistent throughout the app_  
- Added a "default" neutral style (with a beige background) to the Alert component  
  _And updated the app so that pages/components using the "warning" type alert would have the `type` prop set to "warning"_  
- Added the `ContentLanguageAlert` component to display the required content language 
  _It is a reusable/shared component to be used throughout the forms_  
- Added support for a "Content language" tag on the `MultiPageLayout` (the layout used in forms)  
- Added the "Content language" tag to the Project, PD, Investor forms' layout header  
- Added the "Content language" alert to the Project, PD, Investor forms' first page  

## Testing instructions

**Editing an account profile** 

- As a investor  
  - Visit the Dashboard, "Account information" tab
  - Click "Edit profile"  
  - Verify that:  
    - There is a tag on the header with the "Content language"  
    - There is an alert stating which language the content of the profile should be written in  
    - The alert is only shown for the first page of the form  
    - The language for the content is the language of the account   

- As a project developer 
  - Visit the Dashboard, "Account information" tab
  - Click "Edit profile"  
  - Verify that:  
    - There is a tag on the header with the "Content language"  
    - There is an alert stating which language the content of the profile should be written in  
    - The alert is only shown for the first page of the form  
    - The language for the content is the language of the account   

**Editing a project** 

- As a project developer  
  - Visit the Dashboard, "Projects" tab  
  - Click to "Edit" a project  
  - Verify that:  
    - There is a tag on the header with the "Content Language"  
    - There is an alert stating which language the content of the project should be written in  
    - The language for the content is the language of the account  

**Others**  
- Verify that when closing a form, the user is redirected to the page they were previously on, or if none, the Dashboard

## Tracking

[LET-727](https://vizzuality.atlassian.net/browse/LET-727)
This PR should also fix the bug described on [LET-750](https://vizzuality.atlassian.net/browse/LET-750)

## Screenshots
<img width="1680" alt="Screenshot 2022-07-12 at 13 07 23" src="https://user-images.githubusercontent.com/6273795/178486228-a5b0781c-bdbd-493f-bd0d-abdb6b9d6072.png">

