### PR TITLE
Fix discovery search filter button bug

### DIFF
--- a/frontend/containers/layouts/discover-search/component.tsx
+++ b/frontend/containers/layouts/discover-search/component.tsx
@@ -80,9 +80,9 @@ export const DiscoverSearch: FC<DiscoverSearchProps> = ({
               {/* Filters accordion header https://www.w3.org/WAI/ARIA/apg/example-index/accordion/accordion.html */}
               <h3>
                 <Button
-                  className="inline px-0 font-normal bg-white text-green-dark"
+                  className="inline px-4 py-2 font-normal text-center bg-white text-green-dark hover:text-green-light focus-visible:outline-green-dark"
                   id="filters-button"
-                  theme="primary-green"
+                  theme="naked"
                   onClick={() => setOpenFilters(!openFilters)}
                   aria-expanded={openFilters}
                   aria-controls="filters"
@@ -90,10 +90,10 @@ export const DiscoverSearch: FC<DiscoverSearchProps> = ({
                   <FormattedMessage defaultMessage="Filters" id="zSOvI0" />
                   <span
                     className={cx(
-                      'flex items-center justify-center w-6 h-6 ml-2 px-0 py-0 rounded-full border border-bg-green-light bg-green-light bg-opacity-30 text-green-dark font-bold text-xs transition-opacity ease-in',
+                      'flex items-center justify-center h-6 px-0 py-0 rounded-full border border-bg-green-light bg-green-light bg-opacity-30 text-green-dark font-bold text-xs transition-all ease-in',
                       {
-                        'opacity-100': !!filtersQuantity,
-                        'opacity-0': !filtersQuantity,
+                        'opacity-100 w-6 ml-2': !!filtersQuantity,
+                        'opacity-0 w-0 ml-0': !filtersQuantity,
                       }
                     )}
                   >


### PR DESCRIPTION
This PR fixes the bug on the filter button

## Testing instructions

### BUG:
- normal:
<img width="949" alt="Screenshot 2022-07-13 at 18 41 15" src="https://user-images.githubusercontent.com/48164343/178786638-507d24df-d7fa-44e5-a4d5-c358b2ab5da4.png">

- hovered:
<img width="949" alt="Screenshot 2022-07-13 at 18 41 19" src="https://user-images.githubusercontent.com/48164343/178786644-519be50b-74db-48ce-a25d-53d7b3566bda.png">


### FIXED: 

- normal:
<img width="636" alt="Screenshot 2022-07-13 at 18 38 40" src="https://user-images.githubusercontent.com/48164343/178786320-e12324f6-0ad2-4288-a42b-ff70756f3acd.png">

- hovered:
<img width="636" alt="Screenshot 2022-07-13 at 18 38 49" src="https://user-images.githubusercontent.com/48164343/178786315-06f5aa95-0f7a-4d95-be29-2dbd8668b53b.png">

## Tracking

[LET-779](https://vizzuality.atlassian.net/browse/LET-779)
