### PR TITLE
fix: Call after destroy callback for involved_project_developers

### DIFF
--- a/backend/app/models/project.rb
+++ b/backend/app/models/project.rb
@@ -15,7 +15,7 @@ class Project < ApplicationRecord
   has_many :project_images, dependent: :destroy
   has_many :favourite_projects, dependent: :destroy
   has_many :project_involvements, dependent: :destroy
-  has_many :involved_project_developers, through: :project_involvements, source: :project_developer
+  has_many :involved_project_developers, through: :project_involvements, source: :project_developer, dependent: :destroy
 
   translates :name,
     :description,

--- a/backend/app/models/project_developer.rb
+++ b/backend/app/models/project_developer.rb
@@ -6,7 +6,7 @@ class ProjectDeveloper < ApplicationRecord
   has_many :projects, dependent: :destroy
   has_many :favourite_project_developers, dependent: :destroy
   has_many :project_involvements, dependent: :destroy
-  has_many :involved_projects, through: :project_involvements, source: :project
+  has_many :involved_projects, through: :project_involvements, source: :project, dependent: :destroy
 
   validates :categories, array_inclusion: {in: Category::TYPES}, presence: true
   validates :impacts, array_inclusion: {in: Impact::TYPES}

--- a/backend/spec/models/project_spec.rb
+++ b/backend/spec/models/project_spec.rb
@@ -319,20 +319,45 @@ RSpec.describe Project, type: :model do
 
   describe "#notify_project_developers" do
     let(:project_developer) { create :project_developer }
+    let(:removed_project_developer) { create :project_developer }
     let(:new_project_developer) { create :project_developer }
-    let!(:project) { create :project, :draft, involved_project_developers: [project_developer] }
+    let!(:project) { create :project, involved_project_developers: [project_developer, removed_project_developer] }
 
-    it "notifies all involved project developers" do
-      expect {
-        project.update! involved_project_developers: [project_developer, new_project_developer], status: :published
-      }.to have_enqueued_mail(ProjectDeveloperMailer, :added_to_project).with(project_developer, project).once
-        .and have_enqueued_mail(ProjectDeveloperMailer, :added_to_project).with(new_project_developer, project).once
+    context "when project developers are modified on published project" do
+      it "notifies all added project developers" do
+        expect {
+          project.update! involved_project_developers: [new_project_developer]
+        }.to have_enqueued_mail(ProjectDeveloperMailer, :added_to_project).with(new_project_developer, project)
+      end
+
+      it "notifies all removed project developers" do
+        expect {
+          project.update! involved_project_developers: [project_developer]
+        }.to have_enqueued_mail(ProjectDeveloperMailer, :removed_from_project).with(removed_project_developer, project)
+      end
     end
 
-    it "does not notifies project developers when status of project does not change" do
-      expect {
-        project.update! involved_project_developers: [project_developer, new_project_developer]
-      }.not_to have_enqueued_mail(ProjectDeveloperMailer, :added_to_project)
+    context "when project gets published" do
+      before { project.update! status: :draft }
+
+      it "notifies all involved project developers" do
+        expect {
+          project.update! involved_project_developers: [project_developer, new_project_developer], status: :published
+        }.to have_enqueued_mail(ProjectDeveloperMailer, :added_to_project).with(project_developer, project).once
+          .and have_enqueued_mail(ProjectDeveloperMailer, :added_to_project).with(new_project_developer, project).once
+      end
+
+      it "does not notify removed project developers" do
+        expect {
+          project.update! involved_project_developers: [], status: :published
+        }.not_to have_enqueued_mail(ProjectDeveloperMailer, :removed_from_project)
+      end
+
+      it "does not notify project developers when status of project does not change" do
+        expect {
+          project.update! involved_project_developers: [project_developer, new_project_developer]
+        }.not_to have_enqueued_mail(ProjectDeveloperMailer, :added_to_project)
+      end
     end
   end
 end


### PR DESCRIPTION
It looks like `after_destroy` callback is not called till `has_many` relation have `dependent: :destroy` defined <-- rails uses `delete_all` in such case. I am adding `dependent` option and additional tests which ensures that all callbacks for `involved_project_developers ` are called.

## Testing instructions

BugFix --> remove involved project developers from Project via rswag or FE.

## Tracking

https://vizzuality.atlassian.net/browse/LET-525
