### PR TITLE
Fix priority landscapes map layout

### DIFF
--- a/frontend/pages/for-investors.tsx
+++ b/frontend/pages/for-investors.tsx
@@ -286,12 +286,12 @@ const ForInvestorsPage: PageComponent<ForInvestorsPageProps, StaticPageLayoutPro
             <FormattedMessage defaultMessage="By priority landscapes" id="JcS7oJ" />
           </h2>
         </div>
-        <div className="md:hidden block w-full max-h-[300px] mb-6 rounded-lg overflow-hidden">
+        <div className="block max-w-full mb-6 mr-4 rounded-lg sm:mr-0 md:hidden">
           <Image
             src="/images/for-investor/for-investor-priority-landscapes.png"
             alt=""
-            width={604}
-            height={557}
+            width={686}
+            height={632}
             objectFit="cover"
             objectPosition="center"
             className="rounded-lg"
@@ -332,12 +332,12 @@ const ForInvestorsPage: PageComponent<ForInvestorsPageProps, StaticPageLayoutPro
               <FormattedMessage defaultMessage="By priority landscapes" id="JcS7oJ" />
             </h2>
           </div>
-          <div className="hidden md:block w-[calc(100vw-32px)] max-h-[300px] md:w-auto col-start-1 row-start-2 md:col-span-2 md:col-start-2 md:row-span-2 md:row-start-3 lg:row-start-2 lg:col-start-3 rounded-lg overflow-hidden">
+          <div className="hidden md:block w-[calc(100vw-32px)] md:w-auto col-start-1 row-start-2 md:col-span-2 md:col-start-2 md:row-span-2 md:row-start-3 lg:row-start-2 lg:col-start-3 rounded-lg">
             <Image
               src="/images/for-investor/for-investor-priority-landscapes.png"
               alt=""
-              width={604}
-              height={557}
+              width={1124}
+              height={1306}
               objectFit="cover"
               objectPosition="center"
               className="rounded-lg"


### PR DESCRIPTION
This PR fixes the priority landscape layout on the for-investors page

## Testing instructions

The user should see all the priority landscapes on the map image

## Tracking

[LET-751](https://vizzuality.atlassian.net/browse/LET-751)

## Screenshots
<img width="911" alt="Screenshot 2022-07-11 at 12 48 52" src="https://user-images.githubusercontent.com/48164343/178248468-8a509335-3cc9-4de3-97c4-decd9a25713e.png">
<img width="438" alt="Screenshot 2022-07-11 at 12 48 30" src="https://user-images.githubusercontent.com/48164343/178248472-e7b9fd1f-6b90-4e1a-a854-9bb96d8e1b4d.png">

