### PR TITLE
test: Invitation API can be used to resend invitation.

### DIFF
--- a/backend/spec/requests/api/v1/invitation_spec.rb
+++ b/backend/spec/requests/api/v1/invitation_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe "API V1 Invitation", type: :request do
           end
 
           it "sends emails" do
-            mails = ActionMailer::Base.deliveries[-2..]
+            mails = ActionMailer::Base.deliveries.last(2)
             expect(mails.map(&:subject).uniq).to eq([I18n.t("devise.mailer.invitation_instructions.subject")])
             expect(mails.first.to).to eq(["user@example.com"])
             expect(mails.second.to).to eq([user.email])


### PR DESCRIPTION
I am adding test which ensures that invitation API `POST /api/v1/invitation` can be used to resend invitation (already invited users can be invited again). In such case, user receives new email with NEW invitation token --> that also means that previous email is no more usable.

## Testing instructions

Via Rswag -- invite some user twice. He should receive email for every invitation attempt.

## Tracking

https://vizzuality.atlassian.net/browse/LET-461
