### PR TITLE
Add layers tooltip

### DIFF
--- a/frontend/containers/discover-map/layer-tooltip/component.tsx
+++ b/frontend/containers/discover-map/layer-tooltip/component.tsx
@@ -39,6 +39,25 @@ export const LayerTooltip: FC<LayerTooltipProps> = ({ selectedLayer, closeToolti
           </p>
           <p className="text-xs text-gray-900">{selectedLayer?.overview}</p>
         </div>
+        <div>
+          <p className="mt-4 mb-2 text-sm font-semibold text-gray-600">
+            {!!selectedLayer?.dataSource && (
+              <FormattedMessage defaultMessage="Source" id="aH4De2" />
+            )}
+          </p>
+          {selectedLayer?.dataSourceUrl ? (
+            <a
+              className="text-xs text-gray-900 hover:underline"
+              target="_blanc"
+              rel="noopener noreferrer"
+              href={selectedLayer?.dataSourceUrl}
+            >
+              {selectedLayer?.dataSource}
+            </a>
+          ) : (
+            <p className="text-xs text-gray-900">{selectedLayer?.dataSource}</p>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/frontend/containers/discover-map/layer-tooltip/component.tsx
+++ b/frontend/containers/discover-map/layer-tooltip/component.tsx
@@ -1,0 +1,47 @@
+import { FC } from 'react';
+
+import { X as CloseIcon } from 'react-feather';
+import { FormattedMessage } from 'react-intl';
+
+import cx from 'classnames';
+
+import Button from 'components/button';
+
+import { LayerTooltipProps } from '.';
+
+export const LayerTooltip: FC<LayerTooltipProps> = ({ selectedLayer, closeTooltip }) => {
+  const isOpen = !!selectedLayer;
+  return (
+    <div
+      className={cx('z-10 transition-all ease-in-out duration-500', {
+        'left-0 opacity-0 py-0 pt-0 pl-0 pr-0 pb-0 w-0': !isOpen,
+        'left-auto opacity-100 pt-4 pl-6 pr-3 pb-4 w-auto': isOpen,
+      })}
+    >
+      <div className="flex flex-col max-h-[500px] overflow-y-auto pr-2">
+        <div className="flex justify-end">
+          <Button theme="naked" className="px-0 py-0" onClick={closeTooltip}>
+            <CloseIcon className="w-4 h-4 transition-transform rotate-0 hover:rotate-180" />
+          </Button>
+        </div>
+        <div className="text-lg font-semibold text-gray-900">{selectedLayer?.name}</div>
+        <div className="max-w-full">
+          <p className="mt-4 mb-2 text-sm font-semibold text-gray-600">
+            <FormattedMessage defaultMessage="Description" id="Q8Qw5B" />
+          </p>
+          <p className="text-xs text-gray-900">{selectedLayer?.description}</p>
+        </div>
+        <div>
+          <p className="mt-4 mb-2 text-sm font-semibold text-gray-600">
+            {!!selectedLayer?.overview && (
+              <FormattedMessage defaultMessage="Overview" id="9uOFF3" />
+            )}
+          </p>
+          <p className="text-xs text-gray-900">{selectedLayer?.overview}</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LayerTooltip;

--- a/frontend/containers/discover-map/layer-tooltip/index.ts
+++ b/frontend/containers/discover-map/layer-tooltip/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { LayerTooltipProps } from './types';

--- a/frontend/containers/discover-map/layer-tooltip/types.ts
+++ b/frontend/containers/discover-map/layer-tooltip/types.ts
@@ -1,0 +1,6 @@
+import { SelectedLayerTooltip } from '../map-layers-selector/types';
+
+export type LayerTooltipProps = {
+  selectedLayer: SelectedLayerTooltip;
+  closeTooltip: () => void;
+};

--- a/frontend/containers/discover-map/location-searcher/component.tsx
+++ b/frontend/containers/discover-map/location-searcher/component.tsx
@@ -48,7 +48,7 @@ export const LocationSearcher: FC<LocationSearcherProps> = ({ onLocationSelected
   };
 
   return (
-    <div className="relative">
+    <div className="absolute translate-x-80">
       <Script
         // TODO: Activate key and remove mock one
         // src={`https://maps.googleapis.com/maps/api/js?key=${process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}&libraries=places`}

--- a/frontend/containers/discover-map/map-layers-selector/component.tsx
+++ b/frontend/containers/discover-map/map-layers-selector/component.tsx
@@ -117,34 +117,43 @@ export const MapLayersSelector: FC<MapLayersSelectorProps> = ({
                         }
                       >
                         <ol className="flex flex-col gap-3.5 text-xs text-black py-2">
-                          {layerGroup.layers.map(({ id, name, description, overview }) => (
-                            <li key={id} className="flex items-center gap-1.5">
-                              <label
-                                key={id}
-                                htmlFor={id}
-                                className="flex items-center gap-2 cursor-pointer"
-                              >
-                                <Switch
-                                  id={id}
-                                  name="activeLayers"
-                                  switchSize="smallest"
-                                  value={id}
-                                  register={register}
-                                />
-                                {name}
-                              </label>
+                          {layerGroup.layers.map(
+                            ({ id, name, description, overview, dataSource, dataSourceUrl }) => (
+                              <li key={id} className="flex items-center gap-1.5">
+                                <label
+                                  key={id}
+                                  htmlFor={id}
+                                  className="flex items-center gap-2 cursor-pointer"
+                                >
+                                  <Switch
+                                    id={id}
+                                    name="activeLayers"
+                                    switchSize="smallest"
+                                    value={id}
+                                    register={register}
+                                  />
+                                  {name}
+                                </label>
 
-                              <button
-                                onClick={() =>
-                                  handleShowTooltip({ id, name, description, overview })
-                                }
-                                type="button"
-                                className="flex items-center justify-center w-4 h-4 text-gray-800 scale-90 border border-gray-800 rounded-full pointer focus-visible:outline-green-dark focus-visible:outline-2"
-                              >
-                                <p className="pt-0.5 text-xs">i</p>
-                              </button>
-                            </li>
-                          ))}
+                                <button
+                                  onClick={() =>
+                                    handleShowTooltip({
+                                      id,
+                                      name,
+                                      description,
+                                      overview,
+                                      dataSource,
+                                      dataSourceUrl,
+                                    })
+                                  }
+                                  type="button"
+                                  className="flex items-center justify-center w-4 h-4 text-gray-800 scale-90 border border-gray-800 rounded-full pointer focus-visible:outline-green-dark focus-visible:outline-2"
+                                >
+                                  <p className="pt-0.5 text-xs">i</p>
+                                </button>
+                              </li>
+                            )
+                          )}
                         </ol>
                       </Expando>
                     );

--- a/frontend/containers/discover-map/map-layers-selector/component.tsx
+++ b/frontend/containers/discover-map/map-layers-selector/component.tsx
@@ -2,7 +2,7 @@ import { FC, useRef, useState, useEffect } from 'react';
 
 import { FocusScope } from 'react-aria';
 import { Layers as IconLayers } from 'react-feather';
-import { ChevronUp as ChevronUpIcon } from 'react-feather';
+import { ChevronUp as ChevronUpIcon, X as CloseIcon } from 'react-feather';
 import { useForm } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 
@@ -12,20 +12,25 @@ import { useKey, useOutsideClick } from 'rooks';
 
 import { useLayers } from 'hooks/useLayers';
 
+import Button from 'components/button';
 import Expando from 'components/expando';
 import Switch from 'components/forms/switch';
-import Tooltip from 'components/tooltip';
 
-import type { MapLayersSelectorProps, MapLayersSelectorForm } from './types';
+import LayerTooltip from '../layer-tooltip';
+
+import type { MapLayersSelectorProps, MapLayersSelectorForm, SelectedLayerTooltip } from './types';
 
 export const MapLayersSelector: FC<MapLayersSelectorProps> = ({
   className,
   onActiveLayersChange,
 }: MapLayersSelectorProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [selectedLayer, setSelectedlayer] = useState<SelectedLayerTooltip>();
   const containerRef = useRef<HTMLDivElement>(null);
   const selectorRef = useRef<HTMLDivElement>(null);
   const { groupedLayers } = useLayers();
+  const initialOpenLayerGroup = groupedLayers.map((group) => group.id);
+  const [openLayerGroup, setOpenLayerGroup] = useState<string[]>(initialOpenLayerGroup);
 
   const { register, watch } = useForm<MapLayersSelectorForm>({
     defaultValues: {
@@ -42,6 +47,8 @@ export const MapLayersSelector: FC<MapLayersSelectorProps> = ({
   useOutsideClick(containerRef, () => {
     if (!isOpen) return;
     setIsOpen(false);
+    setSelectedlayer(undefined);
+    setOpenLayerGroup(initialOpenLayerGroup);
   });
 
   useEffect(() => {
@@ -50,13 +57,25 @@ export const MapLayersSelector: FC<MapLayersSelectorProps> = ({
 
   const handleButtonClick = () => {
     setIsOpen(!isOpen);
+    setSelectedlayer(undefined);
+  };
+
+  const handleShowTooltip = (layer: SelectedLayerTooltip) => {
+    setSelectedlayer(layer);
+  };
+
+  const handleChangeOpenLayerGroup = (groupId: string) => {
+    const newOpenLayerGroup = openLayerGroup.includes(groupId)
+      ? openLayerGroup.filter((id) => id !== groupId)
+      : [...openLayerGroup, groupId];
+    setOpenLayerGroup(newOpenLayerGroup);
   };
 
   return (
     <div className={className} ref={containerRef}>
       <div className="relative flex flex-col justify-center">
         <button
-          className="flex items-center gap-2.5 shadow-sm h-full bg-white rounded border-xl px-2 py-1 outline-none focus-visible:ring-green-dark focus-visible:ring-2 hover:ring-green-dark hover:ring-1"
+          className="flex items-center gap-2.5 shadow-sm h-full bg-white rounded border-xl px-2 py-1 outline-none focus-visible:ring-green-dark focus-visible:ring-2 hover:ring-green-dark hover:ring-1 w-fit"
           onClick={handleButtonClick}
         >
           <IconLayers className="w-4 h-4" />
@@ -64,32 +83,41 @@ export const MapLayersSelector: FC<MapLayersSelectorProps> = ({
         </button>
         {isOpen && (
           <FocusScope contain restoreFocus>
-            <div className="relative mx-0.5 mt-2" ref={selectorRef}>
-              <div className="absolute top-0 left-0 lg:min-w-[280px] z-10 p-3 -m-0.5 bg-white rounded-md shadow-xl border-xl whitespace-nowrap">
+            <div
+              className="z-10 relative flex flex-col md:flex-row mx-0.5 mt-2 bg-white rounded-2xl"
+              ref={selectorRef}
+            >
+              <div className="flex top-0 left-0 lg:min-w-fit z-10 p-3 -m-0.5 whitespace-nowrap overflow-auto">
                 <form>
                   {groupedLayers.map((layerGroup) => {
                     if (!layerGroup.layers.length) return null;
+                    const groupIsOpen = openLayerGroup.includes(layerGroup.id);
 
                     return (
                       <Expando
+                        defaultOpen={groupIsOpen}
                         key={layerGroup.id}
                         title={
-                          <div className="flex items-center w-full my-2">
-                            <span className="flex flex-grow">{layerGroup.name}</span>
-                            <span>
+                          <Button
+                            theme="naked"
+                            className="w-full px-0 py-0"
+                            onClick={() => handleChangeOpenLayerGroup(layerGroup.id)}
+                          >
+                            <div className="flex items-center w-full my-2">
+                              <span className="flex flex-grow">{layerGroup.name}</span>
                               <ChevronUpIcon
                                 className={cx({
                                   'w-4 h-4 transition-all': true,
-                                  'rotate-0': !isOpen,
-                                  'rotate-180': isOpen,
+                                  'rotate-180': !groupIsOpen,
+                                  'rotate-0': groupIsOpen,
                                 })}
                               />
-                            </span>
-                          </div>
+                            </div>
+                          </Button>
                         }
                       >
                         <ol className="flex flex-col gap-3.5 text-xs text-black py-2">
-                          {layerGroup.layers.map(({ id, name, description }) => (
+                          {layerGroup.layers.map(({ id, name, description, overview }) => (
                             <li key={id} className="flex items-center gap-1.5">
                               <label
                                 key={id}
@@ -105,25 +133,16 @@ export const MapLayersSelector: FC<MapLayersSelectorProps> = ({
                                 />
                                 {name}
                               </label>
-                              {description && (
-                                <Tooltip
-                                  placement="top"
-                                  arrow
-                                  arrowClassName="bg-black"
-                                  content={
-                                    <div className="max-w-md p-2 font-sans text-sm font-normal text-white bg-black rounded-sm w-72">
-                                      {description}
-                                    </div>
-                                  }
-                                >
-                                  <button
-                                    type="button"
-                                    className="flex items-center justify-center w-4 h-4 text-gray-800 scale-90 border border-gray-800 rounded-full pointer focus-visible:outline-green-dark focus-visible:outline-2"
-                                  >
-                                    <p className="text-xs">i</p>
-                                  </button>
-                                </Tooltip>
-                              )}
+
+                              <button
+                                onClick={() =>
+                                  handleShowTooltip({ id, name, description, overview })
+                                }
+                                type="button"
+                                className="flex items-center justify-center w-4 h-4 text-gray-800 scale-90 border border-gray-800 rounded-full pointer focus-visible:outline-green-dark focus-visible:outline-2"
+                              >
+                                <p className="pt-0.5 text-xs">i</p>
+                              </button>
                             </li>
                           ))}
                         </ol>
@@ -132,6 +151,10 @@ export const MapLayersSelector: FC<MapLayersSelectorProps> = ({
                   })}
                 </form>
               </div>
+              <LayerTooltip
+                selectedLayer={selectedLayer}
+                closeTooltip={() => setSelectedlayer(undefined)}
+              />
             </div>
           </FocusScope>
         )}

--- a/frontend/containers/discover-map/map-layers-selector/types.ts
+++ b/frontend/containers/discover-map/map-layers-selector/types.ts
@@ -14,4 +14,6 @@ export type SelectedLayerTooltip = {
   name: string;
   description: string;
   overview?: string;
+  dataSource: string;
+  dataSourceUrl: string;
 };

--- a/frontend/containers/discover-map/map-layers-selector/types.ts
+++ b/frontend/containers/discover-map/map-layers-selector/types.ts
@@ -8,3 +8,10 @@ export type MapLayersSelectorProps = {
 export type MapLayersSelectorForm = {
   activeLayers: string[];
 };
+
+export type SelectedLayerTooltip = {
+  id: string;
+  name: string;
+  description: string;
+  overview?: string;
+};

--- a/frontend/hooks/useLayers.ts
+++ b/frontend/hooks/useLayers.ts
@@ -62,6 +62,9 @@ export const useLayers = () => {
             defaultMessage: 'Displays the areas prioritized for Goal 3 of Herencia Colombia',
             id: 'Id5CnU',
           }),
+          dataSource: 'Ministerio de Medio Ambiente y Desarrollo Sostenible de Colombia',
+          dataSourceUrl:
+            'https://basecamp.com/1756858/projects/18107300/messages/99371742?enlarge=450698651#attachment_450698651',
           specification: {
             type: 'raster',
             source: {
@@ -80,6 +83,9 @@ export const useLayers = () => {
             defaultMessage: 'Displays the political boundaries at country and state levels',
             id: 'CS2uRY',
           }),
+          dataSource: 'Instituto Geográfico Agustín Codazzi - IGAC',
+          dataSourceUrl:
+            'https://basecamp.com/1756858/projects/18107300/messages/99371742?enlarge=452957920#attachment_452957920',
           specification: {
             type: 'raster',
             source: {
@@ -103,6 +109,8 @@ export const useLayers = () => {
               'The dataset represents a series of vectorized polygon layers that depict sub-basin boundaries at a global scale. An important characteristic of any sub-basin delineation is the sub-basin breakdown. At its highest level of sub-basin breakdown, each basin has been divided into two sub-basins at every location where two river branches meet which each have an individual upstream area of at least 100 km². A second critical feature of sub-basin delineations is the way the sub-basins are grouped or coded to allow for the creation of nested sub-basins at different scales, or to navigate within the sub-basin network from up- to downstream. To support these functionalities and topological concepts, the ‘Pfafstetter’ coding system has been implemented, offering 12 hierarchically nested sub-basin breakdowns globally.',
             id: 'Y2HapG',
           }),
+          dataSource: 'HydroSHEDS',
+          dataSourceUrl: 'https://www.hydrosheds.org/products/hydrobasins#downloads',
           specification: {
             type: 'raster',
             source: {
@@ -126,6 +134,8 @@ export const useLayers = () => {
               'Displays the protected areas signed into the RUNAP (Unique Registry of Protected Areas) of Colombia',
             id: 'kTXMXN',
           }),
+          dataSource: 'Parques Nacionales Naturales de Colombia',
+          dataSourceUrl: 'https://runap.parquesnacionales.gov.co/cifras',
           specification: {
             type: 'raster',
             source: {
@@ -151,6 +161,9 @@ export const useLayers = () => {
               'This layer quantifies the impact humans have had on the intactness of species communities. Anthropogenic pressures such as land use conversion have caused dramatic changes to the composition of species communities and this layer illustrates these changes by focusing on the impact of forest change on biodiversity intactness. The maximum value indicates no human impact, while lower values indicate that intactness has been reduced. The Projecting Responses of Ecological Diversity in Changing Terrestrial Systems (PREDICTS) database comprises over 3 million records of geographically and taxonomically representative data of land use impacts to local biodiversity (Hudson et al. 2017). A subset of the PREDICTS database, including data pertaining to forested biomes only, is employed to model the impacts of land use change and human population density on the intactness of local species communities. To produce the land use map, all forested biomes are selected and each 30 x 30 m pixel within the biome is assigned a land use category based upon inputs from the GFW forest change database and a downscaled land use map (Hoskins et al 2016). The modelled results of biodiversity intactness derived from the PREDICTS database are projected onto the land use and human population density maps, and the final product is aggregated to match the resolution of the downscaled land use map (Hoskins et al 2016). The final output models the impacts of forest change on local biodiversity intactness within forested biomes.',
             id: 'vQmgLw',
           }),
+          dataSource:
+            'United Nations Environment World Conservation Monitoring Centre (UNEP-WCMC) and Natural History Museum',
+          dataSourceUrl: '',
           specification: {
             type: 'raster',
             source: {
@@ -174,6 +187,9 @@ export const useLayers = () => {
               'This is a global, wall-to-wall map of aboveground biomass (AGB) at approximately 30-meter resolution. This data product expands on the methodology presented in Baccini et al. (2012) to generate a global map of aboveground live woody biomass (AGB) density (megagrams biomass per ha) at 0.00025-degree (approximately 30-meter) resolution for the year 2000. Aboveground biomass was estimated using a multi-step process of calculating AGB at more than seven hundred thousand points with LiDAR with regional allometric equations, then using those to train a wall-to-wall model based on Landsat imagery. Pixels without tree canopy were assigned a biomass density of 0 Mg/ha.',
             id: 'jvb6yi',
           }),
+          dataSource: 'Global Forest Watch',
+          dataSourceUrl:
+            'https://data.globalforestwatch.org/datasets/aboveground-live-woody-biomass-density',
           specification: {
             type: 'raster',
             source: {
@@ -197,6 +213,9 @@ export const useLayers = () => {
               'This layer shows the permanent and temporal wetlands of Colombia at a 1:100.000 reoslution',
             id: 'U98Mu/',
           }),
+          dataSource: 'Sistema de Información Ambiental de Colombia - SIAC',
+          dataSourceUrl:
+            'https://siac-datosabiertos-mads.hub.arcgis.com/datasets/a499da66b2814db48888343283b57cdb/about',
           specification: {
             type: 'raster',
             source: {
@@ -220,6 +239,9 @@ export const useLayers = () => {
               'The Global Human Settlement Layer (GHSL) Population Grid depicts the distribution and density of population, expressed as the number of people per cell, for 2015. While GFW uses only 2015 data, the GHSL is a multi-temporal population data set that employs new spatial data mining technologies. These methods enable the automatic processing and extraction of analytics and knowledge from different data sets: global, fine-scale satellite image data streams, census data, and crowd sources or volunteered geographic information sources. To produce this population density and distribution data set, researchers mapped global built-up areas, which are defined as all above ground constructions intended for human or animal sheltering or to produce economic goods. The locations of these built up areas was established using Landsat imagery analysis. An additional source used to compile this data set was the Gridded Population of the World (GPW) data set assembled by the Center for International Earth Science Information Network (CIESIN). The GPW data set consists of census population data and bolstered the built-up areas data by enabling researchers to estimate residential population. To present this data as grid cells, GPW data was disaggregated from census or administrative units.',
             id: 'PIc+q2',
           }),
+          dataSource:
+            'European Commission, Joint Research Centre (JRC); Columbia University, Center for International Earth Science Information Network - CIESIN',
+          dataSourceUrl: 'https://data.jrc.ec.europa.eu/dataset/jrc-ghsl-ghs_pop_gpw4_globe_r2015a',
           specification: {
             type: 'raster',
             source: {
@@ -248,6 +270,8 @@ export const useLayers = () => {
               'The dataset represents the boundaries of sites containing 95% or more of the remaining population of one or more species listed as Endangered or Critically Endangered on the International Union for Conservation of Nature (IUCN) Red List of Threatened Species. The Alliance for Zero Extinction (AZE) originally created this dataset with a goal to prevent extinctions by identifying and safeguarding key sites. The 2019 March version of this dataset contains 859 sites, supporting 1483 Critically Endangered or Endangered species.',
             id: 'UVJ5y2',
           }),
+          dataSource: 'Alliance for Zero Extinctions (AZE)',
+          dataSourceUrl: 'https://www.keybiodiversityareas.org/kba-data/request',
           specification: {
             type: 'vector',
             source: {
@@ -306,6 +330,8 @@ export const useLayers = () => {
               'This data set, a collaboration between the Global Land Analysis & Discovery (GLAD) lab at the University of Maryland, Google, USGS, and NASA, measures areas of tree cover loss across all global land (except Antarctica and other Arctic islands) at approximately 30 × 30 meter resolution. The data were generated using multispectral satellite imagery from the Landsat 5 thematic mapper (TM), the Landsat 7 thematic mapper plus (ETM+), and the Landsat 8 Operational Land Imager (OLI) sensors. Over 1 million satellite images were processed and analyzed, including over 600,000 Landsat 7 images for the 2000-2012 interval, and more than 400,000 Landsat 5, 7, and 8 images for updates for the 2011-2021 interval. The clear land surface observations in the satellite images were assembled and a supervised learning algorithm was applied to identify per pixel tree cover loss. In this data set, “tree cover” is defined as all vegetation greater than 5 meters in height, and may take the form of natural forests or plantations across a range of canopy densities. Tree cover loss is defined as “stand replacement disturbance,” or the complete removal of tree cover canopy at the Landsat pixel scale. Tree cover loss may be the result of human activities, including forestry practices such as timber harvesting or deforestation (the conversion of natural forest to other land uses), as well as natural causes such as disease or storm damage. Fire is another widespread cause of tree cover loss, and can be either natural or human-induced.',
             id: 'jJYv/7',
           }),
+          dataSource: 'Hansen/UMD/Google/USGS/NASA',
+          dataSourceUrl: 'https://glad.earthengine.app/view/global-forest-change',
           specification: {
             type: 'raster',
             source: {
@@ -333,6 +359,8 @@ export const useLayers = () => {
         //       'Riverine flood risk measures the percentage of population expected to be affected by Riverine flooding in an average year, accounting for existing flood-protection standards. Flood risk is assessed using hazard (inundation caused by river overflow), exposure (population in flood zone), and vulnerability.16 The existing level of flood protection is also incorporated into the risk calculation. It is important to note that this indicator represents flood risk not in terms of maximum possible impact but rather as average annual impact. The impacts from infrequent, extreme flood years are averaged with more common, less newsworthy flood years to produce the “expected annual affected population.” Higher values indicate that a greater proportion of the population is expected to be impacted by Riverine floods on average.',
         //     id: 'BY6k/1',
         //   }),
+        // dataSource: 'World Resources Institute',
+        // dataSourceUrl: 'https://www.wri.org/data/aqueduct-global-maps-30-data',
         //   specification: {},
         // },
         {
@@ -348,6 +376,9 @@ export const useLayers = () => {
               'Indigenous Reservations are understood as a socio-political legal institution of colonial origin, made up of a recognized territory of a community of Amerindian descent, with inalienable, collective or community property title, governed by a special autonomous statute, with its own cultural guidelines and traditions.',
             id: 'yer18A',
           }),
+          dataSource: 'Agencia Nacional de Tierras',
+          dataSourceUrl:
+            'https://data-agenciadetierras.opendata.arcgis.com/datasets/agenciadetierras::resguardos-ind%C3%ADgenas-1/about',
           specification: {
             type: 'raster',
             source: {

--- a/frontend/hooks/useLayers.ts
+++ b/frontend/hooks/useLayers.ts
@@ -29,24 +29,24 @@ enum LAYERS {
 }
 
 export const useLayers = () => {
-  const intl = useIntl();
+  const { formatMessage } = useIntl();
 
   const layerGroups = useMemo(
     () => [
       {
         id: LAYER_GROUPS.BaseLayer,
-        name: intl.formatMessage({ defaultMessage: 'Base Layers', id: '9nYuln' }),
+        name: formatMessage({ defaultMessage: 'Base Layers', id: '9nYuln' }),
       },
       {
         id: LAYER_GROUPS.ContextLayer,
-        name: intl.formatMessage({ defaultMessage: 'Context Layers', id: 'fIkMFK' }),
+        name: formatMessage({ defaultMessage: 'Context Layers', id: 'fIkMFK' }),
       },
       {
         id: LAYER_GROUPS.PriorityLayer,
-        name: intl.formatMessage({ defaultMessage: 'Priority Layers', id: 'gpOeXW' }),
+        name: formatMessage({ defaultMessage: 'Priority Layers', id: 'gpOeXW' }),
       },
     ],
-    [intl]
+    [formatMessage]
   );
 
   const layers = useMemo(
@@ -56,8 +56,12 @@ export const useLayers = () => {
         {
           id: LAYERS.HeCoMosaics,
           group: LAYER_GROUPS.BaseLayer,
-          name: intl.formatMessage({ defaultMessage: 'HeCo mosaics', id: 'W7un1n' }),
-          // description: '',
+          name: formatMessage({ defaultMessage: 'HeCo mosaics', id: 'W7un1n' }),
+          description: formatMessage({ defaultMessage: 'Herencia Colombia mosaics', id: 'MmtnIe' }),
+          overview: formatMessage({
+            defaultMessage: 'Displays the areas prioritized for Goal 3 of Herencia Colombia',
+            id: 'Id5CnU',
+          }),
           specification: {
             type: 'raster',
             source: {
@@ -71,8 +75,11 @@ export const useLayers = () => {
         {
           id: LAYERS.PoliticalBoundaries,
           group: LAYER_GROUPS.BaseLayer,
-          name: intl.formatMessage({ defaultMessage: 'Political boundaries', id: 'Fm6QvT' }),
-          // description: '',
+          name: formatMessage({ defaultMessage: 'Political boundaries', id: 'Fm6QvT' }),
+          description: formatMessage({
+            defaultMessage: 'Displays the political boundaries at country and state levels',
+            id: 'CS2uRY',
+          }),
           specification: {
             type: 'raster',
             source: {
@@ -86,10 +93,15 @@ export const useLayers = () => {
         {
           id: LAYERS.SubBasinBoundaries,
           group: LAYER_GROUPS.BaseLayer,
-          name: intl.formatMessage({ defaultMessage: 'Sub-basin boundaries', id: 'WskbuL' }),
-          description: intl.formatMessage({
+          name: formatMessage({ defaultMessage: 'Sub-basin boundaries', id: 'WskbuL' }),
+          description: formatMessage({
             defaultMessage: 'Sub-basin boundaries of Colombia.',
             id: 'EmE3wV',
+          }),
+          overview: formatMessage({
+            defaultMessage:
+              'The dataset represents a series of vectorized polygon layers that depict sub-basin boundaries at a global scale. An important characteristic of any sub-basin delineation is the sub-basin breakdown. At its highest level of sub-basin breakdown, each basin has been divided into two sub-basins at every location where two river branches meet which each have an individual upstream area of at least 100 km². A second critical feature of sub-basin delineations is the way the sub-basins are grouped or coded to allow for the creation of nested sub-basins at different scales, or to navigate within the sub-basin network from up- to downstream. To support these functionalities and topological concepts, the ‘Pfafstetter’ coding system has been implemented, offering 12 hierarchically nested sub-basin breakdowns globally.',
+            id: 'Y2HapG',
           }),
           specification: {
             type: 'raster',
@@ -104,8 +116,16 @@ export const useLayers = () => {
         {
           id: LAYERS.ProtectedAreas,
           group: LAYER_GROUPS.BaseLayer,
-          name: intl.formatMessage({ defaultMessage: 'Protected areas', id: 'NUVSd2' }),
-          // description: '',
+          name: formatMessage({ defaultMessage: 'Protected areas', id: 'NUVSd2' }),
+          description: formatMessage({
+            defaultMessage: 'Protected areas of Colombia',
+            id: 'q18ubl',
+          }),
+          overview: formatMessage({
+            defaultMessage:
+              'Displays the protected areas signed into the RUNAP (Unique Registry of Protected Areas) of Colombia',
+            id: 'kTXMXN',
+          }),
           specification: {
             type: 'raster',
             source: {
@@ -120,11 +140,16 @@ export const useLayers = () => {
         {
           id: LAYERS.BiodiversityIntactness,
           group: LAYER_GROUPS.ContextLayer,
-          name: intl.formatMessage({ defaultMessage: 'Biodiversity intactness', id: 'Bt7PVr' }),
-          description: intl.formatMessage({
+          name: formatMessage({ defaultMessage: 'Biodiversity intactness', id: 'Bt7PVr' }),
+          description: formatMessage({
             defaultMessage:
               'Displays the impacts of forest change on local biodiversity intactness.',
             id: 'MJuP2l',
+          }),
+          overview: formatMessage({
+            defaultMessage:
+              'This layer quantifies the impact humans have had on the intactness of species communities. Anthropogenic pressures such as land use conversion have caused dramatic changes to the composition of species communities and this layer illustrates these changes by focusing on the impact of forest change on biodiversity intactness. The maximum value indicates no human impact, while lower values indicate that intactness has been reduced. The Projecting Responses of Ecological Diversity in Changing Terrestrial Systems (PREDICTS) database comprises over 3 million records of geographically and taxonomically representative data of land use impacts to local biodiversity (Hudson et al. 2017). A subset of the PREDICTS database, including data pertaining to forested biomes only, is employed to model the impacts of land use change and human population density on the intactness of local species communities. To produce the land use map, all forested biomes are selected and each 30 x 30 m pixel within the biome is assigned a land use category based upon inputs from the GFW forest change database and a downscaled land use map (Hoskins et al 2016). The modelled results of biodiversity intactness derived from the PREDICTS database are projected onto the land use and human population density maps, and the final product is aggregated to match the resolution of the downscaled land use map (Hoskins et al 2016). The final output models the impacts of forest change on local biodiversity intactness within forested biomes.',
+            id: 'vQmgLw',
           }),
           specification: {
             type: 'raster',
@@ -139,10 +164,15 @@ export const useLayers = () => {
         {
           id: LAYERS.TreeBiomassIntensity,
           group: LAYER_GROUPS.ContextLayer,
-          name: intl.formatMessage({ defaultMessage: 'Tree biomass density', id: 'BSFsv6' }),
-          description: intl.formatMessage({
+          name: formatMessage({ defaultMessage: 'Tree biomass density', id: 'BSFsv6' }),
+          description: formatMessage({
             defaultMessage: 'Shows above ground live woody biomass density.',
             id: 'fvFVbs',
+          }),
+          overview: formatMessage({
+            defaultMessage:
+              'This is a global, wall-to-wall map of aboveground biomass (AGB) at approximately 30-meter resolution. This data product expands on the methodology presented in Baccini et al. (2012) to generate a global map of aboveground live woody biomass (AGB) density (megagrams biomass per ha) at 0.00025-degree (approximately 30-meter) resolution for the year 2000. Aboveground biomass was estimated using a multi-step process of calculating AGB at more than seven hundred thousand points with LiDAR with regional allometric equations, then using those to train a wall-to-wall model based on Landsat imagery. Pixels without tree canopy were assigned a biomass density of 0 Mg/ha.',
+            id: 'jvb6yi',
           }),
           specification: {
             type: 'raster',
@@ -157,10 +187,15 @@ export const useLayers = () => {
         {
           id: LAYERS.Wetlands,
           group: LAYER_GROUPS.ContextLayer,
-          name: intl.formatMessage({ defaultMessage: 'Wetlands', id: 'xa6OiT' }),
-          description: intl.formatMessage({
-            defaultMessage: 'Shows the wetlands of Colombia.',
-            id: 'XKK/dy',
+          name: formatMessage({ defaultMessage: 'Wetlands', id: 'xa6OiT' }),
+          description: formatMessage({
+            defaultMessage: 'National Wetlands Map of Colombia',
+            id: 'GgNMmS',
+          }),
+          overview: formatMessage({
+            defaultMessage:
+              'This layer shows the permanent and temporal wetlands of Colombia at a 1:100.000 reoslution',
+            id: 'U98Mu/',
           }),
           specification: {
             type: 'raster',
@@ -175,10 +210,15 @@ export const useLayers = () => {
         {
           id: LAYERS.PopulationDensity,
           group: LAYER_GROUPS.ContextLayer,
-          name: intl.formatMessage({ defaultMessage: 'Population density', id: 'JBFQAB' }),
-          description: intl.formatMessage({
+          name: formatMessage({ defaultMessage: 'Population density', id: 'JBFQAB' }),
+          description: formatMessage({
             defaultMessage: 'Global estimate of human population density and distribution.',
             id: 'A8lXv/',
+          }),
+          overview: formatMessage({
+            defaultMessage:
+              'The Global Human Settlement Layer (GHSL) Population Grid depicts the distribution and density of population, expressed as the number of people per cell, for 2015. While GFW uses only 2015 data, the GHSL is a multi-temporal population data set that employs new spatial data mining technologies. These methods enable the automatic processing and extraction of analytics and knowledge from different data sets: global, fine-scale satellite image data streams, census data, and crowd sources or volunteered geographic information sources. To produce this population density and distribution data set, researchers mapped global built-up areas, which are defined as all above ground constructions intended for human or animal sheltering or to produce economic goods. The locations of these built up areas was established using Landsat imagery analysis. An additional source used to compile this data set was the Gridded Population of the World (GPW) data set assembled by the Center for International Earth Science Information Network (CIESIN). The GPW data set consists of census population data and bolstered the built-up areas data by enabling researchers to estimate residential population. To present this data as grid cells, GPW data was disaggregated from census or administrative units.',
+            id: 'PIc+q2',
           }),
           specification: {
             type: 'raster',
@@ -194,14 +234,19 @@ export const useLayers = () => {
         {
           id: LAYERS.EndangeredSpecies,
           group: LAYER_GROUPS.PriorityLayer,
-          name: intl.formatMessage({
+          name: formatMessage({
             defaultMessage: 'Endangered species and critical habitats',
             id: 'PD6Q1A',
           }),
-          description: intl.formatMessage({
+          description: formatMessage({
             defaultMessage:
               'Displays the Key Biodiversity Areas containing 95% or more of the remaining population of one or more species listed as Endangered or Critically Endangered on the International Union for Conservation of Nature (IUCN) Red List of Threatened Species.',
             id: '6vrfSY',
+          }),
+          overview: formatMessage({
+            defaultMessage:
+              'The dataset represents the boundaries of sites containing 95% or more of the remaining population of one or more species listed as Endangered or Critically Endangered on the International Union for Conservation of Nature (IUCN) Red List of Threatened Species. The Alliance for Zero Extinction (AZE) originally created this dataset with a goal to prevent extinctions by identifying and safeguarding key sites. The 2019 March version of this dataset contains 859 sites, supporting 1483 Critically Endangered or Endangered species.',
+            id: 'UVJ5y2',
           }),
           specification: {
             type: 'vector',
@@ -248,13 +293,18 @@ export const useLayers = () => {
         {
           id: LAYERS.TreeCoverLoss,
           group: LAYER_GROUPS.PriorityLayer,
-          name: intl.formatMessage({
+          name: formatMessage({
             defaultMessage: 'Tree cover loss',
             id: 'y8AKM4',
           }),
-          description: intl.formatMessage({
+          description: formatMessage({
             defaultMessage: 'Identifies areas of gross tree cover loss.',
             id: 'rw2/NH',
+          }),
+          overview: formatMessage({
+            defaultMessage:
+              'This data set, a collaboration between the Global Land Analysis & Discovery (GLAD) lab at the University of Maryland, Google, USGS, and NASA, measures areas of tree cover loss across all global land (except Antarctica and other Arctic islands) at approximately 30 × 30 meter resolution. The data were generated using multispectral satellite imagery from the Landsat 5 thematic mapper (TM), the Landsat 7 thematic mapper plus (ETM+), and the Landsat 8 Operational Land Imager (OLI) sensors. Over 1 million satellite images were processed and analyzed, including over 600,000 Landsat 7 images for the 2000-2012 interval, and more than 400,000 Landsat 5, 7, and 8 images for updates for the 2011-2021 interval. The clear land surface observations in the satellite images were assembled and a supervised learning algorithm was applied to identify per pixel tree cover loss. In this data set, “tree cover” is defined as all vegetation greater than 5 meters in height, and may take the form of natural forests or plantations across a range of canopy densities. Tree cover loss is defined as “stand replacement disturbance,” or the complete removal of tree cover canopy at the Landsat pixel scale. Tree cover loss may be the result of human activities, including forestry practices such as timber harvesting or deforestation (the conversion of natural forest to other land uses), as well as natural causes such as disease or storm damage. Fire is another widespread cause of tree cover loss, and can be either natural or human-induced.',
+            id: 'jJYv/7',
           }),
           specification: {
             type: 'raster',
@@ -266,29 +316,37 @@ export const useLayers = () => {
             },
           },
         },
-        /*
-        {
-          id: LAYERS.RiverineFloodRisk,
-          group: LAYER_GROUPS.PriorityLayer,
-          name: intl.formatMessage({
-            defaultMessage: 'Riverine flood risk',
-            id: 'deHJ3+',
-          }),
-          description: intl.formatMessage({
-            defaultMessage:
-              'Shows the percentage of the population expected to be affected by riverine flooding in an average year.',
-            id: 'nwXvcg',
-          }),
-          specification: {},
-        },
-        */
+        // {
+        //   id: LAYERS.RiverineFloodRisk,
+        //   group: LAYER_GROUPS.PriorityLayer,
+        //   name: formatMessage({
+        //     defaultMessage: 'Riverine flood risk',
+        //     id: 'deHJ3+',
+        //   }),
+        //   description: formatMessage({
+        //     defaultMessage:
+        //       'Shows the percentage of the population expected to be affected by riverine flooding in an average year.',
+        //     id: 'nwXvcg',
+        //   }),
+        //   overview: formatMessage({
+        //     defaultMessage:
+        //       'Riverine flood risk measures the percentage of population expected to be affected by Riverine flooding in an average year, accounting for existing flood-protection standards. Flood risk is assessed using hazard (inundation caused by river overflow), exposure (population in flood zone), and vulnerability.16 The existing level of flood protection is also incorporated into the risk calculation. It is important to note that this indicator represents flood risk not in terms of maximum possible impact but rather as average annual impact. The impacts from infrequent, extreme flood years are averaged with more common, less newsworthy flood years to produce the “expected annual affected population.” Higher values indicate that a greater proportion of the population is expected to be impacted by Riverine floods on average.',
+        //     id: 'BY6k/1',
+        //   }),
+        //   specification: {},
+        // },
         {
           id: LAYERS.IndigenousReserves,
           group: LAYER_GROUPS.PriorityLayer,
-          name: intl.formatMessage({ defaultMessage: 'Indigenous Reserves', id: 'kN5g/0' }),
-          description: intl.formatMessage({
+          name: formatMessage({ defaultMessage: 'Indigenous Reserves', id: 'kN5g/0' }),
+          description: formatMessage({
             defaultMessage: 'Legalized Indigenous Reservations until the year 2021.',
             id: '1Qvlb5',
+          }),
+          overview: formatMessage({
+            defaultMessage:
+              'Indigenous Reservations are understood as a socio-political legal institution of colonial origin, made up of a recognized territory of a community of Amerindian descent, with inalienable, collective or community property title, governed by a special autonomous statute, with its own cultural guidelines and traditions.',
+            id: 'yer18A',
           }),
           specification: {
             type: 'raster',
@@ -307,7 +365,7 @@ export const useLayers = () => {
           ...layer.specification,
         },
       })),
-    [intl]
+    [formatMessage]
   );
 
   const groupedLayers = useMemo(


### PR DESCRIPTION
This PR adds map layers tooltips 

## Description

As an HeCo visitors, I need a way to see information about the layers that can be used in the projects search results map so that I know what they are about and can interpret the info correctly

## Acceptance criteria

There will be a way to find more information about the layers in the projects results map

Note: tooltip of each layer (if the information is too much this might need a redesign)


The information about each layer will be

- Description: Short description of the dataset we are displaying on the map.
- Overview: Summary of the dataset details.
- Source: Data source provider.
- source_url: Data source link.

The info must be displayed in the language set in the UI

The info is [here](https://docs.google.com/spreadsheets/d/1XbiiS0pv5P3eLbO3HTFVD5R-nQ8C55iyfYIxhiC3uKk/edit#gid=1856162673). The scope of this ticket includes only the following layers

1. Biodiversity intactness
2. Tree biomass density
3. Wetlands
4. Population Density
5. Endangered Species Critical Habitats
6. Tree cover loss
7. Riverine flood risk -> This layer is crashing, so is commented
8. Indigenous Reserves
9. Sub-basin boundaries

## Testing instructions

What to test? How to do it?

## Tracking

[LET-726](https://vizzuality.atlassian.net/browse/LET-726)
