### PR TITLE
feat: Allow edit and deletion of User via Backoffice

### DIFF
--- a/backend/app/assets/images/menu.svg
+++ b/backend/app/assets/images/menu.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5">
+  <circle cx="12" cy="12" r="1"></circle><circle cx="12" cy="5" r="1"></circle>
+  <circle cx="12" cy="19" r="1"></circle>
+</svg>

--- a/backend/app/controllers/backoffice/users_controller.rb
+++ b/backend/app/controllers/backoffice/users_controller.rb
@@ -1,5 +1,11 @@
 module Backoffice
   class UsersController < BaseController
+    include Sections
+
+    before_action :fetch_admin, only: [:edit, :update, :destroy]
+    before_action :set_breadcrumbs, only: [:edit, :update]
+    before_action :set_sections, only: [:edit, :update]
+
     def index
       @q = User.ransack params[:q]
       @users = @q.result.includes(:account)
@@ -15,6 +21,52 @@ module Backoffice
             type: "text/csv; charset=utf-8"
         end
       end
+    end
+
+    def edit
+    end
+
+    def update
+      if @user.update(user_params)
+        redirect_back(
+          fallback_location: edit_backoffice_user_path(@user.id),
+          notice: t("backoffice.messages.success_update", model: t("backoffice.common.user"))
+        )
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    def destroy
+      if @user.destroy
+        redirect_to backoffice_users_path, status: :see_other,
+          notice: t("backoffice.messages.success_delete", model: t("backoffice.common.user"))
+      else
+        redirect_to backoffice_users_path, status: :see_other, alert: @user.errors.first.full_message
+      end
+    end
+
+    private
+
+    def user_params
+      params.require(:user).permit(
+        :avatar,
+        :first_name,
+        :last_name
+      )
+    end
+
+    def fetch_admin
+      @user = User.find(params[:id])
+    end
+
+    def set_breadcrumbs
+      add_breadcrumb(I18n.t("backoffice.layout.users"), backoffice_users_path)
+      add_breadcrumb(@user.full_name)
+    end
+
+    def set_sections
+      sections %w[information], default: "information"
     end
   end
 end

--- a/backend/app/helpers/application_helper.rb
+++ b/backend/app/helpers/application_helper.rb
@@ -77,4 +77,11 @@ module ApplicationHelper
 
     f.input field_name, options
   end
+
+  def account_link_for(record)
+    return if record.blank?
+    return link_to record.name, edit_backoffice_project_developer_path(record.project_developer), class: "link-button" if record.project_developer_id.present?
+
+    link_to record.name, edit_backoffice_investor_path(record.investor), class: "link-button" if record.investor_id.present?
+  end
 end

--- a/backend/app/javascript/controllers/index.js
+++ b/backend/app/javascript/controllers/index.js
@@ -5,4 +5,6 @@
 import { application } from "./application"
 
 import ShapefileController from "./shapefile_controller.js"
+import MenuController from "./menu_controller";
 application.register("shapefile", ShapefileController)
+application.register("menu", MenuController)

--- a/backend/app/javascript/controllers/menu_controller.js
+++ b/backend/app/javascript/controllers/menu_controller.js
@@ -1,0 +1,16 @@
+import { Controller } from "@hotwired/stimulus"
+
+//simple piece of js code controlling visibility of menu
+export default class extends Controller {
+  static targets = ["menu"];
+
+  toggle() {
+    this.menuTarget.classList.toggle("hidden");
+  }
+
+  hide(event) {
+    if (!this.element.contains(event.target) && !this.menuTarget.classList.contains('hidden')) {
+      this.menuTarget.classList.add("hidden");
+    }
+  }
+}

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -11,7 +11,9 @@ class User < ApplicationRecord
   has_many :project_developers, through: :favourite_project_developers
   has_many :favourite_investors, dependent: :destroy
   has_many :investors, through: :favourite_investors
-  has_one :owner_account, class_name: "Account", foreign_key: "owner_id", dependent: :destroy
+  has_one :owner_account, class_name: "Account", foreign_key: "owner_id", dependent: :restrict_with_error
+
+  has_one_attached :avatar
 
   pg_search_scope :search, against: [:first_name, :last_name, :email]
 

--- a/backend/app/serializers/api/v1/user_serializer.rb
+++ b/backend/app/serializers/api/v1/user_serializer.rb
@@ -1,6 +1,8 @@
 module API
   module V1
     class UserSerializer < BaseSerializer
+      include BlobSerializer
+
       attributes :first_name, :last_name, :email, :role, :created_at
       attribute :confirmed, &:confirmed?
       attribute :approved, &:approved?
@@ -17,6 +19,10 @@ module API
 
       attribute :owner do |object, _params|
         object.owner_account.present?
+      end
+
+      attribute :avatar do |object|
+        image_links_for object.avatar
       end
     end
   end

--- a/backend/app/views/backoffice/base/_menu.html.erb
+++ b/backend/app/views/backoffice/base/_menu.html.erb
@@ -1,9 +1,9 @@
 <div class="relative" data-controller="menu">
-  <button data-action="menu#toggle click@window->menu#hide" class="flex items-center rounded-full font-sans transition-all focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:opacity-60 disabled:pointer-events-none px-0 py-0 focus-visible:outline-green-dark" role="button" tabindex="0" id="react-aria-30" aria-haspopup="true" aria-expanded="true" aria-controls="react-aria-31" style="user-select: none;">
+  <button data-action="menu#toggle click@window->menu#hide" class="flex items-center rounded-full font-sans transition-all focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:opacity-60 disabled:pointer-events-none px-0 py-0 focus-visible:outline-green-dark" role="button" tabindex="0" aria-haspopup="true" aria-expanded="true" style="user-select: none;">
     <%= svg "menu" %>
   </button>
   <div>
-    <div data-menu-target="menu" role="menu" tabindex="0" id="react-aria-8" aria-labelledby="react-aria-7" class="hidden z-30 absolute transform whitespace-nowrap bg-white shadow-2xl rounded-md overflow-hidden right-0 -bottom-2 translate-y-full">
+    <div data-menu-target="menu" role="menu" tabindex="0" class="hidden z-30 absolute transform whitespace-nowrap bg-white shadow-2xl rounded-md overflow-hidden right-0 -bottom-2 translate-y-full">
       <ul class="">
         <%= yield if yield.present? %>
       </ul>

--- a/backend/app/views/backoffice/base/_menu.html.erb
+++ b/backend/app/views/backoffice/base/_menu.html.erb
@@ -1,0 +1,12 @@
+<div class="relative" data-controller="menu">
+  <button data-action="menu#toggle click@window->menu#hide" class="flex items-center rounded-full font-sans transition-all focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:opacity-60 disabled:pointer-events-none px-0 py-0 focus-visible:outline-green-dark" role="button" tabindex="0" id="react-aria-30" aria-haspopup="true" aria-expanded="true" aria-controls="react-aria-31" style="user-select: none;">
+    <%= svg "menu" %>
+  </button>
+  <div>
+    <div data-menu-target="menu" role="menu" tabindex="0" id="react-aria-8" aria-labelledby="react-aria-7" class="hidden z-30 absolute transform whitespace-nowrap bg-white shadow-2xl rounded-md overflow-hidden right-0 -bottom-2 translate-y-full">
+      <ul class="">
+        <%= yield if yield.present? %>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/backend/app/views/backoffice/base/menu/_delete.html.erb
+++ b/backend/app/views/backoffice/base/menu/_delete.html.erb
@@ -1,0 +1,9 @@
+<li aria-disabled="false" role="menuitem" tabindex="-1" data-key="delete" class="flex justify-between items-center px-4 py-2 sm:py-2 outline-none text-sm font-sans transition text-black cursor-pointer hover:opacity-60">
+  <div>
+    <%= link_to t("backoffice.common.delete"), path,
+       data: {
+         turbo_method: :delete,
+         turbo_confirm: t("backoffice.messages.delete_confirmation", model: model.downcase)
+       } %>
+  </div>
+</li>

--- a/backend/app/views/backoffice/base/menu/_delete.html.erb
+++ b/backend/app/views/backoffice/base/menu/_delete.html.erb
@@ -1,9 +1,0 @@
-<li aria-disabled="false" role="menuitem" tabindex="-1" data-key="delete" class="flex justify-between items-center px-4 py-2 sm:py-2 outline-none text-sm font-sans transition text-black cursor-pointer hover:opacity-60">
-  <div>
-    <%= link_to t("backoffice.common.delete"), path,
-       data: {
-         turbo_method: :delete,
-         turbo_confirm: t("backoffice.messages.delete_confirmation", model: model.downcase)
-       } %>
-  </div>
-</li>

--- a/backend/app/views/backoffice/base/menu/_item.html.erb
+++ b/backend/app/views/backoffice/base/menu/_item.html.erb
@@ -1,0 +1,5 @@
+<li role="menuitem" tabindex="-1" class="flex justify-between items-center px-4 py-2 sm:py-2 outline-none text-sm font-sans transition text-black cursor-pointer hover:opacity-60">
+  <div>
+    <%= yield if yield.present? %>
+  </div>
+</li>

--- a/backend/app/views/backoffice/users/_form.html.erb
+++ b/backend/app/views/backoffice/users/_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for [:backoffice, admin] do |f| %>
+<%= simple_form_for [:backoffice, user] do |f| %>
   <%= f.error_notification %>
   <%= hidden_field_tag :section, params[:section] %>
 
@@ -6,13 +6,12 @@
     <%= t(".information") %>
   </h2>
 
+  <%= f.input :avatar, as: :file, input_html: { accept: "image/*" } %>
   <%= f.input :first_name %>
   <%= f.input :last_name %>
-  <%= f.input :ui_language, collection: Language.all %>
-  <%= f.input :email, required: true %>
 
   <div class="mt-3 flex justify-end gap-3">
-    <%= link_to t("backoffice.common.cancel"), backoffice_admins_path, class: "button button-secondary-green" %>
+    <%= link_to t("backoffice.common.cancel"), backoffice_users_path, class: "button button-secondary-green" %>
     <%= f.button :submit, t("backoffice.common.save"), class: "button button-primary-green" %>
   </div>
 <% end %>

--- a/backend/app/views/backoffice/users/_section_information.html.erb
+++ b/backend/app/views/backoffice/users/_section_information.html.erb
@@ -1,0 +1,1 @@
+<%= render "form", user: @user %>

--- a/backend/app/views/backoffice/users/edit.html.erb
+++ b/backend/app/views/backoffice/users/edit.html.erb
@@ -1,0 +1,23 @@
+<div class="flex">
+  <aside class="w-2/6">
+    <h1 class="font-semibold text-xl text-black mb-8">
+      <%= @user.full_name %>
+    </h1>
+
+    <ul class="flex flex-col gap-8 mb-8">
+      <li><%= section_link_to t("backoffice.users.information"), edit_backoffice_user_path, :information, default: true %></li>
+    </ul>
+    <%= link_to backoffice_user_path(@user.id),
+       data: {
+         turbo_method: :delete,
+         turbo_confirm: t("backoffice.messages.delete_confirmation", model: t("backoffice.common.user").downcase)
+       },
+       class: "button button-secondary-green button-with-icon" do %>
+      <%= svg "trash" %>
+      <%= t("backoffice.users.delete") %>
+    <% end %>
+  </aside>
+  <div class="w-full h-full bg-white rounded-xl p-6">
+    <%= render section_partial %>
+  </div>
+</div>

--- a/backend/app/views/backoffice/users/index.html.erb
+++ b/backend/app/views/backoffice/users/index.html.erb
@@ -21,6 +21,9 @@
       <th>
         <%= sort_link @q, :last_sign_in_at, t("backoffice.users.index.last_sign_in_at") %>
       </th>
+      <th>
+      </th>
+      <th class="opacity-25"><%= svg "menu" %></th>
     </tr>
   </thead>
   <tbody>
@@ -28,9 +31,15 @@
       <tr>
         <td><%= user.full_name %></td>
         <td><%= user.email %></td>
-        <td><%= user.account&.name %></td>
+        <td><%= account_link_for user.account %></td>
         <td><%= I18n.l user.created_at.to_date %></td>
         <td><%= I18n.l user.last_sign_in_at&.to_date, default: '' %></td>
+        <td><%= link_to t("backoffice.common.edit"), edit_backoffice_user_path(user.id), class: "link-button" %></td>
+        <td>
+          <%= render "menu" do %>
+            <%= render "backoffice/base/menu/delete", path: backoffice_user_path(user), model: t("backoffice.common.user") %>
+          <% end %>
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/backend/app/views/backoffice/users/index.html.erb
+++ b/backend/app/views/backoffice/users/index.html.erb
@@ -37,7 +37,13 @@
         <td><%= link_to t("backoffice.common.edit"), edit_backoffice_user_path(user.id), class: "link-button" %></td>
         <td>
           <%= render "menu" do %>
-            <%= render "backoffice/base/menu/delete", path: backoffice_user_path(user), model: t("backoffice.common.user") %>
+            <%= render "backoffice/base/menu/item" do %>
+              <%= link_to t("backoffice.common.delete"), backoffice_user_path(user.id),
+                 data: {
+                   turbo_method: :delete,
+                   turbo_confirm: t("backoffice.messages.delete_confirmation", model: t("backoffice.common.user").downcase)
+                 } %>
+            <% end %>
           <% end %>
         </td>
       </tr>

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -12,6 +12,10 @@ zu:
     error_notification:
       default_message: "Please review the problems below:"
     labels:
+      user:
+        avatar: Avatar (optional)
+        first_name: First name
+        last_name: Last name
       admin:
         first_name: First name
         last_name: Last name
@@ -96,6 +100,7 @@ zu:
       investor: Investor
       project: Project
       admin: Administrator
+      user: User
       category: Category
       mosaic: Mosaic
       verified: Verified
@@ -103,6 +108,7 @@ zu:
       edit: Edit
       save: Save
       cancel: Cancel
+      delete: Delete
       view_content_in: View content in
       search_placeholder: Search
       apply: Apply
@@ -140,9 +146,13 @@ zu:
       title: Change your password
       button: Change my password
     users:
+      information: User information
+      delete: Delete user
       index:
         account: Account
         last_sign_in_at: Last login
+      form:
+        information: Information
     admins:
       information: User information
       password: Password

--- a/backend/config/routes/backoffice.rb
+++ b/backend/config/routes/backoffice.rb
@@ -20,5 +20,5 @@ namespace :backoffice do
   resources :project_developers, only: [:index, :edit, :update, :destroy]
   resources :projects, only: [:index, :edit, :update, :destroy]
   resources :admins
-  resources :users, only: [:index]
+  resources :users, only: [:index, :edit, :update, :destroy]
 end

--- a/backend/spec/factories/user.rb
+++ b/backend/spec/factories/user.rb
@@ -35,5 +35,9 @@ FactoryBot.define do
     trait :investor do
       role { "investor" }
     end
+
+    trait :with_avatar do
+      avatar { Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/files/picture.jpg"), "image/jpeg") }
+    end
   end
 end

--- a/backend/spec/fixtures/snapshots/api/v1/accounts-investor-include-relationships.json
+++ b/backend/spec/fixtures/snapshots/api/v1/accounts-investor-include-relationships.json
@@ -71,7 +71,12 @@
         "approved": true,
         "invitation": null,
         "created_at": "2022-06-24T09:07:45.229Z",
-        "owner": true
+        "owner": true,
+        "avatar": {
+          "small": null,
+          "medium": null,
+          "original": null
+        }
       }
     }
   ]

--- a/backend/spec/fixtures/snapshots/api/v1/accounts-project-developer-include-relationships.json
+++ b/backend/spec/fixtures/snapshots/api/v1/accounts-project-developer-include-relationships.json
@@ -77,7 +77,12 @@
         "approved": true,
         "invitation": null,
         "created_at": "2022-06-24T09:07:31.493Z",
-        "owner": true
+        "owner": true,
+        "avatar": {
+          "small": null,
+          "medium": null,
+          "original": null
+        }
       }
     }
   ]

--- a/backend/spec/fixtures/snapshots/api/v1/accounts-transfer-ownership.json
+++ b/backend/spec/fixtures/snapshots/api/v1/accounts-transfer-ownership.json
@@ -11,7 +11,12 @@
       "confirmed": true,
       "approved": true,
       "invitation": null,
-      "owner": true
+      "owner": true,
+      "avatar": {
+        "small": null,
+        "medium": null,
+        "original": null
+      }
     }
   }
 }

--- a/backend/spec/fixtures/snapshots/api/v1/accounts-users.json
+++ b/backend/spec/fixtures/snapshots/api/v1/accounts-users.json
@@ -12,7 +12,12 @@
         "approved": true,
         "invitation": null,
         "created_at": "2022-06-24T10:15:01.723Z",
-        "owner": true
+        "owner": true,
+        "avatar": {
+          "small": null,
+          "medium": null,
+          "original": null
+        }
       }
     },
     {
@@ -27,7 +32,12 @@
         "approved": true,
         "invitation": "completed",
         "created_at": "2022-06-24T10:15:01.772Z",
-        "owner": false
+        "owner": false,
+        "avatar": {
+          "small": null,
+          "medium": null,
+          "original": null
+        }
       }
     },
     {
@@ -42,7 +52,12 @@
         "approved": null,
         "invitation": "waiting",
         "created_at": "2022-06-24T10:15:01.782Z",
-        "owner": false
+        "owner": false,
+        "avatar": {
+          "small": null,
+          "medium": null,
+          "original": null
+        }
       }
     }
   ]

--- a/backend/spec/fixtures/snapshots/api/v1/email-confirmation.json
+++ b/backend/spec/fixtures/snapshots/api/v1/email-confirmation.json
@@ -11,7 +11,12 @@
       "approved": null,
       "invitation": null,
       "created_at": "2022-06-24T09:07:48.525Z",
-      "owner": false
+      "owner": false,
+      "avatar": {
+        "small": null,
+        "medium": null,
+        "original": null
+      }
     }
   }
 }

--- a/backend/spec/fixtures/snapshots/api/v1/invitation-accepted.json
+++ b/backend/spec/fixtures/snapshots/api/v1/invitation-accepted.json
@@ -11,7 +11,12 @@
       "approved": true,
       "invitation": "completed",
       "created_at": "2022-06-24T10:14:51.555Z",
-      "owner": false
+      "owner": false,
+      "avatar": {
+        "small": null,
+        "medium": null,
+        "original": null
+      }
     }
   }
 }

--- a/backend/spec/fixtures/snapshots/api/v1/session.json
+++ b/backend/spec/fixtures/snapshots/api/v1/session.json
@@ -11,7 +11,12 @@
       "approved": null,
       "invitation": null,
       "created_at": "2022-06-24T09:07:29.389Z",
-      "owner": false
+      "owner": false,
+      "avatar": {
+        "small": null,
+        "medium": null,
+        "original": null
+      }
     }
   }
 }

--- a/backend/spec/fixtures/snapshots/api/v1/user-create-by-invitation.json
+++ b/backend/spec/fixtures/snapshots/api/v1/user-create-by-invitation.json
@@ -11,7 +11,12 @@
       "approved": null,
       "invitation": "waiting",
       "created_at": "2022-06-24T10:15:12.699Z",
-      "owner": false
+      "owner": false,
+      "avatar": {
+        "small": null,
+        "medium": null,
+        "original": null
+      }
     }
   }
 }

--- a/backend/spec/fixtures/snapshots/api/v1/user-create.json
+++ b/backend/spec/fixtures/snapshots/api/v1/user-create.json
@@ -11,7 +11,12 @@
       "approved": null,
       "invitation": null,
       "created_at": "2022-06-24T09:06:20.081Z",
-      "owner": false
+      "owner": false,
+      "avatar": {
+        "small": null,
+        "medium": null,
+        "original": null
+      }
     }
   }
 }

--- a/backend/spec/fixtures/snapshots/api/v1/user.json
+++ b/backend/spec/fixtures/snapshots/api/v1/user.json
@@ -11,7 +11,12 @@
       "approved": null,
       "invitation": null,
       "created_at": "2022-06-24T09:06:19.915Z",
-      "owner": false
+      "owner": false,
+      "avatar": {
+        "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TWpBNU1XTXlPQzB4TlRVekxUUmxaVFF0T1dNME9TMDNZbU5sTWpRd05UVmhOV01HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--262ce624497216b948a0f82d3c509b0a85f7c5df/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg",
+        "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TWpBNU1XTXlPQzB4TlRVekxUUmxaVFF0T1dNME9TMDNZbU5sTWpRd05UVmhOV01HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--262ce624497216b948a0f82d3c509b0a85f7c5df/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg",
+        "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TWpBNU1XTXlPQzB4TlRVekxUUmxaVFF0T1dNME9TMDNZbU5sTWpRd05UVmhOV01HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--262ce624497216b948a0f82d3c509b0a85f7c5df/picture.jpg"
+      }
     }
   }
 }

--- a/backend/spec/requests/api/v1/user_spec.rb
+++ b/backend/spec/requests/api/v1/user_spec.rb
@@ -2,7 +2,7 @@ require "swagger_helper"
 
 RSpec.describe "API V1 User", type: :request do
   before_all do
-    @user = create(:user, email: "user@example.com", password: "SuperSecret1234")
+    @user = create(:user, :with_avatar, email: "user@example.com", password: "SuperSecret1234")
   end
 
   path "/api/v1/user" do

--- a/backend/spec/swagger_helper.rb
+++ b/backend/spec/swagger_helper.rb
@@ -39,11 +39,23 @@ RSpec.configure do |config|
               id: {type: :string},
               type: {type: :string},
               attributes: {
-                first_name: {type: :string},
-                last_name: {type: :string},
-                email: {type: :string}
+                type: :object,
+                properties: {
+                  first_name: {type: :string},
+                  last_name: {type: :string},
+                  email: {type: :string},
+                  role: {type: :string},
+                  created_at: {type: :string},
+                  confirmed: {type: :boolean},
+                  approved: {type: :boolean, nullable: true},
+                  invitation: {type: :string, nullable: true},
+                  owner: {type: :boolean},
+                  avatar: {"$ref" => "#/components/schemas/image_blob"}
+                },
+                required: %w[first_name last_name email role created_at confirmed approved invitation owner avatar]
               }
-            }
+            },
+            required: %w[id type attributes]
           },
           investor: {
             type: :object,
@@ -55,7 +67,7 @@ RSpec.configure do |config|
                 properties: {
                   name: {type: :string},
                   slug: {type: :string},
-                  picture_url: {type: :string},
+                  picture: {"$ref" => "#/components/schemas/image_blob"},
                   about: {type: :string, nullable: true},
                   website: {type: :string, nullable: true},
                   instagram: {type: :string, nullable: true},
@@ -221,7 +233,7 @@ RSpec.configure do |config|
                 properties: {
                   name: {type: :string},
                   slug: {type: :string},
-                  picture_url: {type: :string},
+                  picture: {"$ref" => "#/components/schemas/image_blob"},
                   about: {type: :string, nullable: true},
                   website: {type: :string, nullable: true},
                   instagram: {type: :string, nullable: true},
@@ -315,6 +327,15 @@ RSpec.configure do |config|
               }
             },
             required: %w[id key filename content_type metadata byte_size checksum created_at service_name signed_id attachable_sgid direct_upload]
+          },
+          image_blob: {
+            type: :object,
+            properties: {
+              small: {type: :string, nullable: true},
+              medium: {type: :string, nullable: true},
+              original: {type: :string, nullable: true}
+            },
+            required: %w[small medium original]
           },
           pagination_meta: {
             type: :object,

--- a/backend/spec/system/backoffice/users_spec.rb
+++ b/backend/spec/system/backoffice/users_spec.rb
@@ -2,15 +2,15 @@ require "system_helper"
 
 RSpec.describe "Backoffice: Users", type: :system do
   let!(:admin) { create(:admin, email: "admin@example.com", password: "SuperSecret6", first_name: "Admin", last_name: "Example") }
-  let!(:user) { create(:account).owner }
-  let!(:users) { create_list :user, 2 }
+  let!(:owner) { create(:project_developer).owner }
+  let!(:user) { create :user }
 
   before { sign_in admin }
 
   describe "Index" do
     before { visit "/backoffice/users" }
 
-    it_behaves_like "with table pagination", expected_total: 3
+    it_behaves_like "with table pagination", expected_total: 2
     it_behaves_like "with table sorting", columns: [
       I18n.t("backoffice.common.name"),
       I18n.t("backoffice.common.email"),
@@ -21,22 +21,81 @@ RSpec.describe "Backoffice: Users", type: :system do
     it_behaves_like "with csv export", file_name: "users.csv"
 
     it "shows users list" do
-      within_row(user.full_name) do
-        expect(page).to have_text(user.email)
-        expect(page).to have_text(user.account.name)
-        expect(page).to have_text(I18n.l(user.created_at.to_date))
-        expect(page).to have_text(I18n.l(user.last_sign_in_at&.to_date, default: ""))
+      within_row(owner.full_name) do
+        expect(page).to have_text(owner.email)
+        expect(page).to have_text(owner.account.name)
+        expect(page).to have_text(I18n.l(owner.created_at.to_date))
+        expect(page).to have_text(I18n.l(owner.last_sign_in_at&.to_date, default: ""))
       end
     end
 
     context "when searching" do
       it "shows only found users" do
+        expect(page).to have_text(owner.full_name)
         expect(page).to have_text(user.full_name)
-        users.each { |u| expect(page).to have_text(u.full_name) }
-        fill_in :q_filter_full_text, with: user.full_name
+        fill_in :q_filter_full_text, with: owner.full_name
         find("form.user_search button").click
-        expect(page).to have_text(user.full_name)
-        users.each { |u| expect(page).not_to have_text(u.full_name) }
+        expect(page).to have_text(owner.full_name)
+        expect(page).not_to have_text(user.full_name)
+      end
+    end
+
+    context "when deleting user via menu" do
+      it "deletes user" do
+        within_row(user.full_name) do
+          find("button.rounded-full").click
+          accept_confirm do
+            click_on t("backoffice.common.delete")
+          end
+        end
+        expect(page).not_to have_text(user.full_name)
+      end
+    end
+  end
+
+  describe "Edit" do
+    before do
+      visit "/backoffice/users"
+      within_row(user.full_name) do
+        click_on t("backoffice.common.edit")
+      end
+    end
+
+    context "user information section" do
+      context "when content is correct" do
+        it "can update admin information" do
+          attach_file t("simple_form.labels.user.avatar"), Rails.root.join("spec/fixtures/files/picture.jpg")
+          fill_in t("simple_form.labels.user.first_name"), with: "First Name"
+          fill_in t("simple_form.labels.user.last_name"), with: "Last Name"
+          click_on t("backoffice.common.save")
+
+          expect(page).to have_text(t("backoffice.messages.success_update", model: t("backoffice.common.user")))
+          user.reload
+          expect(user.avatar.filename.to_s).to eq("picture.jpg")
+          expect(user.first_name).to eq("First Name")
+          expect(user.last_name).to eq("Last Name")
+        end
+      end
+
+      context "when content is incorrect" do
+        it "shows validation errors" do
+          fill_in t("simple_form.labels.user.first_name"), with: ""
+          click_on t("backoffice.common.save")
+
+          expect(page).to have_text(t("simple_form.error_notification.default_message"))
+          expect(page).to have_text("First name can't be blank")
+        end
+      end
+    end
+
+    context "when removing user" do
+      it "removes user" do
+        accept_confirm do
+          click_on t("backoffice.users.delete")
+        end
+        expect(page).to have_text(t("backoffice.messages.success_delete", model: t("backoffice.common.user")))
+        expect(current_path).to eql(backoffice_users_path)
+        expect(page).not_to have_text(user.full_name)
       end
     end
   end

--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -34,7 +34,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 3f20716c-c88b-4b2d-9a54-d55d65372c17
+                  id: c6baadfd-5f44-4ffc-bad2-59055f991bae
                   type: investor
                   attributes:
                     name: Kutch-Spencer
@@ -72,18 +72,18 @@ paths:
                     previously_invested: true
                     language: en
                     review_status: approved
-                    created_at: '2022-07-07T10:47:17.797Z'
+                    created_at: '2022-07-14T12:52:51.490Z'
                     contact_email: contact@example.com
                     contact_phone: "+57-1-xxx-xx-xx"
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4TXpRMk1qbG1aUzB5T1dReUxUUXlPREV0WW1RMk5TMWlZemc0TVRabE1qTTJOR1FHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--7014edcb33534a938b98f1fe069d7b1ba9aac982/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4TXpRMk1qbG1aUzB5T1dReUxUUXlPREV0WW1RMk5TMWlZemc0TVRabE1qTTJOR1FHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--7014edcb33534a938b98f1fe069d7b1ba9aac982/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4TXpRMk1qbG1aUzB5T1dReUxUUXlPREV0WW1RMk5TMWlZemc0TVRabE1qTTJOR1FHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--7014edcb33534a938b98f1fe069d7b1ba9aac982/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswT0dReU16azVOaTA0WXpsa0xUUTJabVF0WWpNMU1pMWlNREEzTURoaU1ETmhNR1VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--d7a5de9a5fe06004582b18e785d4263297a6ae70/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswT0dReU16azVOaTA0WXpsa0xUUTJabVF0WWpNMU1pMWlNREEzTURoaU1ETmhNR1VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--d7a5de9a5fe06004582b18e785d4263297a6ae70/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswT0dReU16azVOaTA0WXpsa0xUUTJabVF0WWpNMU1pMWlNREEzTURoaU1ETmhNR1VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--d7a5de9a5fe06004582b18e785d4263297a6ae70/picture.jpg
                     favourite: false
                   relationships:
                     owner:
                       data:
-                        id: c361e95d-9b80-49a7-a887-07409fe46242
+                        id: a0bd4cfc-9781-4f9d-a737-9aab059820e6
                         type: user
               schema:
                 type: object
@@ -113,7 +113,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: b52f2a4c-a0dc-447d-bfc3-8a5126ca60ff
+                  id: 0357f759-8040-49ea-aa41-f6c8019d229a
                   type: investor
                   attributes:
                     name: Name
@@ -146,18 +146,18 @@ paths:
                     previously_invested: true
                     language: en
                     review_status: unapproved
-                    created_at: '2022-07-07T10:47:18.194Z'
+                    created_at: '2022-07-14T12:52:51.968Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6T0dWaU5HRmhNUzAwWkRWa0xUUXpNRGd0WVdKaU1TMWhORFV6WmpZMU9EQXpaV0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--3a3a05247ab0c084e15220248959d972cf8e30e5/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6T0dWaU5HRmhNUzAwWkRWa0xUUXpNRGd0WVdKaU1TMWhORFV6WmpZMU9EQXpaV0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--3a3a05247ab0c084e15220248959d972cf8e30e5/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6T0dWaU5HRmhNUzAwWkRWa0xUUXpNRGd0WVdKaU1TMWhORFV6WmpZMU9EQXpaV0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--3a3a05247ab0c084e15220248959d972cf8e30e5/test
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0TlRSalptVmhaUzFsTlRSaExUUXpNRGN0T0dObFlTMHlPREEzTkdaaFpUa3lOR1VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e6f6c38926076f97b7ec33c8e831bca836744217/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0TlRSalptVmhaUzFsTlRSaExUUXpNRGN0T0dObFlTMHlPREEzTkdaaFpUa3lOR1VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e6f6c38926076f97b7ec33c8e831bca836744217/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0TlRSalptVmhaUzFsTlRSaExUUXpNRGN0T0dObFlTMHlPREEzTkdaaFpUa3lOR1VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e6f6c38926076f97b7ec33c8e831bca836744217/test
                     favourite: false
                   relationships:
                     owner:
                       data:
-                        id: a2d9b0e9-bb0f-4c8f-897d-c6a823253736
+                        id: 49e1cda0-d7ae-4360-8a6f-4d04a10a936e
                         type: user
               schema:
                 type: object
@@ -327,7 +327,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 4c1e014b-8bc6-405f-84bb-43eb09cdfd3d
+                  id: a51fd8df-3742-4fe4-8772-3d97371fc004
                   type: investor
                   attributes:
                     name: Name
@@ -360,18 +360,18 @@ paths:
                     previously_invested: true
                     language: en
                     review_status: approved
-                    created_at: '2022-07-07T10:47:18.774Z'
+                    created_at: '2022-07-14T12:52:52.698Z'
                     contact_email: contact@example.com
                     contact_phone: '123456789'
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyWXpRME5ETTVZUzAxT1RSaExUUmpaRGd0T1RKalpTMWhNMkkxWVRJeFlUUTNNVElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--fc05d334bda6a20dea9a0b19e91d256a7adc2a82/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyWXpRME5ETTVZUzAxT1RSaExUUmpaRGd0T1RKalpTMWhNMkkxWVRJeFlUUTNNVElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--fc05d334bda6a20dea9a0b19e91d256a7adc2a82/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyWXpRME5ETTVZUzAxT1RSaExUUmpaRGd0T1RKalpTMWhNMkkxWVRJeFlUUTNNVElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--fc05d334bda6a20dea9a0b19e91d256a7adc2a82/test
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpTWpnM00ySXdPUzAwTm1NNExUUTNZVE10T1RBell5MWhORGhtT0RRMU56RmhOemdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--744a683f985f97a958514439f0b9ff904fe8dba1/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpTWpnM00ySXdPUzAwTm1NNExUUTNZVE10T1RBell5MWhORGhtT0RRMU56RmhOemdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--744a683f985f97a958514439f0b9ff904fe8dba1/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpTWpnM00ySXdPUzAwTm1NNExUUTNZVE10T1RBell5MWhORGhtT0RRMU56RmhOemdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--744a683f985f97a958514439f0b9ff904fe8dba1/test
                     favourite: false
                   relationships:
                     owner:
                       data:
-                        id: bd8432f1-e9c7-4283-a70c-4db7a98642d1
+                        id: 8b383279-e18e-4bcc-9fd6-32034f3ccd7c
                         type: user
               schema:
                 type: object
@@ -519,7 +519,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 6ff100d6-ba1e-48ac-8cdc-bced8ac0724f
+                  id: 7556d496-45e6-446b-83d1-be26fc0ba965
                   type: project_developer
                   attributes:
                     name: Kutch-Spencer
@@ -546,26 +546,26 @@ paths:
                     mosaics:
                     - amazon-heart
                     - amazonian-piedmont-massif
-                    created_at: '2022-07-07T10:47:20.027Z'
+                    created_at: '2022-07-14T12:52:54.592Z'
                     contact_email: contact@example.com
                     contact_phone: "+57-1-xxx-xx-xx"
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswTm1VMU56VmhNQzFpT1RobExUUmhOelV0T1dRd05TMDNOekk0TkdVMU1EWXlOMlVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--1eece928063debcbc984221c7fe3cd81f1b5f7d1/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswTm1VMU56VmhNQzFpT1RobExUUmhOelV0T1dRd05TMDNOekk0TkdVMU1EWXlOMlVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--1eece928063debcbc984221c7fe3cd81f1b5f7d1/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswTm1VMU56VmhNQzFpT1RobExUUmhOelV0T1dRd05TMDNOekk0TkdVMU1EWXlOMlVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--1eece928063debcbc984221c7fe3cd81f1b5f7d1/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxWldOaU9UUTNaaTB4TUdFeUxUUXdOREV0T0RKaE5DMHlORFk1TVRVME1EWTVaVElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--86305e92665fac334231e834f99ca0e2eeea422e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxWldOaU9UUTNaaTB4TUdFeUxUUXdOREV0T0RKaE5DMHlORFk1TVRVME1EWTVaVElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--86305e92665fac334231e834f99ca0e2eeea422e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxWldOaU9UUTNaaTB4TUdFeUxUUXdOREV0T0RKaE5DMHlORFk1TVRVME1EWTVaVElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--86305e92665fac334231e834f99ca0e2eeea422e/picture.jpg
                     favourite: false
                   relationships:
                     owner:
                       data:
-                        id: ca471a4d-7d54-4447-a902-4d04a78d4f25
+                        id: 9367869f-f6ce-40d3-a3e3-68915fd9d74d
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data:
-                      - id: 0b220444-b089-471d-ae3f-33e60ca261f3
+                      - id: e3b64359-8d5c-471b-83d0-7eb7b2856447
                         type: project
-                      - id: 6492ece8-8cf8-4e75-b72f-4fec6f96ee53
+                      - id: '03099176-b5fc-4822-b648-d06af4582da0'
                         type: project
               schema:
                 type: object
@@ -595,7 +595,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 406bcf7a-6d31-43d0-b8f6-495cee93aa39
+                  id: 555c0bbb-bef9-4194-979f-9ab4016a3182
                   type: project_developer
                   attributes:
                     name: Name
@@ -619,18 +619,18 @@ paths:
                     review_status: unapproved
                     mosaics:
                     - amazon-heart
-                    created_at: '2022-07-07T10:47:20.819Z'
+                    created_at: '2022-07-14T12:52:55.379Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswTURrMU1qRmlOUzB6TVdRd0xUUTRPRE10T1RKbU1DMWtOamMwWkdRNU1qVTVNVFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--17f2a6b912366d84782b97b3c16cc07a0c5b3b52/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswTURrMU1qRmlOUzB6TVdRd0xUUTRPRE10T1RKbU1DMWtOamMwWkdRNU1qVTVNVFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--17f2a6b912366d84782b97b3c16cc07a0c5b3b52/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswTURrMU1qRmlOUzB6TVdRd0xUUTRPRE10T1RKbU1DMWtOamMwWkdRNU1qVTVNVFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--17f2a6b912366d84782b97b3c16cc07a0c5b3b52/test
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TjJZNU5EQTRNUzB3WmpsakxUUmpNemN0T0dVMFlpMW1PV1kxWTJFek5UazJOak1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--fd34426175c4bf8f562b149732c5d3ca63f9f61d/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TjJZNU5EQTRNUzB3WmpsakxUUmpNemN0T0dVMFlpMW1PV1kxWTJFek5UazJOak1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--fd34426175c4bf8f562b149732c5d3ca63f9f61d/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TjJZNU5EQTRNUzB3WmpsakxUUmpNemN0T0dVMFlpMW1PV1kxWTJFek5UazJOak1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--fd34426175c4bf8f562b149732c5d3ca63f9f61d/test
                     favourite: false
                   relationships:
                     owner:
                       data:
-                        id: bf92972f-39bd-4746-8391-0f048cc2049b
+                        id: 0d9587ee-0164-416c-b5a2-96238911e654
                         type: user
                     projects:
                       data: []
@@ -765,7 +765,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 5d7a078b-49a8-419c-a4f4-3805265b67b6
+                  id: dc52b0de-4f7f-44e6-a1ff-6aa6b9fa6542
                   type: project_developer
                   attributes:
                     name: Name
@@ -789,18 +789,18 @@ paths:
                     review_status: approved
                     mosaics:
                     - amazon-heart
-                    created_at: '2022-07-07T10:47:21.440Z'
+                    created_at: '2022-07-14T12:52:56.087Z'
                     contact_email: contact@example.com
                     contact_phone: "+57-1-xxx-xx-xx"
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtT1dWak9XSTRaaTA0TURFNExUUXlaRGN0WWpGbU9DMWxPV00yTlRZd1l6VmtOR0lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--b486117a6a0eee5dca39fca1d2a45f6417024089/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtT1dWak9XSTRaaTA0TURFNExUUXlaRGN0WWpGbU9DMWxPV00yTlRZd1l6VmtOR0lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--b486117a6a0eee5dca39fca1d2a45f6417024089/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtT1dWak9XSTRaaTA0TURFNExUUXlaRGN0WWpGbU9DMWxPV00yTlRZd1l6VmtOR0lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--b486117a6a0eee5dca39fca1d2a45f6417024089/test
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TldZMk56QXdNUzAwTW1VeUxUUTNaV010T1RnMk5pMHpOemMzT1dOaFpUYzRNamtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--336402c71d63c6b00917e2f1a754f650a1f7eb46/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TldZMk56QXdNUzAwTW1VeUxUUTNaV010T1RnMk5pMHpOemMzT1dOaFpUYzRNamtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--336402c71d63c6b00917e2f1a754f650a1f7eb46/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TldZMk56QXdNUzAwTW1VeUxUUTNaV010T1RnMk5pMHpOemMzT1dOaFpUYzRNamtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--336402c71d63c6b00917e2f1a754f650a1f7eb46/test
                     favourite: false
                   relationships:
                     owner:
                       data:
-                        id: a19690c0-fdf6-47dc-93ae-9f9009aaaf69
+                        id: 32e49d92-b42d-4e21-9541-bc2683961a6b
                         type: user
                     projects:
                       data: []
@@ -925,7 +925,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: 921bf1e8-2e0c-4247-9ca5-9120e55af46c
+                - id: dd108502-b3fb-4ca1-9414-8d7f71e1d99c
                   type: project
                   attributes:
                     name: Draft project
@@ -977,7 +977,7 @@ paths:
                       - 1.0
                       - 2.0
                     trusted: false
-                    created_at: '2022-07-07T10:47:22.719Z'
+                    created_at: '2022-07-14T12:52:58.134Z'
                     municipality_biodiversity_impact:
                     municipality_climate_impact:
                     municipality_water_impact:
@@ -999,19 +999,19 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: b9614d7f-ba9b-4328-b424-52b40b160b5a
+                        id: 37b43ace-fa4b-412c-9710-82674d6d376d
                         type: project_developer
                     country:
                       data:
-                        id: '095ebe81-e0db-4290-b40a-71b314019c10'
+                        id: 34d50f48-a9a2-41b9-a709-21ca867e331d
                         type: location
                     municipality:
                       data:
-                        id: 0421a28c-d75f-4b7e-85e6-9897c976cdbc
+                        id: 601ca4dc-c843-463a-a0d5-4f63e836cc12
                         type: location
                     department:
                       data:
-                        id: da231930-83d3-4751-a8df-07e229f6e9be
+                        id: a8a42230-6216-42d4-a965-4b84d005842c
                         type: location
                     priority_landscape:
                       data:
@@ -1019,7 +1019,7 @@ paths:
                       data: []
                     project_images:
                       data: []
-                - id: a310bca7-1de0-4afb-9568-799d024b0484
+                - id: fbdcd1c8-6c69-4864-8cbf-4c4c9545d5ca
                   type: project
                   attributes:
                     name: This PDs Project Amazing
@@ -1071,7 +1071,7 @@ paths:
                       - 1.0
                       - 2.0
                     trusted: false
-                    created_at: '2022-07-07T10:47:22.561Z'
+                    created_at: '2022-07-14T12:52:57.877Z'
                     municipality_biodiversity_impact:
                     municipality_climate_impact:
                     municipality_water_impact:
@@ -1093,19 +1093,19 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: b9614d7f-ba9b-4328-b424-52b40b160b5a
+                        id: 37b43ace-fa4b-412c-9710-82674d6d376d
                         type: project_developer
                     country:
                       data:
-                        id: 15a5e7da-a1de-4f19-822d-f3e4a844b708
+                        id: ac02a2de-3093-4482-8b0f-613d34bad65d
                         type: location
                     municipality:
                       data:
-                        id: 3bf0d74b-75e0-4252-8ffe-c46a526010c4
+                        id: 7e114726-df0f-4faa-abff-55229753b3ec
                         type: location
                     department:
                       data:
-                        id: c31fa10b-0705-47d8-ad82-5b9b272a8f45
+                        id: 29488ca4-4114-4ba1-bc09-e5e96930201d
                         type: location
                     priority_landscape:
                       data:
@@ -1113,7 +1113,7 @@ paths:
                       data: []
                     project_images:
                       data: []
-                - id: 3af3e66e-4092-4b11-9135-b2e7e4278255
+                - id: 67909f41-585f-48cd-90b7-ae9ee9f93b0f
                   type: project
                   attributes:
                     name: This PDs Project Awesome
@@ -1165,7 +1165,7 @@ paths:
                       - 1.0
                       - 2.0
                     trusted: false
-                    created_at: '2022-07-07T10:47:22.510Z'
+                    created_at: '2022-07-14T12:52:57.775Z'
                     municipality_biodiversity_impact:
                     municipality_climate_impact:
                     municipality_water_impact:
@@ -1187,19 +1187,19 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: b9614d7f-ba9b-4328-b424-52b40b160b5a
+                        id: 37b43ace-fa4b-412c-9710-82674d6d376d
                         type: project_developer
                     country:
                       data:
-                        id: 6fa76ffe-1db0-45be-a65c-934393ff878a
+                        id: 8071e652-9bed-426f-8aa1-cab574c880a2
                         type: location
                     municipality:
                       data:
-                        id: d89ea600-d4bf-42eb-9938-6fd7ff20d4ba
+                        id: c9fda91f-f2bd-42e4-aff7-d06fa4bc02c9
                         type: location
                     department:
                       data:
-                        id: f15ada7c-2e47-4d4d-8ac3-78b9130e762a
+                        id: 59158b9e-b379-4ed4-80a1-c9cfd5fe8750
                         type: location
                     priority_landscape:
                       data:
@@ -1237,7 +1237,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 10616efa-0482-4af8-8459-a35b15ef22d2
+                  id: 0b6f321a-7c41-457c-a8e9-14cb2e391ea0
                   type: project
                   attributes:
                     name: Project Name
@@ -1293,7 +1293,7 @@ paths:
                               - 1.5274297752414188
                         properties: {}
                     trusted: false
-                    created_at: '2022-07-07T10:47:25.462Z'
+                    created_at: '2022-07-14T12:53:01.694Z'
                     municipality_biodiversity_impact:
                     municipality_climate_impact:
                     municipality_water_impact:
@@ -1315,53 +1315,53 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 9c8af633-178d-4f02-824c-e9f6bd686379
+                        id: 03f5a167-9a86-47c2-b4ba-fe0bf45a9cf1
                         type: project_developer
                     country:
                       data:
-                        id: caea616a-dd52-4ea1-9741-3137404b5251
+                        id: 7264925f-2b20-41c1-9eb3-5794d429ff6d
                         type: location
                     municipality:
                       data:
-                        id: e5e465a6-2b6f-4559-9fab-ac21c2dbefe7
+                        id: 0e23969b-c7de-4190-b068-b16aa165258f
                         type: location
                     department:
                       data:
-                        id: 925e7ac3-8e39-4318-9e44-c8cbfc6031e5
+                        id: 2725f49a-de3d-4ec9-ae9e-51d7d4c46ef2
                         type: location
                     priority_landscape:
                       data:
                     involved_project_developers:
                       data:
-                      - id: 11019857-18f4-4da3-969e-297b92489027
+                      - id: 7401a119-aa93-42dd-89ab-a7401d47164d
                         type: project_developer
-                      - id: d6f0f0ad-c7f5-4684-8e78-d99a811925f6
+                      - id: cab9f705-90f5-4f9a-a480-162571301838
                         type: project_developer
                     project_images:
                       data:
-                      - id: d463e15f-d050-49e4-b514-3c3b88f4146e
+                      - id: 18a32866-ae1d-4c91-b16f-f1c05bb9651a
                         type: project_image
-                      - id: 4c4b351e-f9f6-45c0-8ced-d852f1a2bf38
+                      - id: 47f03d96-b706-4ad8-97a7-847e2f77e857
                         type: project_image
                 included:
-                - id: d463e15f-d050-49e4-b514-3c3b88f4146e
+                - id: 18a32866-ae1d-4c91-b16f-f1c05bb9651a
                   type: project_image
                   attributes:
                     cover: true
-                    created_at: '2022-07-07T10:47:25.471Z'
+                    created_at: '2022-07-14T12:53:01.700Z'
                     file:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoWlRrellqZGlaaTA0WVRJMkxUUTFaV0V0T1RobE55MDFObU5pTldGaE5UTTFOalFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6565ab24a371ca33c505daf0a87f559370cd0940/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoWlRrellqZGlaaTA0WVRJMkxUUTFaV0V0T1RobE55MDFObU5pTldGaE5UTTFOalFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6565ab24a371ca33c505daf0a87f559370cd0940/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoWlRrellqZGlaaTA0WVRJMkxUUTFaV0V0T1RobE55MDFObU5pTldGaE5UTTFOalFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6565ab24a371ca33c505daf0a87f559370cd0940/test
-                - id: 4c4b351e-f9f6-45c0-8ced-d852f1a2bf38
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrTjJOak1HWXhOaTB4WVROakxUUTBPVGN0T0RVd01pMDVNVE0xWldabFpqSXdZVEFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--39a8d20fb212037f9dacaf2c58c5e1d058566097/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrTjJOak1HWXhOaTB4WVROakxUUTBPVGN0T0RVd01pMDVNVE0xWldabFpqSXdZVEFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--39a8d20fb212037f9dacaf2c58c5e1d058566097/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrTjJOak1HWXhOaTB4WVROakxUUTBPVGN0T0RVd01pMDVNVE0xWldabFpqSXdZVEFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--39a8d20fb212037f9dacaf2c58c5e1d058566097/test
+                - id: 47f03d96-b706-4ad8-97a7-847e2f77e857
                   type: project_image
                   attributes:
                     cover: false
-                    created_at: '2022-07-07T10:47:25.479Z'
+                    created_at: '2022-07-14T12:53:01.709Z'
                     file:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoWlRrellqZGlaaTA0WVRJMkxUUTFaV0V0T1RobE55MDFObU5pTldGaE5UTTFOalFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6565ab24a371ca33c505daf0a87f559370cd0940/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoWlRrellqZGlaaTA0WVRJMkxUUTFaV0V0T1RobE55MDFObU5pTldGaE5UTTFOalFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6565ab24a371ca33c505daf0a87f559370cd0940/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoWlRrellqZGlaaTA0WVRJMkxUUTFaV0V0T1RobE55MDFObU5pTldGaE5UTTFOalFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6565ab24a371ca33c505daf0a87f559370cd0940/test
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrTjJOak1HWXhOaTB4WVROakxUUTBPVGN0T0RVd01pMDVNVE0xWldabFpqSXdZVEFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--39a8d20fb212037f9dacaf2c58c5e1d058566097/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrTjJOak1HWXhOaTB4WVROakxUUTBPVGN0T0RVd01pMDVNVE0xWldabFpqSXdZVEFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--39a8d20fb212037f9dacaf2c58c5e1d058566097/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrTjJOak1HWXhOaTB4WVROakxUUTBPVGN0T0RVd01pMDVNVE0xWldabFpqSXdZVEFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--39a8d20fb212037f9dacaf2c58c5e1d058566097/test
               schema:
                 type: object
                 properties:
@@ -1603,7 +1603,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 44d4e46c-6a35-47ca-98ae-238e5743f4c0
+                  id: a852ba03-6e08-4a77-ae51-ee061f63c64e
                   type: project
                   attributes:
                     name: Updated Project Name
@@ -1646,7 +1646,7 @@ paths:
                       - 1
                       - 2
                     trusted: false
-                    created_at: '2022-07-07T10:47:29.825Z'
+                    created_at: '2022-07-14T12:53:06.872Z'
                     municipality_biodiversity_impact:
                     municipality_climate_impact:
                     municipality_water_impact:
@@ -1668,31 +1668,31 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: a9da80cd-44d1-4374-8f73-3af05c322bd0
+                        id: 6f6a7dd2-cd8d-4ca5-873c-fd794234f4a6
                         type: project_developer
                     country:
                       data:
-                        id: 2070b75d-52b7-4d88-a138-a50a57575c01
+                        id: 2f85dbfa-2586-4ed4-aa11-39e5645ccaf4
                         type: location
                     municipality:
                       data:
-                        id: bcb6d606-f546-4044-88f3-5c1a807e2bbc
+                        id: 1ec54431-f0a3-4ada-bd2b-5b6b2c37e296
                         type: location
                     department:
                       data:
-                        id: 411337c8-1667-442e-8f7d-936798ce65b1
+                        id: e4520e18-959a-4220-8d2c-8e7c3df4691c
                         type: location
                     priority_landscape:
                       data:
                     involved_project_developers:
                       data:
-                      - id: 54e1a976-34f7-4d13-ba0d-000b9ce4a08c
+                      - id: 97b4c7bd-bd7f-4781-b818-5d399b33ceee
                         type: project_developer
-                      - id: d74087a1-c232-4f91-b5b4-cf6f67708e88
+                      - id: 1e04affe-3aab-46f6-a486-8585b3e0466c
                         type: project_developer
                     project_images:
                       data:
-                      - id: 638868e6-33f7-4b7c-926b-2d87e75a0b62
+                      - id: cecc152a-3601-401a-b7d6-791c19c7e03b
                         type: project_image
               schema:
                 type: object
@@ -1905,42 +1905,54 @@ paths:
             application/json:
               example:
                 data:
-                - id: ebd5974c-70fd-492d-b991-ed30a9f50827
+                - id: e434fc85-9de9-4f61-916f-f28a664c81e1
                   type: user
                   attributes:
                     first_name: Dawna
                     last_name: Block
                     email: dawna.block@example.org
                     role: light
-                    created_at: '2022-07-07T10:47:31.990Z'
+                    created_at: '2022-07-14T12:53:09.516Z'
                     confirmed: true
                     approved: true
                     invitation:
                     owner: true
-                - id: 5f4075c9-4497-4294-b93e-4a68e7485261
+                    avatar:
+                      small:
+                      medium:
+                      original:
+                - id: b37b6d21-872d-4634-a0f6-de79235270dc
                   type: user
                   attributes:
                     first_name: Desmond
                     last_name: Herzog
                     email: desmond_herzog@example.org
                     role: light
-                    created_at: '2022-07-07T10:47:32.041Z'
+                    created_at: '2022-07-14T12:53:09.572Z'
                     confirmed: true
                     approved: true
                     invitation: completed
                     owner: false
-                - id: 64841a4b-841c-41c9-a37c-eb56f94247f3
+                    avatar:
+                      small:
+                      medium:
+                      original:
+                - id: 7fd7a1c7-6136-4b1a-846b-ac32ceca1ffc
                   type: user
                   attributes:
                     first_name: Raymon
                     last_name: Runte
                     email: runte_raymon@example.org
                     role: light
-                    created_at: '2022-07-07T10:47:32.050Z'
+                    created_at: '2022-07-14T12:53:09.583Z'
                     confirmed: true
                     approved:
                     invitation: waiting
                     owner: false
+                    avatar:
+                      small:
+                      medium:
+                      original:
               schema:
                 type: object
                 properties:
@@ -2023,18 +2035,22 @@ paths:
             application/json:
               example:
                 data:
-                  id: 635a908d-bb0d-4d64-a530-50ec2fc7b825
+                  id: 31d7df50-1eda-4ae9-902a-b687001fcf2e
                   type: user
                   attributes:
                     first_name: Desmond
                     last_name: Herzog
                     email: desmond_herzog@example.org
                     role: light
-                    created_at: '2022-07-07T10:47:33.962Z'
+                    created_at: '2022-07-14T12:53:12.166Z'
                     confirmed: true
                     approved: true
                     invitation:
                     owner: true
+                    avatar:
+                      small:
+                      medium:
+                      original:
               schema:
                 type: object
                 properties:
@@ -2046,7 +2062,7 @@ paths:
             application/json:
               example:
                 errors:
-                - title: Couldn't find User with 'id'=63eed055-2270-4b71-8af5-5ae476efeb2f
+                - title: Couldn't find User with 'id'=2335805c-4d62-4636-b8ed-987594d7b3e4
                     [WHERE "users"."account_id" = $1]
               schema:
                 "$ref": "#/components/schemas/errors"
@@ -2104,7 +2120,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: bbbc8928-39c6-4430-9723-7eea50f54330
+                - id: c5681b30-54f2-4d8f-a330-d4e92869bc6c
                   type: background_job_event
                   attributes:
                     status: enqueued
@@ -2114,9 +2130,9 @@ paths:
                     priority:
                     executions: 1
                     message:
-                    created_at: '2022-06-27T10:47:34.296Z'
-                    updated_at: '2022-07-07T10:47:34.297Z'
-                - id: d5a9b419-fd88-4840-8b5a-72ac58fd7de4
+                    created_at: '2022-07-04T12:53:12.533Z'
+                    updated_at: '2022-07-14T12:53:12.533Z'
+                - id: 3378cbb7-7265-4a94-a9c9-cc2c3967a89e
                   type: background_job_event
                   attributes:
                     status: crashed
@@ -2126,8 +2142,8 @@ paths:
                     priority:
                     executions: 1
                     message:
-                    created_at: '2022-07-07T10:47:34.293Z'
-                    updated_at: '2022-07-07T10:47:34.293Z'
+                    created_at: '2022-07-14T12:53:12.529Z'
+                    updated_at: '2022-07-14T12:53:12.529Z'
                 meta:
                   page: 1
                   per_page: 10
@@ -2188,18 +2204,22 @@ paths:
             application/json:
               example:
                 data:
-                  id: 6d3ce95d-691f-479f-bc5a-49ec6560019e
+                  id: 0400aefc-28e6-4767-90d4-a85f3e6f6d46
                   type: user
                   attributes:
                     first_name: Dawna
                     last_name: Block
                     email: user@example.com
                     role: light
-                    created_at: '2022-07-07T10:47:34.666Z'
+                    created_at: '2022-07-14T12:53:13.313Z'
                     confirmed: true
                     approved:
                     invitation:
                     owner: false
+                    avatar:
+                      small:
+                      medium:
+                      original:
               schema:
                 type: object
                 properties:
@@ -3016,7 +3036,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: aa3d3959-8135-47a3-b2cb-ee9245cbd3a5
+                - id: fdb1e52c-ae80-44c5-ac29-209f1eb5563e
                   type: investor
                   attributes:
                     name: Bartoletti and Sons
@@ -3053,20 +3073,20 @@ paths:
                     previously_invested: true
                     language: en
                     review_status: approved
-                    created_at: '2022-07-07T10:47:39.952Z'
+                    created_at: '2022-07-14T12:53:20.699Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5WlRNd1pUVXhNeTB5WkRneExUUXpOamN0T1RWa09DMWtPRE0zWWpNMFl6Um1NemNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--62be2b29e0c65a0397dc8606134f3927023812f7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5WlRNd1pUVXhNeTB5WkRneExUUXpOamN0T1RWa09DMWtPRE0zWWpNMFl6Um1NemNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--62be2b29e0c65a0397dc8606134f3927023812f7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5WlRNd1pUVXhNeTB5WkRneExUUXpOamN0T1RWa09DMWtPRE0zWWpNMFl6Um1NemNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--62be2b29e0c65a0397dc8606134f3927023812f7/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3T1RJMk4yUXlPQzA1TkdJekxUUmpNR0V0WWpObFppMW1aVFZsTWpCaE16VTJZamNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--3c2887e7e74d6a2bb20e96ead579c4b02406909b/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3T1RJMk4yUXlPQzA1TkdJekxUUmpNR0V0WWpObFppMW1aVFZsTWpCaE16VTJZamNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--3c2887e7e74d6a2bb20e96ead579c4b02406909b/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3T1RJMk4yUXlPQzA1TkdJekxUUmpNR0V0WWpObFppMW1aVFZsTWpCaE16VTJZamNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--3c2887e7e74d6a2bb20e96ead579c4b02406909b/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 2f00b0c9-f502-48ca-8b92-22a6739f2f21
+                        id: 33a51ef8-7475-4491-b701-3bae63e29ca7
                         type: user
-                - id: 3a1200a2-aff4-4b0f-948a-87c546bb7eaf
+                - id: 391b9b8d-d6b5-49a8-9799-3b33d6b60e46
                   type: investor
                   attributes:
                     name: Becker LLC
@@ -3103,20 +3123,20 @@ paths:
                     previously_invested: true
                     language: en
                     review_status: approved
-                    created_at: '2022-07-07T10:47:40.296Z'
+                    created_at: '2022-07-14T12:53:21.134Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoT0dJM01EYzRNeTB5WXpaa0xUUTFORGd0WW1OaU5DMHhaRGczTXprMFlXWXlOR0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2456abb31889ac0ea14a1157b8db3f9df285666f/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoT0dJM01EYzRNeTB5WXpaa0xUUTFORGd0WW1OaU5DMHhaRGczTXprMFlXWXlOR0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2456abb31889ac0ea14a1157b8db3f9df285666f/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoT0dJM01EYzRNeTB5WXpaa0xUUTFORGd0WW1OaU5DMHhaRGczTXprMFlXWXlOR0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2456abb31889ac0ea14a1157b8db3f9df285666f/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6WTJFM05qUmlZUzB4TjJaaExUUTROakV0WW1RNFlTMWhObUZqTUdJME9XTmhNaklHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--026ae6191c609c3120f1b7dd6588cad4ffb77af5/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6WTJFM05qUmlZUzB4TjJaaExUUTROakV0WW1RNFlTMWhObUZqTUdJME9XTmhNaklHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--026ae6191c609c3120f1b7dd6588cad4ffb77af5/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6WTJFM05qUmlZUzB4TjJaaExUUTROakV0WW1RNFlTMWhObUZqTUdJME9XTmhNaklHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--026ae6191c609c3120f1b7dd6588cad4ffb77af5/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 292cf88e-2bd7-4eaf-8506-3d7819e87306
+                        id: a35ace57-0539-4463-aceb-2f2b6b853fa8
                         type: user
-                - id: 855ad9a5-7d96-4bbf-b6f8-b128b68d98c3
+                - id: 2bbe8004-7d3f-43b6-854a-56721bd2c89e
                   type: investor
                   attributes:
                     name: Hane, Lehner and Goyette
@@ -3153,20 +3173,20 @@ paths:
                     previously_invested: true
                     language: en
                     review_status: approved
-                    created_at: '2022-07-07T10:47:40.040Z'
+                    created_at: '2022-07-14T12:53:20.776Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTTJKak5EazJZeTAzTWpCaExUUmxZV1F0WVRNM1lpMWlNRGxoTUROak9EZ3pPVGtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--30d064399f01c50b2cd88422676943f20b650570/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTTJKak5EazJZeTAzTWpCaExUUmxZV1F0WVRNM1lpMWlNRGxoTUROak9EZ3pPVGtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--30d064399f01c50b2cd88422676943f20b650570/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTTJKak5EazJZeTAzTWpCaExUUmxZV1F0WVRNM1lpMWlNRGxoTUROak9EZ3pPVGtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--30d064399f01c50b2cd88422676943f20b650570/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6WlRJMU5HUXhNeTFtTkdNekxUUXhObVF0WVROa1lTMHpPVEV4TVRZeE5qVTBNellHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--d37e7747bf2fffa79b736d37c43f924d41cafa1c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6WlRJMU5HUXhNeTFtTkdNekxUUXhObVF0WVROa1lTMHpPVEV4TVRZeE5qVTBNellHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--d37e7747bf2fffa79b736d37c43f924d41cafa1c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6WlRJMU5HUXhNeTFtTkdNekxUUXhObVF0WVROa1lTMHpPVEV4TVRZeE5qVTBNellHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--d37e7747bf2fffa79b736d37c43f924d41cafa1c/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: fd587000-b6ea-4226-ac34-c1b0476990ff
+                        id: 4e9bac84-63e4-4bae-a9c5-f9ad7ce171d1
                         type: user
-                - id: 2047f8d3-5afc-4973-a95c-197f81c23922
+                - id: 4a9c8284-4bc9-45df-9a53-201f2d975953
                   type: investor
                   attributes:
                     name: Hilpert, Waters and Johnston
@@ -3203,20 +3223,20 @@ paths:
                     previously_invested: true
                     language: en
                     review_status: approved
-                    created_at: '2022-07-07T10:47:40.096Z'
+                    created_at: '2022-07-14T12:53:20.860Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtTW1VM1pEWmhPQzFrTW1SakxUUTNZVFl0T0dVeE5TMWpPV0UwTmpZeU56RmxOVFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--36f6efac9b00f3fb9a7dcedc8476540fea33a374/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtTW1VM1pEWmhPQzFrTW1SakxUUTNZVFl0T0dVeE5TMWpPV0UwTmpZeU56RmxOVFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--36f6efac9b00f3fb9a7dcedc8476540fea33a374/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtTW1VM1pEWmhPQzFrTW1SakxUUTNZVFl0T0dVeE5TMWpPV0UwTmpZeU56RmxOVFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--36f6efac9b00f3fb9a7dcedc8476540fea33a374/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TURjd05UaG1ZUzFsTVRobUxUUm1aV1F0WWpsalppMW1NMkl6WTJNeFl6STFaRGdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--18a0fd2783029821e57d8c4c699d1c04cbbc7f9a/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TURjd05UaG1ZUzFsTVRobUxUUm1aV1F0WWpsalppMW1NMkl6WTJNeFl6STFaRGdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--18a0fd2783029821e57d8c4c699d1c04cbbc7f9a/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TURjd05UaG1ZUzFsTVRobUxUUm1aV1F0WWpsalppMW1NMkl6WTJNeFl6STFaRGdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--18a0fd2783029821e57d8c4c699d1c04cbbc7f9a/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: b9a9a1bb-d2fd-4091-a3b3-42f8a1e7177e
+                        id: 70d628a0-f7a8-40fc-8342-119d8a577e2d
                         type: user
-                - id: 4fe61077-813c-4cfc-b89c-c0a161c663ae
+                - id: 77a42fff-f92b-447d-b9d0-bd501ca4ea2c
                   type: investor
                   attributes:
                     name: Jacobson, Fritsch and Stanton
@@ -3253,20 +3273,20 @@ paths:
                     previously_invested: true
                     language: en
                     review_status: approved
-                    created_at: '2022-07-07T10:47:40.180Z'
+                    created_at: '2022-07-14T12:53:20.970Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3T0RneU1XRm1aaTFqWWpBeUxUUm1NV0V0WVRJNE5pMDNPRFE1WkdNeVpUazFaV1FHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--1b4859420e5b6fddf5cf301e4efdf85545ab5aef/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3T0RneU1XRm1aaTFqWWpBeUxUUm1NV0V0WVRJNE5pMDNPRFE1WkdNeVpUazFaV1FHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--1b4859420e5b6fddf5cf301e4efdf85545ab5aef/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3T0RneU1XRm1aaTFqWWpBeUxUUm1NV0V0WVRJNE5pMDNPRFE1WkdNeVpUazFaV1FHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--1b4859420e5b6fddf5cf301e4efdf85545ab5aef/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWWpJME5EUXpZeTB6TnpFM0xUUTFOekl0WW1KbE55MDFNV0V5WkRRek5XRTRZbVlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--633efbfb109270a44f017ad7d1b57d7667af27fd/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWWpJME5EUXpZeTB6TnpFM0xUUTFOekl0WW1KbE55MDFNV0V5WkRRek5XRTRZbVlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--633efbfb109270a44f017ad7d1b57d7667af27fd/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWWpJME5EUXpZeTB6TnpFM0xUUTFOekl0WW1KbE55MDFNV0V5WkRRek5XRTRZbVlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--633efbfb109270a44f017ad7d1b57d7667af27fd/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 1ffb386d-3876-403b-9540-70c33020ccb7
+                        id: 80296f14-5228-4329-a65d-a70a3b9faf04
                         type: user
-                - id: f65c5b28-b269-416d-88dc-91076206b135
+                - id: 66ffb110-a577-4ecd-ba5a-d8746eb1d6e1
                   type: investor
                   attributes:
                     name: Keebler, Kub and Zemlak
@@ -3303,20 +3323,20 @@ paths:
                     previously_invested: true
                     language: en
                     review_status: approved
-                    created_at: '2022-07-07T10:47:40.236Z'
+                    created_at: '2022-07-14T12:53:21.056Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoTXpFd09EUmxOUzB4WkdJNUxUUTFNelV0T0RRMU15MHhOR1ZtTVdKbU16UTFabUVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a6c89c1f2fdf41b5cdd4941d08cad9b47bcff3f3/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoTXpFd09EUmxOUzB4WkdJNUxUUTFNelV0T0RRMU15MHhOR1ZtTVdKbU16UTFabUVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a6c89c1f2fdf41b5cdd4941d08cad9b47bcff3f3/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoTXpFd09EUmxOUzB4WkdJNUxUUTFNelV0T0RRMU15MHhOR1ZtTVdKbU16UTFabUVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a6c89c1f2fdf41b5cdd4941d08cad9b47bcff3f3/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5TXpCak5qTm1NeTAyWVRSakxUUXdaak10T1RJeFpTMWhZVGRrT1RFd05qTTVObUVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--58a6fdb9d2d953ce1d5362469ef5bcbfd53ea979/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5TXpCak5qTm1NeTAyWVRSakxUUXdaak10T1RJeFpTMWhZVGRrT1RFd05qTTVObUVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--58a6fdb9d2d953ce1d5362469ef5bcbfd53ea979/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5TXpCak5qTm1NeTAyWVRSakxUUXdaak10T1RJeFpTMWhZVGRrT1RFd05qTTVObUVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--58a6fdb9d2d953ce1d5362469ef5bcbfd53ea979/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: ccbf0aea-0fc1-4a27-ab46-0ec8f33a44aa
+                        id: 4ba022bf-5ff3-4cc4-bcba-014c5272b059
                         type: user
-                - id: a2787724-da36-4ebd-89c4-b643c3d39e8b
+                - id: da6f0fb1-2a35-43fd-95be-753ff45384ce
                   type: investor
                   attributes:
                     name: Kutch-Spencer
@@ -3353,18 +3373,18 @@ paths:
                     previously_invested: true
                     language: en
                     review_status: approved
-                    created_at: '2022-07-07T10:47:39.881Z'
+                    created_at: '2022-07-14T12:53:20.616Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrWm1RME9XTTFNaTFpT0RneExUUTVNbVV0WVRBeE55MDJNV05tWWpobU56WTRNemdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a6178f26377784ecd2af456f917d98282cc4c9de/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrWm1RME9XTTFNaTFpT0RneExUUTVNbVV0WVRBeE55MDJNV05tWWpobU56WTRNemdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a6178f26377784ecd2af456f917d98282cc4c9de/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrWm1RME9XTTFNaTFpT0RneExUUTVNbVV0WVRBeE55MDJNV05tWWpobU56WTRNemdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a6178f26377784ecd2af456f917d98282cc4c9de/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyWldJME5ERmtOaTFoWXpOaUxUUmpZemd0T1RNek5DMWlNMk0wTVRkak5UVmhNR1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4817002b8796772ec7ad1e3f7f55f822e265cb55/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyWldJME5ERmtOaTFoWXpOaUxUUmpZemd0T1RNek5DMWlNMk0wTVRkak5UVmhNR1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4817002b8796772ec7ad1e3f7f55f822e265cb55/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyWldJME5ERmtOaTFoWXpOaUxUUmpZemd0T1RNek5DMWlNMk0wTVRkak5UVmhNR1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4817002b8796772ec7ad1e3f7f55f822e265cb55/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: dec928bd-b028-4c55-9837-4beae74b3211
+                        id: 1114113f-8dde-4825-8aca-cbc7a382b4c7
                         type: user
                 meta:
                   page: 1
@@ -3422,7 +3442,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: a2787724-da36-4ebd-89c4-b643c3d39e8b
+                  id: da6f0fb1-2a35-43fd-95be-753ff45384ce
                   type: investor
                   attributes:
                     name: Kutch-Spencer
@@ -3459,18 +3479,18 @@ paths:
                     previously_invested: true
                     language: en
                     review_status: approved
-                    created_at: '2022-07-07T10:47:39.881Z'
+                    created_at: '2022-07-14T12:53:20.616Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrWm1RME9XTTFNaTFpT0RneExUUTVNbVV0WVRBeE55MDJNV05tWWpobU56WTRNemdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a6178f26377784ecd2af456f917d98282cc4c9de/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrWm1RME9XTTFNaTFpT0RneExUUTVNbVV0WVRBeE55MDJNV05tWWpobU56WTRNemdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a6178f26377784ecd2af456f917d98282cc4c9de/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrWm1RME9XTTFNaTFpT0RneExUUTVNbVV0WVRBeE55MDJNV05tWWpobU56WTRNemdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a6178f26377784ecd2af456f917d98282cc4c9de/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyWldJME5ERmtOaTFoWXpOaUxUUmpZemd0T1RNek5DMWlNMk0wTVRkak5UVmhNR1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4817002b8796772ec7ad1e3f7f55f822e265cb55/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyWldJME5ERmtOaTFoWXpOaUxUUmpZemd0T1RNek5DMWlNMk0wTVRkak5UVmhNR1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4817002b8796772ec7ad1e3f7f55f822e265cb55/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyWldJME5ERmtOaTFoWXpOaUxUUmpZemd0T1RNek5DMWlNMk0wTVRkak5UVmhNR1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4817002b8796772ec7ad1e3f7f55f822e265cb55/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: dec928bd-b028-4c55-9837-4beae74b3211
+                        id: 1114113f-8dde-4825-8aca-cbc7a382b4c7
                         type: user
               schema:
                 type: object
@@ -3602,18 +3622,22 @@ paths:
             application/json:
               example:
                 data:
-                  id: 3c2e1584-f5ab-4476-ade3-3f5a2b73647d
+                  id: da43ee7f-8dca-4954-a1df-d68417695cfc
                   type: user
                   attributes:
                     first_name: Dawna
                     last_name: Block
                     email: dawna.block@example.org
                     role: light
-                    created_at: '2022-07-07T10:47:42.255Z'
+                    created_at: '2022-07-14T12:53:24.490Z'
                     confirmed: true
                     approved: true
                     invitation: completed
                     owner: false
+                    avatar:
+                      small:
+                      medium:
+                      original:
               schema:
                 type: object
                 properties:
@@ -3687,58 +3711,58 @@ paths:
             application/json:
               example:
                 data:
-                - id: dc332adb-c799-4096-92d8-40996cbe6e29
+                - id: f9c0c220-f352-486c-bb20-004102b9d9cb
                   type: location
                   attributes:
                     name: Canada
                     location_type: country
-                    created_at: '2022-07-07T10:47:42.753Z'
+                    created_at: '2022-07-14T12:53:25.462Z'
                   relationships:
                     parent:
                       data:
-                - id: e149ca7a-1fc8-4111-b972-13a6a5a3fd82
+                - id: e87669b7-c712-4f4c-bb7b-893e745da797
                   type: location
                   attributes:
                     name: Papua New Guinea
                     location_type: department
-                    created_at: '2022-07-07T10:47:42.756Z'
+                    created_at: '2022-07-14T12:53:25.466Z'
                   relationships:
                     parent:
                       data:
-                        id: dc332adb-c799-4096-92d8-40996cbe6e29
+                        id: f9c0c220-f352-486c-bb20-004102b9d9cb
                         type: location
-                - id: fb77f900-953a-4294-ab0e-ffd68a288efb
+                - id: f7d042c8-b122-4c33-8d42-cfec2cc78913
                   type: location
                   attributes:
                     name: Jamaica
                     location_type: municipality
-                    created_at: '2022-07-07T10:47:42.760Z'
+                    created_at: '2022-07-14T12:53:25.471Z'
                   relationships:
                     parent:
                       data:
-                        id: e149ca7a-1fc8-4111-b972-13a6a5a3fd82
+                        id: e87669b7-c712-4f4c-bb7b-893e745da797
                         type: location
-                - id: c7873e63-d07e-40d4-9267-fb7126b91c25
+                - id: 8c28af0d-8ee0-43b0-b337-e05cd4afd551
                   type: location
                   attributes:
                     name: Libyan Arab Jamahiriya
                     location_type: municipality
-                    created_at: '2022-07-07T10:47:42.764Z'
+                    created_at: '2022-07-14T12:53:25.476Z'
                   relationships:
                     parent:
                       data:
-                        id: e149ca7a-1fc8-4111-b972-13a6a5a3fd82
+                        id: e87669b7-c712-4f4c-bb7b-893e745da797
                         type: location
-                - id: f129053f-874f-48cd-8f42-a7b04af1e83d
+                - id: e3811a45-eb7d-41c2-abd0-3dfc28d9b0f1
                   type: location
                   attributes:
                     name: India
                     location_type: municipality
-                    created_at: '2022-07-07T10:47:42.768Z'
+                    created_at: '2022-07-14T12:53:25.483Z'
                   relationships:
                     parent:
                       data:
-                        id: e149ca7a-1fc8-4111-b972-13a6a5a3fd82
+                        id: e87669b7-c712-4f4c-bb7b-893e745da797
                         type: location
               schema:
                 type: object
@@ -3787,16 +3811,16 @@ paths:
             application/json:
               example:
                 data:
-                  id: fb77f900-953a-4294-ab0e-ffd68a288efb
+                  id: f7d042c8-b122-4c33-8d42-cfec2cc78913
                   type: location
                   attributes:
                     name: Jamaica
                     location_type: municipality
-                    created_at: '2022-07-07T10:47:42.760Z'
+                    created_at: '2022-07-14T12:53:25.471Z'
                   relationships:
                     parent:
                       data:
-                        id: e149ca7a-1fc8-4111-b972-13a6a5a3fd82
+                        id: e87669b7-c712-4f4c-bb7b-893e745da797
                         type: location
               schema:
                 type: object
@@ -3875,7 +3899,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: 755b53d5-fb27-4808-97f8-36ebf834c3df
+                - id: 12758d2d-9221-4bb0-90b7-079eea1d02fd
                   type: open_call
                   attributes:
                     name: Open call 1
@@ -3892,16 +3916,16 @@ paths:
                       tempora exercitationem. Qui dolorem quo.
                     impact_description: Enim repellat pariatur. Earum modi eos. Libero
                       tempora exercitationem. Qui dolorem quo.
-                    closing_at: '2023-05-07T10:47:43.044Z'
+                    closing_at: '2023-05-14T12:53:26.057Z'
                     language: en
                     trusted: false
-                    created_at: '2022-07-07T10:47:43.060Z'
+                    created_at: '2022-07-14T12:53:26.102Z'
                   relationships:
                     investor:
                       data:
-                        id: ed8d7ed1-a0f6-4eeb-8419-57c37e1b81ef
+                        id: 9d235f13-2078-42aa-87bd-c0a501edd875
                         type: investor
-                - id: 9a4681cb-d095-430f-949c-612fabe8208a
+                - id: 2aa14fb6-15b7-42e8-956c-b7d0e962057c
                   type: open_call
                   attributes:
                     name: Open call 2
@@ -3918,16 +3942,16 @@ paths:
                       Sunt commodi tempore. Voluptatem et corrupti.
                     impact_description: Placeat commodi libero. Quo recusandae repellat.
                       Sunt commodi tempore. Voluptatem et corrupti.
-                    closing_at: '2023-05-07T10:47:43.124Z'
+                    closing_at: '2023-05-14T12:53:26.223Z'
                     language: en
                     trusted: false
-                    created_at: '2022-07-07T10:47:43.128Z'
+                    created_at: '2022-07-14T12:53:26.227Z'
                   relationships:
                     investor:
                       data:
-                        id: 122764cb-eda2-4149-8876-cb1c21dc9ea6
+                        id: f6320ddb-5ac6-4cf9-9cb5-c25e0de16106
                         type: investor
-                - id: 60b2b9f3-831f-4c93-9827-8aa6cb4acd2f
+                - id: 0ef5752f-1c63-4fa6-a2b7-de334c1c2fcf
                   type: open_call
                   attributes:
                     name: Open call 3
@@ -3944,16 +3968,16 @@ paths:
                       nesciunt voluptas. Suscipit ex cum.
                     impact_description: Et quaerat omnis. Harum voluptas atque. Quo
                       nesciunt voluptas. Suscipit ex cum.
-                    closing_at: '2023-05-07T10:47:43.194Z'
+                    closing_at: '2023-05-14T12:53:26.346Z'
                     language: en
                     trusted: false
-                    created_at: '2022-07-07T10:47:43.196Z'
+                    created_at: '2022-07-14T12:53:26.349Z'
                   relationships:
                     investor:
                       data:
-                        id: 4c5d03d7-f813-4c47-8608-344badca682a
+                        id: 29fd55e6-6451-4d39-94b6-ab975d278a38
                         type: investor
-                - id: f50c6e6e-7a6b-436b-b9e9-9d1575272594
+                - id: e8c32b72-da85-4de9-8256-2a9651ef7d21
                   type: open_call
                   attributes:
                     name: Open call 4
@@ -3970,16 +3994,16 @@ paths:
                       Sit neque eos. Expedita molestiae quia.
                     impact_description: Dolores fugiat nesciunt. Ut laborum dolores.
                       Sit neque eos. Expedita molestiae quia.
-                    closing_at: '2023-05-07T10:47:43.271Z'
+                    closing_at: '2023-05-14T12:53:26.454Z'
                     language: en
                     trusted: false
-                    created_at: '2022-07-07T10:47:43.273Z'
+                    created_at: '2022-07-14T12:53:26.457Z'
                   relationships:
                     investor:
                       data:
-                        id: e2d731f2-9649-4191-a0fc-f91610f673be
+                        id: 87298612-0221-4e54-8665-5f708d001a44
                         type: investor
-                - id: 51bcae77-e21e-4025-bc33-36cbc81ee20a
+                - id: 15e8debb-f7b6-416d-b486-f59948a296d9
                   type: open_call
                   attributes:
                     name: Open call 5
@@ -3996,16 +4020,16 @@ paths:
                       recusandae eum. Eius ex est.
                     impact_description: Autem et et. Voluptatem neque quibusdam. Repellat
                       recusandae eum. Eius ex est.
-                    closing_at: '2023-05-07T10:47:43.338Z'
+                    closing_at: '2023-05-14T12:53:26.533Z'
                     language: en
                     trusted: false
-                    created_at: '2022-07-07T10:47:43.341Z'
+                    created_at: '2022-07-14T12:53:26.536Z'
                   relationships:
                     investor:
                       data:
-                        id: 266b00eb-b5dd-47ce-8895-3347d6712290
+                        id: bd59ac2e-2e8a-4f48-8708-053dc6731467
                         type: investor
-                - id: 9429f172-a1dc-40b2-8930-f607e90d0046
+                - id: 90877f1e-78bc-4e63-b7b4-4ad0440ecbf5
                   type: open_call
                   attributes:
                     name: Open call 6
@@ -4022,16 +4046,16 @@ paths:
                       Eligendi sapiente voluptatem. Quas rerum officia.
                     impact_description: Porro soluta beatae. Quia ratione facilis.
                       Eligendi sapiente voluptatem. Quas rerum officia.
-                    closing_at: '2023-05-07T10:47:43.406Z'
+                    closing_at: '2023-05-14T12:53:26.628Z'
                     language: en
                     trusted: false
-                    created_at: '2022-07-07T10:47:43.409Z'
+                    created_at: '2022-07-14T12:53:26.632Z'
                   relationships:
                     investor:
                       data:
-                        id: 16e60717-c0a1-4390-bc49-6b60b5305caf
+                        id: ffce02fa-0965-4100-988d-ee7a9e76fa3a
                         type: investor
-                - id: 36d828cf-cdeb-4c0b-8724-19c6cf54ac6e
+                - id: a7f63df5-152c-4a06-9c69-e4c283d22746
                   type: open_call
                   attributes:
                     name: Open call 7
@@ -4048,14 +4072,14 @@ paths:
                       laudantium et. Sed recusandae aut.
                     impact_description: Mollitia aut vel. Qui illum accusantium. Et
                       laudantium et. Sed recusandae aut.
-                    closing_at: '2023-05-07T10:47:43.472Z'
+                    closing_at: '2023-05-14T12:53:26.722Z'
                     language: en
                     trusted: false
-                    created_at: '2022-07-07T10:47:43.475Z'
+                    created_at: '2022-07-14T12:53:26.725Z'
                   relationships:
                     investor:
                       data:
-                        id: 0473c4d7-2e6b-40fa-a7a6-c696a46946ae
+                        id: 52fa05b7-4c06-4132-85de-c37066ef78c7
                         type: investor
                 meta:
                   page: 1
@@ -4113,7 +4137,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 755b53d5-fb27-4808-97f8-36ebf834c3df
+                  id: 12758d2d-9221-4bb0-90b7-079eea1d02fd
                   type: open_call
                   attributes:
                     name: Open call 1
@@ -4130,14 +4154,14 @@ paths:
                       tempora exercitationem. Qui dolorem quo.
                     impact_description: Enim repellat pariatur. Earum modi eos. Libero
                       tempora exercitationem. Qui dolorem quo.
-                    closing_at: '2023-05-07T10:47:43.044Z'
+                    closing_at: '2023-05-14T12:53:26.057Z'
                     language: en
                     trusted: false
-                    created_at: '2022-07-07T10:47:43.060Z'
+                    created_at: '2022-07-14T12:53:26.102Z'
                   relationships:
                     investor:
                       data:
-                        id: ed8d7ed1-a0f6-4eeb-8419-57c37e1b81ef
+                        id: 9d235f13-2078-42aa-87bd-c0a501edd875
                         type: investor
               schema:
                 type: object
@@ -4216,7 +4240,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: 313ab8ec-08cc-4857-b027-83535da2dfe6
+                - id: e9ef7864-97f2-49da-bb9f-86620b28f4b0
                   type: project_developer
                   attributes:
                     name: Bartoletti and Sons
@@ -4243,26 +4267,26 @@ paths:
                     mosaics:
                     - amazon-heart
                     - amazonian-piedmont-massif
-                    created_at: '2022-07-07T10:47:44.068Z'
+                    created_at: '2022-07-14T12:53:27.724Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpWlRnNE9HVTVZaTFsWmpWbUxUUXlZVFl0T1RKbU5TMDJOV1kwTjJVd1pXUXhOVFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--08a07ce55bd4d8e98b30decb3293ff78032b8cca/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpWlRnNE9HVTVZaTFsWmpWbUxUUXlZVFl0T1RKbU5TMDJOV1kwTjJVd1pXUXhOVFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--08a07ce55bd4d8e98b30decb3293ff78032b8cca/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpWlRnNE9HVTVZaTFsWmpWbUxUUXlZVFl0T1RKbU5TMDJOV1kwTjJVd1pXUXhOVFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--08a07ce55bd4d8e98b30decb3293ff78032b8cca/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtT1RaallqQXpZeTAwWWpNNExUUXdZMkV0T0RjMk5DMDRNMk5tTkRnMk5HRTNPVElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ce0464c0cdc4ab9d430c1f2d45334aa2c4ec233d/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtT1RaallqQXpZeTAwWWpNNExUUXdZMkV0T0RjMk5DMDRNMk5tTkRnMk5HRTNPVElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ce0464c0cdc4ab9d430c1f2d45334aa2c4ec233d/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtT1RaallqQXpZeTAwWWpNNExUUXdZMkV0T0RjMk5DMDRNMk5tTkRnMk5HRTNPVElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ce0464c0cdc4ab9d430c1f2d45334aa2c4ec233d/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: a4379337-7daf-43d2-93ce-235f515febd1
+                        id: 9171c11c-ff25-4a15-8396-b846cd7253a6
                         type: user
                     projects:
                       data:
-                      - id: d58ba3f2-d90a-46ce-b887-a2d89bbaa9b6
+                      - id: 8cbd0ab2-8535-4220-8a31-7ebc558680d2
                         type: project
                     involved_projects:
                       data: []
-                - id: 0c7d447d-a9b9-442d-8160-787132e68cac
+                - id: bbb3dd35-eadc-46d8-a181-e0dd7b8b7b31
                   type: project_developer
                   attributes:
                     name: Becker LLC
@@ -4289,24 +4313,24 @@ paths:
                     mosaics:
                     - amazon-heart
                     - amazonian-piedmont-massif
-                    created_at: '2022-07-07T10:47:44.437Z'
+                    created_at: '2022-07-14T12:53:28.328Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsWVdWaU9HWXdNQzAxTURBMkxUUTROemt0WVRVd1pDMWtNVEZoTjJFMlpUbGpZbU1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0ce14f35bf5160d5ee6e146ffa0edf38fa102747/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsWVdWaU9HWXdNQzAxTURBMkxUUTROemt0WVRVd1pDMWtNVEZoTjJFMlpUbGpZbU1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0ce14f35bf5160d5ee6e146ffa0edf38fa102747/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsWVdWaU9HWXdNQzAxTURBMkxUUTROemt0WVRVd1pDMWtNVEZoTjJFMlpUbGpZbU1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0ce14f35bf5160d5ee6e146ffa0edf38fa102747/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5TURjNU1ETTJOQzAwTjJFeUxUUXlORGt0T0RjeE5pMW1ZakUzWlRJMFltRmtNVFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--24c72fe6b2af63330e7b3cc31e6da7ee67812d4b/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5TURjNU1ETTJOQzAwTjJFeUxUUXlORGt0T0RjeE5pMW1ZakUzWlRJMFltRmtNVFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--24c72fe6b2af63330e7b3cc31e6da7ee67812d4b/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5TURjNU1ETTJOQzAwTjJFeUxUUXlORGt0T0RjeE5pMW1ZakUzWlRJMFltRmtNVFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--24c72fe6b2af63330e7b3cc31e6da7ee67812d4b/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 445fff93-681d-4617-af74-b1100f390e19
+                        id: 8d17ccbb-00d2-47a1-95b7-8398286ead3c
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data: []
-                - id: f5adcff0-06dd-4298-a0f9-714050a4c9c2
+                - id: 646c75c4-cad6-4bd9-b433-6db86556746b
                   type: project_developer
                   attributes:
                     name: Hane, Lehner and Goyette
@@ -4333,26 +4357,26 @@ paths:
                     mosaics:
                     - amazon-heart
                     - amazonian-piedmont-massif
-                    created_at: '2022-07-07T10:47:44.168Z'
+                    created_at: '2022-07-14T12:53:27.865Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTWpWaE9UVTRNQzAwWW1FMUxUUmpOV0l0T1dKaFlTMHhabUl5WkRBeE0yUmhObUVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4f6b082f7f1783412ddf019bf5160c23af4d6dc6/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTWpWaE9UVTRNQzAwWW1FMUxUUmpOV0l0T1dKaFlTMHhabUl5WkRBeE0yUmhObUVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4f6b082f7f1783412ddf019bf5160c23af4d6dc6/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTWpWaE9UVTRNQzAwWW1FMUxUUmpOV0l0T1dKaFlTMHhabUl5WkRBeE0yUmhObUVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4f6b082f7f1783412ddf019bf5160c23af4d6dc6/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoTW1Zelpqa3dNeTA0TVRBd0xUUXdPVEl0T0dSbE9TMDFOalV4TXpnM1pqQmlOemtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--d567209ff693a01442ebcf49f34fc19e4d275dd7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoTW1Zelpqa3dNeTA0TVRBd0xUUXdPVEl0T0dSbE9TMDFOalV4TXpnM1pqQmlOemtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--d567209ff693a01442ebcf49f34fc19e4d275dd7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoTW1Zelpqa3dNeTA0TVRBd0xUUXdPVEl0T0dSbE9TMDFOalV4TXpnM1pqQmlOemtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--d567209ff693a01442ebcf49f34fc19e4d275dd7/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 7b5a8e54-cb9f-4786-bf06-af1d92868faf
+                        id: c22c364c-19e1-44d1-83dc-346bee9cfd04
                         type: user
                     projects:
                       data:
-                      - id: 0cfa45b6-99ca-43c9-954a-599bc6586b22
+                      - id: 7cb51dc4-c74d-46ca-a6b0-038842959b9e
                         type: project
                     involved_projects:
                       data: []
-                - id: 43cb5d8d-7166-470a-a7f9-0b55c9e86b5c
+                - id: 6fc2a7db-a321-49d4-a1de-09f02360ecc8
                   type: project_developer
                   attributes:
                     name: Hilpert, Waters and Johnston
@@ -4379,24 +4403,24 @@ paths:
                     mosaics:
                     - amazon-heart
                     - amazonian-piedmont-massif
-                    created_at: '2022-07-07T10:47:44.283Z'
+                    created_at: '2022-07-14T12:53:28.031Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpTlRWa1l6ZzNNeTFpTkRRNExUUmlZall0WVRjM055MHlaVEptT1dVd1pqaG1aVFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--d3769387cafe7a780f1f3e0bc959fdbe63381c52/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpTlRWa1l6ZzNNeTFpTkRRNExUUmlZall0WVRjM055MHlaVEptT1dVd1pqaG1aVFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--d3769387cafe7a780f1f3e0bc959fdbe63381c52/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpTlRWa1l6ZzNNeTFpTkRRNExUUmlZall0WVRjM055MHlaVEptT1dVd1pqaG1aVFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--d3769387cafe7a780f1f3e0bc959fdbe63381c52/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrTW1JMVlXVTNNaTB3T0dJNUxUUTBZVGN0T0dJMFppMWhaR1kwWXpVMllXRXhOV0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c26619f70c08f3f6b88a5eb8754d8a12fce70879/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrTW1JMVlXVTNNaTB3T0dJNUxUUTBZVGN0T0dJMFppMWhaR1kwWXpVMllXRXhOV0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c26619f70c08f3f6b88a5eb8754d8a12fce70879/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrTW1JMVlXVTNNaTB3T0dJNUxUUTBZVGN0T0dJMFppMWhaR1kwWXpVMllXRXhOV0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c26619f70c08f3f6b88a5eb8754d8a12fce70879/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 624c39d7-265b-4b69-acbf-20da37f56d99
+                        id: 050d8edc-d9e0-47bd-a225-494be28d4413
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data: []
-                - id: 06bfd570-5fd3-4431-a04d-433f82555f24
+                - id: efe411ae-21e6-46b0-a853-a5f1784cfaa5
                   type: project_developer
                   attributes:
                     name: Jacobson, Fritsch and Stanton
@@ -4423,24 +4447,24 @@ paths:
                     mosaics:
                     - amazon-heart
                     - amazonian-piedmont-massif
-                    created_at: '2022-07-07T10:47:44.335Z'
+                    created_at: '2022-07-14T12:53:28.096Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WTJaallXVXdaUzB4WXpFekxUUmxOemd0WVRaaU5pMWpObVU1WlRjMVpUTXdOelFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a76b625d2d4d3844eaabc5e0e2db02383315f8f1/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WTJaallXVXdaUzB4WXpFekxUUmxOemd0WVRaaU5pMWpObVU1WlRjMVpUTXdOelFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a76b625d2d4d3844eaabc5e0e2db02383315f8f1/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WTJaallXVXdaUzB4WXpFekxUUmxOemd0WVRaaU5pMWpObVU1WlRjMVpUTXdOelFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a76b625d2d4d3844eaabc5e0e2db02383315f8f1/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6WlRrMU4ySTFZeTB6WTJOaExUUmhOell0T1dabVpDMWxNVEkwTWpaaVpXUmxPR1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5081b099fc099837fc97fcd1a198e41dbc5ef065/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6WlRrMU4ySTFZeTB6WTJOaExUUmhOell0T1dabVpDMWxNVEkwTWpaaVpXUmxPR1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5081b099fc099837fc97fcd1a198e41dbc5ef065/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6WlRrMU4ySTFZeTB6WTJOaExUUmhOell0T1dabVpDMWxNVEkwTWpaaVpXUmxPR1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5081b099fc099837fc97fcd1a198e41dbc5ef065/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 4d9f82f0-93e2-41ef-9837-a62ebbcf2cdc
+                        id: c1d5bbd4-2ce6-4756-a6b6-68c9b98a0b35
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data: []
-                - id: '0843fc11-dd57-4d78-92be-025034532281'
+                - id: d7c4e452-83a0-47d6-a769-0271c8caf576
                   type: project_developer
                   attributes:
                     name: Keebler, Kub and Zemlak
@@ -4467,24 +4491,24 @@ paths:
                     mosaics:
                     - amazon-heart
                     - amazonian-piedmont-massif
-                    created_at: '2022-07-07T10:47:44.385Z'
+                    created_at: '2022-07-14T12:53:28.213Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpTWpNNU16WmhZeTB3TjJGa0xUUmlNelF0T1RNeE9DMHhNR1k1WkdJM1lXVmtNek1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--bf29adbdf1c78808c82071af67e67e978cde5cf2/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpTWpNNU16WmhZeTB3TjJGa0xUUmlNelF0T1RNeE9DMHhNR1k1WkdJM1lXVmtNek1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--bf29adbdf1c78808c82071af67e67e978cde5cf2/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpTWpNNU16WmhZeTB3TjJGa0xUUmlNelF0T1RNeE9DMHhNR1k1WkdJM1lXVmtNek1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--bf29adbdf1c78808c82071af67e67e978cde5cf2/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtTVRZNU1UQTNPUzAxWkRnMExUUmxaRFV0T0RFeU5DMHlPREJrTVRObU1HVmlZamNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0aade19aa0953457c4979eaaad2317a5a4f92458/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtTVRZNU1UQTNPUzAxWkRnMExUUmxaRFV0T0RFeU5DMHlPREJrTVRObU1HVmlZamNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0aade19aa0953457c4979eaaad2317a5a4f92458/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtTVRZNU1UQTNPUzAxWkRnMExUUmxaRFV0T0RFeU5DMHlPREJrTVRObU1HVmlZamNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0aade19aa0953457c4979eaaad2317a5a4f92458/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 00a045b6-13a3-4fb4-b3da-d64fd65d6f34
+                        id: d7c9ba4c-99b4-437f-afae-1f8e6ef1b47d
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data: []
-                - id: 0b1c6b2d-56f6-4560-bc82-9d8c2015dbe5
+                - id: 2768ef34-ce8b-491f-bbd7-a9d69a7199ad
                   type: project_developer
                   attributes:
                     name: Kutch-Spencer
@@ -4510,28 +4534,28 @@ paths:
                     mosaics:
                     - amazon-heart
                     - amazonian-piedmont-massif
-                    created_at: '2022-07-07T10:47:44.228Z'
+                    created_at: '2022-07-14T12:53:27.960Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqWXpFNFlXSTBZaTB4WW1ZNUxUUXhaR0l0T0dWbFlTMDVOemt5TXpneU1qRXdOVGtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6cf3c641ea2cbae371ad042891308788f1fa8e9b/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqWXpFNFlXSTBZaTB4WW1ZNUxUUXhaR0l0T0dWbFlTMDVOemt5TXpneU1qRXdOVGtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6cf3c641ea2cbae371ad042891308788f1fa8e9b/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqWXpFNFlXSTBZaTB4WW1ZNUxUUXhaR0l0T0dWbFlTMDVOemt5TXpneU1qRXdOVGtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6cf3c641ea2cbae371ad042891308788f1fa8e9b/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTm1Vd05tRmtPQzAwTURZMUxUUTFPV1F0WW1RMllpMWlZamM1T1dSbVpERXlPRGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4c8311c2a6ead08b33159160a8afc78fa287c3ed/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTm1Vd05tRmtPQzAwTURZMUxUUTFPV1F0WW1RMllpMWlZamM1T1dSbVpERXlPRGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4c8311c2a6ead08b33159160a8afc78fa287c3ed/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTm1Vd05tRmtPQzAwTURZMUxUUTFPV1F0WW1RMllpMWlZamM1T1dSbVpERXlPRGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4c8311c2a6ead08b33159160a8afc78fa287c3ed/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 70565f69-e633-4492-9e57-aa07939349c7
+                        id: 7ab87fd3-07c6-4f3a-8221-29e0ef727f47
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data:
-                      - id: d58ba3f2-d90a-46ce-b887-a2d89bbaa9b6
+                      - id: 8cbd0ab2-8535-4220-8a31-7ebc558680d2
                         type: project
-                      - id: 0cfa45b6-99ca-43c9-954a-599bc6586b22
+                      - id: 7cb51dc4-c74d-46ca-a6b0-038842959b9e
                         type: project
-                - id: d7e4fa7d-9f1c-4ea9-92e5-554162e088d9
+                - id: 51c4976a-f3dc-4374-a369-6cc1d09e873c
                   type: project_developer
                   attributes:
                     name: Ritchie, Glover and Ward
@@ -4558,24 +4582,24 @@ paths:
                     mosaics:
                     - amazon-heart
                     - amazonian-piedmont-massif
-                    created_at: '2022-07-07T10:47:44.580Z'
+                    created_at: '2022-07-14T12:53:28.514Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrWWpWbFkyVXlZUzAyTUdWa0xUUmlOVFV0T1RobVppMWlORFkyTnprME1tVXhNV1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--08890a128702aec4149351bfe0d3bf660eee5c0e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrWWpWbFkyVXlZUzAyTUdWa0xUUmlOVFV0T1RobVppMWlORFkyTnprME1tVXhNV1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--08890a128702aec4149351bfe0d3bf660eee5c0e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrWWpWbFkyVXlZUzAyTUdWa0xUUmlOVFV0T1RobVppMWlORFkyTnprME1tVXhNV1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--08890a128702aec4149351bfe0d3bf660eee5c0e/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWszTW1KbE5Ea3dOQzFpTVRReUxUUXpZMlV0T1dGak15MWxaVFV3TnpBeE5EbGtPRFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--037447fdfa733a024a358a3132f758250f629fda/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWszTW1KbE5Ea3dOQzFpTVRReUxUUXpZMlV0T1dGak15MWxaVFV3TnpBeE5EbGtPRFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--037447fdfa733a024a358a3132f758250f629fda/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWszTW1KbE5Ea3dOQzFpTVRReUxUUXpZMlV0T1dGak15MWxaVFV3TnpBeE5EbGtPRFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--037447fdfa733a024a358a3132f758250f629fda/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: da158d18-a72e-40a5-8f7c-ac5012f28eb3
+                        id: 5fda7ccf-61d8-42de-bce7-743b67d8912c
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data: []
-                - id: 04a3b121-aa23-4d19-b77f-5055524de076
+                - id: 6ddd9896-8485-46cd-b003-f52d5bc6318e
                   type: project_developer
                   attributes:
                     name: Runolfsson and Sons
@@ -4602,18 +4626,18 @@ paths:
                     mosaics:
                     - amazon-heart
                     - amazonian-piedmont-massif
-                    created_at: '2022-07-07T10:47:44.502Z'
+                    created_at: '2022-07-14T12:53:28.426Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqWXpNelpqYzFaUzFqTmpGbExUUmhNMkV0T0dZMFppMWpabVl5T1dObU5qZGpOVEVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--cf1e3ee1cb90e3e8af1684c67b214c8e163bc000/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqWXpNelpqYzFaUzFqTmpGbExUUmhNMkV0T0dZMFppMWpabVl5T1dObU5qZGpOVEVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--cf1e3ee1cb90e3e8af1684c67b214c8e163bc000/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqWXpNelpqYzFaUzFqTmpGbExUUmhNMkV0T0dZMFppMWpabVl5T1dObU5qZGpOVEVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--cf1e3ee1cb90e3e8af1684c67b214c8e163bc000/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TkRGa01URmhNeTAxT0RJMExUUXdNRGt0T0RFek1DMHdNak0yTldSa09ERTNZamdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--97b5e3a159586028aab258ca22ff91ef926e952f/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TkRGa01URmhNeTAxT0RJMExUUXdNRGt0T0RFek1DMHdNak0yTldSa09ERTNZamdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--97b5e3a159586028aab258ca22ff91ef926e952f/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TkRGa01URmhNeTAxT0RJMExUUXdNRGt0T0RFek1DMHdNak0yTldSa09ERTNZamdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--97b5e3a159586028aab258ca22ff91ef926e952f/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: a8438d11-204d-4bbc-a814-0ae17586914e
+                        id: 5f842a4c-0190-476e-9754-b908721b37e9
                         type: user
                     projects:
                       data: []
@@ -4681,7 +4705,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 0b1c6b2d-56f6-4560-bc82-9d8c2015dbe5
+                  id: 2768ef34-ce8b-491f-bbd7-a9d69a7199ad
                   type: project_developer
                   attributes:
                     name: Kutch-Spencer
@@ -4707,26 +4731,26 @@ paths:
                     mosaics:
                     - amazon-heart
                     - amazonian-piedmont-massif
-                    created_at: '2022-07-07T10:47:44.228Z'
+                    created_at: '2022-07-14T12:53:27.960Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqWXpFNFlXSTBZaTB4WW1ZNUxUUXhaR0l0T0dWbFlTMDVOemt5TXpneU1qRXdOVGtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6cf3c641ea2cbae371ad042891308788f1fa8e9b/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqWXpFNFlXSTBZaTB4WW1ZNUxUUXhaR0l0T0dWbFlTMDVOemt5TXpneU1qRXdOVGtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6cf3c641ea2cbae371ad042891308788f1fa8e9b/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqWXpFNFlXSTBZaTB4WW1ZNUxUUXhaR0l0T0dWbFlTMDVOemt5TXpneU1qRXdOVGtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6cf3c641ea2cbae371ad042891308788f1fa8e9b/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTm1Vd05tRmtPQzAwTURZMUxUUTFPV1F0WW1RMllpMWlZamM1T1dSbVpERXlPRGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4c8311c2a6ead08b33159160a8afc78fa287c3ed/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTm1Vd05tRmtPQzAwTURZMUxUUTFPV1F0WW1RMllpMWlZamM1T1dSbVpERXlPRGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4c8311c2a6ead08b33159160a8afc78fa287c3ed/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTm1Vd05tRmtPQzAwTURZMUxUUTFPV1F0WW1RMllpMWlZamM1T1dSbVpERXlPRGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4c8311c2a6ead08b33159160a8afc78fa287c3ed/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 70565f69-e633-4492-9e57-aa07939349c7
+                        id: 7ab87fd3-07c6-4f3a-8221-29e0ef727f47
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data:
-                      - id: d58ba3f2-d90a-46ce-b887-a2d89bbaa9b6
+                      - id: 8cbd0ab2-8535-4220-8a31-7ebc558680d2
                         type: project
-                      - id: 0cfa45b6-99ca-43c9-954a-599bc6586b22
+                      - id: 7cb51dc4-c74d-46ca-a6b0-038842959b9e
                         type: project
               schema:
                 type: object
@@ -4788,49 +4812,49 @@ paths:
             application/json:
               example:
                 data:
-                - id: fb518ec7-1ad2-44e7-ba8b-f7d98d7dca3e
+                - id: 871c0488-4ee8-451f-a439-e6aa02977125
                   type: project_map
                   attributes:
                     trusted: false
                     category: forestry-and-agroforestry
                     latitude: 2.0
                     longitude: 1.0
-                - id: 31c2e34f-89a6-47a9-84eb-d1856d4baf48
+                - id: e40ecc1a-7cc6-4678-b4c1-ebd9407c1862
                   type: project_map
                   attributes:
                     trusted: false
                     category: forestry-and-agroforestry
                     latitude: 2.0
                     longitude: 1.0
-                - id: 7d7a1a7d-0b20-4413-bbc2-167e5401b4f7
+                - id: 04f0ead7-8439-4a06-8ff4-7aa496e7ecd1
                   type: project_map
                   attributes:
                     trusted: false
                     category: forestry-and-agroforestry
                     latitude: 2.0
                     longitude: 1.0
-                - id: 9a3ebabb-2465-4f59-a0fe-f6296382981d
+                - id: 3a4c5930-f1d7-411a-a631-162766676fc1
                   type: project_map
                   attributes:
                     trusted: false
                     category: forestry-and-agroforestry
                     latitude: 2.0
                     longitude: 1.0
-                - id: 46a82932-94e5-4730-b3a8-501a919bd374
+                - id: 5ab6980f-2060-41f8-90a2-4d060354ff34
                   type: project_map
                   attributes:
                     trusted: false
                     category: forestry-and-agroforestry
                     latitude: 2.0
                     longitude: 1.0
-                - id: f11c6115-6171-4969-a985-df66d8cc0c81
+                - id: f679c36a-8ee5-457f-9425-fd67c3e21198
                   type: project_map
                   attributes:
                     trusted: false
                     category: forestry-and-agroforestry
                     latitude: 2.0
                     longitude: 1.0
-                - id: 2394ec1e-cf49-4d4d-9552-8ba5249f2bd5
+                - id: d86621f9-f82e-4e28-a718-eeab333c1af6
                   type: project_map
                   attributes:
                     trusted: false
@@ -4962,7 +4986,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: 037e50f1-2b26-42fd-aecd-d2edd1a76d45
+                - id: 6b454d90-9bae-41f4-9bb6-9eeba270c655
                   type: project
                   attributes:
                     name: Project 1
@@ -5014,7 +5038,7 @@ paths:
                       - 1.0
                       - 2.0
                     trusted: false
-                    created_at: '2022-07-07T10:47:47.200Z'
+                    created_at: '2022-07-14T12:53:34.235Z'
                     municipality_biodiversity_impact:
                     municipality_climate_impact:
                     municipality_water_impact:
@@ -5036,35 +5060,35 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: d59e827e-f2c4-478d-8e11-e77e162f95d8
+                        id: cfb85e70-8645-4f62-aa17-0b49ce12a2c7
                         type: project_developer
                     country:
                       data:
-                        id: bcd24b58-453c-4a9c-97b7-329b54d5cdcb
+                        id: 6e3f7beb-1b59-4622-a3da-a7d90a8c17d5
                         type: location
                     municipality:
                       data:
-                        id: 7c4fa21b-4f35-4446-979e-dba156a57e68
+                        id: 994c502c-0953-419d-a9af-287676a6c400
                         type: location
                     department:
                       data:
-                        id: d8f81bcb-ef00-4b78-9db1-c9891d0d77ea
+                        id: a8296b88-2494-431c-a00b-dd3f2578bc54
                         type: location
                     priority_landscape:
                       data:
                     involved_project_developers:
                       data:
-                      - id: fc5da287-1e73-445a-a499-69bc535b8f60
+                      - id: 07dbd399-ec9e-4c6b-91ff-7fb236289c7d
                         type: project_developer
-                      - id: bb2a11ef-08dc-4f4e-9a24-e1150674cf48
+                      - id: f4b7f407-0402-462f-8573-85ad5d93454c
                         type: project_developer
                     project_images:
                       data:
-                      - id: 2b58533e-715b-4b8f-b358-768ae9983e5e
+                      - id: aed34780-cf35-47b4-9e15-21a732d17040
                         type: project_image
-                      - id: 72235010-a31b-451f-8b18-66c247d61248
+                      - id: cdd3e291-f917-4f7e-bcc5-b38db5051f60
                         type: project_image
-                - id: 0f6457f4-3b40-4d60-bc50-855ed70b1c9e
+                - id: 26e0dd98-9437-4072-9118-1c0f4fa87929
                   type: project
                   attributes:
                     name: Project 2
@@ -5116,7 +5140,7 @@ paths:
                       - 1.0
                       - 2.0
                     trusted: false
-                    created_at: '2022-07-07T10:47:47.351Z'
+                    created_at: '2022-07-14T12:53:34.461Z'
                     municipality_biodiversity_impact:
                     municipality_climate_impact:
                     municipality_water_impact:
@@ -5138,19 +5162,19 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 4fa5349e-8ac0-467d-88e8-ee8048bf0e0a
+                        id: d4c95718-43cf-48d5-a992-12361f11132f
                         type: project_developer
                     country:
                       data:
-                        id: 1cdb4565-9212-4b92-8319-a6d3c2e1f431
+                        id: 1f681907-fcbc-47f1-9850-980e08c01498
                         type: location
                     municipality:
                       data:
-                        id: '04850b20-b260-446f-9737-54d972285535'
+                        id: 3c036ccc-405a-4164-ba89-2c474c9d34fc
                         type: location
                     department:
                       data:
-                        id: fd8cabe4-a57b-445a-83b0-dd68308d4a8e
+                        id: a9037689-ce40-44f6-9cef-e9464481dfd0
                         type: location
                     priority_landscape:
                       data:
@@ -5158,7 +5182,7 @@ paths:
                       data: []
                     project_images:
                       data: []
-                - id: d3c63dc0-ca14-4437-9dc8-1b0c8c1a79df
+                - id: 4f01fcd2-7b42-4904-a1a5-4df25a93dd5b
                   type: project
                   attributes:
                     name: Project 3
@@ -5210,7 +5234,7 @@ paths:
                       - 1.0
                       - 2.0
                     trusted: false
-                    created_at: '2022-07-07T10:47:47.479Z'
+                    created_at: '2022-07-14T12:53:34.607Z'
                     municipality_biodiversity_impact:
                     municipality_climate_impact:
                     municipality_water_impact:
@@ -5232,19 +5256,19 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: e44fdaa8-b51c-49f6-8f99-13928c3470a5
+                        id: 80e942f9-759b-44a4-bcf0-cf1402ed9efc
                         type: project_developer
                     country:
                       data:
-                        id: da0c1c52-9209-43e6-aeea-0063025fb08c
+                        id: 2cead6fc-d62c-4d9e-aa8e-6da485d9d907
                         type: location
                     municipality:
                       data:
-                        id: 757f7826-7aa8-40c5-80e0-1d840f40dfe6
+                        id: 16ebae30-d3ee-4dae-937a-2ad800bd74ce
                         type: location
                     department:
                       data:
-                        id: 24418696-165f-4ac3-8628-053dd5497aa6
+                        id: dacfa2d7-8520-4d0d-9c35-330ae7e56f2e
                         type: location
                     priority_landscape:
                       data:
@@ -5252,7 +5276,7 @@ paths:
                       data: []
                     project_images:
                       data: []
-                - id: 2cf0a876-5b28-4536-b0d7-6b600198f53c
+                - id: f89aa45b-7f21-4bb6-b18f-4c7dd1f03b4f
                   type: project
                   attributes:
                     name: Project 4
@@ -5304,7 +5328,7 @@ paths:
                       - 1.0
                       - 2.0
                     trusted: false
-                    created_at: '2022-07-07T10:47:47.593Z'
+                    created_at: '2022-07-14T12:53:34.733Z'
                     municipality_biodiversity_impact:
                     municipality_climate_impact:
                     municipality_water_impact:
@@ -5326,19 +5350,19 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: eba14530-e4a3-47d5-927d-ca92b0681e7d
+                        id: 0d1684cb-9d2f-4d16-8d55-ab2cdf507489
                         type: project_developer
                     country:
                       data:
-                        id: f4055dba-8d2d-43bc-9ed6-a63ea6f0d43d
+                        id: ce74a5b0-4c84-4466-a2e9-c55995afa32c
                         type: location
                     municipality:
                       data:
-                        id: 4de66b85-3e48-4339-a104-10a6018ab22d
+                        id: 7a04c171-1652-49a1-907f-ae78a91167a1
                         type: location
                     department:
                       data:
-                        id: cad66bc3-574c-4679-be8e-b696466d4320
+                        id: b8d6d395-bec3-4ce7-8620-597cc9241505
                         type: location
                     priority_landscape:
                       data:
@@ -5346,7 +5370,7 @@ paths:
                       data: []
                     project_images:
                       data: []
-                - id: ae8b2108-3b5c-4eb2-a6cf-11d755172bf5
+                - id: d8f3b082-9e3c-42b7-939d-df9f5276a614
                   type: project
                   attributes:
                     name: Project 5
@@ -5398,7 +5422,7 @@ paths:
                       - 1.0
                       - 2.0
                     trusted: false
-                    created_at: '2022-07-07T10:47:47.695Z'
+                    created_at: '2022-07-14T12:53:34.928Z'
                     municipality_biodiversity_impact:
                     municipality_climate_impact:
                     municipality_water_impact:
@@ -5420,19 +5444,19 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: c15e2c9f-113d-49dc-8cca-d555864244e7
+                        id: b034bbb2-db5f-4f7c-9861-0399120d6e3f
                         type: project_developer
                     country:
                       data:
-                        id: 84bd6173-90e2-46ab-b8a4-52cdb9e21cd3
+                        id: 78fee7ad-1e78-4bf3-8551-2c795a05c58d
                         type: location
                     municipality:
                       data:
-                        id: ac89eeb3-c861-4fd7-8418-99a0eeb95bc4
+                        id: 853908cb-8487-4148-b78f-acf62cce8b2e
                         type: location
                     department:
                       data:
-                        id: a42abb4c-c295-4875-9b7e-efa8b3dea4c1
+                        id: 0fb7c8b1-fcbb-410b-a725-5f9dff549003
                         type: location
                     priority_landscape:
                       data:
@@ -5440,7 +5464,7 @@ paths:
                       data: []
                     project_images:
                       data: []
-                - id: bf6d1bd7-ed76-4fc2-b01c-f18a77d9cd6e
+                - id: 41bbd788-48cd-4776-8bd5-132a19c63f8f
                   type: project
                   attributes:
                     name: Project 6
@@ -5492,7 +5516,7 @@ paths:
                       - 1.0
                       - 2.0
                     trusted: false
-                    created_at: '2022-07-07T10:47:47.790Z'
+                    created_at: '2022-07-14T12:53:35.270Z'
                     municipality_biodiversity_impact:
                     municipality_climate_impact:
                     municipality_water_impact:
@@ -5514,19 +5538,19 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: da8e2427-117c-458f-a602-ed191b955b48
+                        id: a8be4a63-2c97-477a-b0f6-96d7cd16ebed
                         type: project_developer
                     country:
                       data:
-                        id: 51b69f8a-51ff-4839-96b4-07a354e38e00
+                        id: f8436df5-230d-4d0e-be38-fc192d58cb19
                         type: location
                     municipality:
                       data:
-                        id: 38ef5dbd-c0a7-4a1d-931b-91e9ab5ccc8f
+                        id: 8455cffe-098a-45a7-969e-17686b2adf94
                         type: location
                     department:
                       data:
-                        id: 011a192f-1208-4937-a2b1-eb44650148e7
+                        id: 5b13931e-1d7f-4df5-a7ba-f9280d163c44
                         type: location
                     priority_landscape:
                       data:
@@ -5534,7 +5558,7 @@ paths:
                       data: []
                     project_images:
                       data: []
-                - id: c6e578d9-d69e-4ab6-9cc5-21be05c1e0e4
+                - id: d3a09b91-eccf-4fef-91ff-4135874806c9
                   type: project
                   attributes:
                     name: Project 7
@@ -5586,7 +5610,7 @@ paths:
                       - 1.0
                       - 2.0
                     trusted: false
-                    created_at: '2022-07-07T10:47:47.892Z'
+                    created_at: '2022-07-14T12:53:35.456Z'
                     municipality_biodiversity_impact:
                     municipality_climate_impact:
                     municipality_water_impact:
@@ -5608,19 +5632,19 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 16a6f696-7513-43e3-89b5-ebca16d74c29
+                        id: f1784b84-ef55-44b3-890f-7ef33c99c8d2
                         type: project_developer
                     country:
                       data:
-                        id: ef5d9c0c-94a7-449b-8080-6cc5f6c0109e
+                        id: 3fe8f40a-0155-4ecc-ae53-9d71be113d71
                         type: location
                     municipality:
                       data:
-                        id: 60e87409-16b2-4804-8cc8-288007283388
+                        id: e4c48368-5a6e-42dd-9348-7daaf34c2a17
                         type: location
                     department:
                       data:
-                        id: eec9592a-56ea-4cb5-b8a3-4eebf1f80eed
+                        id: 569dfe45-dbfe-4c75-a9ed-246b18457185
                         type: location
                     priority_landscape:
                       data:
@@ -5690,7 +5714,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 037e50f1-2b26-42fd-aecd-d2edd1a76d45
+                  id: 6b454d90-9bae-41f4-9bb6-9eeba270c655
                   type: project
                   attributes:
                     name: Project 1
@@ -5742,7 +5766,7 @@ paths:
                       - 1.0
                       - 2.0
                     trusted: false
-                    created_at: '2022-07-07T10:47:47.200Z'
+                    created_at: '2022-07-14T12:53:34.235Z'
                     municipality_biodiversity_impact:
                     municipality_climate_impact:
                     municipality_water_impact:
@@ -5764,33 +5788,33 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: d59e827e-f2c4-478d-8e11-e77e162f95d8
+                        id: cfb85e70-8645-4f62-aa17-0b49ce12a2c7
                         type: project_developer
                     country:
                       data:
-                        id: bcd24b58-453c-4a9c-97b7-329b54d5cdcb
+                        id: 6e3f7beb-1b59-4622-a3da-a7d90a8c17d5
                         type: location
                     municipality:
                       data:
-                        id: 7c4fa21b-4f35-4446-979e-dba156a57e68
+                        id: 994c502c-0953-419d-a9af-287676a6c400
                         type: location
                     department:
                       data:
-                        id: d8f81bcb-ef00-4b78-9db1-c9891d0d77ea
+                        id: a8296b88-2494-431c-a00b-dd3f2578bc54
                         type: location
                     priority_landscape:
                       data:
                     involved_project_developers:
                       data:
-                      - id: fc5da287-1e73-445a-a499-69bc535b8f60
+                      - id: 07dbd399-ec9e-4c6b-91ff-7fb236289c7d
                         type: project_developer
-                      - id: bb2a11ef-08dc-4f4e-9a24-e1150674cf48
+                      - id: f4b7f407-0402-462f-8573-85ad5d93454c
                         type: project_developer
                     project_images:
                       data:
-                      - id: 2b58533e-715b-4b8f-b358-768ae9983e5e
+                      - id: aed34780-cf35-47b4-9e15-21a732d17040
                         type: project_image
-                      - id: 72235010-a31b-451f-8b18-66c247d61248
+                      - id: cdd3e291-f917-4f7e-bcc5-b38db5051f60
                         type: project_image
               schema:
                 type: object
@@ -5838,18 +5862,22 @@ paths:
             application/json:
               example:
                 data:
-                  id: c6c0fdd7-aa93-4287-b68f-288608ce35a1
+                  id: afa9ccad-019e-4c1e-9411-d1b723cfc2e3
                   type: user
                   attributes:
                     first_name: Dawna
                     last_name: Block
                     email: user@example.com
                     role: light
-                    created_at: '2022-07-07T10:47:49.458Z'
+                    created_at: '2022-07-14T12:53:38.714Z'
                     confirmed: true
                     approved:
                     invitation:
                     owner: false
+                    avatar:
+                      small:
+                      medium:
+                      original:
               schema:
                 type: object
                 properties:
@@ -5890,18 +5918,22 @@ paths:
             application/json:
               example:
                 data:
-                  id: cc74b426-03a3-4806-bb2d-a1a3d375e643
+                  id: 958743f2-95fd-4ec7-82ce-ec7f1af30303
                   type: user
                   attributes:
                     first_name: Dawna
                     last_name: Block
                     email: user@example.com
                     role: light
-                    created_at: '2022-07-07T10:47:49.621Z'
+                    created_at: '2022-07-14T12:53:38.907Z'
                     confirmed: true
                     approved:
                     invitation:
                     owner: false
+                    avatar:
+                      small:
+                      medium:
+                      original:
               schema:
                 type: object
                 properties:
@@ -6021,18 +6053,22 @@ paths:
             application/json:
               example:
                 data:
-                  id: 74e6c611-913b-4be0-966f-efd6ea36d960
+                  id: d00d1e10-7de9-44dd-9ab1-2cfa73b729f2
                   type: user
                   attributes:
                     first_name: Jan
                     last_name: Kowalski
                     email: jankowalski@example.com
                     role: light
-                    created_at: '2022-07-07T10:47:50.091Z'
+                    created_at: '2022-07-14T12:53:40.189Z'
                     confirmed: true
                     approved:
                     invitation: waiting
                     owner: false
+                    avatar:
+                      small:
+                      medium:
+                      original:
               schema:
                 type: object
                 properties:
@@ -6105,18 +6141,22 @@ paths:
             application/json:
               example:
                 data:
-                  id: '0987be20-6138-4394-905d-176c4871955a'
+                  id: 79833138-9a94-4345-951e-991c06e03aea
                   type: user
                   attributes:
                     first_name: Dawna
                     last_name: Block
                     email: user@example.com
                     role: light
-                    created_at: '2022-07-07T10:47:49.902Z'
+                    created_at: '2022-07-14T12:53:39.506Z'
                     confirmed: true
                     approved:
                     invitation:
                     owner: false
+                    avatar:
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswTnpRMk1qTTVPQzB5WlRoaUxUUmhaakV0WVRabE9DMWtPVEJtTkdJeVlUYzVNek1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--63aa4609dae8b049544f941bd693a3a993e6a3e3/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswTnpRMk1qTTVPQzB5WlRoaUxUUmhaakV0WVRabE9DMWtPVEJtTkdJeVlUYzVNek1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--63aa4609dae8b049544f941bd693a3a993e6a3e3/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswTnpRMk1qTTVPQzB5WlRoaUxUUmhaakV0WVRabE9DMWtPVEJtTkdJeVlUYzVNek1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--63aa4609dae8b049544f941bd693a3a993e6a3e3/picture.jpg
               schema:
                 type: object
                 properties:
@@ -6145,19 +6185,19 @@ paths:
           content:
             application/json:
               example:
-                id: fbab2569-0c37-4927-a5fe-a3e571bf2106
-                key: fs8gyb9nyeb0a10xn8cq1lizeil3
+                id: 9304b87a-8770-4809-b964-264ecf402118
+                key: jgiegnrri7yzg3zlpeg3lspsodw4
                 filename: test.jpg
                 content_type: image/jpeg
                 metadata: {}
                 service_name: test
                 byte_size: 32326
                 checksum: QYeLAwqIj9HrwITqtTYaEw==
-                created_at: '2022-07-07T10:47:50.406Z'
-                signed_id: eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWW1GaU1qVTJPUzB3WXpNM0xUUTVNamN0WVRWbVpTMWhNMlUxTnpGaVpqSXhNRFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5f0f4ec3a53e22c9d8925ec090e8d8cbf93878f3
-                attachable_sgid: BAh7CEkiCGdpZAY6BkVUSSJWZ2lkOi8vYmFja2VuZC9BY3RpdmVTdG9yYWdlOjpCbG9iL2ZiYWIyNTY5LTBjMzctNDkyNy1hNWZlLWEzZTU3MWJmMjEwNj9leHBpcmVzX2luBjsAVEkiDHB1cnBvc2UGOwBUSSIPYXR0YWNoYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--fe12d0b8108cfa9fc6dba9622a7f45f7961d350e
+                created_at: '2022-07-14T12:53:40.968Z'
+                signed_id: eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TXpBMFlqZzNZUzA0Tnpjd0xUUTRNRGt0WWprMk5DMHlOalJsWTJZME1ESXhNVGdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--9c45b2f093ce555414475b289df8a39658fe6063
+                attachable_sgid: BAh7CEkiCGdpZAY6BkVUSSJWZ2lkOi8vYmFja2VuZC9BY3RpdmVTdG9yYWdlOjpCbG9iLzkzMDRiODdhLTg3NzAtNDgwOS1iOTY0LTI2NGVjZjQwMjExOD9leHBpcmVzX2luBjsAVEkiDHB1cnBvc2UGOwBUSSIPYXR0YWNoYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--537f6bdaf23bf8a3b39581af8364848255c04163
                 direct_upload:
-                  url: http://www.example.com/backend/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDam9JYTJWNVNTSWhabk00WjNsaU9XNTVaV0l3WVRFd2VHNDRZM0V4YkdsNlpXbHNNd1k2QmtWVU9oRmpiMjUwWlc1MFgzUjVjR1ZKSWc5cGJXRm5aUzlxY0dWbkJqc0dWRG9UWTI5dWRHVnVkRjlzWlc1bmRHaHBBa1orT2cxamFHVmphM04xYlVraUhWRlpaVXhCZDNGSmFqbEljbmRKVkhGMFZGbGhSWGM5UFFZN0JsUTZFWE5sY25acFkyVmZibUZ0WlRvSmRHVnpkQT09IiwiZXhwIjoiMjAyMi0wNy0wN1QxMDo1Mjo1MC40MDlaIiwicHVyIjoiYmxvYl90b2tlbiJ9fQ==--2b4991bb11af5fb5b0ade3ce8c5febf96f57a54f
+                  url: http://www.example.com/backend/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDam9JYTJWNVNTSWhhbWRwWldkdWNuSnBOM2w2WnpONmJIQmxaek5zYzNCemIyUjNOQVk2QmtWVU9oRmpiMjUwWlc1MFgzUjVjR1ZKSWc5cGJXRm5aUzlxY0dWbkJqc0dWRG9UWTI5dWRHVnVkRjlzWlc1bmRHaHBBa1orT2cxamFHVmphM04xYlVraUhWRlpaVXhCZDNGSmFqbEljbmRKVkhGMFZGbGhSWGM5UFFZN0JsUTZFWE5sY25acFkyVmZibUZ0WlRvSmRHVnpkQT09IiwiZXhwIjoiMjAyMi0wNy0xNFQxMjo1ODo0MC45NzJaIiwicHVyIjoiYmxvYl90b2tlbiJ9fQ==--6e21a4278db02c91bd70a7d7def466ae7d5f9156
                   headers:
                     Content-Type: image/jpeg
               schema:
@@ -6211,12 +6251,45 @@ components:
         type:
           type: string
         attributes:
-          first_name:
-            type: string
-          last_name:
-            type: string
-          email:
-            type: string
+          type: object
+          properties:
+            first_name:
+              type: string
+            last_name:
+              type: string
+            email:
+              type: string
+            role:
+              type: string
+            created_at:
+              type: string
+            confirmed:
+              type: boolean
+            approved:
+              type: boolean
+              nullable: true
+            invitation:
+              type: string
+              nullable: true
+            owner:
+              type: boolean
+            avatar:
+              "$ref": "#/components/schemas/image_blob"
+          required:
+          - first_name
+          - last_name
+          - email
+          - role
+          - created_at
+          - confirmed
+          - approved
+          - invitation
+          - owner
+          - avatar
+      required:
+      - id
+      - type
+      - attributes
     investor:
       type: object
       properties:
@@ -6231,8 +6304,8 @@ components:
               type: string
             slug:
               type: string
-            picture_url:
-              type: string
+            picture:
+              "$ref": "#/components/schemas/image_blob"
             about:
               type: string
               nullable: true
@@ -6555,8 +6628,8 @@ components:
               type: string
             slug:
               type: string
-            picture_url:
-              type: string
+            picture:
+              "$ref": "#/components/schemas/image_blob"
             about:
               type: string
               nullable: true
@@ -6716,6 +6789,22 @@ components:
       - signed_id
       - attachable_sgid
       - direct_upload
+    image_blob:
+      type: object
+      properties:
+        small:
+          type: string
+          nullable: true
+        medium:
+          type: string
+          nullable: true
+        original:
+          type: string
+          nullable: true
+      required:
+      - small
+      - medium
+      - original
     pagination_meta:
       type: object
       properties:


### PR DESCRIPTION
I am adding possibility to edit existing users --> you can modify `first_name`, `last_name` and `avatar` (new attribute added to User model).

It is also possible to delete User either via button next to edit formular or at index page after clicking on menu next to appropriate user record. I have made it impossible to delete Users which are owners of accounts (`restrict_with_error`) --> in such case, user receives error that this particular record cannot be deleted. Delete option for such records  will be automatically grayed out as part of some future ticket, but for needs of these tickets, error should be enough ;).

![Screenshot 2022-07-14 at 15 26 46](https://user-images.githubusercontent.com/20660167/178993388-4aafe3d2-8857-44fb-8f3a-c5a86c91ff79.png)
![Screenshot 2022-07-14 at 15 26 37](https://user-images.githubusercontent.com/20660167/178993461-368558c4-baab-47ce-a540-d6c6d9f94e50.png)
## Testing instructions

Everything should be quite easily testable via Backoffice.

## Tracking

https://vizzuality.atlassian.net/browse/LET-761
https://vizzuality.atlassian.net/browse/LET-762
