### PR TITLE
Send invitation email in account language

### DIFF
--- a/backend/app/controllers/api/v1/invitations_controller.rb
+++ b/backend/app/controllers/api/v1/invitations_controller.rb
@@ -11,10 +11,12 @@ module API
         response = params[:emails].to_a.each_with_object({}) do |email, statuses|
           next statuses[email] = 422 if email.match(Devise.email_regexp).blank?
 
-          user = User.find_by_email(email) || User.new(email: email)
+          user = User.find_by_email(email) || User.new(email: email, ui_language: current_user.locale)
           next statuses[email] = 409 if user.account_id.present?
 
-          user.invite! current_user
+          I18n.with_locale(current_user.locale) do
+            user.invite! current_user
+          end
           statuses[email] = 200
         end
         render json: response.to_json

--- a/backend/app/models/admin.rb
+++ b/backend/app/models/admin.rb
@@ -16,6 +16,10 @@ class Admin < ApplicationRecord
     Arel.sql("CONCAT_WS(' ', admins.first_name, admins.last_name)")
   end
 
+  def locale
+    ui_language
+  end
+
   def full_name
     "#{first_name} #{last_name}"
   end

--- a/backend/spec/fixtures/snapshots/api/v1/invitation-accepted.json
+++ b/backend/spec/fixtures/snapshots/api/v1/invitation-accepted.json
@@ -17,8 +17,8 @@
         "medium": null,
         "original": null
       },
-      "ui_language": "en",
-      "account_language": "en"
+      "ui_language": "es",
+      "account_language": "pt"
     }
   }
 }

--- a/backend/spec/requests/api/v1/invitation_spec.rb
+++ b/backend/spec/requests/api/v1/invitation_spec.rb
@@ -1,8 +1,8 @@
 require "swagger_helper"
 
 RSpec.describe "API V1 Invitation", type: :request do
-  let(:account) { create :account }
-  let(:user) { create :user }
+  let(:account) { create :account, language: "pt" }
+  let(:user) { create :user, ui_language: "es" }
 
   path "/api/v1/invitation/info" do
     post "Invited User information" do
@@ -105,9 +105,13 @@ RSpec.describe "API V1 Invitation", type: :request do
 
           it "sends emails" do
             mails = ActionMailer::Base.deliveries.last(2)
-            expect(mails.map(&:subject).uniq).to eq([I18n.t("devise.mailer.invitation_instructions.subject")])
+            expect(mails.map(&:subject).uniq).to eq([I18n.with_locale(account.language) { I18n.t("devise.mailer.invitation_instructions.subject") }])
             expect(mails.first.to).to eq(["user@example.com"])
             expect(mails.second.to).to eq([user.email])
+          end
+
+          it "sets unregistered user's ui_language to inviting account language" do
+            expect(User.find_by_email("user@example.com").ui_language).to eq("pt")
           end
         end
 
@@ -124,7 +128,7 @@ RSpec.describe "API V1 Invitation", type: :request do
 
           it "sends email" do
             mail = ActionMailer::Base.deliveries.last
-            expect(mail.subject).to eq(I18n.t("devise.mailer.invitation_instructions.subject"))
+            expect(mail.subject).to eq(I18n.with_locale(account.language) { I18n.t("devise.mailer.invitation_instructions.subject") })
             expect(mail.to).to eq([user.email])
           end
         end


### PR DESCRIPTION
Invitation email for joining an account should be sent in account language

## Testing instructions

Invite a user to an account, expect email in correct language

## Tracking

https://vizzuality.atlassian.net/browse/LET-796?atlOrigin=eyJpIjoiZjE3M2FiYjhjZTRhNGEyNTg4M2Q2MjU1ZjkyM2U4YjQiLCJwIjoiaiJ9
https://vizzuality.atlassian.net/browse/LET-794?atlOrigin=eyJpIjoiYmMwYzBlYjI3YTQwNDI3Nzk5MzAyZDVlNjJmMGI0MWMiLCJwIjoiaiJ9

