### PR TITLE
Project developer public page wording changes

### DIFF
--- a/frontend/containers/social-contact/website-social/component.tsx
+++ b/frontend/containers/social-contact/website-social/component.tsx
@@ -47,7 +47,7 @@ export const WebsiteSocial: FC<WebsiteSocialProps> = ({
       {social.length > 0 && (
         <>
           <span className="mt-4 text-gray-800 sm:mt-0">
-            <FormattedMessage defaultMessage="Social media" id="ZEEVQX" />
+            <FormattedMessage defaultMessage="Reach them in" id="G9iCfx" />
           </span>
           <span className="flex items-center gap-2">
             {social.map(({ id, url }: SocialType) => {

--- a/frontend/containers/tags-grid/component.stories.tsx
+++ b/frontend/containers/tags-grid/component.stories.tsx
@@ -14,6 +14,7 @@ export const Default: Story<TagsGridProps> = Template.bind({});
 Default.args = {
   rows: [
     {
+      id: 'category',
       title: 'Invests in',
       type: 'category',
       tags: [
@@ -24,14 +25,17 @@ Default.args = {
       ],
     },
     {
+      id: 'ticket-size',
       title: 'Ticket size',
       tags: ['US$50k', '$50k - $500k', '$500k - $1M'],
     },
     {
+      id: 'instrument-size',
       title: 'Instrument size',
       tags: ['Grand', 'Loan'],
     },
     {
+      id: 'impact',
       title: 'Impact they invest on',
       tags: ['Biodiversity', 'Community'],
     },

--- a/frontend/containers/tags-grid/component.tsx
+++ b/frontend/containers/tags-grid/component.tsx
@@ -2,8 +2,6 @@ import { FC } from 'react';
 
 import cx from 'classnames';
 
-import { slugify } from 'helpers/slugify';
-
 import CategoryTag from 'containers/category-tag';
 
 import Tag from 'components/tag';
@@ -11,9 +9,7 @@ import Tag from 'components/tag';
 import type { TagsGridProps } from './types';
 
 export const TagsGrid: FC<TagsGridProps> = ({ className, rows }: TagsGridProps) => {
-  const gridCells = rows.reduce((arr, { title, type, tags }) => {
-    const id = slugify(title);
-
+  const gridCells = rows.reduce((arr, { id, title, type, tags }) => {
     // Do not display grid rows that have no tags
     if (!tags?.length) return arr;
 

--- a/frontend/containers/tags-grid/types.ts
+++ b/frontend/containers/tags-grid/types.ts
@@ -1,6 +1,10 @@
+import { ReactNode } from 'react';
+
 export type TagsGridRowType = {
-  /** Label for the tags list */
-  title: string;
+  /** Id for the tags list row */
+  id: string;
+  /** Label for the tags list row */
+  title: string | ReactNode;
   /** Type of tags to display. Defaults to `default` */
   type?: 'default' | 'category';
   /** Array of strings for `default` tags, or array of { id, title } for `category` tags */

--- a/frontend/helpers/slugify.ts
+++ b/frontend/helpers/slugify.ts
@@ -1,7 +1,0 @@
-import { default as slugifyExt } from 'slugify';
-
-/**
- * Return a slug based on a string
- * @param string String to slugify
- */
-export const slugify = (string: string) => slugifyExt(string, { lower: true });

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -56,9 +56,6 @@
   "0DNR+D": {
     "string": "Tell us what you value in the projects you invest in / what will make you invest in projects"
   },
-  "0FJhbi": {
-    "string": "HeCo priority landscapes {test}"
-  },
   "0L/mZC": {
     "string": "Target group"
   },
@@ -199,6 +196,9 @@
   },
   "5c08Qp": {
     "string": "Project information"
+  },
+  "5gd2Z7": {
+    "string": "HeCo <a>priority landscapes</a>"
   },
   "5kZ+j+": {
     "string": "Duration of the project"

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -512,6 +512,9 @@
   "G6tmT0": {
     "string": "Select the ticket size(s) that you provide"
   },
+  "G9iCfx": {
+    "string": "Reach them in"
+  },
   "GKONs7": {
     "string": "Start having impact now."
   },

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -56,6 +56,9 @@
   "0DNR+D": {
     "string": "Tell us what you value in the projects you invest in / what will make you invest in projects"
   },
+  "0FJhbi": {
+    "string": "HeCo priority landscapes {test}"
+  },
   "0L/mZC": {
     "string": "Target group"
   },
@@ -659,6 +662,9 @@
   },
   "KxPY7j": {
     "string": "Date of creation"
+  },
+  "L2CvBU": {
+    "string": "Expect to have impact"
   },
   "LFDgTb": {
     "string": "Leave project developer edition?"
@@ -1316,6 +1322,9 @@
   },
   "in26xr": {
     "string": "{organization} logo"
+  },
+  "inQ2Q1": {
+    "string": "Topics/sector categories"
   },
   "itfsqC": {
     "string": "Currently you don’t have any <b>Projects</b>."

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -104,6 +104,9 @@
   "25WwxF": {
     "string": "Don't have an account?"
   },
+  "2AZiFU": {
+    "string": "Instrument size"
+  },
   "2Cbk6h": {
     "string": "Add your logo or a picture that identifies the account."
   },
@@ -175,6 +178,9 @@
   },
   "4vn+6A": {
     "string": "{inputName} is focused, type to refine list, press down to open the menu, press left to focus selected values"
+  },
+  "4y9VoH": {
+    "string": "Impact they invest on"
   },
   "4zK41e": {
     "string": "Investing in the Amazon means contributing to improving the quality of life of more than 30 million people. It is also contributing to the development and conservation of a vital region for South America and the world."
@@ -1283,6 +1289,9 @@
   },
   "hxIQ/8": {
     "string": "Projects waiting funding"
+  },
+  "i9cSUD": {
+    "string": "Invests in"
   },
   "i9eK6b": {
     "string": "Show verified content only"

--- a/frontend/pages/investor/[id]/index.tsx
+++ b/frontend/pages/investor/[id]/index.tsx
@@ -1,4 +1,4 @@
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import { useRouter } from 'next/router';
 
@@ -55,6 +55,7 @@ const InvestorPage: PageComponent<InvestorPageProps, StaticPageLayoutProps> = ({
   investor: investorProp,
   enums,
 }) => {
+  const intl = useIntl();
   const router = useRouter();
 
   const { data: investor } = useInvestor(router.query.id as string, investorProp);
@@ -110,20 +111,24 @@ const InvestorPage: PageComponent<InvestorPageProps, StaticPageLayoutProps> = ({
 
   const tagsGridRows: TagsGridRowType[] = [
     {
-      title: 'Invests in',
+      id: 'category',
+      title: intl.formatMessage({ defaultMessage: 'Invests in', id: 'i9cSUD' }),
       type: 'category',
       tags: allCategories.filter(({ id }) => categories?.includes(id)),
     },
     {
-      title: 'Ticket size',
+      id: 'ticket-size',
+      title: intl.formatMessage({ defaultMessage: 'Ticket size', id: 'lfx6Nc' }),
       tags: allTicketSizes.filter(({ id }) => ticket_sizes?.includes(id)),
     },
     {
-      title: 'Instrument size',
+      id: 'instrument-size',
+      title: intl.formatMessage({ defaultMessage: 'Instrument size', id: '2AZiFU' }),
       tags: allInstrumentTypes.filter(({ id }) => instrument_types?.includes(id)),
     },
     {
-      title: 'Impact they invest on',
+      id: 'impact',
+      title: intl.formatMessage({ defaultMessage: 'Impact they invest on', id: '4y9VoH' }),
       tags: allImpacts.filter(({ id }) => impacts?.includes(id)),
     },
   ];

--- a/frontend/pages/investor/[id]/index.tsx
+++ b/frontend/pages/investor/[id]/index.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-
 import { FormattedMessage } from 'react-intl';
 
 import { useRouter } from 'next/router';

--- a/frontend/pages/project-developer/[id]/index.tsx
+++ b/frontend/pages/project-developer/[id]/index.tsx
@@ -1,4 +1,4 @@
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import { useRouter } from 'next/router';
 
@@ -70,6 +70,7 @@ const ProjectDeveloperPage: PageComponent<ProjectDeveloperPageProps, StaticPageL
   projectDeveloper: projectDeveloperProp,
   enums,
 }) => {
+  const intl = useIntl();
   const router = useRouter();
 
   const {
@@ -103,18 +104,38 @@ const ProjectDeveloperPage: PageComponent<ProjectDeveloperPageProps, StaticPageL
 
   const tagsRows: TagsGridRowType[] = [
     {
-      title: 'Categories of interest',
+      id: 'categories',
+      title: intl.formatMessage({ defaultMessage: 'Topics/sector categories', id: 'inQ2Q1' }),
       type: 'category',
       tags: enums[EnumTypes.Category].filter(({ id }) =>
         projectDeveloper.categories?.includes(id as CategoryType)
       ),
     },
     {
-      title: 'Areas of work',
+      id: 'priority-landscapes',
+      title: intl.formatMessage(
+        {
+          defaultMessage: 'HeCo <a>priority landscapes</a>',
+          id: '5gd2Z7',
+        },
+        {
+          a: (chunks) => (
+            <a
+              href="/images/mosaics.png"
+              className="underline rounded-full focus-visible:outline-green-dark"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              {chunks}
+            </a>
+          ),
+        }
+      ),
       tags: enums[EnumTypes.Mosaic].filter(({ id }) => projectDeveloper.mosaics?.includes(id)),
     },
     {
-      title: 'Impact',
+      id: 'impact',
+      title: intl.formatMessage({ defaultMessage: 'Expect to have impact', id: 'L2CvBU' }),
       tags: enums[EnumTypes.Impact].filter(({ id }) => projectDeveloper.impacts?.includes(id)),
     },
   ];


### PR DESCRIPTION
## Description

This PR implements some wording changes on the project developer public page, as described in the JIRA task linked below. 

**PR notes:**  
- The `TagsGrid` component only supported `string`s as titles; it had to be reworked so we could pass elements as well  
  This was required due to the necessity of putting a link in row title  
  - Due to this change, I've added an `id` as required property; we were slugifying the title to use as an `id`, which was now no longer possible given the title can be an element  
    - Removed the `slugify` helper, which was no longer being used anywhere
  - While adding `id`s to pages which used the `TagsGrid` component, I noticed missing translations for the Investor public page, I've added them

## Testing instructions

Verify that the changes match the description in the task. 

**Acceptance criteria**
- The label “Social media” must say: “Reach them in”
- The label “Categories of interest” must say: “Topics/sector categories”
- The label “Areas of work” must say: “HeCo priority landscapes”
  - “priority landscapes” links to the [image of the HeCo priority landscapes](https://github.com/Vizzuality/heco-invest/blob/d18e986eea182eeffb16a7501fb712f41ae114b0/frontend/public/images/mosaics.png) in a new tab
- The label “Impact” must say: “Expect to have impact”

## Tracking

[LET-772](https://vizzuality.atlassian.net/browse/LET-772)

## Screenshots 

<img width="841" alt="Screenshot 2022-07-14 at 14 18 09" src="https://user-images.githubusercontent.com/6273795/178991727-278fc286-1759-4bd4-be8a-5a5a48c71724.png">
<img width="527" alt="Screenshot 2022-07-14 at 14 18 14" src="https://user-images.githubusercontent.com/6273795/178991737-571fdefe-ce5c-45a9-8940-06fec9687b58.png">

