### PR TITLE
Fix bug causing discover map to not be interactable

### DIFF
--- a/frontend/containers/discover-map/component.tsx
+++ b/frontend/containers/discover-map/component.tsx
@@ -76,10 +76,19 @@ export const DiscoverMap: FC<DiscoverMapProps> = ({ onSelectProjectPin }) => {
 
         <div
           // `bottom-12` ensures the layers menu doesn't overflow the map
-          className="absolute flex items-start gap-2 inset-3.5 bottom-12 text-gray-800 text-sm"
+          // `pointer-events-none` because this div covers the map, this class is necessary to ensure the user can
+          // interact with the map; however children elements inside need the `pointer-events-auto` added to make them
+          // interactable
+          className="absolute flex items-start gap-2 inset-3.5 bottom-12 text-gray-800 text-sm pointer-events-none"
         >
-          <MapLayersSelector onActiveLayersChange={setVisibleLayers} />
-          <LocationSearcher onLocationSelected={handleLocationSelected} />
+          <MapLayersSelector
+            className="pointer-events-auto"
+            onActiveLayersChange={setVisibleLayers}
+          />
+          <LocationSearcher
+            className="pointer-events-auto"
+            onLocationSelected={handleLocationSelected}
+          />
         </div>
 
         <Controls className="absolute bottom-10 xl:bottom-4 right-4">

--- a/frontend/containers/discover-map/location-searcher/component.tsx
+++ b/frontend/containers/discover-map/location-searcher/component.tsx
@@ -14,7 +14,7 @@ import CloseIcon from 'svgs/ui/close.svg';
 
 import { LocationSearcherProps } from './types';
 
-export const LocationSearcher: FC<LocationSearcherProps> = ({ onLocationSelected }) => {
+export const LocationSearcher: FC<LocationSearcherProps> = ({ className, onLocationSelected }) => {
   const intl = useIntl();
   const placesRef = useRef();
 
@@ -51,7 +51,12 @@ export const LocationSearcher: FC<LocationSearcherProps> = ({ onLocationSelected
       <Script
         src={`https://maps.googleapis.com/maps/api/js?key=${process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}&libraries=places&callback=onGoogleMapsReady`}
       />
-      <div className="relative z-10">
+      <div
+        className={cx({
+          'relative z-10': true,
+          [className]: !!className,
+        })}
+      >
         <PlacesAutocomplete
           ref={placesRef}
           value={address}

--- a/frontend/containers/discover-map/location-searcher/types.ts
+++ b/frontend/containers/discover-map/location-searcher/types.ts
@@ -1,3 +1,6 @@
 export interface LocationSearcherProps {
+  /** Classes to add to the container */
+  className?: string;
+  /** Callback to pass the bbox of a selected location */
   onLocationSelected: ({ bbox }: { bbox: number[] }) => void;
 }


### PR DESCRIPTION
## Description

This bug fixes an issue preventing the `discover/projects` map from being interacted with. 

## Testing instructions

1. Visit `discover/projects` 
    - Verify that the map can be interacted (the bug)
    - Verify that the _"Find location"_ input still works  
    - Verify that the _"Map layers"_ button still works  

## Tracking

[LET-803](https://vizzuality.atlassian.net/browse/LET-803)

## Screen recording

https://user-images.githubusercontent.com/6273795/180433837-c3c93608-6dee-4f53-8b3f-58eed81828de.mp4


