### PR TITLE
refactoring: Private endpoint for projects does FTS only by name attr…

### DIFF
--- a/backend/app/controllers/api/v1/accounts/projects_controller.rb
+++ b/backend/app/controllers/api/v1/accounts/projects_controller.rb
@@ -10,7 +10,7 @@ module API
           projects = @projects
             .where(project_developer_id: current_user.account.project_developer.id)
             .includes(:project_developer, :involved_project_developers, project_images: {file_attachment: :blob})
-          projects = API::Filterer.new(projects, filter_params.to_h).call
+          projects = projects.dynamic_search ["name_#{I18n.locale}"], filter_params[:full_text], [] if filter_params[:full_text].present?
           projects = projects.order(created_at: :desc)
           render json: ProjectSerializer.new(
             projects,


### PR DESCRIPTION
It was decided that FTS at private endpoint for projects will use only `name` attribute for now. 

There was already test which verifies that searching by name works so I have just replaced `API::Filterer` with simple searching by name.

## Testing instructions

Double check via Rswag doc that FTS for projects still works

## Tracking

https://vizzuality.atlassian.net/browse/LET-797
