### PR TITLE
User can save a project as a draft

### DIFF
--- a/frontend/containers/investor-form/component.tsx
+++ b/frontend/containers/investor-form/component.tsx
@@ -126,6 +126,7 @@ const InvestorForm: FC<InvestorFormProps> = ({
         alert={alert}
         isSubmitting={mutation.isLoading}
         showOutro={isOutroPage}
+        siteHeader={isOutroPage}
         onNextClick={handleNextClick}
         onPreviousClick={() => setCurrentPage(currentPage - 1)}
         showProgressBar

--- a/frontend/containers/multi-page-layout/component.tsx
+++ b/frontend/containers/multi-page-layout/component.tsx
@@ -9,6 +9,7 @@ import LayoutContainer from 'components/layout-container';
 import MultiPageLayoutAriaLive from './aria-live';
 import MultiPageLayoutFooter from './footer';
 import MultiPageLayoutHeader from './header';
+import MultiPageLayoutLoading from './loading';
 import MultiPageLayoutOutroPage from './outro-page';
 import MultiPageLayoutPage from './page';
 import type { MultiPageLayoutProps } from './types';
@@ -18,6 +19,7 @@ export const MultiPageLayout: FC<MultiPageLayoutProps> = ({
   layout,
   title,
   locale,
+  isLoading = false,
   showProgressBar = true,
   isSubmitting = false,
   showOutro = false,
@@ -112,9 +114,12 @@ export const MultiPageLayout: FC<MultiPageLayoutProps> = ({
         leaveButtonText={leaveButtonText}
         onCloseClick={onCloseClick}
       />
-      <LayoutContainer layout={layout}>{CurrentPage}</LayoutContainer>
+      <LayoutContainer layout={layout}>
+        {isLoading ? <MultiPageLayoutLoading /> : CurrentPage}
+      </LayoutContainer>
       {(!showOutro || (showOutro && showOutroFooter)) && (
         <MultiPageLayoutFooter
+          disabled={isLoading}
           numPages={numPages}
           currentPage={autoNavigation ? currentPage : pageProp}
           showProgressBar={showProgressBar}

--- a/frontend/containers/multi-page-layout/component.tsx
+++ b/frontend/containers/multi-page-layout/component.tsx
@@ -20,6 +20,7 @@ export const MultiPageLayout: FC<MultiPageLayoutProps> = ({
   title,
   locale,
   isLoading = false,
+  siteHeader = false,
   showProgressBar = true,
   isSubmitting = false,
   showOutro = false,
@@ -111,6 +112,7 @@ export const MultiPageLayout: FC<MultiPageLayoutProps> = ({
       <MultiPageLayoutHeader
         title={title}
         locale={locale}
+        siteHeader={siteHeader}
         leaveButtonText={leaveButtonText}
         onCloseClick={onCloseClick}
       />

--- a/frontend/containers/multi-page-layout/component.tsx
+++ b/frontend/containers/multi-page-layout/component.tsx
@@ -31,6 +31,7 @@ export const MultiPageLayout: FC<MultiPageLayoutProps> = ({
   page: pageProp,
   children,
   autoNavigation = true,
+  footerElements,
   onPreviousClick = noop,
   onNextClick = noop,
   onPageClick = noop,
@@ -125,6 +126,7 @@ export const MultiPageLayout: FC<MultiPageLayoutProps> = ({
           outroButtonText={outroButtonText}
           pagesWithErrors={pagesWithErrors}
           alert={alert}
+          footerElements={footerElements}
           onPreviousClick={handlePreviousClick}
           onNextClick={handleNextClick}
           onSubmitClick={onSubmitClick}

--- a/frontend/containers/multi-page-layout/footer/component.tsx
+++ b/frontend/containers/multi-page-layout/footer/component.tsx
@@ -28,6 +28,7 @@ export const MultiPageLayoutFooter: FC<MultiPageLayoutFooterProps> = ({
   outroButtonText,
   pagesWithErrors = [],
   alert,
+  footerElements,
   onPreviousClick = noop,
   onNextClick = noop,
   onSubmitClick = noop,
@@ -72,7 +73,8 @@ export const MultiPageLayoutFooter: FC<MultiPageLayoutFooterProps> = ({
       )}
       <LayoutContainer>
         <div className="flex flex-row-reverse items-center justify-between w-full h-20 gap-x-8 md:gap-x-16">
-          <div className="flex justify-end flex-1">
+          <div className="flex justify-end flex-1 gap-3">
+            {footerElements}
             {!showOutro &&
               (isLastPage ? (
                 <Button

--- a/frontend/containers/multi-page-layout/footer/component.tsx
+++ b/frontend/containers/multi-page-layout/footer/component.tsx
@@ -19,6 +19,7 @@ export const MultiPageLayoutFooter: FC<MultiPageLayoutFooterProps> = ({
   className,
   isSubmitting = false,
   showOutro = false,
+  disabled = false,
   showProgressBar = true,
   numPages,
   currentPage,
@@ -74,14 +75,14 @@ export const MultiPageLayoutFooter: FC<MultiPageLayoutFooterProps> = ({
       <LayoutContainer>
         <div className="flex flex-row-reverse items-center justify-between w-full h-20 gap-x-8 md:gap-x-16">
           <div className="flex justify-end flex-1 gap-3">
-            {footerElements}
+            {!disabled && footerElements}
             {!showOutro &&
               (isLastPage ? (
                 <Button
                   className="px-3 py-2 leading-none md:px-8 md:py-4"
                   size="base"
                   onClick={onSubmitClick}
-                  disabled={isSubmitting || pagesWithErrors.length > 0}
+                  disabled={disabled || isSubmitting || pagesWithErrors.length > 0}
                 >
                   <Loading className="w-5 h-5 mr-3 -ml-5" visible={isSubmitting} />
                   {submitButtonText ? (
@@ -96,6 +97,7 @@ export const MultiPageLayoutFooter: FC<MultiPageLayoutFooterProps> = ({
                   size="base"
                   type="submit"
                   onClick={onNextClick}
+                  disabled={disabled}
                 >
                   {nextButtonText ? (
                     nextButtonText
@@ -109,6 +111,7 @@ export const MultiPageLayoutFooter: FC<MultiPageLayoutFooterProps> = ({
                 className="px-3 py-2 leading-none md:px-8 md:py-4"
                 size="base"
                 onClick={onCompleteClick}
+                disabled={disabled}
               >
                 {outroButtonText ? (
                   outroButtonText
@@ -125,6 +128,7 @@ export const MultiPageLayoutFooter: FC<MultiPageLayoutFooterProps> = ({
                 numPages={numPages}
                 pagesWithErrors={pagesWithErrors}
                 isSubmitting={isSubmitting}
+                disabled={disabled}
                 onPageClick={onPageClick}
               />
             )}

--- a/frontend/containers/multi-page-layout/footer/paging/component.tsx
+++ b/frontend/containers/multi-page-layout/footer/paging/component.tsx
@@ -14,6 +14,7 @@ export const MultiPageLayoutFooterPaging: FC<MultiPageLayoutFooterPagingProps> =
   numPages,
   pagesWithErrors = [],
   isSubmitting,
+  disabled = false,
   onPageClick,
 }: MultiPageLayoutFooterPagingProps) => {
   const intl = useIntl();
@@ -61,7 +62,7 @@ export const MultiPageLayoutFooterPaging: FC<MultiPageLayoutFooterPagingProps> =
                   !isCurrentPage && !hasErrors && isBeforeCurrent && !isSubmitting,
                 'bg-background-light border border-beige text-beige': isSubmitting,
               })}
-              disabled={isSubmitting}
+              disabled={disabled || isSubmitting}
               onClick={() => onPageClick(page)}
             >
               {page + 1}

--- a/frontend/containers/multi-page-layout/footer/paging/types.ts
+++ b/frontend/containers/multi-page-layout/footer/paging/types.ts
@@ -9,6 +9,8 @@ export type MultiPageLayoutFooterPagingProps = {
   pagesWithErrors?: number[];
   /** Whether the form is being submitted */
   isSubmitting?: boolean;
+  /** Whether to disable the paging buttons. Defaults to `false` */
+  disabled?: boolean;
   /** onClick handler for when a page button is clicked */
   onPageClick?: (pageIndex: number) => void;
 };

--- a/frontend/containers/multi-page-layout/footer/types.ts
+++ b/frontend/containers/multi-page-layout/footer/types.ts
@@ -5,6 +5,8 @@ export interface MultiPageLayoutFooterProps {
   isSubmitting?: boolean;
   /** Whether to show the outro page */
   showOutro?: boolean;
+  /** Whether to disable the footer buttons. Defaults to `false` */
+  disabled?: boolean;
   /** Whether to display a progress bar. Defaults to `true` */
   showProgressBar?: boolean;
   /** Number of total pages */

--- a/frontend/containers/multi-page-layout/footer/types.ts
+++ b/frontend/containers/multi-page-layout/footer/types.ts
@@ -23,6 +23,8 @@ export interface MultiPageLayoutFooterProps {
   pagesWithErrors?: number[];
   /** Alert to display right above the footer */
   alert?: string | string[];
+  /** Allows us to pass custom elements to be displayed on the footer. (Eg: custom buttons) */
+  footerElements?: JSX.Element;
   /** Previous Button click callback */
   onPreviousClick?: () => void;
   /** Next Button click callback */

--- a/frontend/containers/multi-page-layout/header/component.tsx
+++ b/frontend/containers/multi-page-layout/header/component.tsx
@@ -9,17 +9,21 @@ import { noop } from 'lodash-es';
 
 import Button from 'components/button';
 import LayoutContainer from 'components/layout-container';
+import Header from 'layouts/static-page/header';
 
 import { MultiPageLayoutHeaderProps } from './types';
 
 export const MultiPageLayoutHeader: React.FC<MultiPageLayoutHeaderProps> = ({
   className,
   title,
+  siteHeader = false,
   locale,
   leaveButtonText,
   onCloseClick = noop,
 }: MultiPageLayoutHeaderProps) => {
   const intl = useIntl();
+
+  if (siteHeader) return <Header />;
 
   return (
     <header

--- a/frontend/containers/multi-page-layout/header/types.ts
+++ b/frontend/containers/multi-page-layout/header/types.ts
@@ -5,6 +5,8 @@ export interface MultiPageLayoutHeaderProps {
   className?: string;
   /** Title to display at the top of the page */
   title: string;
+  /** Whether to show the regular static page header. Defaults to `false` */
+  siteHeader?: boolean;
   /** Locale of the layout to display in a tag */
   locale?: LanguageType;
   /** Text to display on top right "Leave" button. Defaults to +Leave` */

--- a/frontend/containers/multi-page-layout/loading/component.tsx
+++ b/frontend/containers/multi-page-layout/loading/component.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { motion, AnimatePresence } from 'framer-motion';
+
+import Loading from 'components/loading';
+
+export const MultiPageLayoutLoading: React.FC = () => {
+  const variants = {
+    initial: { opacity: 0 },
+    animate: { opacity: 1 },
+    exit: { opacity: 0 },
+  };
+
+  return (
+    <AnimatePresence>
+      <motion.div {...variants} className="h-screen">
+        <main className="flex items-center justify-center w-full h-full">
+          <Loading visible={true} iconClassName="w-10 h-10" />
+        </main>
+      </motion.div>
+    </AnimatePresence>
+  );
+};
+
+export default MultiPageLayoutLoading;

--- a/frontend/containers/multi-page-layout/loading/index.ts
+++ b/frontend/containers/multi-page-layout/loading/index.ts
@@ -1,0 +1,1 @@
+export { default } from './component';

--- a/frontend/containers/multi-page-layout/types.ts
+++ b/frontend/containers/multi-page-layout/types.ts
@@ -14,6 +14,8 @@ export type MultiPageLayoutProps = PropsWithChildren<
     locale?: LanguageType;
     /** Whether to show a loading spinner instead of the pages. Defaults to `false` */
     isLoading?: boolean;
+    /** Whether to show the regular static page header. Defaults to `false` */
+    siteHeader?: boolean;
     /** Whether to show the outro page */
     showOutro?: boolean;
     /** Whether to show the footer on the outro page. Defaults to `false` */

--- a/frontend/containers/multi-page-layout/types.ts
+++ b/frontend/containers/multi-page-layout/types.ts
@@ -32,6 +32,7 @@ export type MultiPageLayoutProps = PropsWithChildren<
     Pick<MultiPageLayoutHeaderProps, 'title' | 'onCloseClick' | 'leaveButtonText'> &
     Pick<
       MultiPageLayoutFooterProps,
+      | 'footerElements'
       | 'alert'
       | 'showProgressBar'
       | 'isSubmitting'

--- a/frontend/containers/multi-page-layout/types.ts
+++ b/frontend/containers/multi-page-layout/types.ts
@@ -12,6 +12,8 @@ export type MultiPageLayoutProps = PropsWithChildren<
     className?: string;
     /** Locale of the layout to display in a tag in the header */
     locale?: LanguageType;
+    /** Whether to show a loading spinner instead of the pages. Defaults to `false` */
+    isLoading?: boolean;
     /** Whether to show the outro page */
     showOutro?: boolean;
     /** Whether to show the footer on the outro page. Defaults to `false` */

--- a/frontend/containers/project-developer-form/component.tsx
+++ b/frontend/containers/project-developer-form/component.tsx
@@ -132,6 +132,7 @@ export const ProjectDeveloperForm: FC<ProjectDeveloperFormProps> = ({
         alert={alert}
         isSubmitting={mutation.isLoading}
         showOutro={isOutroPage}
+        siteHeader={isOutroPage}
         onNextClick={handleNextClick}
         onPreviousClick={() => setCurrentPage(currentPage - 1)}
         showProgressBar

--- a/frontend/containers/project-form/component.tsx
+++ b/frontend/containers/project-form/component.tsx
@@ -11,8 +11,9 @@ import ContentLanguageAlert from 'containers/forms/content-language-alert';
 import LeaveFormModal from 'containers/leave-form-modal';
 import MultiPageLayout, { OutroPage, Page } from 'containers/multi-page-layout';
 
+import Button from 'components/button';
 import Head from 'components/head';
-import { Paths } from 'enums';
+import { Paths, ProjectStatus } from 'enums';
 import {
   ProjectCreationPayload,
   ProjectForm as ProjectFormType,
@@ -65,6 +66,7 @@ export const ProjectForm: FC<ProjectFormProps> = ({
 
   const defaultValues = useDefaultValues(project);
   const languageNames = useLanguageNames();
+  const isLastPage = currentPage === totalPages - 1;
 
   const {
     register,
@@ -135,7 +137,7 @@ export const ProjectForm: FC<ProjectFormProps> = ({
   );
 
   const onSubmit: SubmitHandler<ProjectFormType> = (values: ProjectFormType) => {
-    if (currentPage === totalPages - 1) {
+    if (isLastPage) {
       const {
         involved_project_developer,
         project_gallery,
@@ -161,6 +163,7 @@ export const ProjectForm: FC<ProjectFormProps> = ({
       const involved_project_developer_ids = values.involved_project_developer_ids?.filter(
         (id) => id !== 'not-listed'
       );
+
       if (isCreateForm) {
         handleCreate({
           ...rest,
@@ -188,6 +191,16 @@ export const ProjectForm: FC<ProjectFormProps> = ({
     await handleSubmit(onSubmit)();
   };
 
+  const handleSubmitDraft = async () => {
+    setValue('status', ProjectStatus.Draft);
+    await handleSubmit(onSubmit)();
+  };
+
+  const handleSubmitPublish = async () => {
+    setValue('status', ProjectStatus.Published);
+    await handleSubmit(onSubmit)();
+  };
+
   const contentLocale = defaultValues?.language || userAccount?.language;
 
   return (
@@ -207,7 +220,20 @@ export const ProjectForm: FC<ProjectFormProps> = ({
         onPreviousClick={() => setCurrentPage(currentPage - 1)}
         showProgressBar
         onCloseClick={() => setShowLeave(true)}
-        onSubmitClick={handleSubmit(onSubmit)}
+        onSubmitClick={handleSubmitPublish}
+        footerElements={
+          isLastPage &&
+          project?.status !== ProjectStatus.Published && (
+            <Button
+              className="px-3 py-2 leading-none md:px-8 md:py-4"
+              theme="secondary-green"
+              size="base"
+              onClick={handleSubmitDraft}
+            >
+              <FormattedMessage defaultMessage="Save as draft" id="JHJJAH" />
+            </Button>
+          )
+        }
       >
         <Page key="general-information">
           <ContentLanguageAlert className="mb-6">

--- a/frontend/containers/project-form/component.tsx
+++ b/frontend/containers/project-form/component.tsx
@@ -239,6 +239,7 @@ export const ProjectForm: FC<ProjectFormProps> = ({
         alert={useGetAlert(updateProject.error)}
         isSubmitting={updateProject.isLoading}
         showOutro={isOutroPage}
+        siteHeader={isOutroPage}
         onNextClick={handleNextClick}
         onPreviousClick={() => setCurrentPage(currentPage - 1)}
         showProgressBar

--- a/frontend/containers/project-form/component.tsx
+++ b/frontend/containers/project-form/component.tsx
@@ -203,6 +203,7 @@ export const ProjectForm: FC<ProjectFormProps> = ({
   };
 
   const contentLocale = defaultValues?.language || userAccount?.language;
+  const isOutroPage = isCreateForm && currentPage === totalPages;
 
   return (
     <>
@@ -216,11 +217,13 @@ export const ProjectForm: FC<ProjectFormProps> = ({
         page={currentPage}
         alert={useGetAlert(updateProject.error)}
         isSubmitting={updateProject.isLoading}
-        showOutro={currentPage === totalPages && !!projectSlug}
+        showOutro={isOutroPage}
         onNextClick={handleNextClick}
         onPreviousClick={() => setCurrentPage(currentPage - 1)}
         showProgressBar
-        onCloseClick={() => setShowLeave(true)}
+        onCloseClick={() =>
+          isOutroPage ? router.push(queryReturnPath || Paths.Dashboard) : setShowLeave(true)
+        }
         onSubmitClick={handleSubmitPublish}
         isLoading={isLoading}
         footerElements={

--- a/frontend/containers/project-form/component.tsx
+++ b/frontend/containers/project-form/component.tsx
@@ -45,6 +45,7 @@ export const ProjectForm: FC<ProjectFormProps> = ({
   initialValues: project,
   isCreateForm,
   enums,
+  isLoading,
 }) => {
   const [currentPage, setCurrentPage] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
@@ -221,6 +222,7 @@ export const ProjectForm: FC<ProjectFormProps> = ({
         showProgressBar
         onCloseClick={() => setShowLeave(true)}
         onSubmitClick={handleSubmitPublish}
+        isLoading={isLoading}
         footerElements={
           isLastPage &&
           project?.status !== ProjectStatus.Published && (

--- a/frontend/containers/project-form/helpers.ts
+++ b/frontend/containers/project-form/helpers.ts
@@ -16,6 +16,7 @@ export const useDefaultValues = (project: Project): Partial<ProjectForm> => {
     const general = pickBy(project, (value, key: any) => projectFormKeys.includes(key));
     return {
       ...general,
+      status: project.status,
       language: project.language,
       municipality_id: project.municipality?.id,
       department_id: project.municipality.parent.id,

--- a/frontend/containers/project-form/pages/pending-approval.tsx
+++ b/frontend/containers/project-form/pages/pending-approval.tsx
@@ -7,57 +7,49 @@ import Link from 'next/link';
 
 import Button from 'components/button';
 import { Paths } from 'enums';
-import Header from 'layouts/static-page/header';
 
 export const PendingApproval = ({ projectSlug }: { projectSlug: string }) => {
   return (
-    <div className="flex items-center justify-center h-screen md:p-4">
-      <Header />
-      <div className="flex flex-col items-center max-w-xl m-auto text-center">
-        <Image
-          width={178}
-          height={170}
-          aria-hidden="true"
-          src="/images/pending-approval.svg"
-          alt=""
+    <div className="flex flex-col items-center max-w-xl m-auto text-center">
+      <Image
+        width={178}
+        height={170}
+        aria-hidden="true"
+        src="/images/pending-approval.svg"
+        alt=""
+      />
+      <h1 className="mt-6 font-serif text-3xl font-semibold text-green-dark">
+        <FormattedMessage defaultMessage="Pending verification" id="n6KNWj" />
+      </h1>
+      <p className="my-6">
+        <FormattedMessage
+          defaultMessage="Your project is awaiting verification. This means that the project is visible in the platform but without the <b>Verification badge</b>."
+          id="ygAxHr"
+          values={{
+            b: (chunks: string) => <span className="font-semibold">{chunks}</span>,
+          }}
         />
-        <h1 className="mt-6 font-serif text-3xl font-semibold text-green-dark">
-          <FormattedMessage defaultMessage="Pending verification" id="n6KNWj" />
-        </h1>
-        <p className="my-6">
+      </p>
+      <Button className="mt-6 mb-12" to={`${Paths.Project}/${projectSlug}`}>
+        <FormattedMessage defaultMessage="Go to project page" id="mMReor" />
+      </Button>
+      <Link href="/faq#pending-approval" passHref>
+        <a target="_blank" rel="noopener noreferrer" className="font-sans text-gray-600 underline">
+          <FormattedMessage defaultMessage="What is a verification badge?" id="qZPjW2" />
+        </a>
+      </Link>
+      <Link href="/faq#pending-approval" passHref>
+        <a
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-2 font-sans text-gray-600 underline"
+        >
           <FormattedMessage
-            defaultMessage="Your project is awaiting verification. This means that the project is visible in the platform but without the <b>Verification badge</b>."
-            id="ygAxHr"
-            values={{
-              b: (chunks: string) => <span className="font-semibold">{chunks}</span>,
-            }}
+            defaultMessage="When will the project have the Verification badge?"
+            id="E/YxHp"
           />
-        </p>
-        <Button className="mt-6 mb-12" to={`${Paths.Project}/${projectSlug}`}>
-          <FormattedMessage defaultMessage="Go to project page" id="mMReor" />
-        </Button>
-        <Link href="/faq#pending-approval" passHref>
-          <a
-            target="_blank"
-            rel="noopener noreferrer"
-            className="font-sans text-gray-600 underline"
-          >
-            <FormattedMessage defaultMessage="What is a verification badge?" id="qZPjW2" />
-          </a>
-        </Link>
-        <Link href="/faq#pending-approval" passHref>
-          <a
-            target="_blank"
-            rel="noopener noreferrer"
-            className="mt-2 font-sans text-gray-600 underline"
-          >
-            <FormattedMessage
-              defaultMessage="When will the project have the Verification badge?"
-              id="E/YxHp"
-            />
-          </a>
-        </Link>
-      </div>
+        </a>
+      </Link>
     </div>
   );
 };

--- a/frontend/containers/project-form/types.ts
+++ b/frontend/containers/project-form/types.ts
@@ -29,6 +29,8 @@ export type ProjectFormProps = {
   isCreateForm?: boolean;
   /** Values of the current project developer, in case it is the update form */
   initialValues?: Project;
+  /** Whether the project data is still being loaded/fetched */
+  isLoading?: boolean;
   /** UseMutation hook values */
   mutation: UseMutationResult<AxiosResponse<ResponseData<Project>>, AxiosError<ErrorResponse>>;
   /** Callback to execute when form has been submitted successfully */

--- a/frontend/enums/index.ts
+++ b/frontend/enums/index.ts
@@ -73,8 +73,6 @@ export enum Queries {
   EnumList = 'enum_list',
   /** Locations */
   Locations = 'locations',
-  /** Single Project */
-  ProjectQuery = 'project',
   /** Projects Map location */
   ProjectsMap = 'projects_map',
   /** Current user's account owner name */

--- a/frontend/enums/index.ts
+++ b/frontend/enums/index.ts
@@ -152,3 +152,8 @@ export enum InvitationStatus {
   Waiting = 'waiting',
   Completed = 'completed',
 }
+
+export enum ProjectStatus {
+  Published = 'published',
+  Draft = 'draft',
+}

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -509,6 +509,9 @@
   "ErIkUS": {
     "string": "Insert your email"
   },
+  "EvP1Ut": {
+    "string": "Preview project page"
+  },
   "EwRIOm": {
     "string": "User"
   },

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -636,6 +636,9 @@
   "JFkvlB": {
     "string": "Please use the contacts below to reach the project developer."
   },
+  "JHJJAH": {
+    "string": "Save as draft"
+  },
   "JIehAU": {
     "string": "This is why ARIES is developing a 'Wikipedia-like' platform, that is collaborative, open-source and enables interoperable models and data. For the first time, this generates new knowledge through integrating the existing platform with the ultimate scope of building a more sustainable and resilient future for all."
   },

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -61,6 +61,10 @@ module.exports = {
         source: '/backend/:path*',
         destination: `${process.env.NEXT_PUBLIC_BACKEND_URL}/:path*`,
       },
+      {
+        source: '/project/:id/preview',
+        destination: '/project/:id?preview=true',
+      },
     ];
   },
   async redirects() {

--- a/frontend/pages/dashboard/projects.tsx
+++ b/frontend/pages/dashboard/projects.tsx
@@ -21,7 +21,7 @@ import Button from 'components/button';
 import Head from 'components/head';
 import Icon from 'components/icon';
 import Table from 'components/table';
-import { UserRoles } from 'enums';
+import { ProjectStatus, UserRoles } from 'enums';
 import { Paths } from 'enums';
 import DashboardLayout, { DashboardLayoutProps } from 'layouts/dashboard';
 import NakedLayout from 'layouts/naked';
@@ -76,6 +76,9 @@ export const ProjectsPage: PageComponent<ProjectsPageProps, DashboardLayoutProps
           `${Paths.Project}/${slug}/edit?returnPath=${encodeURIComponent(router.asPath)}`,
           `${Paths.Project}/${slug}/edit`
         );
+        return;
+      case 'preview':
+        router.push(`${Paths.Project}/${slug}/preview`);
         return;
       case 'open':
         router.push(`${Paths.Project}/${slug}`);
@@ -138,30 +141,38 @@ export const ProjectsPage: PageComponent<ProjectsPageProps, DashboardLayoutProps
         canSort: false,
         hideHeader: true,
         width: 0,
-        Cell: ({ cell }) => {
+        Cell: ({
+          cell: {
+            row: {
+              original: { slug, status },
+            },
+          },
+        }) => {
           return (
             <div className="flex items-center justify-center gap-3">
               <Link
-                href={`${Paths.Project}/${
-                  cell.row.original.slug
-                }/edit?returnPath=${encodeURIComponent(router.asPath)}`}
-                as={`${Paths.Project}/${cell.row.original.slug}/edit`}
+                href={`${Paths.Project}/${slug}/edit?returnPath=${encodeURIComponent(
+                  router.asPath
+                )}`}
+                as={`${Paths.Project}/${slug}/edit`}
               >
                 <a className="px-2 py-1 text-sm transition-all text-green-dark focus-visible:outline-green-dark rounded-2xl">
                   <FormattedMessage defaultMessage="Edit" id="wEQDC6" />
                 </a>
               </Link>
-              <RowMenu
-                onAction={(key: string) =>
-                  handleRowMenuItemClick({ key, slug: cell.row.original.slug })
-                }
-              >
+              <RowMenu onAction={(key: string) => handleRowMenuItemClick({ key, slug })}>
                 <RowMenuItem key="edit">
                   <FormattedMessage defaultMessage="Edit" id="wEQDC6" />
                 </RowMenuItem>
-                <RowMenuItem key="open">
-                  <FormattedMessage defaultMessage="View project page" id="ToXG99" />
-                </RowMenuItem>
+                {status === ProjectStatus.Draft ? (
+                  <RowMenuItem key="preview">
+                    <FormattedMessage defaultMessage="Preview project page" id="EvP1Ut" />
+                  </RowMenuItem>
+                ) : (
+                  <RowMenuItem key="open">
+                    <FormattedMessage defaultMessage="View project page" id="ToXG99" />
+                  </RowMenuItem>
+                )}
                 <RowMenuItem key="delete">
                   <FormattedMessage defaultMessage="Delete" id="K3r6DQ" />
                 </RowMenuItem>

--- a/frontend/pages/project/[id]/edit.tsx
+++ b/frontend/pages/project/[id]/edit.tsx
@@ -112,7 +112,7 @@ const EditProject: PageComponent<EditProjectProps, FormPageLayoutProps> = ({
         mutation={updateProject}
         onComplete={handleOnComplete}
         initialValues={project}
-        isLoading={isFetchingProject}
+        isLoading={!project && isFetchingProject}
         enums={enums}
       />
     </ProtectedPage>

--- a/frontend/pages/project/[id]/edit.tsx
+++ b/frontend/pages/project/[id]/edit.tsx
@@ -23,29 +23,34 @@ import { User } from 'types/user';
 
 import { useUpdateProject } from 'services/account';
 import { getEnums } from 'services/enums/enumService';
-import { getProject } from 'services/projects/projectService';
+import { getProject, useProject } from 'services/projects/projectService';
+
+const PROJECT_QUERY_PARAMS = {
+  includes: [
+    'project_images',
+    'country',
+    'municipality',
+    'department',
+    'project_developer',
+    'involved_project_developers',
+    'project_developer',
+  ],
+  // We set the `locale` as `null` so that we get the project in the account's language instead of the UI language
+  locale: null,
+};
 
 export const getServerSideProps = withLocalizedRequests(async ({ params: { id }, locale }) => {
   let project;
   let enums;
 
   try {
-    ({ data: project } = await getProject(id as string, {
-      includes: [
-        'project_images',
-        'country',
-        'municipality',
-        'department',
-        'project_developer',
-        'involved_project_developers',
-        'project_developer',
-      ],
-      // We set the `locale` as `null` so that we get the project in the account's language instead of the UI language
-      locale: null,
-    }));
+    ({ data: project } = await getProject(id as string, PROJECT_QUERY_PARAMS));
     enums = await getEnums();
   } catch (e) {
-    return { notFound: true };
+    // The user may be attempting to preview a drafted project, which the endpoint won't return
+    // unless the ownership can be verified. We'll be loading it client side and redirect the user
+    // to the dashboard if the project really doesn't exist or the user doesn't have permissions
+    project = null;
   }
 
   return {
@@ -62,12 +67,20 @@ type EditProjectProps = {
   enums: GroupedEnumsType;
 };
 
-const EditProject: PageComponent<EditProjectProps, FormPageLayoutProps> = ({ project, enums }) => {
+const EditProject: PageComponent<EditProjectProps, FormPageLayoutProps> = ({
+  project: projectProp,
+  enums,
+}) => {
   const { formatMessage } = useIntl();
   const router = useRouter();
 
   const updateProject = useUpdateProject();
   const queryReturnPath = useQueryReturnPath();
+
+  const {
+    data: { data: project },
+    isFetching: isFetchingProject,
+  } = useProject(router.query.id as string, PROJECT_QUERY_PARAMS, projectProp);
 
   const getIsOwner = (_user: User, userAccount: ProjectDeveloper | Investor) => {
     // The user must be a the creator of the project to be allowed to edit it.
@@ -99,6 +112,7 @@ const EditProject: PageComponent<EditProjectProps, FormPageLayoutProps> = ({ pro
         mutation={updateProject}
         onComplete={onComplete}
         initialValues={project}
+        isLoading={isFetchingProject}
         enums={enums}
       />
     </ProtectedPage>

--- a/frontend/pages/project/[id]/edit.tsx
+++ b/frontend/pages/project/[id]/edit.tsx
@@ -91,7 +91,7 @@ const EditProject: PageComponent<EditProjectProps, FormPageLayoutProps> = ({
     );
   };
 
-  const onComplete = () => {
+  const handleOnComplete = () => {
     router.push(queryReturnPath || Paths.DashboardProjects);
   };
 
@@ -110,7 +110,7 @@ const EditProject: PageComponent<EditProjectProps, FormPageLayoutProps> = ({
           id: 'vygPIS',
         })}
         mutation={updateProject}
-        onComplete={onComplete}
+        onComplete={handleOnComplete}
         initialValues={project}
         isLoading={isFetchingProject}
         enums={enums}

--- a/frontend/pages/project/[id]/index.tsx
+++ b/frontend/pages/project/[id]/index.tsx
@@ -43,8 +43,10 @@ export const getServerSideProps = withLocalizedRequests(
   // Property 'query' does not exist on type 'GetStaticPropsContext<ParsedUrlQuery, PreviewData>'.
   async ({ params: { id }, locale, query }) => {
     let project;
+    let enums;
 
     try {
+      enums = await getEnums();
       ({ data: project } = await getProject(id as string, PROJECT_QUERY_PARAMS));
     } catch (e) {
       // If getting the project fails, it's most likely because the record has not been found.
@@ -62,8 +64,6 @@ export const getServerSideProps = withLocalizedRequests(
     if (project && query?.preview) {
       return { notFound: true };
     }
-
-    const enums = await getEnums();
 
     return {
       props: {

--- a/frontend/pages/project/[id]/index.tsx
+++ b/frontend/pages/project/[id]/index.tsx
@@ -87,7 +87,7 @@ const ProjectPage: PageComponent<ProjectPageProps, StaticPageLayoutProps> = ({
   } = useProject(router.query.id as string, PROJECT_QUERY_PARAMS, projectProp);
 
   if (!project) {
-    if (!isFetchingProject) router.push(Paths.Dashboard);
+    if (!project && !isFetchingProject) router.push(Paths.Dashboard);
     return (
       <div className="flex items-center justify-center min-h-screen -mt-28 md:-mt-36 lg:-mt-44">
         <Loading visible={true} iconClassName="w-10 h-10" />

--- a/frontend/pages/project/[id]/index.tsx
+++ b/frontend/pages/project/[id]/index.tsx
@@ -87,7 +87,7 @@ const ProjectPage: PageComponent<ProjectPageProps, StaticPageLayoutProps> = ({
   } = useProject(router.query.id as string, PROJECT_QUERY_PARAMS, projectProp);
 
   if (!project) {
-    if (!project && !isFetchingProject) router.push(Paths.Dashboard);
+    if (!isFetchingProject) router.push(Paths.Dashboard);
     return (
       <div className="flex items-center justify-center min-h-screen -mt-28 md:-mt-36 lg:-mt-44">
         <Loading visible={true} iconClassName="w-10 h-10" />

--- a/frontend/pages/project/[id]/index.tsx
+++ b/frontend/pages/project/[id]/index.tsx
@@ -16,6 +16,8 @@ import Overview from 'containers/project-page/overview';
 
 import Head from 'components/head';
 import LayoutContainer from 'components/layout-container';
+import Loading from 'components/loading';
+import { Paths } from 'enums';
 import { StaticPageLayoutProps } from 'layouts/static-page';
 import { PageComponent } from 'types';
 import { GroupedEnums as GroupedEnumsType } from 'types/enums';
@@ -36,26 +38,37 @@ const PROJECT_QUERY_PARAMS = {
   ],
 };
 
-export const getServerSideProps = withLocalizedRequests(async ({ params: { id }, locale }) => {
-  let project;
+export const getServerSideProps = withLocalizedRequests(
+  /** @ts-ignore */
+  // Property 'query' does not exist on type 'GetStaticPropsContext<ParsedUrlQuery, PreviewData>'.
+  async ({ params: { id }, locale, query }) => {
+    let project;
 
-  // If getting the project fails, it's most likely because the record has not been found. Let's return a 404. Anything else will trigger a 500 by default.
-  try {
-    ({ data: project } = await getProject(id as string, PROJECT_QUERY_PARAMS));
-  } catch (e) {
-    return { notFound: true };
+    try {
+      ({ data: project } = await getProject(id as string, PROJECT_QUERY_PARAMS));
+    } catch (e) {
+      // If getting the project fails, it's most likely because the record has not been found.
+      if (query?.preview) {
+        // The user is attempting to preview a drafted project, which the endpoint won't return
+        // unless the ownership can be verified. We'll be loading it client side.
+        project = null;
+      } else {
+        // Not previewing a drafted project and project doesn't exist. Return a 404.
+        return { notFound: true };
+      }
+    }
+
+    const enums = await getEnums();
+
+    return {
+      props: {
+        intlMessages: await loadI18nMessages({ locale }),
+        enums: groupBy(enums, 'type'),
+        project,
+      },
+    };
   }
-
-  const enums = await getEnums();
-
-  return {
-    props: {
-      intlMessages: await loadI18nMessages({ locale }),
-      enums: groupBy(enums, 'type'),
-      project,
-    },
-  };
-});
+);
 
 type ProjectPageProps = {
   project: ProjectType;
@@ -70,27 +83,39 @@ const ProjectPage: PageComponent<ProjectPageProps, StaticPageLayoutProps> = ({
 
   const {
     data: { data: project },
+    isFetching: isFetchingProject,
   } = useProject(router.query.id as string, PROJECT_QUERY_PARAMS, projectProp);
+
+  if (!project) {
+    if (!isFetchingProject) router.push(Paths.Dashboard);
+    return (
+      <div className="flex items-center justify-center min-h-screen -mt-28 md:-mt-36 lg:-mt-44">
+        <Loading visible={true} iconClassName="w-10 h-10" />
+      </div>
+    );
+  }
 
   return (
     <>
       <Head title={project.name} description={project.description} />
 
-      <LayoutContainer className="-mt-10 md:mt-0 lg:-mt-16">
-        <Breadcrumbs
-          className="px-4 sm:px-6 lg:px-8"
-          substitutions={{
-            id: { name: project.name },
-          }}
-        />
-        <Header className="mt-6" project={project} />
-      </LayoutContainer>
+      <>
+        <LayoutContainer className="-mt-10 md:mt-0 lg:-mt-16">
+          <Breadcrumbs
+            className="px-4 sm:px-6 lg:px-8"
+            substitutions={{
+              id: { name: project.name },
+            }}
+          />
+          <Header className="mt-6" project={project} />
+        </LayoutContainer>
 
-      <Overview project={project} />
-      <Impact project={project} enums={enums} />
-      <Funding project={project} enums={enums} />
-      <ProjectDevelopers project={project} />
-      <Contact project={project} />
+        <Overview project={project} />
+        <Impact project={project} enums={enums} />
+        <Funding project={project} enums={enums} />
+        <ProjectDevelopers project={project} />
+        <Contact project={project} />
+      </>
     </>
   );
 };

--- a/frontend/pages/project/[id]/index.tsx
+++ b/frontend/pages/project/[id]/index.tsx
@@ -58,6 +58,11 @@ export const getServerSideProps = withLocalizedRequests(
       }
     }
 
+    // If a project is published, let's make it so the "Preview" page doesn't exist
+    if (project && query?.preview) {
+      return { notFound: true };
+    }
+
     const enums = await getEnums();
 
     return {

--- a/frontend/pages/projects/new.tsx
+++ b/frontend/pages/projects/new.tsx
@@ -1,14 +1,17 @@
 import { useIntl } from 'react-intl';
 
+import { useRouter } from 'next/router';
+
 import { withLocalizedRequests } from 'hoc/locale';
 
 import { groupBy } from 'lodash-es';
 
 import { loadI18nMessages } from 'helpers/i18n';
+import { useQueryReturnPath } from 'helpers/pages';
 
 import ProjectForm from 'containers/project-form';
 
-import { UserRoles } from 'enums';
+import { Paths, UserRoles } from 'enums';
 import FormPageLayout from 'layouts/form-page';
 import ProtectedPage from 'layouts/protected-page';
 import { PageComponent } from 'types';
@@ -34,7 +37,14 @@ type CreateProjectProps = {
 
 const CreateProject: PageComponent<CreateProjectProps> = ({ enums }) => {
   const { formatMessage } = useIntl();
+  const router = useRouter();
+
   const createProject = useCreateProject();
+  const queryReturnPath = useQueryReturnPath();
+
+  const handleOnComplete = () => {
+    router.push(queryReturnPath || Paths.DashboardProjects);
+  };
 
   return (
     <ProtectedPage permissions={[UserRoles.ProjectDeveloper]}>
@@ -45,6 +55,7 @@ const CreateProject: PageComponent<CreateProjectProps> = ({ enums }) => {
           id: 'vygPIS',
         })}
         mutation={createProject}
+        onComplete={handleOnComplete}
         enums={enums}
         isCreateForm
       />

--- a/frontend/services/account/index.ts
+++ b/frontend/services/account/index.ts
@@ -115,11 +115,16 @@ export function useUpdateProject(): UseMutationResult<
   const updateProject = async (
     project: ProjectUpdatePayload
   ): Promise<AxiosResponse<ResponseData<Project>>> => {
-    queryClient.invalidateQueries(Queries.AccountProjectList);
     return API.put(`/api/v1/account/projects/${project.id}`, project);
   };
 
-  return useMutation(updateProject);
+  return useMutation(updateProject, {
+    onSuccess: (result) => {
+      queryClient.setQueryData(Queries.Project, result.data.data);
+      queryClient.invalidateQueries(Queries.AccountProjectList);
+      queryClient.invalidateQueries(Queries.Project);
+    },
+  });
 }
 
 const getInvestor = async (includes?: string): Promise<Investor> => {

--- a/frontend/services/account/index.ts
+++ b/frontend/services/account/index.ts
@@ -97,12 +97,19 @@ export function useCreateProject(): UseMutationResult<
   AxiosError<ErrorResponse>,
   ProjectCreationPayload
 > {
+  const queryClient = useQueryClient();
+
   const createProject = async (
     data: ProjectCreationPayload
   ): Promise<AxiosResponse<ResponseData<Project>>> => {
     return await API.post('/api/v1/account/projects', data);
   };
-  return useMutation(createProject);
+
+  return useMutation(createProject, {
+    onSuccess: () => {
+      queryClient.invalidateQueries(Queries.AccountProjectList);
+    },
+  });
 }
 
 export function useUpdateProject(): UseMutationResult<
@@ -119,10 +126,9 @@ export function useUpdateProject(): UseMutationResult<
   };
 
   return useMutation(updateProject, {
-    onSuccess: (result) => {
-      queryClient.setQueryData(Queries.Project, result.data.data);
-      queryClient.invalidateQueries(Queries.AccountProjectList);
+    onSuccess: () => {
       queryClient.invalidateQueries(Queries.Project);
+      queryClient.invalidateQueries(Queries.AccountProjectList);
     },
   });
 }

--- a/frontend/services/projects/projectService.ts
+++ b/frontend/services/projects/projectService.ts
@@ -90,7 +90,7 @@ export function useProject(
   params?: Parameters<typeof getProject>[1],
   initialData?: Project
 ) {
-  const query = useLocalizedQuery([Queries.ProjectQuery, id], () => getProject(id, params), {
+  const query = useLocalizedQuery([Queries.Project, id], () => getProject(id, params), {
     refetchOnWindowFocus: false,
     initialData: { data: initialData, included: [] },
   });

--- a/frontend/types/project.ts
+++ b/frontend/types/project.ts
@@ -4,7 +4,7 @@ import { string } from 'yup';
 import { ValidGeometryType } from 'containers/forms/geometry/types';
 import { ProjectGalleryImageType } from 'containers/forms/project-gallery/project-gallery-image/types';
 
-import { DevelopmentStages, Languages, TicketSizes } from 'enums';
+import { DevelopmentStages, Languages, TicketSizes, ProjectStatus } from 'enums';
 
 import { Locations } from './locations';
 
@@ -60,6 +60,7 @@ export type ProjectBase = {
   project_images: ProjectImageType[];
   trusted?: boolean;
   favourite?: boolean;
+  status?: ProjectStatus;
   project_developer?: any; // Cannot use ProjectDeveloperType because linting will complain about circular references
   involved_project_developers?: any[]; // Cannot use ProjectDeveloperType because linting will complain about circular references
 };


### PR DESCRIPTION
## Description

This PR adds the ability to save a new project as a draft, and preview its public page.  
The user can keep saving it as a Draft for as long as they need to, but once it's Published it cannot be turned into a draft again. The pending verification screen is only shown for published projects (or when publishing a new or drafted one). 

&nbsp; 

**In this PR**  

- `MultiPageLayout` changes: 
    - Added the ability to pass custom elements to the layout's footer
      _So we can add custom buttons, in this case the "Save as draft" one_  
    - Added a loading spinner screen
      _Which can be used while data to be used is still loading (eg: re-fetching, slow internet connections)_  
        - Footer buttons will be disabled while the spinner is being shown
    - Added an option so that we can show the website's static page header on any screen
      _Can be used in any screen, but the forms are set up to only display it in the Outro screen, to match the designs_  
- `ProjectForm` changes:  
    - Added a _Save as Draft_ button to the form footer, next to the _Submit_ button 
      _Only visible on the last page as long as the project hasn't been published yet_  
    - Extracted the logic related to where the user is redirected to after form completion to the respective new/edit pages  
      _To keep it consistent with the implementation done in the PD & Investor pages/forms done in #396_  
    - Reworked the "Outro" screen logic  
        - Will now only be shown when the user publishes a project, and the project is pending verification  
        - Will not be shown when the user is saving as draft, as it wouldn't be visible in the backoffice either    
        - Fixed the outro screens logic/redirection similar to the implementation on #396 
          _Although it's not really needed, due to the next point_
        - Fixed an issue where the "Pending verification" screen would display both the form and the static page header
          _The former hidden under the latter_
    - Fixed the "Pending verification" component's display
        - So it's centered in the page much like the "Pending approval" in the PD and Investor forms
- `Project` public page / preview  
    - Reworked the logic so that the page can also be used to preview unpublished projects  
      _Data loading logic changes are similar to the ones done for the PD and Investor public pages, in #342_
        - We still attempt to pre-render the project page, so that published projects work as before and are indexed by search engines
        - Unless previewing an unpublished project page, attempting to load an inexistent project page will still render a 404  
        - When previewing an unpublished project, the project will not be accessible from the endpoint so we load it client side (when the ownership can be verified and the endpoint returns the project)  
        - Project public pages can be previewed by either appending a `/preview` to the normal project public page url or a `?preview=true` query param. Logic is set to the former.  
        - Because when previewing a project public page, the data will be loaded in the client, a Loading spinner was added  
        - If a project is published, its preview page will not be accessible

**Other notes**  
- To keep all forms looking similar and better match the designs, the PD and Investor forms also show the site's static header when displaying the _Outro_ screen  
- Fixed some issues with updating a project twice consecutively loading the previous data
  _Not the best of solutions, but it was solved by invalidating the `Project` query completely when updating a project, so it'll be re-fetched_  
- Added ProjectList query invalidation when creating/updating a project
  _So that the dashboard's ProjectList is updated_  
- Removed the `ProjectQuery` enum, as it was a duplicate of the `Project` one  

## Testing instructions

**Saving as draft** 

1. Sign in as a Project Developer  
2. Visit the Dashboard and advance through the Project creation form but do not submit
    - Verify that validation works normally  
3. Click "Save as draft". Verify that:
    - The "Pending verification" screen does not show  
    - The user is redirected to dashboard/projects  
    - The newly created project is visible in the table  
    - The newly created project has a "Draft" status

**Previewing the project**  

1. From dashboard/projects, click on the three dots at the end of the project row  
2. Click on "Preview project page"  
    - Verify that the project page preview loads  

**Unpublished public page**  

1. Visit the project public page
  _Can be done easily by removing the `/preview`_ from the preview url  
    - Verify that the project public page doesn't load

**Publishing the project**  

1. Visit the dashboard/projects page  
2. Click on "Edit" next to the project  
3. Go through the form, this time click "Submit" to publish the project
    - Verify that the "Pending verification" screen is shown  
4. Click on "View project page" 
    - Verify that the project page loads  
5. Visit dashboard/projects and verify that:  
    - Verify that the project has a "Draft" status  
6. Click to edit and go through the form again:
    - Verify that at the last step, the "Save as draft" button is no longer  visible

## Tracking

[LET-775](https://vizzuality.atlassian.net/browse/LET-775)
