### PR TITLE
Fix typo

### DIFF
--- a/frontend/pages/for-project-developers.tsx
+++ b/frontend/pages/for-project-developers.tsx
@@ -140,8 +140,8 @@ const ForProjectDevelopers: PageComponent<ForProjectDevelopersProps, StaticPageL
       <Description
         title={
           <FormattedMessage
-            defaultMessage="Find the support and ressources to grow your business or project"
-            id="wGWm2r"
+            defaultMessage="Find the support and resources to grow your business or project"
+            id="5UMEjA"
           />
         }
         descriptions={[


### PR DESCRIPTION
This PR fixes the for-project-developers page title typo of “resources” that was wrongly written “ressources” 


## Testing instructions

/for-project-developers page main title

## Tracking

[LET-802](https://vizzuality.atlassian.net/browse/LET-802)