### PR TITLE
fix: Use correct text at UserMailer (destroyed)

### DIFF
--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -237,8 +237,8 @@ zu:
       subject: Account ownership changed
       content: Congratulations! You are now owner of account %{name}.
     destroyed:
-      subject: Your account has been removed!
-      content: We would like to inform you that your account at HeCo platform was removed.
+      subject: Your user has been removed!
+      content: We would like to inform you that your user at HeCo platform was removed.
   admin_mailer:
     greetings: Dear %{full_name},
     farewell_html: Best Regards,<br />Your HeCo Team


### PR DESCRIPTION
Using slightly different naming convention at User Mailer when user gets destroyed --> it contained `account` word, which can be confusing for user, so it was replaced with `user`