### PR TITLE
Let 610 fe project developer and investor account owners can remove users from the account

### DIFF
--- a/frontend/components/confirmation-prompt/component.tsx
+++ b/frontend/components/confirmation-prompt/component.tsx
@@ -4,8 +4,10 @@ import { FormattedMessage } from 'react-intl';
 
 import classnames from 'classnames';
 
+import Alert from 'components/alert';
 import Button from 'components/button';
 import Icon from 'components/icon';
+import Loading from 'components/loading';
 import Modal from 'components/modal';
 
 import type { ConfirmationPromptProps } from './types';
@@ -19,11 +21,20 @@ export const ConfirmationPrompt: FC<ConfirmationPromptProps> = ({
   onDismiss,
   onAccept,
   onRefuse,
+  onAcceptLoading = false,
+  confirmationError,
 }: ConfirmationPromptProps) => (
   <Modal open={open} title={title} size="default" dismissable={dismissible} onDismiss={onDismiss}>
     <div className="flex flex-col items-center px-8 py-4">
       <div className="font-serif text-3xl font-semibold text-center text-black">{title}</div>
       <p className="mt-4 font-sans text-base text-center text-black">{description}</p>
+      {!!confirmationError && (
+        <div className="w-full mt-6">
+          <Alert type="warning" withLayoutContainer={true}>
+            {confirmationError}
+          </Alert>
+        </div>
+      )}
       <div
         className={classnames({
           'flex justify-start items-end': true,
@@ -46,8 +57,14 @@ export const ConfirmationPrompt: FC<ConfirmationPromptProps> = ({
           size="small"
           className="flex-shrink-0 sm:mr-5"
           onClick={onAccept}
+          disabled={onAcceptLoading}
         >
-          <FormattedMessage defaultMessage="Delete" id="K3r6DQ" />
+          <Loading className="mr-2" visible={onAcceptLoading} />
+          {!confirmationError ? (
+            <FormattedMessage defaultMessage="Delete" id="K3r6DQ" />
+          ) : (
+            <FormattedMessage defaultMessage="Try again" id="FazwRl" />
+          )}
         </Button>
 
         {icon && (

--- a/frontend/components/confirmation-prompt/types.d.ts
+++ b/frontend/components/confirmation-prompt/types.d.ts
@@ -27,6 +27,12 @@ export interface ConfirmationPromptProps {
    */
   onAccept: () => void;
   /**
+   * Whether the onAccept function is loading. Defauts to 'false'
+   */
+  onAcceptLoading?: boolean;
+  /** Message of the error triggered by the confirmation the action. */
+  confirmationError?: string;
+  /**
    * Callback executed when the user refuses the action
    */
   onRefuse: () => void;

--- a/frontend/containers/dashboard/users/table/cells/actions/component.tsx
+++ b/frontend/containers/dashboard/users/table/cells/actions/component.tsx
@@ -39,6 +39,13 @@ export const CellActions = ({ row }: CellActionsProps) => {
     });
   };
 
+  const handleDismiss = () => {
+    if (deleteUser.isError) {
+      deleteUser.reset();
+    }
+    setConfirmDelete(false);
+  };
+
   return (
     <div
       className={cx({
@@ -90,8 +97,10 @@ export const CellActions = ({ row }: CellActionsProps) => {
       <ConfirmationPrompt
         open={confirmDelete}
         onAccept={() => handleDeleteUser(id)}
-        onDismiss={() => setConfirmDelete(false)}
-        onRefuse={() => setConfirmDelete(false)}
+        onDismiss={handleDismiss}
+        onRefuse={handleDismiss}
+        onAcceptLoading={deleteUser.isLoading}
+        confirmationError={deleteUser.error?.message[0]?.title}
         title={intl.formatMessage({ id: 'tSCuG5', defaultMessage: 'Delete user?' })}
         description={intl.formatMessage(
           {

--- a/frontend/containers/dashboard/users/table/cells/actions/component.tsx
+++ b/frontend/containers/dashboard/users/table/cells/actions/component.tsx
@@ -2,12 +2,16 @@ import React, { useState } from 'react';
 
 import { Mail as MailIcon, Trash2 as TrashIcon } from 'react-feather';
 import { FormattedMessage, useIntl } from 'react-intl';
+import { useQueryClient } from 'react-query';
 
 import cx from 'classnames';
 
 import ConfirmationPrompt from 'components/confirmation-prompt';
 import Icon from 'components/icon';
 import Tooltip from 'components/tooltip';
+import { InvitationStatus, Queries } from 'enums';
+
+import { useDeleteUser } from 'services/account';
 
 import { CellActionsProps } from './types';
 
@@ -15,17 +19,31 @@ export const CellActions = ({ row }: CellActionsProps) => {
   const [confirmDelete, setConfirmDelete] = useState(false);
   const intl = useIntl();
 
+  const deleteUser = useDeleteUser();
+  const queryClient = useQueryClient();
+
   if (!row) return null;
   const {
-    original: { id, confirmed, first_name, last_name },
+    original: { id, invitation, first_name, last_name },
   } = row;
   const displayName = first_name + ' ' + last_name;
+  const canResendInvitation =
+    invitation === InvitationStatus.Expired || invitation === InvitationStatus.Waiting;
+
+  const handleDeleteUser = (userId: string) => {
+    deleteUser.mutate(userId, {
+      onSuccess: () => {
+        queryClient.invalidateQueries(Queries.AccountUsersList);
+        setConfirmDelete(false);
+      },
+    });
+  };
 
   return (
     <div
       className={cx({
         'flex justify-end': true,
-        'space-x-2': !confirmed,
+        'space-x-2': canResendInvitation,
       })}
     >
       <Tooltip
@@ -43,7 +61,7 @@ export const CellActions = ({ row }: CellActionsProps) => {
           className={cx({
             'flex items-center justify-center w-8 h-8 border rounded-full pointer border-green-dark hover:bg-green-light hover:bg-opacity-20':
               true,
-            invisible: confirmed,
+            invisible: !canResendInvitation,
           })}
         >
           <Icon className="w-5 h-5 text-green-dark" icon={MailIcon} />
@@ -71,7 +89,7 @@ export const CellActions = ({ row }: CellActionsProps) => {
 
       <ConfirmationPrompt
         open={confirmDelete}
-        onAccept={() => console.log(`Delete ${id} user`)}
+        onAccept={() => handleDeleteUser(id)}
         onDismiss={() => setConfirmDelete(false)}
         onRefuse={() => setConfirmDelete(false)}
         title="Delete user?"

--- a/frontend/containers/dashboard/users/table/cells/actions/component.tsx
+++ b/frontend/containers/dashboard/users/table/cells/actions/component.tsx
@@ -100,7 +100,14 @@ export const CellActions = ({ row }: CellActionsProps) => {
         onDismiss={handleDismiss}
         onRefuse={handleDismiss}
         onAcceptLoading={deleteUser.isLoading}
-        confirmationError={deleteUser.error?.message[0]?.title}
+        confirmationError={
+          deleteUser.isError &&
+          (deleteUser.error?.message?.[0]?.title ||
+            intl.formatMessage({
+              defaultMessage: 'Something went wrong while trying to delete the user',
+              id: 'sIhhxz',
+            }))
+        }
         title={intl.formatMessage({ id: 'tSCuG5', defaultMessage: 'Delete user?' })}
         description={intl.formatMessage(
           {

--- a/frontend/containers/dashboard/users/table/cells/actions/component.tsx
+++ b/frontend/containers/dashboard/users/table/cells/actions/component.tsx
@@ -24,9 +24,9 @@ export const CellActions = ({ row }: CellActionsProps) => {
 
   if (!row) return null;
   const {
-    original: { id, invitation, first_name, last_name },
+    original: { id, invitation, first_name, last_name, email },
   } = row;
-  const displayName = first_name + ' ' + last_name;
+  const displayName = first_name ? first_name + ' ' + last_name : email;
   const canResendInvitation =
     invitation === InvitationStatus.Expired || invitation === InvitationStatus.Waiting;
 
@@ -92,15 +92,15 @@ export const CellActions = ({ row }: CellActionsProps) => {
         onAccept={() => handleDeleteUser(id)}
         onDismiss={() => setConfirmDelete(false)}
         onRefuse={() => setConfirmDelete(false)}
-        title="Delete user?"
+        title={intl.formatMessage({ id: 'tSCuG5', defaultMessage: 'Delete user?' })}
         description={intl.formatMessage(
           {
             defaultMessage:
-              'Are you sure you want to delete <strong>{displayName}</strong>? You cant undo this action.',
-            id: 'bQc7X2',
+              "Are you sure you want to delete <strong>{displayName}</strong>? You can't undo this action.",
+            id: 'eXH6WV',
           },
           {
-            displayName: displayName,
+            displayName,
             strong: (chunk: string) => <strong>{chunk}</strong>,
           }
         )}

--- a/frontend/containers/dashboard/users/table/cells/actions/types.ts
+++ b/frontend/containers/dashboard/users/table/cells/actions/types.ts
@@ -1,3 +1,5 @@
+import { InvitationStatus } from 'enums';
+
 export interface CellActionsProps {
   row: {
     original: {
@@ -6,6 +8,7 @@ export interface CellActionsProps {
       confirmed: boolean;
       first_name: string;
       last_name: string;
+      invitation: InvitationStatus;
     };
   };
 }

--- a/frontend/containers/dashboard/users/table/cells/invitation/component.tsx
+++ b/frontend/containers/dashboard/users/table/cells/invitation/component.tsx
@@ -24,12 +24,9 @@ export const CellInvitation = ({ value }: CellInvitationProps) => {
     }
   };
 
-  console.log(value);
-
   return (
     <div
-      className={cx({
-        'items-center inline-block px-2.5 py-0.5 bg-opacity-20 rounded-2xl': true,
+      className={cx('items-center inline-block px-2.5 py-0.5 bg-opacity-20 rounded-2xl', {
         'bg-green-light': value === InvitationStatus.Completed,
         'bg-orange ml-2': value === InvitationStatus.Waiting,
         'bg-red-300 ml-2': value === InvitationStatus.Expired,

--- a/frontend/containers/dashboard/users/table/cells/invitation/component.tsx
+++ b/frontend/containers/dashboard/users/table/cells/invitation/component.tsx
@@ -4,28 +4,45 @@ import { FormattedMessage } from 'react-intl';
 
 import cx from 'classnames';
 
+import { InvitationStatus } from 'enums';
+
 import { CellInvitationProps } from './types';
 
 export const CellInvitation = ({ value }: CellInvitationProps) => {
   if (value === undefined) return null;
 
+  const getInvitationStatus = (status: string) => {
+    switch (status) {
+      case InvitationStatus.Completed:
+        return <FormattedMessage defaultMessage="Accepted" id="aFyFm0" />;
+      case InvitationStatus.Waiting:
+        return <FormattedMessage defaultMessage="Waiting" id="dZd8H/" />;
+      case InvitationStatus.Expired:
+        return <FormattedMessage defaultMessage="Expired" id="RahCRH" />;
+      default:
+        return null;
+    }
+  };
+
+  console.log(value);
+
   return (
     <div
       className={cx({
         'items-center inline-block px-2.5 py-0.5 bg-opacity-20 rounded-2xl': true,
-        'bg-green-light': value,
-        'bg-orange ml-2': !value,
+        'bg-green-light': value === InvitationStatus.Completed,
+        'bg-orange ml-2': value === InvitationStatus.Waiting,
+        'bg-red-300 ml-2': value === InvitationStatus.Expired,
       })}
     >
       <p
-        className={cx({
-          'text-sm': true,
-          'text-green-dark': value,
-          'text-orange': !value,
+        className={cx('text-sm', {
+          'text-green-dark': value === InvitationStatus.Completed,
+          'text-orange': value === InvitationStatus.Waiting,
+          'text-red-700': value === InvitationStatus.Expired,
         })}
       >
-        {value && <FormattedMessage defaultMessage="Accepted" id="aFyFm0" />}
-        {!value && <FormattedMessage defaultMessage="Waiting" id="dZd8H/" />}
+        {getInvitationStatus(value)}
       </p>
     </div>
   );

--- a/frontend/containers/dashboard/users/table/cells/invitation/types.ts
+++ b/frontend/containers/dashboard/users/table/cells/invitation/types.ts
@@ -1,3 +1,5 @@
+import { InvitationStatus } from 'enums';
+
 export interface CellInvitationProps {
-  value: string;
+  value: InvitationStatus;
 }

--- a/frontend/containers/dashboard/users/table/component.tsx
+++ b/frontend/containers/dashboard/users/table/component.tsx
@@ -55,7 +55,7 @@ export const UsersTable: FC<UsersTableProps> = ({ isOwner }) => {
       },
       {
         Header: 'Invitation',
-        accessor: 'confirmed',
+        accessor: 'invitation',
         className: 'text-sm leading-8',
         width: 50,
         Cell: Invitation,

--- a/frontend/enums/index.ts
+++ b/frontend/enums/index.ts
@@ -151,4 +151,5 @@ export enum ImpactAreas {
 export enum InvitationStatus {
   Waiting = 'waiting',
   Completed = 'completed',
+  Expired = 'expired',
 }

--- a/frontend/services/account/index.ts
+++ b/frontend/services/account/index.ts
@@ -286,3 +286,10 @@ export function useAccountUsersList(
     [query]
   );
 }
+
+export const useDeleteUser = (): UseMutationResult<{}> => {
+  const deleteUser = async (id: string) =>
+    await API.delete(`/api/v1/account/users/${id}`, { data: {} });
+
+  return useMutation(deleteUser);
+};

--- a/frontend/services/account/index.ts
+++ b/frontend/services/account/index.ts
@@ -287,7 +287,7 @@ export function useAccountUsersList(
   );
 }
 
-export const useDeleteUser = (): UseMutationResult<{}> => {
+export const useDeleteUser = (): UseMutationResult<{}, ErrorResponse> => {
   const deleteUser = async (id: string) =>
     await API.delete(`/api/v1/account/users/${id}`, { data: {} });
 


### PR DESCRIPTION
This PR add the possibility fot the account owners to delete the account users through the page dashboard/users

## Description

This will be done from  “My area“ (Dashboard)

The modal should make use of the existing confirmation prompt

[LET-611: FE - Existing confirmation prompt can also be used as a confirmation prompt for deletionsIN PROGRESS](https://vizzuality.atlassian.net/browse/LET-611) 

Respects the Figma designs [HeCo - Work in progress](https://www.figma.com/file/KC49uMR9t1YARmFR0Sr6aN/HeCo---Work-in-progress?node-id=2695%3A33430) 

## Testing instructions

1. Sign-in as a PD or Investor account owner
2. Go to dashboard/users (my area) page
3. There should be a table with the account users, and the last column should display the DELETE icon. Click on the icon
4. A modal with a confirmation prompt should be appear. 
  - Clicking 'cancel' button should just dismiss the modal.
  - Clicking 'delete' button should trigger a loading icon on the same button. 
  - If the action succeeds, the modal should be dismissed and the users table updated removing the deleted user from the list. 
  - If the action fails an error message should be displayed on the modal and the 'delete' text will change to 'try again'

Notes

The confirmation prompt may need some tweaks to be made us from


## Tracking

[LET-610](https://vizzuality.atlassian.net/browse/LET-610)

