### PR TITLE
Allow DELETE through CORS

### DIFF
--- a/infrastructure/base/modules/storage/main.tf
+++ b/infrastructure/base/modules/storage/main.tf
@@ -16,7 +16,7 @@ resource "google_storage_bucket" "storage_bucket" {
 
   cors {
     origin          = [var.cors_origin]
-    method          = ["GET", "HEAD", "PUT", "POST"]
+    method          = ["GET", "HEAD", "PUT", "POST", "DELETE"]
     response_header = ["*"]
     max_age_seconds = 3600
   }


### PR DESCRIPTION
Deleting users doesn't seem to work due to CORS, so I'm allowing DELETE

## Testing instructions

Test deleting users from account using swagger
<img width="1365" alt="Screenshot 2022-07-12 at 14 20 41" src="https://user-images.githubusercontent.com/134055/178490022-be64a322-169a-4333-a0db-508b63c0ce66.png">


## Tracking

https://vizzuality.atlassian.net/browse/LET-680
