### PR TITLE
fix: Jobs instance can access backoffice routes

### DIFF
--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     post "/rails/active_storage/direct_uploads", to: "active_storage/direct_uploads#create"
   end
 
-  draw :backoffice if ENV["IS_API_INSTANCE"].to_s == "true"
+  draw :backoffice if ENV["IS_API_INSTANCE"].to_s == "true" || ENV["IS_JOBS_INSTANCE"].to_s == "true"
   draw :api if ENV["IS_API_INSTANCE"].to_s == "true"
   draw :jobs if ENV["IS_JOBS_INSTANCE"].to_s == "true"
 end


### PR DESCRIPTION
I am enabling backoffice routes for JOBS instance -- it is required to generate links inside `first_time_login_instructions` email.

## Testing instructions

Set `IS_API_INSTANCE` to `false` and try to render `first_time_login_instructions` email <-- there is unit test which does same stuff.

## Tracking

https://vizzuality.atlassian.net/browse/LET-749
