### PR TITLE
fix(front): home improvements[LET-650]

### DIFF
--- a/frontend/containers/home/start-banner/component.tsx
+++ b/frontend/containers/home/start-banner/component.tsx
@@ -94,7 +94,7 @@ export const StartBanner = () => {
             <Button
               theme="primary-green"
               size="small"
-              className="mb-20 text-sm mt-44"
+              className="mt-24 mb-20 text-sm md:mt-44"
               to="/sign-up"
             >
               <FormattedMessage defaultMessage="Create account" id="huqKGl" />

--- a/frontend/containers/home/use-platform/component.tsx
+++ b/frontend/containers/home/use-platform/component.tsx
@@ -74,8 +74,11 @@ export const UsePlatform = () => {
                 </dt>
                 <dd className="mt-1 text-black/70">
                   <FormattedMessage
-                    defaultMessage="Call on our community of project developers to identify opportunities in your preferred sectors and geographies."
-                    id="yqBX7I"
+                    defaultMessage="<b>Call on our community</b> of project developers to identify opportunities in your preferred sectors and geographies."
+                    id="qe+BvO"
+                    values={{
+                      b: (chunks: string) => <span className="font-semibold">{chunks}</span>,
+                    }}
                   />
                 </dd>
               </div>
@@ -85,8 +88,11 @@ export const UsePlatform = () => {
                 </dt>
                 <dd className="mt-1 text-black/70">
                   <FormattedMessage
-                    defaultMessage="Find opportunities that have the greatest impact on challenges like biodiversity, climate, community and water."
-                    id="p1NkQY"
+                    defaultMessage="Find opportunities that have the greatest impact on challenges like <b>biodiversity, climate, community</b> and <b>water</b>."
+                    id="GtP2gp"
+                    values={{
+                      b: (chunks: string) => <span className="font-semibold">{chunks}</span>,
+                    }}
                   />
                 </dd>
               </div>
@@ -192,8 +198,10 @@ export const UsePlatform = () => {
                     id="btdgGc"
                     values={{
                       a: (chunks) => (
-                        <Link href="/discover/open-call">
-                          <a className="text-green-dark">{chunks}</a>
+                        <Link href="/discover/open-calls">
+                          <a className="font-semibold underline text-green-dark hover:no-underline">
+                            {chunks}
+                          </a>
                         </Link>
                       ),
                     }}

--- a/frontend/containers/home/working/component.tsx
+++ b/frontend/containers/home/working/component.tsx
@@ -28,7 +28,7 @@ export const Working = () => (
             icon={CreateAccountIcon}
             className="w-24 h-24 p-3 mx-auto bg-white rounded-full text-green-dark"
           />
-          <h3 className="mt-4 text-xl font-medium uppercase md:mt-14">
+          <h3 className="mt-4 text-xl font-semibold uppercase md:mt-14">
             <FormattedMessage defaultMessage="Create an account" id="0vL5u1" />
           </h3>
           <p className="mt-2 md:mt-2.5 text-black/70">
@@ -43,7 +43,7 @@ export const Working = () => (
             icon={SearchFindIcon}
             className="w-24 h-24 p-3 mx-auto bg-white rounded-full text-green-dark"
           />
-          <h3 className="mt-4 text-xl font-medium uppercase md:mt-14">
+          <h3 className="mt-4 text-xl font-semibold uppercase md:mt-14">
             <FormattedMessage defaultMessage="Search and find" id="oiQKNY" />
           </h3>
           <p className="mt-2 md:mt-2.5 text-black/70">
@@ -58,7 +58,7 @@ export const Working = () => (
             icon={ConnectIcon}
             className="w-24 h-24 p-3 mx-auto bg-white rounded-full text-green-dark"
           />
-          <h3 className="mt-4 text-xl font-medium uppercase md:mt-14">
+          <h3 className="mt-4 text-xl font-semibold uppercase md:mt-14">
             <FormattedMessage defaultMessage="Connect" id="+vVZ/G" />
           </h3>
           <p className="mt-2 md:mt-2.5 text-black/70">

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -515,6 +515,9 @@
   "GdS9Mk": {
     "string": "Has this project been funded before?"
   },
+  "GtP2gp": {
+    "string": "Find opportunities that have the greatest impact on challenges like <b>biodiversity, climate, community</b> and <b>water</b>."
+  },
   "GufXy5": {
     "string": "Value"
   },
@@ -1407,9 +1410,6 @@
   "p+Qmws": {
     "string": "Which of these topic/sector categories better describe your project?"
   },
-  "p1NkQY": {
-    "string": "Find opportunities that have the greatest impact on challenges like biodiversity, climate, community and water."
-  },
   "pONqz8": {
     "string": "First name"
   },
@@ -1454,6 +1454,9 @@
   },
   "qcsPS9": {
     "string": "{duration} months"
+  },
+  "qe+BvO": {
+    "string": "<b>Call on our community</b> of project developers to identify opportunities in your preferred sectors and geographies."
   },
   "qoImFc": {
     "string": "Replicability of the project"
@@ -1676,9 +1679,6 @@
   },
   "ygAxHr": {
     "string": "Your project is awaiting verification. This means that the project is visible in the platform but without the <b>Verification badge</b>."
-  },
-  "yqBX7I": {
-    "string": "Call on our community of project developers to identify opportunities in your preferred sectors and geographies."
   },
   "yqJ5XD": {
     "string": "Select the amount of money that you need"


### PR DESCRIPTION
This PR contains next improvements:

- Some texts should be bold in the “Create open calls”, “Enable positive impact” and “Apply to open calls” section
- The titles of the cards in “How it works” should have a different font weight (should be 600)
- When the screen is between 640px and 768px wide, there is too much space above the “Create account” button at the bottom of the screen

## Tracking

[LET-650](https://vizzuality.atlassian.net/browse/LET-650)
