### PR TITLE
feat: Show image thumbnail inside backoffice forms

### DIFF
--- a/backend/app/views/backoffice/base/_image_with_thumbnail.html.erb
+++ b/backend/app/views/backoffice/base/_image_with_thumbnail.html.erb
@@ -1,0 +1,8 @@
+<% blob_object = f.object.public_send blob %>
+
+<% if blob_object.present? %>
+  <%= link_to url_for(blob_object) do %>
+    <%= image_tag blob_object.variant(resize: "200x200"), class: "inline" %>
+  <% end %>
+<% end %>
+<%= f.input blob, as: :file, input_html: { accept: "image/*" } %>

--- a/backend/app/views/backoffice/investors/_form.html.erb
+++ b/backend/app/views/backoffice/investors/_form.html.erb
@@ -8,7 +8,7 @@
   </h2>
 
   <%= f.simple_fields_for :account do |ff|  %>
-    <%= ff.input :picture %>
+    <%= render "image_with_thumbnail", f: ff, blob: :picture %>
   <% end %>
   <div class="grid grid-cols-2 gap-4">
     <%= f.simple_fields_for :account do |ff|  %>

--- a/backend/app/views/backoffice/project_developers/_form.html.erb
+++ b/backend/app/views/backoffice/project_developers/_form.html.erb
@@ -8,7 +8,7 @@
   </h2>
 
   <%= f.simple_fields_for :account do |ff|  %>
-    <%= ff.input :picture %>
+    <%= render "image_with_thumbnail", f: ff, blob: :picture %>
   <% end %>
   <div class="grid grid-cols-2 gap-4">
     <%= f.simple_fields_for :account do |ff|  %>

--- a/backend/app/views/backoffice/users/_form.html.erb
+++ b/backend/app/views/backoffice/users/_form.html.erb
@@ -6,7 +6,7 @@
     <%= t(".information") %>
   </h2>
 
-  <%= f.input :avatar, as: :file, input_html: { accept: "image/*" } %>
+  <%= render "image_with_thumbnail", f: f, blob: :avatar %>
   <%= f.input :first_name %>
   <%= f.input :last_name %>
 

--- a/backend/spec/system/backoffice/investors_spec.rb
+++ b/backend/spec/system/backoffice/investors_spec.rb
@@ -183,6 +183,7 @@ RSpec.describe "Backoffice: Investors", type: :system do
           expect(page).to have_text(t("backoffice.messages.success_update", model: t("backoffice.common.investor")))
           approved_investor.reload
           expect(approved_investor.account.picture.filename.to_s).to eq("picture_2.jpg")
+          expect(page).to have_css "form a img", count: 1
           expect(approved_investor.account.name).to eq("New profile name")
           expect(approved_investor.investor_type).to eq("angel-investor")
           expect(approved_investor.account.about).to eq("New about description")

--- a/backend/spec/system/backoffice/project_developers_spec.rb
+++ b/backend/spec/system/backoffice/project_developers_spec.rb
@@ -175,6 +175,7 @@ RSpec.describe "Backoffice: Project Developers", type: :system do
           expect(page).to have_text(t("backoffice.messages.success_update", model: t("backoffice.common.project_developer")))
           approved_pd.reload
           expect(approved_pd.account.picture.filename.to_s).to eq("picture_2.jpg")
+          expect(page).to have_css "form a img", count: 1
           expect(approved_pd.account.name).to eq("New profile name")
           expect(approved_pd.project_developer_type).to eq("academic")
           expect(approved_pd.entity_legal_registration_number).to eq("1111111111")

--- a/backend/spec/system/backoffice/users_spec.rb
+++ b/backend/spec/system/backoffice/users_spec.rb
@@ -74,6 +74,7 @@ RSpec.describe "Backoffice: Users", type: :system do
           expect(page).to have_text(t("backoffice.messages.success_update", model: t("backoffice.common.user")))
           user.reload
           expect(user.avatar.filename.to_s).to eq("picture.jpg")
+          expect(page).to have_css "form a img", count: 1
           expect(user.first_name).to eq("First Name")
           expect(user.last_name).to eq("Last Name")
         end

--- a/backend/spec/system_helper.rb
+++ b/backend/spec/system_helper.rb
@@ -11,9 +11,9 @@ Capybara.register_driver(:cuprite) do |app|
     browser_options: {
       "no-sandbox": nil
     },
-    timeout: 45,
+    timeout: 120,
     # Increase Chrome startup wait time (required for stable CI builds)
-    process_timeout: 60,
+    process_timeout: 120,
     inspector: true,
     headless: ENV["HEADLESS"] != "false"
   )

--- a/backend/spec/system_helper.rb
+++ b/backend/spec/system_helper.rb
@@ -11,9 +11,9 @@ Capybara.register_driver(:cuprite) do |app|
     browser_options: {
       "no-sandbox": nil
     },
-    timeout: 30,
+    timeout: 45,
     # Increase Chrome startup wait time (required for stable CI builds)
-    process_timeout: 45,
+    process_timeout: 60,
     inspector: true,
     headless: ENV["HEADLESS"] != "false"
   )


### PR DESCRIPTION
I am adding image thumbnail to formulars which allows to upload images (Users/Investors/PDs). Thumbnail is places above upload field.

## Testing instructions

Open Backoffice and check that User/Investor/PD records with images uploaded contain its thumbnail inside edit formular.

## Tracking

https://vizzuality.atlassian.net/browse/LET-628
