### PR TITLE
Fix too strick permissions preventing users from signing up

### DIFF
--- a/frontend/pages/investors/new.tsx
+++ b/frontend/pages/investors/new.tsx
@@ -53,7 +53,7 @@ const NewInvestorPage: PageComponent<NewInvestorServerSideProps, FormPageLayoutP
   };
 
   return (
-    <ProtectedPage permissions={[UserRoles.Light]}>
+    <ProtectedPage allowUnapproved permissions={[UserRoles.Light]}>
       <InvestorForm
         title={formatMessage({ defaultMessage: 'Setup investor profile', id: '7Rh11y' })}
         leaveMessage={formatMessage({

--- a/frontend/pages/project-developers/new.tsx
+++ b/frontend/pages/project-developers/new.tsx
@@ -49,7 +49,7 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, FormPageLayoutProps
   };
 
   return (
-    <ProtectedPage permissions={[UserRoles.Light]}>
+    <ProtectedPage allowUnapproved permissions={[UserRoles.Light]}>
       <ProjectDeveloperForm
         title={formatMessage({ defaultMessage: 'Setup project developer’s account', id: 'bhxvPM' })}
         leaveMessage={formatMessage({

--- a/frontend/pages/sign-up/account-type.tsx
+++ b/frontend/pages/sign-up/account-type.tsx
@@ -32,7 +32,7 @@ const SignUpAccountTypePage: PageComponent<{}, StaticPageLayoutProps> = () => {
   };
 
   return (
-    <ProtectedPage permissions={[UserRoles.Light]}>
+    <ProtectedPage allowUnapproved permissions={[UserRoles.Light]}>
       <Head
         title={intl.formatMessage({
           defaultMessage: 'Choose your account type',


### PR DESCRIPTION
## Description

This PR fixes a bug introduced in #398 where too strict permissions prevent a new user from successfully signing up for a PD or Investor account; they would be shown the "pending approval" screen before being able to create their investor or project developer profile.

## Testing instructions

Verify that, as a new user, you can successfully sign up as a PD/Investor. 

## Tracking

[LET-795](https://vizzuality.atlassian.net/browse/LET-795)
