### PR TITLE
fix: Owner of account can remove invited Users

### DIFF
--- a/backend/app/controllers/api/v1/accounts/users_controller.rb
+++ b/backend/app/controllers/api/v1/accounts/users_controller.rb
@@ -16,7 +16,7 @@ module API
 
         def destroy
           # @user cannot be account owner AND
-          # either current_user == @user OR current_user is account owner in @user's account
+          # either current_user == @user OR current_user is account owner in @user's account OR @user is invited by current_user
           @user.destroy!
           UserMailer.destroyed(@user.email, @user.full_name, @user.locale).deliver_later
           head :ok

--- a/backend/app/models/ability.rb
+++ b/backend/app/models/ability.rb
@@ -55,9 +55,8 @@ class Ability
 
   def owner_rights
     can %i[invite], User, account_id: nil
-    can %i[index show], User, invited_by_id: user.id, invited_by_type: "User"
+    can %i[index show destroy], User, invited_by_id: user.id, invited_by_type: "User", account_id: nil
     can %i[destroy], User.where(account_id: user.account_id).where.not(id: user.id)
-    can %i[destroy], User, invited_by_id: user.id, invited_by_type: "User", account_id: nil
     can :transfer_ownership, User, account_id: user.account.id
 
     can :destroy, Project, {project_developer: {account: {owner_id: user.id}}}

--- a/backend/app/models/ability.rb
+++ b/backend/app/models/ability.rb
@@ -57,6 +57,7 @@ class Ability
     can %i[invite], User, account_id: nil
     can %i[index show], User, invited_by_id: user.id, invited_by_type: "User"
     can %i[destroy], User.where(account_id: user.account_id).where.not(id: user.id)
+    can %i[destroy], User, invited_by_id: user.id, invited_by_type: "User", account_id: nil
     can :transfer_ownership, User, account_id: user.account.id
 
     can :destroy, Project, {project_developer: {account: {owner_id: user.id}}}

--- a/backend/spec/system/backoffice/projects_spec.rb
+++ b/backend/spec/system/backoffice/projects_spec.rb
@@ -114,7 +114,8 @@ RSpec.describe "Backoffice: Projects", type: :system do
         it "can update project information" do
           fill_in t("simple_form.labels.project.name"), with: "New name"
           attach_file t("simple_form.labels.project.project_images"), [Rails.root.join("spec/fixtures/files/picture.jpg"), Rails.root.join("spec/fixtures/files/picture_2.jpg")]
-          using_wait_time 15 do
+          using_wait_time 30 do
+            sleep 1
             attach_file :shapefile, Rails.root.join("spec/fixtures/files/shapefile.zip")
             expect(page).to have_text(t("backoffice.projects.form.shapefile_loaded"))
           end


### PR DESCRIPTION
I am adding missing cancancan policy which allows Owner of account remove users which he invited, but they have not accepted invitation yet (are not part of account yet).

## Testing instructions

Invite new user via Rswag doc and try to remove him afterwards

## Tracking

Bugfix mentioned by @barbara-chaves at https://vizzuality.atlassian.net/browse/LET-610
