### PR TITLE
Remove add-users button for non account owners

### DIFF
--- a/frontend/pages/dashboard/users.tsx
+++ b/frontend/pages/dashboard/users.tsx
@@ -7,6 +7,8 @@ import { withLocalizedRequests } from 'hoc/locale';
 
 import { InferGetStaticPropsType } from 'next';
 
+import useMe from 'hooks/me';
+
 import { loadI18nMessages } from 'helpers/i18n';
 
 import UsersTable from 'containers/dashboard/users/table';
@@ -34,20 +36,23 @@ type UsersPageProps = InferGetStaticPropsType<typeof getStaticProps>;
 export const UsersPage: PageComponent<UsersPageProps, DashboardLayoutProps> = () => {
   const [openInvitationModal, setOpenInvitationModal] = useState(false);
   const intl = useIntl();
+  const { user } = useMe();
 
   return (
     <ProtectedPage permissions={[UserRoles.ProjectDeveloper, UserRoles.Investor]}>
       <Head title={intl.formatMessage({ defaultMessage: 'My users', id: 'lda5xz' })} />
       <DashboardLayout
         buttons={
-          <Button
-            className="drop-shadow-xl"
-            theme="primary-white"
-            onClick={() => setOpenInvitationModal(true)}
-          >
-            <Icon icon={MailIcon} className="w-4 h-4 mr-2" aria-hidden />
-            <FormattedMessage defaultMessage="Invite user" id="/4GN+O" />
-          </Button>
+          user?.owner && (
+            <Button
+              className="drop-shadow-xl"
+              theme="primary-white"
+              onClick={() => setOpenInvitationModal(true)}
+            >
+              <Icon icon={MailIcon} className="w-4 h-4 mr-2" aria-hidden />
+              <FormattedMessage defaultMessage="Invite user" id="/4GN+O" />
+            </Button>
+          )
         }
       >
         <div className="pt-4">

--- a/frontend/types/user.ts
+++ b/frontend/types/user.ts
@@ -26,6 +26,7 @@ export interface User {
   role: UserRoles;
   confirmed: boolean;
   approved: boolean;
+  owner: boolean;
 }
 
 export type UserAccount = {


### PR DESCRIPTION
This PR hide the 'Invite user' button and 'Actions' column from non account owners.

## Testing instructions

A logged PD or Investor user should see the  'Invite user' button and 'Actions' column

## Tracking

[LET-756]