### PR TITLE
feat: Disable delete links for owners at Backoffice

### DIFF
--- a/backend/app/assets/stylesheets/application.tailwind.css
+++ b/backend/app/assets/stylesheets/application.tailwind.css
@@ -82,4 +82,12 @@
   .select-input {
     @apply block px-4 py-2 text-base text-gray-900 placeholder-gray-400 placeholder-opacity-100 border border-solid border-beige hover:shadow-sm focus:shadow-sm focus:border-green-dark outline-none bg-white rounded-lg disabled:opacity-60 transition
   }
+
+  li[role="menuitem"] a {
+    @apply block px-8 py-2 hover:bg-gray-200;
+  }
+
+  li[role="menuitem"] .disabled-item {
+    @apply block px-8 py-2 opacity-60;
+  }
 }

--- a/backend/app/controllers/backoffice/users_controller.rb
+++ b/backend/app/controllers/backoffice/users_controller.rb
@@ -8,7 +8,7 @@ module Backoffice
 
     def index
       @q = User.ransack params[:q]
-      @users = @q.result.includes(:account)
+      @users = @q.result.includes(:owner_account, account: %i[project_developer investor])
       @users = @users.search params.dig(:q, :filter_full_text) if params.dig(:q, :filter_full_text).present?
 
       respond_to do |format|

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -34,6 +34,9 @@ class User < ApplicationRecord
   ransacker :full_name do
     Arel.sql("CONCAT_WS(' ', users.first_name, users.last_name)")
   end
+  ransacker :owner_account_exists do
+    Arel.sql("(SELECT EXISTS (SELECT 1 FROM accounts WHERE accounts.owner_id = users.id))")
+  end
 
   def send_confirmation_instructions
     return if confirmation_sent_within_limited_period?

--- a/backend/app/services/backoffice/csv/user_exporter.rb
+++ b/backend/app/services/backoffice/csv/user_exporter.rb
@@ -6,6 +6,7 @@ module Backoffice
           column(I18n.t("backoffice.common.name")) { |r| r.full_name }
           column(I18n.t("backoffice.common.email")) { |r| r.email }
           column(I18n.t("backoffice.users.index.account")) { |r| r.account&.name }
+          column(I18n.t("backoffice.common.account_owner")) { |r| I18n.t r.owner_account.present? }
           column(I18n.t("backoffice.common.created_at")) { |r| I18n.l r.created_at.to_date }
           column(I18n.t("backoffice.admins.index.last_sign_in_at")) { |r| I18n.l r.last_sign_in_at&.to_date, default: "" }
         end

--- a/backend/app/views/backoffice/base/menu/_item.html.erb
+++ b/backend/app/views/backoffice/base/menu/_item.html.erb
@@ -1,4 +1,4 @@
-<li role="menuitem" tabindex="-1" class="flex justify-between items-center px-4 py-2 sm:py-2 outline-none text-sm font-sans transition text-black cursor-pointer hover:opacity-60">
+<li role="menuitem" tabindex="-1" class="text-sm font-sans transition text-black">
   <div>
     <%= yield if yield.present? %>
   </div>

--- a/backend/app/views/backoffice/users/edit.html.erb
+++ b/backend/app/views/backoffice/users/edit.html.erb
@@ -7,14 +7,21 @@
     <ul class="flex flex-col gap-8 mb-8">
       <li><%= section_link_to t("backoffice.users.information"), edit_backoffice_user_path, :information, default: true %></li>
     </ul>
-    <%= link_to backoffice_user_path(@user.id),
-       data: {
-         turbo_method: :delete,
-         turbo_confirm: t("backoffice.messages.delete_confirmation", model: t("backoffice.common.user").downcase)
-       },
-       class: "button button-secondary-green button-with-icon" do %>
-      <%= svg "trash" %>
-      <%= t("backoffice.users.delete") %>
+    <% if @user.owner_account.present? %>
+      <div class="button button-secondary-green button-with-icon opacity-60 hover:bg-green-lighter/0">
+        <%= svg "trash" %>
+        <%= t("backoffice.users.delete") %>
+      </div>
+    <% else %>
+      <%= link_to backoffice_user_path(@user.id),
+         data: {
+           turbo_method: :delete,
+           turbo_confirm: t("backoffice.messages.delete_confirmation", model: t("backoffice.common.user").downcase)
+         },
+         class: "button button-secondary-green button-with-icon" do %>
+        <%= svg "trash" %>
+        <%= t("backoffice.users.delete") %>
+      <% end %>
     <% end %>
   </aside>
   <div class="w-full h-full bg-white rounded-xl p-6">

--- a/backend/app/views/backoffice/users/index.html.erb
+++ b/backend/app/views/backoffice/users/index.html.erb
@@ -16,6 +16,9 @@
         <%= sort_link @q, :account_name, t("backoffice.users.index.account") %>
       </th>
       <th>
+        <%= sort_link @q, :owner_account_exists, t("backoffice.common.account_owner") %>
+      </th>
+      <th>
         <%= sort_link @q, :created_at, t("backoffice.common.created_at") %>
       </th>
       <th>
@@ -32,17 +35,22 @@
         <td><%= user.full_name %></td>
         <td><%= user.email %></td>
         <td><%= account_link_for user.account %></td>
+        <td><%= t user.owner_account.present? %></td>
         <td><%= I18n.l user.created_at.to_date %></td>
         <td><%= I18n.l user.last_sign_in_at&.to_date, default: '' %></td>
         <td><%= link_to t("backoffice.common.edit"), edit_backoffice_user_path(user.id), class: "link-button" %></td>
         <td>
           <%= render "menu" do %>
             <%= render "backoffice/base/menu/item" do %>
-              <%= link_to t("backoffice.common.delete"), backoffice_user_path(user.id),
-                 data: {
-                   turbo_method: :delete,
-                   turbo_confirm: t("backoffice.messages.delete_confirmation", model: t("backoffice.common.user").downcase)
-                 } %>
+              <% if user.owner_account.present? %>
+                <div class="disabled-item"><%= t("backoffice.common.delete") %></div>
+              <% else %>
+                <%= link_to t("backoffice.common.delete"), backoffice_user_path(user.id),
+                   data: {
+                     turbo_method: :delete,
+                     turbo_confirm: t("backoffice.messages.delete_confirmation", model: t("backoffice.common.user").downcase)
+                   } %>
+              <% end %>
             <% end %>
           <% end %>
         </td>

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -1,4 +1,6 @@
 zu:
+  "true": "yes"
+  "false": "no"
   date:
     formats:
       default: "%d %B %Y"

--- a/backend/spec/services/backoffice/csv/user_exporter_spec.rb
+++ b/backend/spec/services/backoffice/csv/user_exporter_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Backoffice::CSV::UserExporter do
         I18n.t("backoffice.common.name"),
         I18n.t("backoffice.common.email"),
         I18n.t("backoffice.users.index.account"),
+        I18n.t("backoffice.common.account_owner"),
         I18n.t("backoffice.common.created_at"),
         I18n.t("backoffice.admins.index.last_sign_in_at")
       ])
@@ -23,6 +24,7 @@ RSpec.describe Backoffice::CSV::UserExporter do
         query.first.full_name,
         query.first.email,
         query.first.account.name,
+        I18n.t(query.first.owner_account.present?),
         I18n.l(query.first.created_at.to_date),
         I18n.l(query.first.last_sign_in_at&.to_date, default: "")
       ])

--- a/backend/spec/system/backoffice/users_spec.rb
+++ b/backend/spec/system/backoffice/users_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "Backoffice: Users", type: :system do
       I18n.t("backoffice.common.name"),
       I18n.t("backoffice.common.email"),
       I18n.t("backoffice.users.index.account"),
+      I18n.t("backoffice.common.account_owner"),
       I18n.t("backoffice.common.created_at"),
       I18n.t("backoffice.users.index.last_sign_in_at")
     ]
@@ -24,6 +25,7 @@ RSpec.describe "Backoffice: Users", type: :system do
       within_row(owner.full_name) do
         expect(page).to have_text(owner.email)
         expect(page).to have_text(owner.account.name)
+        expect(page).to have_text(I18n.t(owner.owner_account.present?))
         expect(page).to have_text(I18n.l(owner.created_at.to_date))
         expect(page).to have_text(I18n.l(owner.last_sign_in_at&.to_date, default: ""))
       end


### PR DESCRIPTION
I am making sure that all users which are owners of account cannot be deleted --> links used for deletion are grayed out. I am also adding new column to index of users table which shows information if user is owner or not.

![Screenshot 2022-07-15 at 12 21 15](https://user-images.githubusercontent.com/20660167/179204638-3a3e1a42-1d55-4224-ad46-612babdd3da1.png)

## Testing instructions

Via backoffice --> check that Owner of account cannot be deleted and other users can be (links are grayed out)

## Tracking

https://vizzuality.atlassian.net/browse/LET-681
