### PR TITLE
feat: Notify involved project developers when project gets destroyed

### DIFF
--- a/backend/app/controllers/api/v1/accounts/projects_controller.rb
+++ b/backend/app/controllers/api/v1/accounts/projects_controller.rb
@@ -39,7 +39,11 @@ module API
         end
 
         def destroy
+          project_developers = [@project.project_developer] + @project.involved_project_developers
           @project.destroy!
+          project_developers.each do |project_developer|
+            ProjectDeveloperMailer.project_destroyed(project_developer, @project.name).deliver_later
+          end
           head :ok
         end
 
@@ -77,12 +81,12 @@ module API
             :progress_impact_tracking,
             :description,
             :relevant_links,
-            involved_project_developer_ids: [],
             target_groups: [],
             impact_areas: [],
             sdgs: [],
             instrument_types: [],
-            project_images_attributes: %i[id file cover _destroy]
+            project_images_attributes: %i[id file cover _destroy],
+            involved_project_developer_ids: []
           ).tap { |r| r[:geometry] = params[:geometry].permit! if params[:geometry].present? }
         end
 

--- a/backend/app/controllers/api/v1/accounts/users_controller.rb
+++ b/backend/app/controllers/api/v1/accounts/users_controller.rb
@@ -18,7 +18,7 @@ module API
           # @user cannot be account owner AND
           # either current_user == @user OR current_user is account owner in @user's account
           @user.destroy!
-          UserMailer.destroyed(@user.email, @user.full_name).deliver_later
+          UserMailer.destroyed(@user.email, @user.full_name, @user.locale).deliver_later
           head :ok
         end
 

--- a/backend/app/controllers/backoffice/projects_controller.rb
+++ b/backend/app/controllers/backoffice/projects_controller.rb
@@ -40,7 +40,11 @@ module Backoffice
     end
 
     def destroy
+      project_developers = [@project.project_developer] + @project.involved_project_developers
       @project.destroy!
+      project_developers.each do |project_developer|
+        ProjectDeveloperMailer.project_destroyed(project_developer, @project.name).deliver_later
+      end
 
       redirect_to backoffice_projects_path, status: :see_other,
         notice: t("backoffice.messages.success_delete", model: t("backoffice.common.project"))

--- a/backend/app/controllers/backoffice/users_controller.rb
+++ b/backend/app/controllers/backoffice/users_controller.rb
@@ -2,7 +2,7 @@ module Backoffice
   class UsersController < BaseController
     include Sections
 
-    before_action :fetch_admin, only: [:edit, :update, :destroy]
+    before_action :fetch_user, only: [:edit, :update, :destroy]
     before_action :set_breadcrumbs, only: [:edit, :update]
     before_action :set_sections, only: [:edit, :update]
 
@@ -39,7 +39,7 @@ module Backoffice
 
     def destroy
       if @user.destroy
-        UserMailer.destroyed(@user.email, @user.full_name).deliver_later
+        UserMailer.destroyed(@user.email, @user.full_name, @user.locale).deliver_later
         redirect_to backoffice_users_path, status: :see_other,
           notice: t("backoffice.messages.success_delete", model: t("backoffice.common.user"))
       else
@@ -57,7 +57,7 @@ module Backoffice
       )
     end
 
-    def fetch_admin
+    def fetch_user
       @user = User.find(params[:id])
     end
 

--- a/backend/app/mailers/admin_mailer.rb
+++ b/backend/app/mailers/admin_mailer.rb
@@ -3,7 +3,9 @@ class AdminMailer < ApplicationMailer
     @admin = admin
     @token = set_reset_password_token admin
 
-    mail to: admin.email
+    I18n.with_locale admin.ui_language do
+      mail to: admin.email
+    end
   end
 
   private

--- a/backend/app/mailers/project_developer_mailer.rb
+++ b/backend/app/mailers/project_developer_mailer.rb
@@ -12,4 +12,11 @@ class ProjectDeveloperMailer < ApplicationMailer
 
     mail to: @user.email
   end
+
+  def project_destroyed(project_developer, project_name)
+    @user = project_developer.owner
+    @project_name = project_name
+
+    mail to: @user.email
+  end
 end

--- a/backend/app/mailers/project_developer_mailer.rb
+++ b/backend/app/mailers/project_developer_mailer.rb
@@ -3,20 +3,26 @@ class ProjectDeveloperMailer < ApplicationMailer
     @user = project_developer.owner
     @project = project
 
-    mail to: @user.email
+    I18n.with_locale project_developer.account_language do
+      mail to: @user.email
+    end
   end
 
   def removed_from_project(project_developer, project)
     @user = project_developer.owner
     @project = project
 
-    mail to: @user.email
+    I18n.with_locale project_developer.account_language do
+      mail to: @user.email
+    end
   end
 
   def project_destroyed(project_developer, project_name)
     @user = project_developer.owner
     @project_name = project_name
 
-    mail to: @user.email
+    I18n.with_locale project_developer.account_language do
+      mail to: @user.email
+    end
   end
 end

--- a/backend/app/mailers/user_mailer.rb
+++ b/backend/app/mailers/user_mailer.rb
@@ -2,24 +2,32 @@ class UserMailer < ApplicationMailer
   def approved(user)
     @user = user
 
-    mail to: @user.email
+    I18n.with_locale user.locale do
+      mail to: @user.email
+    end
   end
 
   def rejected(user)
     @user = user
 
-    mail to: @user.email
+    I18n.with_locale user.locale do
+      mail to: @user.email
+    end
   end
 
   def ownership_transferred(user)
     @user = user
 
-    mail to: @user.email
+    I18n.with_locale user.locale do
+      mail to: @user.email
+    end
   end
 
-  def destroyed(email, full_name)
+  def destroyed(email, full_name, language)
     @full_name = full_name
 
-    mail to: email
+    I18n.with_locale(language) do
+      mail to: email
+    end
   end
 end

--- a/backend/app/models/project.rb
+++ b/backend/app/models/project.rb
@@ -68,7 +68,7 @@ class Project < ApplicationRecord
   before_validation :clear_received_funding_fields, unless: -> { received_funding? }
   before_save :assign_priority_landscape, if: :centroid_changed?
   after_save :calculate_impacts, if: -> { saved_change_to_geometry? || saved_change_to_impact_areas? }
-  after_update :notify_project_developers, if: -> { saved_change_to_status? && published? }
+  after_save :notify_project_developers, if: -> { saved_change_to_status? && published? }
 
   accepts_nested_attributes_for :project_images, reject_if: :all_blank, allow_destroy: true
 

--- a/backend/app/models/project_involvement.rb
+++ b/backend/app/models/project_involvement.rb
@@ -5,13 +5,13 @@ class ProjectInvolvement < ApplicationRecord
   validates_uniqueness_of :project_id, scope: :project_developer_id
 
   after_create do
-    if project.valid? && project.published? && !project.status_changed?
+    if project.valid? && project.published? && !project.status_changed? # notification is send only when project status has not changed to published, in such case project itself notifies all users on its own
       ProjectDeveloperMailer.added_to_project(project_developer, project).deliver_later
     end
   end
 
   after_destroy do
-    if project.valid? && project.published? && destroyed_by_association.blank?
+    if project.valid? && project.published? && destroyed_by_association.blank? # notification is send only when record is not destroyed by parent association, in such case parent takes care of notification
       ProjectDeveloperMailer.removed_from_project(project_developer, project).deliver_later
     end
   end

--- a/backend/app/models/project_involvement.rb
+++ b/backend/app/models/project_involvement.rb
@@ -5,10 +5,14 @@ class ProjectInvolvement < ApplicationRecord
   validates_uniqueness_of :project_id, scope: :project_developer_id
 
   after_create do
-    ProjectDeveloperMailer.added_to_project(project_developer, project).deliver_later if project.published?
+    if project.valid? && project.published? && !project.status_changed?
+      ProjectDeveloperMailer.added_to_project(project_developer, project).deliver_later
+    end
   end
 
   after_destroy do
-    ProjectDeveloperMailer.removed_from_project(project_developer, project).deliver_later if project.published?
+    if project.valid? && project.published? && destroyed_by_association.blank?
+      ProjectDeveloperMailer.removed_from_project(project_developer, project).deliver_later
+    end
   end
 end

--- a/backend/app/models/project_involvement.rb
+++ b/backend/app/models/project_involvement.rb
@@ -4,15 +4,19 @@ class ProjectInvolvement < ApplicationRecord
 
   validates_uniqueness_of :project_id, scope: :project_developer_id
 
-  after_create do
-    if project.valid? && project.published? && !project.status_changed? # notification is send only when project status has not changed to published, in such case project itself notifies all users on its own
-      ProjectDeveloperMailer.added_to_project(project_developer, project).deliver_later
+  after_create_commit do
+    ProjectDeveloperMailer.added_to_project(project_developer, project).deliver_later if notify_project_developer?
+  end
+
+  after_destroy_commit do
+    if notify_project_developer? && destroyed_by_association.blank? # notification is send only when record is not destroyed by parent association, in such case parent takes care of notification
+      ProjectDeveloperMailer.removed_from_project(project_developer, project).deliver_later
     end
   end
 
-  after_destroy do
-    if project.valid? && project.published? && destroyed_by_association.blank? # notification is send only when record is not destroyed by parent association, in such case parent takes care of notification
-      ProjectDeveloperMailer.removed_from_project(project_developer, project).deliver_later
-    end
+  private
+
+  def notify_project_developer?
+    project.published? && !project.saved_change_to_status? # notification is send only when project is published and it does not changed its status just now -- in such case project itself notifies all users
   end
 end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -39,6 +39,10 @@ class User < ApplicationRecord
     Arel.sql("(SELECT EXISTS (SELECT 1 FROM accounts WHERE accounts.owner_id = users.id))")
   end
 
+  def locale
+    account_language.presence || ui_language
+  end
+
   def send_confirmation_instructions
     return if confirmation_sent_within_limited_period?
 

--- a/backend/app/views/project_developer_mailer/project_destroyed.html.erb
+++ b/backend/app/views/project_developer_mailer/project_destroyed.html.erb
@@ -1,0 +1,3 @@
+<h3><%= t "project_developer_mailer.greetings", full_name: @user.full_name %></h3>
+<p><%= t "project_developer_mailer.project_destroyed.content", project_name: @project_name %></p>
+<p><%= t "project_developer_mailer.farewell_html" %></p>

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -255,6 +255,9 @@ zu:
     removed_from_project:
       subject: Your collaboration has ended.
       content: We would like to inform you that your collaboration with project %{project_name} has ended.
+    project_destroyed:
+      subject: Project has been removed.
+      content: Project %{project_name} which you have been collaborator of have been removed.
   enums:
     review_status:
       approved:

--- a/backend/spec/fixtures/snapshots/api/v1/accounts-project-create.json
+++ b/backend/spec/fixtures/snapshots/api/v1/accounts-project-create.json
@@ -97,7 +97,7 @@
       "priority_landscape_community_impact": null,
       "priority_landscape_total_impact": null,
       "created_at": "2022-06-24T09:06:23.534Z",
-      "status": "draft",
+      "status": "published",
       "account_language": "en"
     },
     "relationships": {

--- a/backend/spec/mailers/project_developer_mailer_spec.rb
+++ b/backend/spec/mailers/project_developer_mailer_spec.rb
@@ -35,4 +35,19 @@ RSpec.describe ProjectDeveloperMailer, type: :mailer do
       expect(mail.body.encoded).to match(I18n.t("project_developer_mailer.farewell_html"))
     end
   end
+
+  describe ".project_destroyed" do
+    let(:mail) { ProjectDeveloperMailer.project_destroyed project_developer, project.name }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq(I18n.t("project_developer_mailer.project_destroyed.subject"))
+      expect(mail.to).to eq([project_developer.owner.email])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match(I18n.t("project_developer_mailer.greetings", full_name: project_developer.owner.full_name))
+      expect(mail.body.encoded).to match(I18n.t("project_developer_mailer.project_destroyed.content", project_name: project.name))
+      expect(mail.body.encoded).to match(I18n.t("project_developer_mailer.farewell_html"))
+    end
+  end
 end

--- a/backend/spec/mailers/user_mailer_spec.rb
+++ b/backend/spec/mailers/user_mailer_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe UserMailer, type: :mailer do
   end
 
   describe ".destroyed" do
-    let(:mail) { UserMailer.destroyed user.email, user.full_name }
+    let(:mail) { UserMailer.destroyed user.email, user.full_name, "en" }
 
     it "renders the headers" do
       expect(mail.subject).to eq(I18n.t("user_mailer.destroyed.subject"))

--- a/backend/spec/models/project_involvement_spec.rb
+++ b/backend/spec/models/project_involvement_spec.rb
@@ -16,42 +16,45 @@ RSpec.describe ProjectInvolvement, type: :model do
   end
 
   describe "added_to_project notification" do
+    let!(:project_developer) { create :project_developer }
+    let!(:project) { create :project }
+
     context "when project is published" do
       it "notifies project developer owner" do
         expect {
-          subject.save!
-        }.to have_enqueued_mail(ProjectDeveloperMailer, :added_to_project).with(subject.project_developer, subject.project)
+          create :project_involvement, project: project.reload, project_developer: project_developer
+        }.to have_enqueued_mail(ProjectDeveloperMailer, :added_to_project).with(project_developer, project)
       end
     end
 
     context "when project is draft" do
-      before { subject.project.update! status: :draft }
+      before { project.update! status: :draft }
 
       it "does not notifies project developer owner" do
         expect {
-          subject.save!
+          create :project_involvement, project: project.reload, project_developer: project_developer
         }.not_to have_enqueued_mail(ProjectDeveloperMailer, :added_to_project)
       end
     end
   end
 
   describe "removed_from_project notification" do
-    before { subject.save! }
+    let!(:project_involvement) { create :project_involvement }
 
     context "when project is published" do
       it "notifies project developer owner" do
         expect {
-          subject.destroy!
-        }.to have_enqueued_mail(ProjectDeveloperMailer, :removed_from_project).with(subject.project_developer, subject.project)
+          project_involvement.reload.destroy!
+        }.to have_enqueued_mail(ProjectDeveloperMailer, :removed_from_project).with(project_involvement.project_developer, project_involvement.project)
       end
     end
 
     context "when project is draft" do
-      before { subject.project.update! status: :draft }
+      before { project_involvement.project.update! status: :draft }
 
       it "does not notifies project developer owner" do
         expect {
-          subject.destroy!
+          project_involvement.reload.destroy!
         }.not_to have_enqueued_mail(ProjectDeveloperMailer, :removed_from_project)
       end
     end

--- a/backend/spec/models/user_spec.rb
+++ b/backend/spec/models/user_spec.rb
@@ -79,4 +79,24 @@ RSpec.describe User, type: :model do
       expect(user.reload.token).not_to eq(token)
     end
   end
+
+  describe "#locale" do
+    let(:user) { create :user, ui_language: "en" }
+
+    context "when user have account" do
+      let(:account) { create :account, language: "pt" }
+
+      before { user.update! account: account }
+
+      it "returns account language" do
+        expect(user.locale).to eq("pt")
+      end
+    end
+
+    context "when user does not have account" do
+      it "returns ui_language" do
+        expect(user.locale).to eq("en")
+      end
+    end
+  end
 end

--- a/backend/spec/requests/api/v1/accounts/projects_spec.rb
+++ b/backend/spec/requests/api/v1/accounts/projects_spec.rb
@@ -239,7 +239,7 @@ RSpec.describe "API V1 Account Projects", type: :request do
       parameter name: :project_params, in: :body, schema: project_params_schema
 
       let(:project_image) { create :project_image }
-      let!(:project) { create :project, :draft, :with_involved_project_developers, project_images: [project_image] }
+      let!(:project) { create :project, :with_involved_project_developers, project_images: [project_image] }
       let(:id) { project.id }
       let(:project_params) do
         {

--- a/backend/spec/requests/api/v1/accounts/users_spec.rb
+++ b/backend/spec/requests/api/v1/accounts/users_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe "API V1 Account Users", type: :request do
           it "send email" do |example|
             expect {
               submit_request example.metadata
-            }.to have_enqueued_mail(UserMailer, :destroyed).with(account_user.email, account_user.full_name)
+            }.to have_enqueued_mail(UserMailer, :destroyed).with(account_user.email, account_user.full_name, account_user.account_language)
           end
         end
 
@@ -147,7 +147,7 @@ RSpec.describe "API V1 Account Users", type: :request do
           it "send email" do |example|
             expect {
               submit_request example.metadata
-            }.to have_enqueued_mail(UserMailer, :destroyed).with(account_user.email, account_user.full_name)
+            }.to have_enqueued_mail(UserMailer, :destroyed).with(account_user.email, account_user.full_name, account_user.account_language)
           end
         end
       end

--- a/backend/spec/system/backoffice/projects_spec.rb
+++ b/backend/spec/system/backoffice/projects_spec.rb
@@ -315,9 +315,12 @@ RSpec.describe "Backoffice: Projects", type: :system do
 
     context "when removing project" do
       it "removes project" do
-        accept_confirm do
-          click_on t("backoffice.projects.delete")
-        end
+        expect {
+          accept_confirm do
+            click_on t("backoffice.projects.delete")
+          end
+        }.to have_enqueued_mail(ProjectDeveloperMailer, :project_destroyed).with(project.project_developer, project.name)
+          .and have_enqueued_mail(ProjectDeveloperMailer, :project_destroyed).with(project.involved_project_developers.first, project.name)
         expect(page).to have_text(t("backoffice.messages.success_delete", model: t("backoffice.common.project")))
         expect(current_path).to eql(backoffice_projects_path)
         expect(page).not_to have_text(project.name)

--- a/backend/spec/system/backoffice/users_spec.rb
+++ b/backend/spec/system/backoffice/users_spec.rb
@@ -3,14 +3,14 @@ require "system_helper"
 RSpec.describe "Backoffice: Users", type: :system do
   let!(:admin) { create(:admin, email: "admin@example.com", password: "SuperSecret6", first_name: "Admin", last_name: "Example") }
   let!(:owner) { create(:project_developer).owner }
-  let!(:user) { create :user }
+  let!(:user) { create :user, account: create(:account, language: "pt") }
 
   before { sign_in admin }
 
   describe "Index" do
     before { visit "/backoffice/users" }
 
-    it_behaves_like "with table pagination", expected_total: 2
+    it_behaves_like "with table pagination", expected_total: 3
     it_behaves_like "with table sorting", columns: [
       I18n.t("backoffice.common.name"),
       I18n.t("backoffice.common.email"),
@@ -97,7 +97,7 @@ RSpec.describe "Backoffice: Users", type: :system do
           accept_confirm do
             click_on t("backoffice.users.delete")
           end
-        }.to have_enqueued_mail(UserMailer, :destroyed).with(user.email, user.full_name)
+        }.to have_enqueued_mail(UserMailer, :destroyed).with(user.email, user.full_name, user.account_language)
         expect(page).to have_text(t("backoffice.messages.success_delete", model: t("backoffice.common.user")))
         expect(current_path).to eql(backoffice_users_path)
         expect(page).not_to have_text(user.full_name)


### PR DESCRIPTION
I am adding `ProjectDeveloperMailer.project_destroyed` which is send when project is deleted. Email is send as part of controller action to `project_developer/owner` and all `involved_project_developers` of project.

Tricky part was to tweak `ProjectInvolvement ` model and its `after_create`/`after_destroy` callbacks which also sends collaboration emails so users are not getting two emails when project is destroyed (one that their collaboration ended, second that project was destroyed). Hopefully I have managed to catch all use cases --> please see tests ;).

During adding of new email, I have also added localization to already existing custom emails.

## Testing instructions

Delete project via Rswag doc or Backoffice --> you should receive information that project was deleted. No other email should be received.

## Tracking

https://vizzuality.atlassian.net/browse/LET-752
https://vizzuality.atlassian.net/browse/LET-759
