### PR TITLE
Fix bug preventing a project developer from being able to edit their projects

### DIFF
--- a/frontend/containers/project-form/helpers.ts
+++ b/frontend/containers/project-form/helpers.ts
@@ -33,7 +33,7 @@ export const useDefaultValues = (project: Project): Partial<ProjectForm> => {
           src: file.original,
         };
       }),
-      involved_project_developer: !!project.involved_project_developers.length ? 1 : 0,
+      involved_project_developer: !!project.involved_project_developers?.length ? 1 : 0,
       involved_project_developer_ids: project.involved_project_developers?.map(({ id }) => id),
       involved_project_developer_not_listed: project.involved_project_developer_not_listed,
     };

--- a/frontend/pages/project/[id]/edit.tsx
+++ b/frontend/pages/project/[id]/edit.tsx
@@ -36,6 +36,7 @@ export const getServerSideProps = withLocalizedRequests(async ({ params: { id },
         'country',
         'municipality',
         'department',
+        'project_developer',
         'involved_project_developers',
       ],
     }));


### PR DESCRIPTION
## Description

Due to the change in library used to deserialise the json API, relationships aren't returned unless specified. Since a `project_developer` `id` for a project was never returned, access would always be denied to the user. 

The project form helper change is because if there aren't any `involved_project_developers`, we won't have the property (in with the previous library we'd get an empty array. 

## Testing instructions

Verify that a PD can edit their own projects. 

## Tracking

N/A
