### PR TITLE
Fix location dropdowns crashing the app when creating a project

### DIFF
--- a/frontend/containers/project-form/pages/general-information.tsx
+++ b/frontend/containers/project-form/pages/general-information.tsx
@@ -48,7 +48,7 @@ const GeneralInformation = ({
   const [coverImage, setCoverImage] = useState<string>();
 
   const { formatMessage } = useIntl();
-  const { locations } = useGroupedLocations();
+  const { locations } = useGroupedLocations({ includes: 'parent' });
 
   const { projectDevelopers } = useProjectDevelopersList({
     'page[size]': 1000,


### PR DESCRIPTION
## Description

This PR fixes a bug introduced by #342, which was causing the frontend to crash when the user selected a location from the dropdown while creating a new project. 

The issue is that #342 replaced the `jsona` package with the `deserialize-json-api`. The reason for the change was because we were having issues with circular dependencies/relationships in the JSON API responses, which we had been mitigating by using the `cycle` package. 

Two caveats with that change were: 
- Empty relationships are now `undefined` instead of an empty array  
- We no longer get relationship `ids` in the response, unless we specifically include the relationship in our request

The latter was causing the bug; since we weren't specifically using `?includes=parent`, we didn't have a `parent.id` which is used to filter the locations in the dropdowns. 

## Testing instructions

TODO

## Tracking

N/A
