### PR TITLE
Fix frontend crashing when trying to access Dashboard/AccountInformation

### DIFF
--- a/frontend/services/account/index.ts
+++ b/frontend/services/account/index.ts
@@ -40,7 +40,7 @@ export function useProjectDeveloper(
   includes?: string
 ): UseQueryResult<ProjectDeveloper> & { projectDeveloper: ProjectDeveloper } {
   const query = useLocalizedQuery(
-    [Queries.CurrentProjectDeveloper],
+    [Queries.CurrentProjectDeveloper, includes],
     () => getProjectDeveloper(includes),
     {
       refetchOnWindowFocus: false,
@@ -132,10 +132,14 @@ const getInvestor = async (includes?: string): Promise<Investor> => {
 };
 
 export function useInvestor(options: UseQueryOptions<Investor>, includes?: string) {
-  const query = useLocalizedQuery([Queries.CurrentInvestor], () => getInvestor(includes), {
-    refetchOnWindowFocus: false,
-    ...options,
-  });
+  const query = useLocalizedQuery(
+    [Queries.CurrentInvestor, includes],
+    () => getInvestor(includes),
+    {
+      refetchOnWindowFocus: false,
+      ...options,
+    }
+  );
   return useMemo(() => ({ ...query, investor: query.data }), [query]);
 }
 


### PR DESCRIPTION
## Description

This PR fixes a bug causing the app to crash when visiting the _"Dashboard"_'s _"Account Information"_ tab. 

We are using `useAccount()` in multiple components both with and without `includes`, but not using the params (in this case only `includes`) in the query key, causing the returned data to often not include `owner` at all. 

## Testing instructions

With a PD account:  
- Visit the _"Dashboard"_, _"Account Information"_  
- Verify that the app doesn't crash  
- Verify that the account _"Owner"_ information is visible

With an Investor account:  
- Visit the _"Dashboard"_, _"Account Information"_  
- Verify that the app doesn't crash  
- Verify that the account _"Owner"_ information is visible

## Tracking

N/A
