### PR TITLE
Remove queries on signout

### DIFF
--- a/frontend/services/authentication/authService.ts
+++ b/frontend/services/authentication/authService.ts
@@ -21,7 +21,7 @@ export function useSignOut(): UseMutationResult<AxiosResponse, AxiosError> {
   const queryClient = useQueryClient();
   return useMutation(signOut, {
     onSuccess: () => {
-      queryClient.setQueryData([Queries.User, locale], undefined);
+      queryClient.removeQueries();
     },
   });
 }


### PR DESCRIPTION
## Description

Remove queries on signout; otherwise when changing users the previous users' queries may be shown. 

## Testing instructions

- Log in with a PD  
- Visit the dashboard/projects  
- Sign out  
- Log in with a different PD  
- Visit the dashboard/projects  

Verify that the correct projects are shown (and previous' PD's aren't)

## Tracking

N/A
