### PR TITLE
feat: Notify user on user deletion via backoffice

### DIFF
--- a/backend/app/controllers/backoffice/users_controller.rb
+++ b/backend/app/controllers/backoffice/users_controller.rb
@@ -39,6 +39,7 @@ module Backoffice
 
     def destroy
       if @user.destroy
+        UserMailer.destroyed(@user.email, @user.full_name).deliver_later
         redirect_to backoffice_users_path, status: :see_other,
           notice: t("backoffice.messages.success_delete", model: t("backoffice.common.user"))
       else

--- a/backend/spec/system/backoffice/users_spec.rb
+++ b/backend/spec/system/backoffice/users_spec.rb
@@ -90,9 +90,11 @@ RSpec.describe "Backoffice: Users", type: :system do
 
     context "when removing user" do
       it "removes user" do
-        accept_confirm do
-          click_on t("backoffice.users.delete")
-        end
+        expect {
+          accept_confirm do
+            click_on t("backoffice.users.delete")
+          end
+        }.to have_enqueued_mail(UserMailer, :destroyed).with(user.email, user.full_name)
         expect(page).to have_text(t("backoffice.messages.success_delete", model: t("backoffice.common.user")))
         expect(current_path).to eql(backoffice_users_path)
         expect(page).not_to have_text(user.full_name)


### PR DESCRIPTION
Notify user after his/her user account have been removed via Backoffice.

## Testing instructions

Via backoffice --> you should receive notification after user deletion

## Tracking

https://vizzuality.atlassian.net/browse/LET-763
