### PR TITLE
Implement collapsible map legend as per designs

### DIFF
--- a/frontend/components/map/project-legend/component.tsx
+++ b/frontend/components/map/project-legend/component.tsx
@@ -1,13 +1,16 @@
 import { FC, useCallback, useState } from 'react';
 
+import { ChevronDown as ChevronDownIcon } from 'react-feather';
 import { FormattedMessage } from 'react-intl';
 
 import cx from 'classnames';
 
 import { useId } from '@react-aria/utils';
+import { motion } from 'framer-motion';
 
 import { CategoryTagDot } from 'containers/category-tag';
 
+import Icon from 'components/icon';
 import { CategoryType } from 'types/category';
 
 import { useEnums } from 'services/enums/enumService';
@@ -23,28 +26,50 @@ export const ProjectLegend: FC<ProjectLegendProps> = ({ className }: ProjectLege
   const onToggleActive = useCallback(() => {
     setActive(!active);
   }, [active]);
+
   if (isLoading || isError) {
     return null;
   }
 
+  const legendVariants = {
+    open: { opacity: 1, height: 'auto' },
+    closed: { opacity: 0, height: 0 },
+  };
+
   return (
     <div
       className={cx({
-        'w-56 px-4 py-2 bg-white rounded-2xl shadow-xl text-xs flex flex-col': true,
+        'flex flex-col items-end h-full gap-px': true,
         [className]: !!className,
       })}
     >
       <button
         type="button"
-        aria-expanded={active}
         aria-controls={id}
-        className="relative flex flex-col items-start"
+        aria-expanded={active}
+        className="relative flex items-center justify-center w-8 h-8 bg-white rounded shadow-xl focus-visible:outline-green-dark"
         onClick={onToggleActive}
       >
-        <div className="font-semibold text-gray-700">
-          <FormattedMessage defaultMessage="Project categories" id="rginRA" />
-        </div>
-        {active && (
+        <Icon
+          aria-hidden={true}
+          icon={ChevronDownIcon}
+          className={cx({
+            'w-4.5 h-4.5 text-gray-600 shrink-0 transition duration-500': true,
+            '-scale-y-100': !active,
+          })}
+        />
+      </button>
+      <motion.div
+        id={id}
+        animate={active ? 'open' : 'closed'}
+        transition={{ duration: 0.6 }}
+        variants={legendVariants}
+        className="w-56 z-10 bg-white rounded shadow-xl text-xs flex flex-col lg:min-w-[280px]"
+      >
+        <div className="px-2 py-2">
+          <div className="font-semibold text-black">
+            <FormattedMessage defaultMessage="Project categories" id="rginRA" />
+          </div>
           <ol className="flex flex-col gap-2 mt-2 text-left">
             {data.category.map((category) => (
               <li key={category.id}>
@@ -53,8 +78,8 @@ export const ProjectLegend: FC<ProjectLegendProps> = ({ className }: ProjectLege
               </li>
             ))}
           </ol>
-        )}
-      </button>
+        </div>
+      </motion.div>
     </div>
   );
 };

--- a/frontend/components/map/project-legend/component.tsx
+++ b/frontend/components/map/project-legend/component.tsx
@@ -10,6 +10,7 @@ import { motion } from 'framer-motion';
 
 import { CategoryTagDot } from 'containers/category-tag';
 
+import Button from 'components/button';
 import Icon from 'components/icon';
 import { CategoryType } from 'types/category';
 
@@ -43,13 +44,17 @@ export const ProjectLegend: FC<ProjectLegendProps> = ({ className }: ProjectLege
         [className]: !!className,
       })}
     >
-      <button
-        type="button"
+      <Button
+        theme="naked"
+        size="smallest"
         aria-controls={id}
         aria-expanded={active}
-        className="relative flex items-center justify-center w-8 h-8 bg-white rounded shadow-xl focus-visible:outline-green-dark"
+        className="flex items-center justify-center w-8 h-8 bg-white rounded shadow-xl focus-visible:outline-green-dark"
         onClick={onToggleActive}
       >
+        <span className="sr-only">
+          <FormattedMessage defaultMessage="Legend" id="iZuO+L" />
+        </span>
         <Icon
           aria-hidden={true}
           icon={ChevronDownIcon}
@@ -58,9 +63,10 @@ export const ProjectLegend: FC<ProjectLegendProps> = ({ className }: ProjectLege
             '-scale-y-100': !active,
           })}
         />
-      </button>
+      </Button>
       <motion.div
         id={id}
+        aria-hidden={!active}
         animate={active ? 'open' : 'closed'}
         transition={{ duration: 0.6 }}
         variants={legendVariants}

--- a/frontend/containers/discover-map/component.tsx
+++ b/frontend/containers/discover-map/component.tsx
@@ -79,7 +79,7 @@ export const DiscoverMap: FC<DiscoverMapProps> = ({ onSelectProjectPin }) => {
           <LocationSearcher onLocationSelected={handleLocationSelected} />
         </div>
 
-        <Controls className="absolute border bottom-10 xl:bottom-6 right-11">
+        <Controls className="absolute bottom-10 xl:bottom-4 right-4">
           <ProjectLegend />
         </Controls>
       </div>

--- a/frontend/containers/project-details/component.tsx
+++ b/frontend/containers/project-details/component.tsx
@@ -79,7 +79,7 @@ export const ProjectDetails: FC<ProjectDetailsProps> = ({
 
   return (
     <div className={className}>
-      <div className="absolute top-0 right-0 z-10 w-full h-full overflow-hidden pointer-events-none">
+      <div className="absolute top-0 right-0 z-20 w-full h-full overflow-hidden pointer-events-none">
         <Button
           size="smallest"
           theme="naked"

--- a/frontend/pages/discover/projects.tsx
+++ b/frontend/pages/discover/projects.tsx
@@ -144,7 +144,7 @@ const ProjectsPage: PageComponent<ProjectsPageProps, DiscoverPageLayoutProps> = 
                 autoFocus
               >
                 <motion.div
-                  className="z-10"
+                  className="z-20"
                   transition={{ duration: 0.15 }}
                   initial={{ opacity: 0 }}
                   animate={{ opacity: 1 }}
@@ -176,7 +176,7 @@ const ProjectsPage: PageComponent<ProjectsPageProps, DiscoverPageLayoutProps> = 
           </Modal>
         )}
       </div>
-      <aside className="flex-grow min-h-full p-2 m-1 bg-white rounded-2xl lg:min-h-0 lg:absolute lg:right-0 lg:w-7/12 lg:bottom-1 lg:top-1">
+      <aside className="flex-grow min-h-full m-1 overflow-hidden bg-white rounded-2xl lg:min-h-0 lg:absolute lg:right-0 lg:w-7/12 lg:bottom-1 lg:top-1">
         <DiscoverMap onSelectProjectPin={handleProjectCardClick} />
       </aside>
     </div>


### PR DESCRIPTION
## Description

This PR implements a collapsible map legend as per designs, including animation. 

**Figma design:** https://www.figma.com/file/3epSYh4KQZBCyh4Y5OzmHw/HeCo---Design-System?node-id=3656%3A12756  

**Video of how it should work:** https://vizzuality.atlassian.net/browse/LET-695?focusedCommentId=17510

## Testing instructions

- Verify that the map legend can be collapsed and expanded
- Verify that the map legend matches the designs  

## Tracking

[LET-745](https://vizzuality.atlassian.net/browse/LET-745)

## Screenshot  

<img width="652" alt="Screenshot 2022-07-14 at 12 51 14" src="https://user-images.githubusercontent.com/6273795/178976126-c4ec8936-d1e6-4f16-a590-58e57c3f9b52.png">

## Video

https://user-images.githubusercontent.com/6273795/178975847-e4d9c2c3-3a9e-4e11-8fd8-9e48c40d44aa.mp4

