### PR TITLE
Users can delete a project from the Dashboard

### DIFF
--- a/frontend/containers/dashboard/projects/table/cells/actions/component.tsx
+++ b/frontend/containers/dashboard/projects/table/cells/actions/component.tsx
@@ -1,0 +1,73 @@
+import { FC } from 'react';
+
+import { FormattedMessage } from 'react-intl';
+
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+import RowMenu, { RowMenuItem } from 'containers/dashboard/row-menu';
+
+import { Paths, ProjectStatus } from 'enums';
+
+import { CellActionsProps } from './types';
+
+export const CellActions: FC<CellActionsProps> = ({
+  row: {
+    original: { slug, status },
+  },
+}: CellActionsProps) => {
+  const router = useRouter();
+
+  const handleRowMenuItemClick = (key: string) => {
+    switch (key) {
+      case 'edit':
+        router.push(
+          `${Paths.Project}/${slug}/edit?returnPath=${encodeURIComponent(router.asPath)}`,
+          `${Paths.Project}/${slug}/edit`
+        );
+        return;
+      case 'preview':
+        router.push(`${Paths.Project}/${slug}/preview`);
+        return;
+      case 'open':
+        router.push(`${Paths.Project}/${slug}`);
+        return;
+      case 'delete':
+        // TODO: confirm and delete
+        console.log('Delete:', slug);
+        return;
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center gap-3">
+      <Link
+        href={`${Paths.Project}/${slug}/edit?returnPath=${encodeURIComponent(router.asPath)}`}
+        as={`${Paths.Project}/${slug}/edit`}
+      >
+        <a className="px-2 py-1 text-sm transition-all text-green-dark focus-visible:outline-green-dark rounded-2xl">
+          <FormattedMessage defaultMessage="Edit" id="wEQDC6" />
+        </a>
+      </Link>
+      <RowMenu onAction={handleRowMenuItemClick}>
+        <RowMenuItem key="edit">
+          <FormattedMessage defaultMessage="Edit" id="wEQDC6" />
+        </RowMenuItem>
+        {status === ProjectStatus.Draft ? (
+          <RowMenuItem key="preview">
+            <FormattedMessage defaultMessage="Preview project page" id="EvP1Ut" />
+          </RowMenuItem>
+        ) : (
+          <RowMenuItem key="open">
+            <FormattedMessage defaultMessage="View project page" id="ToXG99" />
+          </RowMenuItem>
+        )}
+        <RowMenuItem key="delete">
+          <FormattedMessage defaultMessage="Delete" id="K3r6DQ" />
+        </RowMenuItem>
+      </RowMenu>
+    </div>
+  );
+};
+
+export default CellActions;

--- a/frontend/containers/dashboard/projects/table/cells/actions/index.ts
+++ b/frontend/containers/dashboard/projects/table/cells/actions/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { CellActionsProps } from './types';

--- a/frontend/containers/dashboard/projects/table/cells/actions/types.ts
+++ b/frontend/containers/dashboard/projects/table/cells/actions/types.ts
@@ -1,0 +1,19 @@
+import { ProjectStatus } from 'enums';
+
+import { StatusTag } from '../status';
+
+export type CellActionsProps = {
+  row: {
+    original: {
+      category: string;
+      country: string;
+      instrumentType: boolean;
+      municipality: string;
+      name: string;
+      slug: string;
+      status: ProjectStatus;
+      ticketSize: string;
+      statusTag: StatusTag;
+    };
+  };
+};

--- a/frontend/containers/dashboard/projects/table/cells/status/component.tsx
+++ b/frontend/containers/dashboard/projects/table/cells/status/component.tsx
@@ -1,0 +1,30 @@
+import { FC } from 'react';
+
+import { FormattedMessage } from 'react-intl';
+
+import cx from 'classnames';
+
+import { CellStatusProps, StatusTag } from './types';
+
+export const CellStatus: FC<CellStatusProps> = ({ value }: CellStatusProps) => {
+  if (value === undefined) return null;
+
+  return (
+    <span
+      className={cx({
+        'bg-opacity-20 text-sm px-2.5 py-0.5 rounded-2xl': true,
+        'bg-gray-800 text-gray-800': value === StatusTag.Draft,
+        'bg-green-light text-green-dark': value === StatusTag.Verified,
+        'bg-orange text-orange': value === StatusTag.Unverified,
+      })}
+    >
+      {value === StatusTag.Draft && <FormattedMessage defaultMessage="Draft" id="W6nwjo" />}
+      {value === StatusTag.Verified && <FormattedMessage defaultMessage="Verified" id="Z8971h" />}
+      {value === StatusTag.Unverified && (
+        <FormattedMessage defaultMessage="Unverified" id="n9fdaJ" />
+      )}
+    </span>
+  );
+};
+
+export default CellStatus;

--- a/frontend/containers/dashboard/projects/table/cells/status/index.ts
+++ b/frontend/containers/dashboard/projects/table/cells/status/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { CellStatusProps, StatusTag } from './types';

--- a/frontend/containers/dashboard/projects/table/cells/status/types.ts
+++ b/frontend/containers/dashboard/projects/table/cells/status/types.ts
@@ -1,0 +1,9 @@
+export enum StatusTag {
+  Draft = 'draft',
+  Verified = 'verified',
+  Unverified = 'unverified',
+}
+
+export type CellStatusProps = {
+  value: StatusTag;
+};

--- a/frontend/containers/dashboard/projects/table/component.tsx
+++ b/frontend/containers/dashboard/projects/table/component.tsx
@@ -1,0 +1,225 @@
+import { FC } from 'react';
+
+import { FormattedMessage, useIntl } from 'react-intl';
+
+import cx from 'classnames';
+
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+import { useQueryParams } from 'helpers/pages';
+
+import NoSearchResults from 'containers/dashboard/no-search-results';
+import RowMenu, { RowMenuItem } from 'containers/dashboard/row-menu';
+import SearchAndInfo from 'containers/dashboard/search-and-info';
+
+import Button from 'components/button';
+import Table from 'components/table';
+import { Paths, ProjectStatus } from 'enums';
+
+import { useAccountProjectsList } from 'services/account';
+import { useEnums } from 'services/enums/enumService';
+
+import { ProjectsTableProps } from '.';
+
+export const ProjectsTable: FC<ProjectsTableProps> = () => {
+  const intl = useIntl();
+  const router = useRouter();
+
+  const queryOptions = { keepPreviousData: true, refetchOnMount: true };
+  const queryParams = useQueryParams();
+
+  const {
+    data: {
+      category: allCategories,
+      instrument_type: allInstrumentTypes,
+      ticket_size: allTicketSizes,
+    },
+    isLoading: isLoadingEnums,
+  } = useEnums();
+
+  const {
+    data: { data: projects } = { data: [] },
+    isLoading: isLoadingProjects,
+    isFetching: isFetchingProjects,
+  } = useAccountProjectsList(
+    { ...queryParams, includes: ['municipality', 'country'] },
+    queryOptions
+  );
+
+  const isSearching = !!queryParams.search;
+  const isLoading = isLoadingEnums || isLoadingProjects || isFetchingProjects;
+  const hasProjects = !!projects.length;
+
+  const handleRowMenuItemClick = ({ key, slug }: { key: string; slug: string }) => {
+    switch (key) {
+      case 'edit':
+        router.push(
+          `${Paths.Project}/${slug}/edit?returnPath=${encodeURIComponent(router.asPath)}`,
+          `${Paths.Project}/${slug}/edit`
+        );
+        return;
+      case 'preview':
+        router.push(`${Paths.Project}/${slug}/preview`);
+        return;
+      case 'open':
+        router.push(`${Paths.Project}/${slug}`);
+        return;
+      case 'delete':
+        // TODO
+        console.log('Delete:', slug);
+        return;
+    }
+  };
+
+  const tableProps = {
+    columns: [
+      { Header: intl.formatMessage({ defaultMessage: 'Title', id: '9a9+ww' }), accessor: 'name' },
+      {
+        Header: intl.formatMessage({ defaultMessage: 'Category', id: 'ccXLVi' }),
+        accessor: 'category',
+      },
+      {
+        Header: intl.formatMessage({ defaultMessage: 'Country', id: 'vONi+O' }),
+        accessor: 'country',
+      },
+      {
+        Header: intl.formatMessage({ defaultMessage: 'Municipality', id: '9I1zvK' }),
+        accessor: 'municipality',
+      },
+      {
+        Header: intl.formatMessage({ defaultMessage: 'Instrument type', id: 'fDd10o' }),
+        accessor: 'instrumentType',
+      },
+      {
+        Header: intl.formatMessage({ defaultMessage: 'Value', id: 'GufXy5' }),
+        accessor: 'ticketSize',
+        canSort: false,
+      },
+      {
+        Header: intl.formatMessage({ defaultMessage: 'Status', id: 'tzMNF3' }),
+        accessor: 'status',
+        Cell: ({ cell: { value } }) => {
+          return (
+            <span
+              className={cx({
+                'bg-opacity-20 text-sm px-2.5 py-0.5 rounded-2xl': true,
+                'bg-gray-800 text-gray-800': value === 'draft',
+                'bg-green-light text-green-dark': value === 'verified',
+                'bg-orange text-orange': value === 'unverified',
+              })}
+            >
+              {value === 'draft' && <FormattedMessage defaultMessage="Draft" id="W6nwjo" />}
+              {value === 'verified' && <FormattedMessage defaultMessage="Verified" id="Z8971h" />}
+              {value === 'unverified' && (
+                <FormattedMessage defaultMessage="Unverified" id="n9fdaJ" />
+              )}
+            </span>
+          );
+        },
+      },
+      {
+        accessor: 'actions',
+        canSort: false,
+        hideHeader: true,
+        width: 0,
+        Cell: ({
+          cell: {
+            row: {
+              original: { slug, status },
+            },
+          },
+        }) => {
+          return (
+            <div className="flex items-center justify-center gap-3">
+              <Link
+                href={`${Paths.Project}/${slug}/edit?returnPath=${encodeURIComponent(
+                  router.asPath
+                )}`}
+                as={`${Paths.Project}/${slug}/edit`}
+              >
+                <a className="px-2 py-1 text-sm transition-all text-green-dark focus-visible:outline-green-dark rounded-2xl">
+                  <FormattedMessage defaultMessage="Edit" id="wEQDC6" />
+                </a>
+              </Link>
+              <RowMenu onAction={(key: string) => handleRowMenuItemClick({ key, slug })}>
+                <RowMenuItem key="edit">
+                  <FormattedMessage defaultMessage="Edit" id="wEQDC6" />
+                </RowMenuItem>
+                {status === ProjectStatus.Draft ? (
+                  <RowMenuItem key="preview">
+                    <FormattedMessage defaultMessage="Preview project page" id="EvP1Ut" />
+                  </RowMenuItem>
+                ) : (
+                  <RowMenuItem key="open">
+                    <FormattedMessage defaultMessage="View project page" id="ToXG99" />
+                  </RowMenuItem>
+                )}
+                <RowMenuItem key="delete">
+                  <FormattedMessage defaultMessage="Delete" id="K3r6DQ" />
+                </RowMenuItem>
+              </RowMenu>
+            </div>
+          );
+        },
+      },
+    ],
+    data: projects.map((project) => ({
+      slug: project.slug,
+      name: project.name,
+      category: allCategories.find(({ id }) => id === project.category)?.name,
+      country: project.country.name,
+      municipality: project.municipality.name,
+      instrumentType: allInstrumentTypes
+        ?.filter(({ id }) => project.instrument_types?.includes(id))
+        .map(({ name }, idx) => (idx === 0 ? name : name.toLowerCase()))
+        .join(', '),
+      status: project.status === 'draft' ? 'draft' : project.trusted ? 'verified' : 'unverified',
+      ticketSize: allTicketSizes?.find(({ id }) => project.ticket_size === id)?.description,
+    })),
+    loading: isLoading,
+    sortingEnabled: true,
+    manualSorting: false,
+    className: 'h-screen',
+  };
+
+  return (
+    <>
+      <SearchAndInfo className="mt-4 mb-6">
+        <FormattedMessage
+          defaultMessage="Total <span>{numProjects}</span> {numProjects, plural, one {project} other {projects}}"
+          id="0iaD3T"
+          values={{
+            span: (chunks: string) => <span className="px-1 font-semibold">{chunks}</span>,
+            numProjects: projects.length,
+          }}
+        />
+      </SearchAndInfo>
+      {(isLoading || hasProjects) && <Table {...tableProps} />}
+      {!isLoading && !hasProjects && (
+        <div className="flex flex-col items-center mt-10 lg:mt-20">
+          {isSearching ? (
+            <NoSearchResults />
+          ) : (
+            <>
+              <p className="text-lg text-gray-800 lg:text-xl">
+                <FormattedMessage
+                  defaultMessage="Currently you don’t have any <b>Projects</b>."
+                  id="itfsqC"
+                  values={{
+                    b: (chunks: string) => <span className="font-semibold">{chunks}</span>,
+                  }}
+                />
+              </p>
+              <Button className="mt-8" to={Paths.ProjectCreation}>
+                <FormattedMessage defaultMessage="Create project" id="VUN1K7" />
+              </Button>
+            </>
+          )}
+        </div>
+      )}
+    </>
+  );
+};
+
+export default ProjectsTable;

--- a/frontend/containers/dashboard/projects/table/component.tsx
+++ b/frontend/containers/dashboard/projects/table/component.tsx
@@ -1,6 +1,8 @@
-import { FC } from 'react';
+import { FC, useEffect } from 'react';
 
 import { FormattedMessage, useIntl } from 'react-intl';
+
+import { noop } from 'lodash-es';
 
 import { useQueryParams } from 'helpers/pages';
 
@@ -19,7 +21,7 @@ import CellStatus from './cells/status';
 
 import { ProjectsTableProps } from '.';
 
-export const ProjectsTable: FC<ProjectsTableProps> = () => {
+export const ProjectsTable: FC<ProjectsTableProps> = ({ onLoaded = noop }) => {
   const intl = useIntl();
 
   const queryOptions = { keepPreviousData: true, refetchOnMount: true };
@@ -46,6 +48,10 @@ export const ProjectsTable: FC<ProjectsTableProps> = () => {
   const isSearching = !!queryParams.search;
   const isLoading = isLoadingEnums || isLoadingProjects || isFetchingProjects;
   const hasProjects = !!projects.length;
+
+  useEffect(() => {
+    if (!isLoadingProjects) onLoaded();
+  }, [isLoadingProjects, onLoaded]);
 
   const tableProps = {
     columns: [
@@ -116,8 +122,8 @@ export const ProjectsTable: FC<ProjectsTableProps> = () => {
           }}
         />
       </SearchAndInfo>
-      {(isLoading || hasProjects) && <Table {...tableProps} />}
-      {!isLoading && !hasProjects && (
+      {hasProjects && <Table {...tableProps} />}
+      {!hasProjects && (
         <div className="flex flex-col items-center mt-10 lg:mt-20">
           {isSearching ? (
             <NoSearchResults />

--- a/frontend/containers/dashboard/projects/table/index.ts
+++ b/frontend/containers/dashboard/projects/table/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { ProjectsTableProps } from './types';

--- a/frontend/containers/dashboard/projects/table/types.ts
+++ b/frontend/containers/dashboard/projects/table/types.ts
@@ -1,1 +1,4 @@
-export type ProjectsTableProps = {};
+export type ProjectsTableProps = {
+  /** Callback to execute when the projects have been loaded */
+  onLoaded?: () => void;
+};

--- a/frontend/containers/dashboard/projects/table/types.ts
+++ b/frontend/containers/dashboard/projects/table/types.ts
@@ -1,0 +1,1 @@
+export type ProjectsTableProps = {};

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -572,6 +572,9 @@
   "GgNMmS": {
     "string": "National Wetlands Map of Colombia"
   },
+  "GsO+rH": {
+    "string": "Delete project?"
+  },
   "GtP2gp": {
     "string": "Find opportunities that have the greatest impact on challenges like <b>biodiversity, climate, community</b> and <b>water</b>."
   },
@@ -944,6 +947,9 @@
   },
   "U98Mu/": {
     "string": "This layer shows the permanent and temporal wetlands of Colombia at a 1:100.000 reoslution"
+  },
+  "UIQdVc": {
+    "string": "Are you sure you want to delete “<strong>{projectName}</strong>”?"
   },
   "URLNhk": {
     "string": "The Inter-American Development Bank (IDB) is the largest source of development financing for Latin America and the Caribbean. Established in 1959, the IDB supports Latin American and Caribbean economic development, social development and regional integration by lending to governments and government agencies, including State corporations."
@@ -1451,6 +1457,9 @@
   },
   "jwimQJ": {
     "string": "Ok"
+  },
+  "k0xbVH": {
+    "string": "You can't undo this action."
   },
   "k5DITM": {
     "string": "Users will receive an email to sign up into the platform and join <strong>{name}</strong> account."

--- a/frontend/layouts/dashboard/component.tsx
+++ b/frontend/layouts/dashboard/component.tsx
@@ -48,12 +48,11 @@ export const DashboardLayout: FC<DashboardLayoutProps> = ({
             </LayoutContainer>
           </div>
           <main ref={mainContainerRef} className="h-full overflow-y-scroll bg-background-dark">
-            {isLoading ? (
-              <div className="absolute flex items-center justify-center bg-background-dark top-px bottom-px left-px bg-opacity-20 right-px rounded-2xl backdrop-blur-sm">
+            <LayoutContainer className="py-8">{children}</LayoutContainer>
+            {isLoading && (
+              <div className="absolute flex items-center justify-center bg-background-dark top-px bottom-px left-px right-px rounded-2xl backdrop-blur-sm">
                 <Loading visible={true} iconClassName="w-10 h-10" />
               </div>
-            ) : (
-              <LayoutContainer className="py-8">{children}</LayoutContainer>
             )}
           </main>
         </div>

--- a/frontend/pages/dashboard/projects.tsx
+++ b/frontend/pages/dashboard/projects.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import { PlusCircle as PlusCircleIcon } from 'react-feather';
 import { FormattedMessage, useIntl } from 'react-intl';
 
@@ -31,11 +33,13 @@ type ProjectsPageProps = InferGetStaticPropsType<typeof getStaticProps>;
 
 export const ProjectsPage: PageComponent<ProjectsPageProps, DashboardLayoutProps> = () => {
   const intl = useIntl();
+  const [isLoaded, setIsLoaded] = useState<boolean>(false);
 
   return (
     <ProtectedPage permissions={[UserRoles.ProjectDeveloper]}>
       <Head title={intl.formatMessage({ defaultMessage: 'My projects', id: 'qFZuSl' })} />
       <DashboardLayout
+        isLoading={!isLoaded}
         buttons={
           <Button className="drop-shadow-xl" theme="primary-white" to={Paths.ProjectCreation}>
             <Icon icon={PlusCircleIcon} className="w-4 h-4 mr-2" aria-hidden />
@@ -43,7 +47,7 @@ export const ProjectsPage: PageComponent<ProjectsPageProps, DashboardLayoutProps
           </Button>
         }
       >
-        <ProjectsTable />
+        <ProjectsTable onLoaded={() => setIsLoaded(true)} />
       </DashboardLayout>
     </ProtectedPage>
   );

--- a/frontend/pages/dashboard/projects.tsx
+++ b/frontend/pages/dashboard/projects.tsx
@@ -1,213 +1,41 @@
 import { PlusCircle as PlusCircleIcon } from 'react-feather';
 import { FormattedMessage, useIntl } from 'react-intl';
 
-import cx from 'classnames';
-
-import Link from 'next/link';
-import { useRouter } from 'next/router';
-
 import { withLocalizedRequests } from 'hoc/locale';
 
-import { groupBy } from 'lodash-es';
+import { InferGetStaticPropsType } from 'next';
 
 import { loadI18nMessages } from 'helpers/i18n';
-import { useQueryParams } from 'helpers/pages';
 
-import NoSearchResults from 'containers/dashboard/no-search-results';
-import RowMenu, { RowMenuItem } from 'containers/dashboard/row-menu';
-import SearchAndInfo from 'containers/dashboard/search-and-info';
+import ProjectsTable from 'containers/dashboard/projects/table';
 
 import Button from 'components/button';
 import Head from 'components/head';
 import Icon from 'components/icon';
-import Table from 'components/table';
-import { ProjectStatus, UserRoles } from 'enums';
+import { UserRoles } from 'enums';
 import { Paths } from 'enums';
 import DashboardLayout, { DashboardLayoutProps } from 'layouts/dashboard';
 import NakedLayout from 'layouts/naked';
 import ProtectedPage from 'layouts/protected-page';
 import { PageComponent } from 'types';
-import { GroupedEnums as GroupedEnumsType } from 'types/enums';
 
-import { useAccountProjectsList } from 'services/account';
-import { getEnums } from 'services/enums/enumService';
-
-export const getServerSideProps = withLocalizedRequests(async ({ locale }) => {
-  const enums = await getEnums();
-
+export const getStaticProps = withLocalizedRequests(async ({ locale }) => {
   return {
     props: {
       intlMessages: await loadI18nMessages({ locale }),
-      enums: groupBy(enums, 'type'),
     },
   };
 });
 
-type ProjectsPageProps = {
-  enums: GroupedEnumsType;
-};
+type ProjectsPageProps = InferGetStaticPropsType<typeof getStaticProps>;
 
-export const ProjectsPage: PageComponent<ProjectsPageProps, DashboardLayoutProps> = ({ enums }) => {
+export const ProjectsPage: PageComponent<ProjectsPageProps, DashboardLayoutProps> = () => {
   const intl = useIntl();
-  const router = useRouter();
-
-  const {
-    category: allCategories,
-    instrument_type: allInstrumentTypes,
-    ticket_size: allTicketSizes,
-  } = enums;
-
-  const queryOptions = { keepPreviousData: true, refetchOnMount: true };
-  const queryParams = useQueryParams();
-
-  const {
-    data: { data: projects } = { data: [] },
-    isLoading: isLoadingProjects,
-    isFetching: isFetchingProjects,
-  } = useAccountProjectsList(
-    { ...queryParams, includes: ['municipality', 'country'] },
-    queryOptions
-  );
-
-  const handleRowMenuItemClick = ({ key, slug }: { key: string; slug: string }) => {
-    switch (key) {
-      case 'edit':
-        router.push(
-          `${Paths.Project}/${slug}/edit?returnPath=${encodeURIComponent(router.asPath)}`,
-          `${Paths.Project}/${slug}/edit`
-        );
-        return;
-      case 'preview':
-        router.push(`${Paths.Project}/${slug}/preview`);
-        return;
-      case 'open':
-        router.push(`${Paths.Project}/${slug}`);
-        return;
-      case 'delete':
-        // TODO
-        console.log('Delete:', slug);
-        return;
-    }
-  };
-
-  const tableProps = {
-    columns: [
-      { Header: intl.formatMessage({ defaultMessage: 'Title', id: '9a9+ww' }), accessor: 'name' },
-      {
-        Header: intl.formatMessage({ defaultMessage: 'Category', id: 'ccXLVi' }),
-        accessor: 'category',
-      },
-      {
-        Header: intl.formatMessage({ defaultMessage: 'Country', id: 'vONi+O' }),
-        accessor: 'country',
-      },
-      {
-        Header: intl.formatMessage({ defaultMessage: 'Municipality', id: '9I1zvK' }),
-        accessor: 'municipality',
-      },
-      {
-        Header: intl.formatMessage({ defaultMessage: 'Instrument type', id: 'fDd10o' }),
-        accessor: 'instrumentType',
-      },
-      {
-        Header: intl.formatMessage({ defaultMessage: 'Value', id: 'GufXy5' }),
-        accessor: 'ticketSize',
-        canSort: false,
-      },
-      {
-        Header: intl.formatMessage({ defaultMessage: 'Status', id: 'tzMNF3' }),
-        accessor: 'status',
-        Cell: ({ cell: { value } }) => {
-          return (
-            <span
-              className={cx({
-                'bg-opacity-20 text-sm px-2.5 py-0.5 rounded-2xl': true,
-                'bg-gray-800 text-gray-800': value === 'draft',
-                'bg-green-light text-green-dark': value === 'verified',
-                'bg-orange text-orange': value === 'unverified',
-              })}
-            >
-              {value === 'draft' && <FormattedMessage defaultMessage="Draft" id="W6nwjo" />}
-              {value === 'verified' && <FormattedMessage defaultMessage="Verified" id="Z8971h" />}
-              {value === 'unverified' && (
-                <FormattedMessage defaultMessage="Unverified" id="n9fdaJ" />
-              )}
-            </span>
-          );
-        },
-      },
-      {
-        accessor: 'actions',
-        canSort: false,
-        hideHeader: true,
-        width: 0,
-        Cell: ({
-          cell: {
-            row: {
-              original: { slug, status },
-            },
-          },
-        }) => {
-          return (
-            <div className="flex items-center justify-center gap-3">
-              <Link
-                href={`${Paths.Project}/${slug}/edit?returnPath=${encodeURIComponent(
-                  router.asPath
-                )}`}
-                as={`${Paths.Project}/${slug}/edit`}
-              >
-                <a className="px-2 py-1 text-sm transition-all text-green-dark focus-visible:outline-green-dark rounded-2xl">
-                  <FormattedMessage defaultMessage="Edit" id="wEQDC6" />
-                </a>
-              </Link>
-              <RowMenu onAction={(key: string) => handleRowMenuItemClick({ key, slug })}>
-                <RowMenuItem key="edit">
-                  <FormattedMessage defaultMessage="Edit" id="wEQDC6" />
-                </RowMenuItem>
-                {status === ProjectStatus.Draft ? (
-                  <RowMenuItem key="preview">
-                    <FormattedMessage defaultMessage="Preview project page" id="EvP1Ut" />
-                  </RowMenuItem>
-                ) : (
-                  <RowMenuItem key="open">
-                    <FormattedMessage defaultMessage="View project page" id="ToXG99" />
-                  </RowMenuItem>
-                )}
-                <RowMenuItem key="delete">
-                  <FormattedMessage defaultMessage="Delete" id="K3r6DQ" />
-                </RowMenuItem>
-              </RowMenu>
-            </div>
-          );
-        },
-      },
-    ],
-    data: projects.map((project) => ({
-      slug: project.slug,
-      name: project.name,
-      category: allCategories.find(({ id }) => id === project.category)?.name,
-      country: project.country.name,
-      municipality: project.municipality.name,
-      instrumentType: allInstrumentTypes
-        ?.filter(({ id }) => project.instrument_types?.includes(id))
-        .map(({ name }, idx) => (idx === 0 ? name : name.toLowerCase()))
-        .join(', '),
-      status: project.status === 'draft' ? 'draft' : project.trusted ? 'verified' : 'unverified',
-      ticketSize: allTicketSizes?.find(({ id }) => project.ticket_size === id)?.description,
-    })),
-    loading: isLoadingProjects || isFetchingProjects,
-    sortingEnabled: true,
-    manualSorting: false,
-  };
-
-  const isSearching = !!queryParams.search;
-  const hasProjects = !!projects.length;
 
   return (
     <ProtectedPage permissions={[UserRoles.ProjectDeveloper]}>
       <Head title={intl.formatMessage({ defaultMessage: 'My projects', id: 'qFZuSl' })} />
       <DashboardLayout
-        isLoading={isLoadingProjects}
         buttons={
           <Button className="drop-shadow-xl" theme="primary-white" to={Paths.ProjectCreation}>
             <Icon icon={PlusCircleIcon} className="w-4 h-4 mr-2" aria-hidden />
@@ -215,39 +43,7 @@ export const ProjectsPage: PageComponent<ProjectsPageProps, DashboardLayoutProps
           </Button>
         }
       >
-        <SearchAndInfo className="mt-4 mb-6">
-          <FormattedMessage
-            defaultMessage="Total <span>{numProjects}</span> {numProjects, plural, one {project} other {projects}}"
-            id="0iaD3T"
-            values={{
-              span: (chunks: string) => <span className="px-1 font-semibold">{chunks}</span>,
-              numProjects: projects.length,
-            }}
-          />
-        </SearchAndInfo>
-        {hasProjects && <Table {...tableProps} />}
-        {!hasProjects && (
-          <div className="flex flex-col items-center mt-10 lg:mt-20">
-            {isSearching ? (
-              <NoSearchResults />
-            ) : (
-              <>
-                <p className="text-lg text-gray-800 lg:text-xl">
-                  <FormattedMessage
-                    defaultMessage="Currently you don’t have any <b>Projects</b>."
-                    id="itfsqC"
-                    values={{
-                      b: (chunks: string) => <span className="font-semibold">{chunks}</span>,
-                    }}
-                  />
-                </p>
-                <Button className="mt-8" to={Paths.ProjectCreation}>
-                  <FormattedMessage defaultMessage="Create project" id="VUN1K7" />
-                </Button>
-              </>
-            )}
-          </div>
-        )}
+        <ProjectsTable />
       </DashboardLayout>
     </ProtectedPage>
   );

--- a/frontend/services/account/index.ts
+++ b/frontend/services/account/index.ts
@@ -221,6 +221,29 @@ export function useAccount(includes?: string) {
   };
 }
 
+/** Hook with mutation to delete a project from the account */
+export const useDeleteAccountProject = () => {
+  const queryClient = useQueryClient();
+
+  const deleteAccountProject = (id: string): Promise<Project> => {
+    const config: AxiosRequestConfig = {
+      method: 'DELETE',
+      url: `/api/v1/account/projects/${id}`,
+      data: { id },
+    };
+
+    return API.request(config).then((response) => response.data.data);
+  };
+
+  return useMutation(({ id }: { id: string }) => deleteAccountProject(id), {
+    onSuccess: () => {
+      queryClient.invalidateQueries(Queries.Project);
+      queryClient.invalidateQueries(Queries.ProjectList);
+      queryClient.invalidateQueries(Queries.AccountProjectList);
+    },
+  });
+};
+
 const getAccountProjects = async (params?: PagedRequest): Promise<PagedResponse<Project>> => {
   const { search, page, includes, ...rest } = params || {};
 


### PR DESCRIPTION
## Description

**In this PR:** 

- Extracted the projects table from `pages/dashboard/` into `containers/dashboard/projects`  
  _Following the pattern done for the users_  
- Split the `ProjectsTable`'s custom cells into their own individual components
  _Following the pattern done for the users_
- Added the `useDeleteAccountProject` mutation  
- Added the "Delete project?" confirmation modal to the Projects table  
  _Following the pattern done for the users_
- Minor tweak to ensure the Dashboard layout shows the loading spinner while the projects data is not yet loaded

## Testing instructions

1. Sign in as a project developer  
2. Visit the dashboard, projects section  
3. Attempt to delete a project from the list, using the 3 dots menu

Verify that:  
  - The confirmation modal works correctly  
  - The project is removed from the list  
  - The project is really deleted

## Tracking

[LET-770](https://vizzuality.atlassian.net/browse/LET-770)
