### PR TITLE
Let 757 fe location search suggestion box not fully visible in project form

### DIFF
--- a/frontend/containers/discover-map/location-searcher/component.tsx
+++ b/frontend/containers/discover-map/location-searcher/component.tsx
@@ -51,7 +51,7 @@ export const LocationSearcher: FC<LocationSearcherProps> = ({ onLocationSelected
       <Script
         src={`https://maps.googleapis.com/maps/api/js?key=${process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}&libraries=places&callback=onGoogleMapsReady`}
       />
-      <div className="relative">
+      <div className="relative z-10">
         <PlacesAutocomplete
           ref={placesRef}
           value={address}

--- a/frontend/containers/forms/geometry/component.tsx
+++ b/frontend/containers/forms/geometry/component.tsx
@@ -164,7 +164,7 @@ export const GeometryInput = <FormValues extends FieldValues>({
           'border-red-700': invalid,
         })}
       >
-        <div className="w-full h-full overflow-hidden rounded-lg">
+        <div className="w-full h-full rounded-lg">
           <div ref={mapContainerRef} className="relative w-full h-full bg-white">
             <Map
               bounds={bounds}

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -203,6 +203,9 @@
   "5Hzwqs": {
     "string": "Favorite"
   },
+  "5UMEjA": {
+    "string": "Find the support and resources to grow your business or project"
+  },
   "5c08Qp": {
     "string": "Project information"
   },
@@ -1772,9 +1775,6 @@
   },
   "wEQDC6": {
     "string": "Edit"
-  },
-  "wGWm2r": {
-    "string": "Find the support and ressources to grow your business or project"
   },
   "wQteLO": {
     "string": "Go to page {page}"


### PR DESCRIPTION
## Description

This PR fixes two issues with the `LocationSearcher` in the `ProjectForm`: 

1. Search results being displayed underneath the map zoom's controls  
2. Search results being cut off at the bottom by the map border

## Testing instructions

1. Navigate to the project creation form (1st screen). 
2. Verify that:  
    - The search results are not displayed underneath the map zoom's controls  
    - The search results are not cut off at the bottom by the map border

## Tracking

[LET-757](https://vizzuality.atlassian.net/browse/LET-757)

## Screenshot 

<img width="1040" alt="Screenshot 2022-07-21 at 12 55 40" src="https://user-images.githubusercontent.com/6273795/180208569-60531ba5-059b-4b83-a61a-3f5ca1d01ef0.png">

