### PR TITLE
refactoring: use salt for authentication

### DIFF
--- a/backend/app/controllers/api/v1/sessions_controller.rb
+++ b/backend/app/controllers/api/v1/sessions_controller.rb
@@ -17,7 +17,9 @@ module API
       end
 
       def destroy
-        sign_out current_user
+        user = current_user
+        sign_out user
+        user.invalidate_session!
         head :ok
       end
     end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -51,6 +51,14 @@ class User < ApplicationRecord
   end
   alias_method :to_s, :full_name
 
+  def invalidate_session!
+    update! token: SecureRandom.hex, remember_created_at: nil
+  end
+
+  def authenticatable_salt
+    "#{super}#{token}"
+  end
+
   private
 
   def confirmation_sent_within_limited_period?

--- a/backend/db/migrate/20220718082600_add_token_to_users.rb
+++ b/backend/db/migrate/20220718082600_add_token_to_users.rb
@@ -1,0 +1,5 @@
+class AddTokenToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :token, :string
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_13_091005) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_18_082600) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -385,6 +385,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_13_091005) do
     t.datetime "last_sign_in_at"
     t.string "current_sign_in_ip"
     t.string "last_sign_in_ip"
+    t.string "token"
     t.index ["account_id"], name: "index_users_on_account_id"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/backend/spec/models/user_spec.rb
+++ b/backend/spec/models/user_spec.rb
@@ -68,4 +68,15 @@ RSpec.describe User, type: :model do
       User::EMAIL_CONFIRMATION_LIMIT_PERIOD
     end
   end
+
+  describe "#invalidate_session!" do
+    let!(:user) { create :user }
+    let!(:token) { user.token }
+
+    before { user.invalidate_session! }
+
+    it "changes token" do
+      expect(user.reload.token).not_to eq(token)
+    end
+  end
 end

--- a/backend/spec/requests/api/v1/session_spec.rb
+++ b/backend/spec/requests/api/v1/session_spec.rb
@@ -105,6 +105,7 @@ RSpec.describe "API V1 Session", type: :request do
 
       response "200", :success do
         let("X-CSRF-TOKEN") { get_csrf_token }
+        let!(:token) { @user.token }
 
         before(:each) { sign_in @user }
 
@@ -112,6 +113,7 @@ RSpec.describe "API V1 Session", type: :request do
 
         it "removes user from session" do
           expect(session["warden.user.user.key"]).to be_nil
+          expect(@user.reload.token).not_to eq(token)
         end
       end
     end

--- a/backend/spec/requests/api/v1/session_spec.rb
+++ b/backend/spec/requests/api/v1/session_spec.rb
@@ -109,9 +109,13 @@ RSpec.describe "API V1 Session", type: :request do
 
         before(:each) { sign_in @user }
 
-        run_test!
+        it "returns correct response" do |example|
+          submit_request example.metadata
+          assert_response_matches_metadata example.metadata
+        end
 
-        it "removes user from session" do
+        it "removes user from session" do |example|
+          submit_request example.metadata
           expect(session["warden.user.user.key"]).to be_nil
           expect(@user.reload.token).not_to eq(token)
         end

--- a/backend/spec/requests/api/v1/session_spec.rb
+++ b/backend/spec/requests/api/v1/session_spec.rb
@@ -1,9 +1,7 @@
 require "swagger_helper"
 
 RSpec.describe "API V1 Session", type: :request do
-  before_all do
-    @user = create(:user, email: "user@example.com", password: "SuperSecret1234")
-  end
+  let!(:user) { create(:user, email: "user@example.com", password: "SuperSecret1234") }
 
   path "/api/v1/session" do
     post "Creates User Session/Logs In" do
@@ -43,7 +41,7 @@ RSpec.describe "API V1 Session", type: :request do
 
         context "when invited user tries to login" do
           before do
-            @user.invite! create(:account).owner
+            user.invite! create(:account).owner
           end
 
           run_test!
@@ -105,19 +103,15 @@ RSpec.describe "API V1 Session", type: :request do
 
       response "200", :success do
         let("X-CSRF-TOKEN") { get_csrf_token }
-        let!(:token) { @user.token }
+        let!(:token) { user.token }
 
-        before(:each) { sign_in @user }
+        before(:each) { sign_in user }
 
-        it "returns correct response" do |example|
-          submit_request example.metadata
-          assert_response_matches_metadata example.metadata
-        end
+        run_test!
 
-        it "removes user from session" do |example|
-          submit_request example.metadata
+        it "removes user from session" do
           expect(session["warden.user.user.key"]).to be_nil
-          expect(@user.reload.token).not_to eq(token)
+          expect(user.reload.token).not_to eq(token)
         end
       end
     end


### PR DESCRIPTION
This tweak is related to bug discovered by @clementprdhomme and documented at https://vizzuality.atlassian.net/browse/LET-793. I have run couple of tests and I am almost 100% sure that bug is cased by FE implementation. First of all when testing same flow via Rswag documentation (https://staging.hecoinvest.org/backend/api-docs/index.html), logout always works properly. Backoffice uses same logic for login/logout and it works there as well. I believe that when FE calls logout API (which removes active user session from browser), it is returned by some piece of code back into play by FE. I was not able to find exact cause why this happens, sometimes logout works properly, sometimes it does not, from my point of view, everytime I clicked on `Account information` at user profile, I have not logged out properly afterwards so maybe problem is there.

Whatever, I am adding mechanism which invalidates auth session so even when It somehow survives at user browser after logout, It will not be valid anymore and user will be required to login again. There is just minor cons to this approach --> If user is logged in at multiple places at same time (for example desktop and mobile), he gets logged out from both devices on logout. I don't think this is issue for us, but to deal with this cons would require some more robust API key management, which goes again purpose of using sessions and keep auth simple.

## Testing instructions

Just check that logout via Rswag documentation still works. User should be always logged out at FE (test after merge ;))

## Tracking

https://vizzuality.atlassian.net/browse/LET-793
