### PR TITLE
Add status column to dashboard projects

### DIFF
--- a/frontend/pages/dashboard/projects.tsx
+++ b/frontend/pages/dashboard/projects.tsx
@@ -1,6 +1,8 @@
 import { PlusCircle as PlusCircleIcon } from 'react-feather';
 import { FormattedMessage, useIntl } from 'react-intl';
 
+import cx from 'classnames';
+
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 
@@ -93,6 +95,28 @@ export const ProjectsPage: PageComponent<ProjectsPageProps, DashboardLayoutProps
       { Header: 'Instrument type', accessor: 'instrumentType' },
       { Header: 'Value', accessor: 'ticketSize', canSort: false },
       {
+        Header: 'Status',
+        accessor: 'status',
+        Cell: ({ cell: { value } }) => {
+          return (
+            <span
+              className={cx({
+                'bg-opacity-20 text-sm px-2.5 py-0.5 rounded-2xl': true,
+                'bg-gray-800 text-gray-800': value === 'draft',
+                'bg-green-light text-green-dark': value === 'verified',
+                'bg-orange text-orange': value === 'unverified',
+              })}
+            >
+              {value === 'draft' && <FormattedMessage defaultMessage="Draft" id="W6nwjo" />}
+              {value === 'verified' && <FormattedMessage defaultMessage="Verified" id="Z8971h" />}
+              {value === 'unverified' && (
+                <FormattedMessage defaultMessage="Unverified" id="n9fdaJ" />
+              )}
+            </span>
+          );
+        },
+      },
+      {
         accessor: 'actions',
         canSort: false,
         hideHeader: true,
@@ -139,6 +163,7 @@ export const ProjectsPage: PageComponent<ProjectsPageProps, DashboardLayoutProps
         ?.filter(({ id }) => project.instrument_types?.includes(id))
         .map(({ name }, idx) => (idx === 0 ? name : name.toLowerCase()))
         .join(', '),
+      status: project.status === 'draft' ? 'draft' : project.trusted ? 'verified' : 'unverified',
       ticketSize: allTicketSizes?.find(({ id }) => project.ticket_size === id)?.description,
     })),
     loading: isLoadingProjects || isFetchingProjects,


### PR DESCRIPTION
## Description

This PR adds a sortable _"Status"_ column to the Dashboard/Projects table, with the project status. 
Projects with a `draft` `status` will have a _"Draft"_ tag, the ones with a `published` `status` will show as either _"Verified"_ or _"Unverified"_ depending on their `trusted` property.  

## Testing instructions

Visit the Dashboard, projects section and verify that:  
- Projects with a `draft` status have a _"Draft"_ tag  
  _It doesn't look like we have any in the database right now though_  
- Projects with a `published` status:  
  - If they're `trusted`, they have a _"Verified"_ tag  
  - If they're not `trusted`, they have an _"Unverified"_ tag  
- The _"Status"_ column is sortable  

## Tracking

[LET-729](https://vizzuality.atlassian.net/browse/LET-729)

## Screenshot
<img width="1680" alt="Screenshot 2022-07-12 at 16 13 21" src="https://user-images.githubusercontent.com/6273795/178524308-2a16b6c8-3bb2-4192-9dab-d5765760d853.png">

