### PR TITLE
fix: Invited users can sign in

### DIFF
--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -57,4 +57,8 @@ class User < ApplicationRecord
 
     errors.add :password, :password_complexity
   end
+
+  def block_from_invitation?
+    false # invited users can still sign-in
+  end
 end

--- a/backend/spec/requests/api/v1/session_spec.rb
+++ b/backend/spec/requests/api/v1/session_spec.rb
@@ -32,11 +32,25 @@ RSpec.describe "API V1 Session", type: :request do
         end
         let("X-CSRF-TOKEN") { get_csrf_token }
 
-        run_test!
+        context "when non-invited user tries to login" do
+          run_test!
 
-        it "matches snapshot", generate_swagger_example: true do
-          expect(response.body).to match_snapshot("api/v1/session")
-          expect(session["warden.user.user.key"]).to be_present
+          it "matches snapshot", generate_swagger_example: true do
+            expect(response.body).to match_snapshot("api/v1/session")
+            expect(session["warden.user.user.key"]).to be_present
+          end
+        end
+
+        context "when invited user tries to login" do
+          before do
+            @user.invite! create(:account).owner
+          end
+
+          run_test!
+
+          it "can still login" do
+            expect(session["warden.user.user.key"]).to be_present
+          end
         end
       end
 


### PR DESCRIPTION
Bug discovered by @barbara-chaves  -> devise prevented any invited users to sign-in. In our invitation flow, you first sign-in or sign-up and accept invitation afterwards, therefore I am disabling this behaviour.