### PR TITLE
Quick fix to bug causing only 10 possible involved project developers to show on the project form

### DIFF
--- a/frontend/containers/project-form/pages/general-information.tsx
+++ b/frontend/containers/project-form/pages/general-information.tsx
@@ -51,7 +51,7 @@ const GeneralInformation = ({
   const { locations } = useGroupedLocations({ includes: 'parent' });
 
   const { projectDevelopers } = useProjectDevelopersList({
-    'page[size]': 1000,
+    perPage: 1000,
     fields: ['name'],
   });
 

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -203,6 +203,9 @@
   "5Hzwqs": {
     "string": "Favorite"
   },
+  "5UMEjA": {
+    "string": "Find the support and resources to grow your business or project"
+  },
   "5c08Qp": {
     "string": "Project information"
   },
@@ -1772,9 +1775,6 @@
   },
   "wEQDC6": {
     "string": "Edit"
-  },
-  "wGWm2r": {
-    "string": "Find the support and ressources to grow your business or project"
   },
   "wQteLO": {
     "string": "Go to page {page}"


### PR DESCRIPTION
Addresses the issue mentioned in JIRA: https://vizzuality.atlassian.net/browse/LET-264?focusedCommentId=17931

On the project form (first page), the list of project developers only shows a maximum of 10 project developers. 

This bug was caused by myself 2 months ago with [this change](https://github.com/Vizzuality/heco-invest/commit/a746cd9c7e9d37ca88a73637f1c13517453388c8#diff-18dfd57af10a343449c2ad032fc3df9b82c305326054c1a1f9cd1ff2e04b4100R30).