### PR TITLE
feat: Can change ownership via backoffice

### DIFF
--- a/backend/app/controllers/api/v1/accounts/investors_controller.rb
+++ b/backend/app/controllers/api/v1/accounts/investors_controller.rb
@@ -8,8 +8,8 @@ module API
           current_user.with_lock do
             raise API::UnprocessableEntityError, I18n.t("errors.messages.user.multiple_accounts") if current_user.account_id.present?
 
-            account = Account.create! account_params.merge(owner: current_user)
-            current_user.update! account: account, role: :investor
+            account = Account.create! account_params.merge(owner: current_user, users: [current_user])
+            current_user.update! role: :investor
             investor = Investor.create! investor_params.merge(account: account)
             render json: InvestorSerializer.new(
               investor,

--- a/backend/app/controllers/api/v1/accounts/project_developers_controller.rb
+++ b/backend/app/controllers/api/v1/accounts/project_developers_controller.rb
@@ -8,8 +8,8 @@ module API
           current_user.with_lock do
             raise API::UnprocessableEntityError, I18n.t("errors.messages.user.multiple_accounts") if current_user.account_id.present?
 
-            account = Account.create! account_params.merge(owner: current_user)
-            current_user.update! account: account, role: :project_developer
+            account = Account.create! account_params.merge(owner: current_user, users: [current_user])
+            current_user.update! role: :project_developer
             project_developer = ProjectDeveloper.create! project_developer_params.merge(account: account)
             render json: ProjectDeveloperSerializer.new(
               project_developer,

--- a/backend/app/controllers/backoffice/investors_controller.rb
+++ b/backend/app/controllers/backoffice/investors_controller.rb
@@ -68,7 +68,8 @@ module Backoffice
           :twitter,
           :instagram,
           :contact_email,
-          :contact_phone
+          :contact_phone,
+          :owner_id
         ],
         categories: [],
         instrument_types: [],
@@ -88,7 +89,7 @@ module Backoffice
     end
 
     def set_sections
-      sections %w[language profile status], default: "profile"
+      sections %w[language profile status owner], default: "profile"
     end
 
     def set_content_language_default

--- a/backend/app/controllers/backoffice/project_developers_controller.rb
+++ b/backend/app/controllers/backoffice/project_developers_controller.rb
@@ -66,7 +66,8 @@ module Backoffice
           :twitter,
           :instagram,
           :contact_email,
-          :contact_phone
+          :contact_phone,
+          :owner_id
         ],
         categories: [],
         impacts: [],
@@ -84,7 +85,7 @@ module Backoffice
     end
 
     def set_sections
-      sections %w[language profile status], default: "profile"
+      sections %w[language profile status owner], default: "profile"
     end
 
     def set_content_language_default

--- a/backend/app/models/account.rb
+++ b/backend/app/models/account.rb
@@ -30,6 +30,7 @@ class Account < ApplicationRecord
   validates :picture, attached: true, content_type: /\Aimage\/.*\z/
   validates :contact_email, presence: true
   validates :contact_email, format: {with: Devise.email_regexp}, unless: -> { contact_email.blank? }
+  validate :owner_is_part_of_account, if: :owner_id_changed?
 
   before_update :set_reviewed_at, if: :review_status_changed?
 
@@ -39,6 +40,10 @@ class Account < ApplicationRecord
   end
 
   private
+
+  def owner_is_part_of_account
+    errors.add :owner_id, :owner_not_part_of_account unless owner_id.in? user_ids
+  end
 
   def set_reviewed_at
     self.reviewed_at = Time.now

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -44,6 +44,7 @@ class User < ApplicationRecord
   def full_name
     "#{first_name} #{last_name}"
   end
+  alias_method :to_s, :full_name
 
   private
 

--- a/backend/app/views/backoffice/accounts/_owner_form.html.erb
+++ b/backend/app/views/backoffice/accounts/_owner_form.html.erb
@@ -1,0 +1,17 @@
+<%= simple_form_for [:backoffice, form_object] do |f| %>
+  <%= f.error_notification %>
+  <%= hidden_field_tag :section, params[:section] %>
+
+  <h2 class="mb-2 text-gray-900 font-semibold">
+    <%= t("backoffice.common.account_owner") %>
+  </h2>
+
+  <%= f.simple_fields_for :account do |ff|  %>
+    <%= ff.input :owner_id, collection: ff.object.users, include_blank: false %>
+  <% end %>
+
+  <div class="mt-3 flex justify-end gap-3">
+    <%= link_to t("backoffice.common.cancel"), cancel_path, class: "button button-secondary-green" %>
+    <%= f.button :submit, t("backoffice.common.save"), class: "button button-primary-green" %>
+  </div>
+<% end %>

--- a/backend/app/views/backoffice/investors/_section_owner.html.erb
+++ b/backend/app/views/backoffice/investors/_section_owner.html.erb
@@ -1,0 +1,1 @@
+<%= render "backoffice/accounts/owner_form", form_object: @investor, cancel_path: backoffice_investors_path %>

--- a/backend/app/views/backoffice/investors/edit.html.erb
+++ b/backend/app/views/backoffice/investors/edit.html.erb
@@ -8,6 +8,7 @@
       <li><%= section_link_to t("backoffice.account.account_language"), edit_backoffice_investor_path, :language %></li>
       <li><%= section_link_to t("backoffice.account.profile"), edit_backoffice_investor_path, :profile, default: true %></li>
       <li><%= section_link_to t("backoffice.account.approval_status"), edit_backoffice_investor_path, :status %></li>
+      <li><%= section_link_to t("backoffice.common.account_owner"), edit_backoffice_investor_path, :owner %></li>
     </ul>
     <%= link_to backoffice_investor_path(@investor.id),
        data: {

--- a/backend/app/views/backoffice/project_developers/_section_owner.html.erb
+++ b/backend/app/views/backoffice/project_developers/_section_owner.html.erb
@@ -1,0 +1,1 @@
+<%= render "backoffice/accounts/owner_form", form_object: @project_developer, cancel_path: backoffice_project_developers_path %>

--- a/backend/app/views/backoffice/project_developers/edit.html.erb
+++ b/backend/app/views/backoffice/project_developers/edit.html.erb
@@ -8,6 +8,7 @@
       <li><%= section_link_to t("backoffice.account.account_language"), edit_backoffice_project_developer_path, :language %></li>
       <li><%= section_link_to t("backoffice.account.profile"), edit_backoffice_project_developer_path, :profile, default: true %></li>
       <li><%= section_link_to t("backoffice.account.approval_status"), edit_backoffice_project_developer_path, :status %></li>
+      <li><%= section_link_to t("backoffice.common.account_owner"), edit_backoffice_project_developer_path, :owner %></li>
     </ul>
     <%= link_to backoffice_project_developer_path(@project_developer.id),
        data: {

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -31,6 +31,7 @@ zu:
         language: Language
         review_status: Review status
         type: Type
+        owner_id: Owner
       project_developer:
         impacts: Expect to have impact on
         project_developer_type: Project developer type
@@ -201,6 +202,7 @@ zu:
       not_geojson: is not geojson
       unsupported_geometry: shape is not supported
       missing_geometry: inside geojson is empty
+      owner_not_part_of_account: is not part of account
       user:
         multiple_accounts: User already have account!
         no_project_developer: User is not project developer!

--- a/backend/spec/factories/account.rb
+++ b/backend/spec/factories/account.rb
@@ -36,7 +36,7 @@ FactoryBot.define do
       review_status { "rejected" }
     end
 
-    after :create do |account|
+    before :create do |account|
       account.users << account.owner
     end
   end

--- a/backend/spec/models/account_spec.rb
+++ b/backend/spec/models/account_spec.rb
@@ -66,6 +66,11 @@ RSpec.describe Account, type: :model do
     expect(subject).to have(1).errors_on(:contact_email)
   end
 
+  it "should not be valid with owner from different account" do
+    subject.owner = create(:user)
+    expect(subject).to have(1).errors_on(:owner_id)
+  end
+
   context "when changing review_status" do
     subject { create(:account, :unapproved) }
 


### PR DESCRIPTION
New section for PD and Investor pages which allows to edit Account Owner:

![Screenshot 2022-07-12 at 11 47 06](https://user-images.githubusercontent.com/20660167/178478169-91078d1e-f667-4b33-b2fb-c28ea2dea7fe.png)

## Testing instructions

Via backoffice -- just find some Account with more then 2 users and change ownership

## Tracking

https://vizzuality.atlassian.net/browse/LET-736