### PR TITLE
Let 662 preview card of a project must open when clicking the project pin on the map

### DIFF
--- a/frontend/components/map/layers/cluster/component.tsx
+++ b/frontend/components/map/layers/cluster/component.tsx
@@ -4,8 +4,6 @@ import { Marker } from 'react-map-gl';
 
 import Supercluster from 'supercluster';
 
-import Button from 'components/button';
-
 import type { ClusterLayerProps } from './types';
 
 export const ClusterLayer: FC<ClusterLayerProps> = ({
@@ -46,10 +44,13 @@ export const ClusterLayer: FC<ClusterLayerProps> = ({
         }
 
         return (
-          <Marker key={id} latitude={latitude} longitude={longitude}>
-            <Button theme="naked" onClick={() => onSelectProjectPin(`${id}`)}>
-              {cloneElement(MarkerComponent, properties)}
-            </Button>
+          <Marker
+            key={id}
+            latitude={latitude}
+            longitude={longitude}
+            onClick={() => onSelectProjectPin(`${id}`)}
+          >
+            {cloneElement(MarkerComponent, properties)}
           </Marker>
         );
       })}

--- a/frontend/components/map/layers/cluster/component.tsx
+++ b/frontend/components/map/layers/cluster/component.tsx
@@ -1,3 +1,5 @@
+import { Paths } from 'enums';
+import Link from 'next/link';
 import { cloneElement, FC, useMemo } from 'react';
 
 import { Marker } from 'react-map-gl';
@@ -44,7 +46,9 @@ export const ClusterLayer: FC<ClusterLayerProps> = ({
 
         return (
           <Marker key={id} latitude={latitude} longitude={longitude}>
-            {cloneElement(MarkerComponent, properties)}
+            <Link href={`${Paths.Project}/${id}`}>
+              <a>{cloneElement(MarkerComponent, properties)}</a>
+            </Link>
           </Marker>
         );
       })}

--- a/frontend/components/map/layers/cluster/component.tsx
+++ b/frontend/components/map/layers/cluster/component.tsx
@@ -1,10 +1,10 @@
-import { Paths } from 'enums';
-import Link from 'next/link';
 import { cloneElement, FC, useMemo } from 'react';
 
 import { Marker } from 'react-map-gl';
 
 import Supercluster from 'supercluster';
+
+import Button from 'components/button';
 
 import type { ClusterLayerProps } from './types';
 
@@ -13,6 +13,7 @@ export const ClusterLayer: FC<ClusterLayerProps> = ({
   map,
   MarkerComponent,
   ClusterComponent,
+  onSelectProjectPin,
 }: ClusterLayerProps) => {
   const bbox = map.getBounds().toArray().flat();
   const zoom = map.getZoom();
@@ -46,9 +47,9 @@ export const ClusterLayer: FC<ClusterLayerProps> = ({
 
         return (
           <Marker key={id} latitude={latitude} longitude={longitude}>
-            <Link href={`${Paths.Project}/${id}`}>
-              <a>{cloneElement(MarkerComponent, properties)}</a>
-            </Link>
+            <Button theme="naked" onClick={() => onSelectProjectPin(`${id}`)}>
+              {cloneElement(MarkerComponent, properties)}
+            </Button>
           </Marker>
         );
       })}

--- a/frontend/components/map/layers/cluster/types.ts
+++ b/frontend/components/map/layers/cluster/types.ts
@@ -5,4 +5,5 @@ export type ClusterLayerProps = {
   map: any; // TODO: change type
   MarkerComponent: JSX.Element;
   ClusterComponent: JSX.Element;
+  onSelectProjectPin: (projectId: string) => void;
 };

--- a/frontend/containers/discover-map/component.tsx
+++ b/frontend/containers/discover-map/component.tsx
@@ -24,7 +24,7 @@ import { DiscoverMapProps } from './types';
 
 const cartoProvider = new CartoProvider();
 
-export const DiscoverMap: FC<DiscoverMapProps> = () => {
+export const DiscoverMap: FC<DiscoverMapProps> = ({ onSelectProjectPin }) => {
   const [visibleLayers, setVisibleLayers] = useState<string[]>([]);
   const { layers } = useLayers();
   const { query } = useRouter();
@@ -68,6 +68,7 @@ export const DiscoverMap: FC<DiscoverMapProps> = () => {
                 map={map}
                 MarkerComponent={<MapPin />}
                 ClusterComponent={<MapPinCluster />}
+                onSelectProjectPin={onSelectProjectPin}
               />
             </>
           )}

--- a/frontend/containers/discover-map/pin/component.tsx
+++ b/frontend/containers/discover-map/pin/component.tsx
@@ -1,7 +1,10 @@
 import { FC } from 'react';
 
+import { FormattedMessage } from 'react-intl';
+
 import cx from 'classnames';
 
+import Button from 'components/button';
 import Icon from 'components/icon';
 
 import MapPinIcon from 'svgs/project/marker.svg';
@@ -13,18 +16,24 @@ export const MapPin: FC<MapPinProps> = (props) => {
   const { category, trusted } = props;
 
   return (
-    <Icon
-      icon={trusted ? TrustedMapPinIcon : MapPinIcon}
-      className={cx({
-        'fill-category-tourism text-category-tourism': category === 'tourism-and-recreation',
-        'fill-category-production text-category-production':
-          category === 'non-timber-forest-production',
-        'fill-category-agrosystems text-category-agrosystems':
-          category === 'sustainable-agrosystems',
-        'fill-category-forestry text-category-forestry': category === 'forestry-and-agroforestry',
-        'fill-category-human text-category-human': category === 'human-capital-and-inclusion',
-      })}
-    />
+    <Button theme="naked" size="smallest" className="focus-visible:outline-green-dark">
+      <span className="sr-only">
+        {trusted && <FormattedMessage defaultMessage="Open verified project" id="9fHGyd" />}
+        {!trusted && <FormattedMessage defaultMessage="Open project" id="fUM67k" />}
+      </span>
+      <Icon
+        icon={trusted ? TrustedMapPinIcon : MapPinIcon}
+        className={cx({
+          'fill-category-tourism text-category-tourism': category === 'tourism-and-recreation',
+          'fill-category-production text-category-production':
+            category === 'non-timber-forest-production',
+          'fill-category-agrosystems text-category-agrosystems':
+            category === 'sustainable-agrosystems',
+          'fill-category-forestry text-category-forestry': category === 'forestry-and-agroforestry',
+          'fill-category-human text-category-human': category === 'human-capital-and-inclusion',
+        })}
+      />
+    </Button>
   );
 };
 

--- a/frontend/containers/discover-map/types.ts
+++ b/frontend/containers/discover-map/types.ts
@@ -1,1 +1,3 @@
-export interface DiscoverMapProps {}
+export interface DiscoverMapProps {
+  onSelectProjectPin: (projectId: string) => void;
+}

--- a/frontend/containers/project-details/component.tsx
+++ b/frontend/containers/project-details/component.tsx
@@ -37,11 +37,11 @@ export const ProjectDetails: FC<ProjectDetailsProps> = ({
   const impactArea = ImpactAreas.Municipality;
 
   const [projectDeveloperImage, setProjectDeveloperImage] = useState<string>(
-    project.project_developer?.picture.small
+    project.project_developer?.picture?.small
   );
 
   useEffect(() => {
-    setProjectDeveloperImage(project.project_developer?.picture.small);
+    setProjectDeveloperImage(project.project_developer?.picture?.small);
   }, [project]);
 
   const {

--- a/frontend/pages/discover/projects.tsx
+++ b/frontend/pages/discover/projects.tsx
@@ -81,7 +81,7 @@ const ProjectsPage: PageComponent<ProjectsPageProps, DiscoverPageLayoutProps> = 
     if (!selected) {
       // if the selected project from the map is not in the filtered list, the project will be fetched
       const newSelectedProject = await getProject(projectId, {
-        includes: ['project_images', 'priority_landscape', 'project_developer'],
+        includes: ['project_developer', 'involved_project_developers'],
       });
       if (!!newSelectedProject.data) {
         setSelectedProject(newSelectedProject.data);

--- a/frontend/pages/discover/projects.tsx
+++ b/frontend/pages/discover/projects.tsx
@@ -164,7 +164,7 @@ const ProjectsPage: PageComponent<ProjectsPageProps, DiscoverPageLayoutProps> = 
         )}
       </div>
       <aside className="flex-grow min-h-full p-2 m-1 bg-white rounded-2xl lg:min-h-0 lg:absolute lg:right-0 lg:w-7/12 lg:bottom-1 lg:top-1">
-        <DiscoverMap />
+        <DiscoverMap onSelectProjectPin={handleProjectCardClick} />
       </aside>
     </div>
   );

--- a/frontend/pages/discover/projects.tsx
+++ b/frontend/pages/discover/projects.tsx
@@ -29,6 +29,8 @@ import DiscoverPageLayout, { DiscoverPageLayoutProps } from 'layouts/discover-pa
 import { PageComponent } from 'types';
 import { Project as ProjectType } from 'types/project';
 
+import { getProject } from 'services/projects/projectService';
+
 export const getServerSideProps = withLocalizedRequests(async ({ locale }) => {
   return {
     props: {
@@ -74,8 +76,19 @@ const ProjectsPage: PageComponent<ProjectsPageProps, DiscoverPageLayoutProps> = 
     setSelectedProject(null);
   }, [query]);
 
-  const handleProjectCardClick = (projectId: string) => {
-    setSelectedProject(projects.find(({ id }) => id === projectId));
+  const handleProjectCardClick = async (projectId: string) => {
+    const selected = projects.find(({ id }) => id === projectId);
+    if (!selected) {
+      // if the selected project from the map is not in the filtered list, the project will be fetched
+      const newSelectedProject = await getProject(projectId, {
+        includes: ['project_images', 'priority_landscape', 'project_developer'],
+      });
+      if (!!newSelectedProject.data) {
+        setSelectedProject(newSelectedProject.data);
+      }
+      return;
+    }
+    setSelectedProject(selected);
   };
 
   const handleProjectDetailsClose = () => {


### PR DESCRIPTION
This pr add the functionality: select project clicking on map pin

## Testing

When clicking one of the projects in the search results or the map, a “card” will be displayed with the map details

Steps to reproduce

Log in with a valid user

Go to search results page

Click on one of the projects pin on the map

Expected results

The preview card of the project is displayed

## Tracking

https://vizzuality.atlassian.net/browse/LET-662