### PR TITLE
Split the "Location" column into "Country" and "Municipality" (dashboard/projects)

### DIFF
--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -323,6 +323,9 @@
   "9WcWke": {
     "string": "{name} investor"
   },
+  "9a9+ww": {
+    "string": "Title"
+  },
   "9cE0nR": {
     "string": "How is the impact calculated?"
   },

--- a/frontend/pages/dashboard/projects.tsx
+++ b/frontend/pages/dashboard/projects.tsx
@@ -89,14 +89,30 @@ export const ProjectsPage: PageComponent<ProjectsPageProps, DashboardLayoutProps
 
   const tableProps = {
     columns: [
-      { Header: 'Title', accessor: 'name' },
-      { Header: 'Category', accessor: 'category' },
-      { Header: 'Country', accessor: 'country' },
-      { Header: 'Municipality', accessor: 'municipality' },
-      { Header: 'Instrument type', accessor: 'instrumentType' },
-      { Header: 'Value', accessor: 'ticketSize', canSort: false },
+      { Header: intl.formatMessage({ defaultMessage: 'Title', id: '9a9+ww' }), accessor: 'name' },
       {
-        Header: 'Status',
+        Header: intl.formatMessage({ defaultMessage: 'Category', id: 'ccXLVi' }),
+        accessor: 'category',
+      },
+      {
+        Header: intl.formatMessage({ defaultMessage: 'Country', id: 'vONi+O' }),
+        accessor: 'country',
+      },
+      {
+        Header: intl.formatMessage({ defaultMessage: 'Municipality', id: '9I1zvK' }),
+        accessor: 'municipality',
+      },
+      {
+        Header: intl.formatMessage({ defaultMessage: 'Instrument type', id: 'fDd10o' }),
+        accessor: 'instrumentType',
+      },
+      {
+        Header: intl.formatMessage({ defaultMessage: 'Value', id: 'GufXy5' }),
+        accessor: 'ticketSize',
+        canSort: false,
+      },
+      {
+        Header: intl.formatMessage({ defaultMessage: 'Status', id: 'tzMNF3' }),
         accessor: 'status',
         Cell: ({ cell: { value } }) => {
           return (


### PR DESCRIPTION
## Description

This PR splits the "Location" column into separate "Country" and "Municipality" columns. The resulting two new columns are still sortable. 

**Notes:**  I've noticed the table's column headers weren't being translated, so that was fixed as well. 

## Testing instructions

- Login in as a Project Developer  
- Visit `dashboard/projects`  
- Verify that the table has the following columns: 
  - Title
  - Category
  - Country
  - Municipality
  - Instrument type
  - Value
  - Status

## Tracking

[LET-767](https://vizzuality.atlassian.net/browse/LET-767)

## Screenshot

<img width="1502" alt="Screenshot 2022-07-14 at 14 44 25" src="https://user-images.githubusercontent.com/6273795/178996842-f4db6aa2-af3e-4812-813c-37e0097b9b79.png">

