### PR TITLE
Fix PD, Investor, Project editing updating the data in the wrong language

### DIFF
--- a/frontend/containers/project-form/component.tsx
+++ b/frontend/containers/project-form/component.tsx
@@ -50,7 +50,10 @@ export const ProjectForm: FC<ProjectFormProps> = ({
   const [showLeave, setShowLeave] = useState(false);
   const [projectSlug, setProjectSlug] = useState<string>();
   const resolver = useProjectValidation(currentPage);
-  const updateProject = useUpdateProject();
+  const updateProject = useUpdateProject({
+    // We set the `locale` as `null` so that we get the project in the account's language instead of the UI language
+    locale: null,
+  });
   const { userAccount } = useAccount();
   const {
     category,

--- a/frontend/containers/project-form/component.tsx
+++ b/frontend/containers/project-form/component.tsx
@@ -19,8 +19,7 @@ import {
 } from 'types/project';
 import useProjectValidation, { formPageInputs } from 'validations/project';
 
-import { useAccount } from 'services/account';
-import { useUpdateProject } from 'services/account';
+import { useAccount, useUpdateProject } from 'services/account';
 
 import { useDefaultValues } from './helpers';
 
@@ -109,7 +108,7 @@ export const ProjectForm: FC<ProjectFormProps> = ({
 
   const handleUpdate = useCallback(
     (formData: ProjectUpdatePayload) => {
-      return updateProject.mutate(formData, {
+      return mutation.mutate(formData, {
         onError: (error) => {
           const { errorPages, fieldErrors } = getServiceErrors<ProjectFormType>(
             error,

--- a/frontend/containers/users/invite-users-modal/component.tsx
+++ b/frontend/containers/users/invite-users-modal/component.tsx
@@ -30,7 +30,7 @@ export const InviteUsersModal: FC<InviteUsersModalProps> = ({
 }: InviteUsersModalProps) => {
   const { formatMessage } = useIntl();
   const inviteUsers = useInviteUsers();
-  const { userAccount } = useAccount('owner');
+  const { userAccount } = useAccount({ includes: 'owner' });
   const { name } = userAccount || {};
   const queryClient = useQueryClient();
 

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -140,6 +140,9 @@
   "2O2sfp": {
     "string": "Finish"
   },
+  "2ffyX7": {
+    "string": "This page is coming soon"
+  },
   "2inebt": {
     "string": "The opportunities are located in geographies that are are unique due to of their biodiversity, cultural heritages, and regulation of water systems. As such, these projects will have the greatest impact for people and nature."
   },
@@ -241,9 +244,6 @@
   },
   "5zAKQ7": {
     "string": "About HeCo"
-  },
-  "6//v4m": {
-    "string": "+123456789"
   },
   "62pTkz": {
     "string": "Save your favorites"
@@ -1185,9 +1185,6 @@
   "ZATT08": {
     "string": "Pagination"
   },
-  "ZEEVQX": {
-    "string": "Social media"
-  },
   "ZKsAVY": {
     "string": "This project isn’t currently looking for funding."
   },
@@ -1331,6 +1328,9 @@
   },
   "e0c9xF": {
     "string": "insert the name of the investor/funder"
+  },
+  "e61Jf3": {
+    "string": "Coming soon"
   },
   "eE6uKi": {
     "string": "This data set, a collaboration between the Global Land Analysis & Discovery (GLAD) lab at the University of Maryland, Google, USGS, and NASA, measures areas of tree cover loss across all global land (except Antarctica and other Arctic islands) at approximately 30 × 30 meter resolution. The data were generated using multispectral satellite imagery from the Landsat 5 thematic mapper (TM), the Landsat 7 thematic mapper plus (ETM+), and the Landsat 8 Operational Land Imager (OLI) sensors. Over 1 million satellite images were processed and analyzed, including over 600,000 Landsat 7 images for the 2000-2012 interval, and more than 400,000 Landsat 5, 7, and 8 images for updates for the 2011-2021 interval. The clear land surface observations in the satellite images were assembled and a supervised learning algorithm was applied to identify per pixel tree cover loss."

--- a/frontend/layouts/dashboard/component.tsx
+++ b/frontend/layouts/dashboard/component.tsx
@@ -21,7 +21,7 @@ export const DashboardLayout: FC<DashboardLayoutProps> = ({
 }: DashboardLayoutProps) => {
   const mainContainerRef = useRef(null);
 
-  const { user, userAccount } = useAccount('owner');
+  const { user, userAccount } = useAccount({ includes: 'owner' });
 
   return (
     <ProtectedPage permissions={[UserRoles.ProjectDeveloper, UserRoles.Investor]}>

--- a/frontend/pages/dashboard/account-information.tsx
+++ b/frontend/pages/dashboard/account-information.tsx
@@ -36,7 +36,7 @@ type AccountInfoPageProps = InferGetStaticPropsType<typeof getStaticProps>;
 
 export const AccountInfoPage: PageComponent<AccountInfoPageProps, DashboardLayoutProps> = () => {
   const intl = useIntl();
-  const { user, userAccount, userAccountLoading } = useAccount('owner');
+  const { user, userAccount, userAccountLoading } = useAccount({ includes: 'owner' });
 
   const isProjectDeveloper = user?.role === UserRoles.ProjectDeveloper;
 

--- a/frontend/pages/investors/edit.tsx
+++ b/frontend/pages/investors/edit.tsx
@@ -19,6 +19,11 @@ import { GroupedEnums } from 'types/enums';
 import { useInvestor, useUpdateInvestor } from 'services/account';
 import { getEnums } from 'services/enums/enumService';
 
+const INVESTOR_QUERY_PARAMS = {
+  // We set the `locale` as `null` so that we get the project in the account's language instead of the UI language
+  locale: null,
+};
+
 export async function getServerSideProps(ctx) {
   const enums = await getEnums();
   return {
@@ -39,8 +44,10 @@ const EditInvestorPage: PageComponent<EditInvestorServerSideProps, FormPageLayou
   const router = useRouter();
   const { formatMessage } = useIntl();
 
-  const updateInvestor = useUpdateInvestor();
   const queryReturnPath = useQueryReturnPath();
+  const updateInvestor = useUpdateInvestor(INVESTOR_QUERY_PARAMS);
+
+  const { data: investor } = useInvestor(INVESTOR_QUERY_PARAMS);
 
   const handleOnComplete = () => {
     router.push(queryReturnPath || Paths.Dashboard);
@@ -49,11 +56,6 @@ const EditInvestorPage: PageComponent<EditInvestorServerSideProps, FormPageLayou
   const handleOnLeave = (isOutroPage) => {
     router.push(queryReturnPath || (isOutroPage ? Paths.Discover : Paths.Dashboard));
   };
-
-  const { data: investor } = useInvestor({
-    // We set the `locale` as `null` so that we get the project in the account's language instead of the UI language
-    locale: null,
-  });
 
   return (
     <ProtectedPage permissions={[UserRoles.Investor]}>

--- a/frontend/pages/investors/edit.tsx
+++ b/frontend/pages/investors/edit.tsx
@@ -50,7 +50,7 @@ const EditInvestorPage: PageComponent<EditInvestorServerSideProps, FormPageLayou
     router.push(queryReturnPath || (isOutroPage ? Paths.Discover : Paths.Dashboard));
   };
 
-  const { investor } = useInvestor({});
+  const { data: investor } = useInvestor();
 
   return (
     <ProtectedPage permissions={[UserRoles.Investor]}>

--- a/frontend/pages/investors/edit.tsx
+++ b/frontend/pages/investors/edit.tsx
@@ -50,7 +50,10 @@ const EditInvestorPage: PageComponent<EditInvestorServerSideProps, FormPageLayou
     router.push(queryReturnPath || (isOutroPage ? Paths.Discover : Paths.Dashboard));
   };
 
-  const { data: investor } = useInvestor();
+  const { data: investor } = useInvestor({
+    // We set the `locale` as `null` so that we get the project in the account's language instead of the UI language
+    locale: null,
+  });
 
   return (
     <ProtectedPage permissions={[UserRoles.Investor]}>

--- a/frontend/pages/project-developers/edit.tsx
+++ b/frontend/pages/project-developers/edit.tsx
@@ -20,6 +20,11 @@ import { PageComponent } from 'types';
 import { useProjectDeveloper, useUpdateProjectDeveloper } from 'services/account';
 import { getEnums } from 'services/enums/enumService';
 
+const PROJECT_DEVELOPER_QUERY_PARAMS = {
+  // We set the `locale` as `null` so that we get the project in the account's language instead of the UI language
+  locale: null,
+};
+
 export const getStaticProps = withLocalizedRequests(async ({ locale }) => {
   const queryClient = new QueryClient();
   queryClient.prefetchQuery(Queries.EnumList, getEnums);
@@ -37,11 +42,9 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, FormPageLayoutProps
   const router = useRouter();
   const { formatMessage } = useIntl();
 
-  const updateProjectDeveloper = useUpdateProjectDeveloper();
-  const { data: projectDeveloper } = useProjectDeveloper({
-    // We set the `locale` as `null` so that we get the project in the account's language instead of the UI language
-    locale: null,
-  });
+  const updateProjectDeveloper = useUpdateProjectDeveloper(PROJECT_DEVELOPER_QUERY_PARAMS);
+
+  const { data: projectDeveloper } = useProjectDeveloper(PROJECT_DEVELOPER_QUERY_PARAMS);
 
   const queryReturnPath = useQueryReturnPath();
 

--- a/frontend/pages/project-developers/edit.tsx
+++ b/frontend/pages/project-developers/edit.tsx
@@ -38,7 +38,8 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, FormPageLayoutProps
   const { formatMessage } = useIntl();
 
   const updateProjectDeveloper = useUpdateProjectDeveloper();
-  const { projectDeveloper } = useProjectDeveloper({});
+  const { data: projectDeveloper } = useProjectDeveloper();
+
   const queryReturnPath = useQueryReturnPath();
 
   const handleOnComplete = () => {

--- a/frontend/pages/project-developers/edit.tsx
+++ b/frontend/pages/project-developers/edit.tsx
@@ -38,7 +38,10 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, FormPageLayoutProps
   const { formatMessage } = useIntl();
 
   const updateProjectDeveloper = useUpdateProjectDeveloper();
-  const { data: projectDeveloper } = useProjectDeveloper();
+  const { data: projectDeveloper } = useProjectDeveloper({
+    // We set the `locale` as `null` so that we get the project in the account's language instead of the UI language
+    locale: null,
+  });
 
   const queryReturnPath = useQueryReturnPath();
 

--- a/frontend/pages/project-developers/edit.tsx
+++ b/frontend/pages/project-developers/edit.tsx
@@ -17,9 +17,8 @@ import FormPageLayout, { FormPageLayoutProps } from 'layouts/form-page';
 import ProtectedPage from 'layouts/protected-page';
 import { PageComponent } from 'types';
 
-import { useUpdateProjectDeveloper } from 'services/account';
+import { useProjectDeveloper, useUpdateProjectDeveloper } from 'services/account';
 import { getEnums } from 'services/enums/enumService';
-import { useCurrentProjectDeveloper } from 'services/project-developers/projectDevelopersService';
 
 export const getStaticProps = withLocalizedRequests(async ({ locale }) => {
   const queryClient = new QueryClient();
@@ -39,7 +38,7 @@ const ProjectDeveloper: PageComponent<ProjectDeveloperProps, FormPageLayoutProps
   const { formatMessage } = useIntl();
 
   const updateProjectDeveloper = useUpdateProjectDeveloper();
-  const { projectDeveloper } = useCurrentProjectDeveloper();
+  const { projectDeveloper } = useProjectDeveloper({});
   const queryReturnPath = useQueryReturnPath();
 
   const handleOnComplete = () => {

--- a/frontend/pages/project/[id]/edit.tsx
+++ b/frontend/pages/project/[id]/edit.tsx
@@ -74,7 +74,10 @@ const EditProject: PageComponent<EditProjectProps, FormPageLayoutProps> = ({
   const { formatMessage } = useIntl();
   const router = useRouter();
 
-  const updateProject = useUpdateProject();
+  const updateProject = useUpdateProject({
+    // We set the `locale` as `null` so that we get the project in the account's language instead of the UI language
+    locale: null,
+  });
   const queryReturnPath = useQueryReturnPath();
 
   const {

--- a/frontend/pages/project/[id]/edit.tsx
+++ b/frontend/pages/project/[id]/edit.tsx
@@ -11,7 +11,7 @@ import { useQueryReturnPath } from 'helpers/pages';
 
 import ProjectForm from 'containers/project-form';
 
-import { EnumTypes, Paths, UserRoles } from 'enums';
+import { Paths, UserRoles } from 'enums';
 import FormPageLayout, { FormPageLayoutProps } from 'layouts/form-page';
 import ProtectedPage from 'layouts/protected-page';
 import { PageComponent } from 'types';
@@ -39,12 +39,28 @@ const PROJECT_QUERY_PARAMS = {
   locale: null,
 };
 
+const SHARED_PROJECT_QUERY_PARAMS = {
+  // We set the `locale` as `null` so that we get the project in the account's language instead of the UI language
+  locale: null,
+};
+
 export const getServerSideProps = withLocalizedRequests(async ({ params: { id }, locale }) => {
   let project;
   let enums;
 
   try {
-    ({ data: project } = await getProject(id as string, PROJECT_QUERY_PARAMS));
+    ({ data: project } = await getProject(id as string, {
+      includes: [
+        'project_images',
+        'country',
+        'municipality',
+        'department',
+        'project_developer',
+        'involved_project_developers',
+        'project_developer',
+      ],
+      ...SHARED_PROJECT_QUERY_PARAMS,
+    }));
     enums = await getEnums();
   } catch (e) {
     // The user may be attempting to preview a drafted project, which the endpoint won't return
@@ -74,10 +90,7 @@ const EditProject: PageComponent<EditProjectProps, FormPageLayoutProps> = ({
   const { formatMessage } = useIntl();
   const router = useRouter();
 
-  const updateProject = useUpdateProject({
-    // We set the `locale` as `null` so that we get the project in the account's language instead of the UI language
-    locale: null,
-  });
+  const updateProject = useUpdateProject(SHARED_PROJECT_QUERY_PARAMS);
   const queryReturnPath = useQueryReturnPath();
 
   const {

--- a/frontend/pages/project/[id]/edit.tsx
+++ b/frontend/pages/project/[id]/edit.tsx
@@ -39,28 +39,12 @@ const PROJECT_QUERY_PARAMS = {
   locale: null,
 };
 
-const SHARED_PROJECT_QUERY_PARAMS = {
-  // We set the `locale` as `null` so that we get the project in the account's language instead of the UI language
-  locale: null,
-};
-
 export const getServerSideProps = withLocalizedRequests(async ({ params: { id }, locale }) => {
   let project;
   let enums;
 
   try {
-    ({ data: project } = await getProject(id as string, {
-      includes: [
-        'project_images',
-        'country',
-        'municipality',
-        'department',
-        'project_developer',
-        'involved_project_developers',
-        'project_developer',
-      ],
-      ...SHARED_PROJECT_QUERY_PARAMS,
-    }));
+    ({ data: project } = await getProject(id as string, PROJECT_QUERY_PARAMS));
     enums = await getEnums();
   } catch (e) {
     // The user may be attempting to preview a drafted project, which the endpoint won't return
@@ -89,14 +73,14 @@ const EditProject: PageComponent<EditProjectProps, FormPageLayoutProps> = ({
 }) => {
   const { formatMessage } = useIntl();
   const router = useRouter();
-
-  const updateProject = useUpdateProject(SHARED_PROJECT_QUERY_PARAMS);
   const queryReturnPath = useQueryReturnPath();
 
   const {
     data: { data: project },
     isFetching: isFetchingProject,
   } = useProject(router.query.id as string, PROJECT_QUERY_PARAMS, projectProp);
+
+  const updateProject = useUpdateProject({ locale: project.language });
 
   const getIsOwner = (_user: User, userAccount: ProjectDeveloper | Investor) => {
     // The user must be a the creator of the project to be allowed to edit it.

--- a/frontend/pages/projects/new.tsx
+++ b/frontend/pages/projects/new.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import { useIntl } from 'react-intl';
 
 import { useRouter } from 'next/router';
@@ -11,7 +13,7 @@ import { useQueryReturnPath } from 'helpers/pages';
 
 import ProjectForm from 'containers/project-form';
 
-import { Paths, UserRoles } from 'enums';
+import { Languages, Paths, UserRoles } from 'enums';
 import FormPageLayout from 'layouts/form-page';
 import ProtectedPage from 'layouts/protected-page';
 import { PageComponent } from 'types';
@@ -19,11 +21,6 @@ import { GroupedEnums } from 'types/enums';
 
 import { useCreateProject } from 'services/account';
 import { getEnums } from 'services/enums/enumService';
-
-const PROJECT_QUERY_PARAMS = {
-  // We set the `locale` as `null` so that we get the project in the account's language instead of the UI language
-  locale: null,
-};
 
 export const getServerSideProps = withLocalizedRequests(async ({ locale }) => {
   const enums = await getEnums();
@@ -49,10 +46,21 @@ const CreateProject: PageComponent<CreateProjectProps> = ({ enums }) => {
   const handleOnComplete = () => {
     router.push(queryReturnPath || Paths.DashboardProjects);
   };
-  const createProject = useCreateProject(PROJECT_QUERY_PARAMS);
+  const [pdLanguage, setPdLanguage] = useState<Languages>();
+  const createProject = useCreateProject({ locale: pdLanguage });
 
   return (
-    <ProtectedPage permissions={[UserRoles.ProjectDeveloper]}>
+    <ProtectedPage
+      ownership={{
+        //The protected page already fetches the user's account, so we don't need to fetch it again. The userAccount is the project-developer. Whe are using the userAccount to determine the project-developer's language.
+        getIsOwner(_user, userAccount) {
+          setPdLanguage(userAccount.language);
+          return true;
+        },
+        allowOwner: false,
+      }}
+      permissions={[UserRoles.ProjectDeveloper]}
+    >
       <ProjectForm
         title={formatMessage({ defaultMessage: 'Create project', id: 'VUN1K7' })}
         leaveMessage={formatMessage({

--- a/frontend/pages/projects/new.tsx
+++ b/frontend/pages/projects/new.tsx
@@ -20,6 +20,11 @@ import { GroupedEnums } from 'types/enums';
 import { useCreateProject } from 'services/account';
 import { getEnums } from 'services/enums/enumService';
 
+const PROJECT_QUERY_PARAMS = {
+  // We set the `locale` as `null` so that we get the project in the account's language instead of the UI language
+  locale: null,
+};
+
 export const getServerSideProps = withLocalizedRequests(async ({ locale }) => {
   const enums = await getEnums();
 
@@ -39,12 +44,12 @@ const CreateProject: PageComponent<CreateProjectProps> = ({ enums }) => {
   const { formatMessage } = useIntl();
   const router = useRouter();
 
-  const createProject = useCreateProject();
   const queryReturnPath = useQueryReturnPath();
 
   const handleOnComplete = () => {
     router.push(queryReturnPath || Paths.DashboardProjects);
   };
+  const createProject = useCreateProject(PROJECT_QUERY_PARAMS);
 
   return (
     <ProtectedPage permissions={[UserRoles.ProjectDeveloper]}>

--- a/frontend/services/account/index.ts
+++ b/frontend/services/account/index.ts
@@ -81,19 +81,30 @@ export function useCreateProjectDeveloper(): UseMutationResult<
   });
 }
 
-// Update PD
-const updateProjectDeveloper = async (
-  data: ProjectDeveloperSetupForm
+export const updateProjectDeveloper = async (
+  data: ProjectDeveloperSetupForm,
+  params?: {
+    locale?: string;
+  }
 ): Promise<AxiosResponse<ResponseData<ProjectDeveloper>>> => {
-  return await API.put('/api/v1/account/project_developer', data);
+  const config: AxiosRequestConfig = {
+    url: `/api/v1/account/project_developer`,
+    method: 'PUT',
+    data: data,
+    params: params || {},
+  };
+
+  return await API(config);
 };
 
-export function useUpdateProjectDeveloper(): UseMutationResult<
+export function useUpdateProjectDeveloper(
+  params?: Parameters<typeof updateProjectDeveloper>[1]
+): UseMutationResult<
   AxiosResponse<ResponseData<ProjectDeveloper>>,
   AxiosError<ErrorResponse>,
   ProjectDeveloperSetupForm
 > {
-  return useMutation(updateProjectDeveloper);
+  return useMutation((data) => updateProjectDeveloper(data, params));
 }
 
 // Create Project

--- a/frontend/services/account/index.ts
+++ b/frontend/services/account/index.ts
@@ -76,6 +76,8 @@ export function useCreateProjectDeveloper(): UseMutationResult<
 
   return useMutation(createProjectDeveloper, {
     onSuccess: (result) => {
+      queryClient.invalidateQueries(Queries.ProjectDeveloper);
+      queryClient.invalidateQueries(Queries.ProjectDeveloperList);
       queryClient.setQueryData([Queries.ProjectDeveloper, locale], result.data.data);
     },
   });
@@ -104,7 +106,16 @@ export function useUpdateProjectDeveloper(
   AxiosError<ErrorResponse>,
   ProjectDeveloperSetupForm
 > {
-  return useMutation((data) => updateProjectDeveloper(data, params));
+  const queryClient = useQueryClient();
+
+  return useMutation((data) => updateProjectDeveloper(data, params), {
+    onSuccess: (result) => {
+      const { data } = result.data;
+      queryClient.invalidateQueries(Queries.ProjectDeveloper);
+      queryClient.invalidateQueries(Queries.ProjectDeveloperList);
+      queryClient.setQueryData([Queries.ProjectDeveloper, data.id], data);
+    },
+  });
 }
 
 // Create Project
@@ -135,10 +146,11 @@ export function useCreateProject(
 
   return useMutation((data) => createProject(data, params), {
     onSuccess: (result) => {
-      const { id } = result.data.data;
-      queryClient.invalidateQueries([Queries.Project, id]);
+      const { data } = result.data;
+      queryClient.invalidateQueries(Queries.Project);
+      queryClient.invalidateQueries(Queries.ProjectList);
       queryClient.invalidateQueries(Queries.AccountProjectList);
-      queryClient.setQueryData([Queries.Project, id], result.data.data);
+      queryClient.setQueryData([Queries.Project, data.id], data);
     },
   });
 }
@@ -170,10 +182,11 @@ export function useUpdateProject(
 
   return useMutation((data) => updateProject(data, params), {
     onSuccess: (result) => {
-      const { id } = result.data.data;
+      const { data } = result.data;
       queryClient.invalidateQueries(Queries.Project);
+      queryClient.invalidateQueries(Queries.ProjectList);
       queryClient.invalidateQueries(Queries.AccountProjectList);
-      queryClient.setQueryData([Queries.Project, id], result.data.data);
+      queryClient.setQueryData([Queries.Project, data.id], data);
     },
   });
 }
@@ -222,6 +235,8 @@ export function useCreateInvestor(): UseMutationResult<
 
   return useMutation(createInvestor, {
     onSuccess: (result) => {
+      queryClient.invalidateQueries(Queries.Investor);
+      queryClient.invalidateQueries(Queries.InvestorList);
       queryClient.setQueryData([Queries.Investor, locale], result.data.data);
     },
   });
@@ -250,7 +265,16 @@ export function useUpdateInvestor(
   AxiosError<ErrorResponse>,
   InvestorForm
 > {
-  return useMutation((data) => updateInvestor(data, params));
+  const queryClient = useQueryClient();
+
+  return useMutation((data) => updateInvestor(data, params), {
+    onSuccess: (result) => {
+      const { data } = result.data;
+      queryClient.invalidateQueries(Queries.Investor);
+      queryClient.invalidateQueries(Queries.InvestorList);
+      queryClient.setQueryData([Queries.ProjectDeveloper, data.id], data);
+    },
+  });
 }
 
 export function useAccount(params = {}) {

--- a/frontend/services/account/index.ts
+++ b/frontend/services/account/index.ts
@@ -126,7 +126,7 @@ export const createProject = async (
   }
 ): Promise<AxiosResponse<ResponseData<Project>>> => {
   const config: AxiosRequestConfig = {
-    url: `/api/v1/account/projects/`,
+    url: `/api/v1/account/projects`,
     method: 'POST',
     data: data,
     params: params || {},

--- a/frontend/services/account/index.ts
+++ b/frontend/services/account/index.ts
@@ -25,30 +25,35 @@ import API from 'services/api';
 import { staticDataQueryOptions } from 'services/helpers';
 import { ErrorResponse, PagedRequest, PagedResponse, ResponseData } from 'services/types';
 
-// Create PD
-const getProjectDeveloper = async (includes?: string): Promise<ProjectDeveloper> => {
+// Get Account PD
+export const getProjectDeveloper = async (params?: {
+  includes?: string[];
+  locale?: string;
+}): Promise<ProjectDeveloper> => {
   const config: AxiosRequestConfig = {
     url: `/api/v1/account/project_developer`,
     method: 'GET',
-    params: { includes },
+    params: params || {},
   };
+
   return await API.request(config).then((response) => response.data.data);
 };
 
-export function useProjectDeveloper(
-  options: UseQueryOptions<ProjectDeveloper>,
-  includes?: string
-): UseQueryResult<ProjectDeveloper> & { projectDeveloper: ProjectDeveloper } {
-  const query = useLocalizedQuery(
-    [Queries.CurrentProjectDeveloper, includes],
-    () => getProjectDeveloper(includes),
+export const useProjectDeveloper = (
+  params?: Parameters<typeof getProjectDeveloper>[0],
+  options?: UseQueryOptions
+): UseQueryResult<ProjectDeveloper> => {
+  const query = useLocalizedQuery<any>(
+    [Queries.CurrentProjectDeveloper, params],
+    () => getProjectDeveloper(params),
     {
       refetchOnWindowFocus: false,
       ...options,
     }
   );
-  return useMemo(() => ({ ...query, projectDeveloper: query.data }), [query]);
-}
+
+  return query;
+};
 
 const createProjectDeveloper = async (
   data: ProjectDeveloperSetupForm
@@ -133,26 +138,35 @@ export function useUpdateProject(): UseMutationResult<
   });
 }
 
-const getInvestor = async (includes?: string): Promise<Investor> => {
+// Get Account Investor
+export const getInvestor = async (params?: {
+  includes?: string[];
+  locale?: string;
+}): Promise<Investor> => {
   const config: AxiosRequestConfig = {
     url: `/api/v1/account/investor`,
     method: 'GET',
-    params: { includes },
+    params: params || {},
   };
+
   return await API.request(config).then((response) => response.data.data);
 };
 
-export function useInvestor(options: UseQueryOptions<Investor>, includes?: string) {
-  const query = useLocalizedQuery(
-    [Queries.CurrentInvestor, includes],
-    () => getInvestor(includes),
+export const useInvestor = (
+  params?: Parameters<typeof getInvestor>[0],
+  options?: UseQueryOptions
+): UseQueryResult<Investor> => {
+  const query = useLocalizedQuery<any>(
+    [Queries.CurrentInvestor, params],
+    () => getInvestor(params),
     {
       refetchOnWindowFocus: false,
       ...options,
     }
   );
-  return useMemo(() => ({ ...query, investor: query.data }), [query]);
-}
+
+  return query;
+};
 
 export function useCreateInvestor(): UseMutationResult<
   AxiosResponse<ResponseData<Investor>>,
@@ -185,7 +199,7 @@ export function useUpdateInvestor(): UseMutationResult<
   return useMutation(updateInvestor);
 }
 
-export function useAccount(includes?: string) {
+export function useAccount(params = {}) {
   const { user, isLoading, isError: userIsError } = useMe();
   const isProjectDeveloper = user?.role === UserRoles.ProjectDeveloper;
   const isInvestor = user?.role === UserRoles.Investor;
@@ -194,18 +208,13 @@ export function useAccount(includes?: string) {
     data: projectDeveloperData,
     isLoading: isLoadingProjectDeveloperData,
     isError: projectDeveloperIsError,
-  } = useProjectDeveloper(
-    {
-      enabled: isProjectDeveloper && !userIsError,
-    },
-    includes
-  );
+  } = useProjectDeveloper(params, { enabled: isProjectDeveloper && !userIsError });
 
   const {
     data: investorData,
     isLoading: isLoadingInvestorData,
     isError: investorIsError,
-  } = useInvestor({ enabled: isInvestor && !userIsError }, includes);
+  } = useInvestor(params, { enabled: isInvestor && !userIsError });
 
   const userAccount = isProjectDeveloper ? projectDeveloperData : investorData;
   const userAccountLoading = isLoadingProjectDeveloperData || isLoadingInvestorData;

--- a/frontend/services/account/index.ts
+++ b/frontend/services/account/index.ts
@@ -198,16 +198,30 @@ export function useCreateInvestor(): UseMutationResult<
   });
 }
 
-export function useUpdateInvestor(): UseMutationResult<
+export const updateInvestor = async (
+  data: InvestorForm,
+  params?: {
+    locale?: string;
+  }
+): Promise<AxiosResponse<ResponseData<Investor>>> => {
+  const config: AxiosRequestConfig = {
+    url: `/api/v1/account/investor`,
+    method: 'PUT',
+    data: data,
+    params: params || {},
+  };
+
+  return await API(config);
+};
+
+export function useUpdateInvestor(
+  params?: Parameters<typeof updateProjectDeveloper>[1]
+): UseMutationResult<
   AxiosResponse<ResponseData<Investor>>,
   AxiosError<ErrorResponse>,
   InvestorForm
 > {
-  const updateInvestor = async (
-    data: InvestorForm
-  ): Promise<AxiosResponse<ResponseData<Investor>>> => API.put('/api/v1/account/investor', data);
-
-  return useMutation(updateInvestor);
+  return useMutation((data) => updateInvestor(data, params));
 }
 
 export function useAccount(params = {}) {

--- a/frontend/services/investors/investorsService.ts
+++ b/frontend/services/investors/investorsService.ts
@@ -4,13 +4,12 @@ import { UseQueryResult, UseQueryOptions, useMutation, useQueryClient } from 're
 
 import { useRouter } from 'next/router';
 
-import { AxiosResponse, AxiosRequestConfig } from 'axios';
+import { AxiosRequestConfig } from 'axios';
 
 import { useLocalizedQuery } from 'hooks/query';
 
-import { Queries, UserRoles } from 'enums';
+import { Queries } from 'enums';
 import { Investor } from 'types/investor';
-import { User } from 'types/user';
 
 import API from 'services/api';
 import { staticDataQueryOptions } from 'services/helpers';
@@ -73,29 +72,6 @@ export function useInvestor(id: string, initialData?: Investor, params?: SingleR
     [query]
   );
 }
-
-/** Get the Current Investor if the UserRole is investor */
-export const useCurrentInvestor = (user: User) => {
-  const getCurrentInvestor = async (): Promise<Investor> =>
-    await API.get('/api/v1/account/investor').then(
-      (response: AxiosResponse<ResponseData<Investor>> & { investor: Investor }) =>
-        response.data.data
-    );
-
-  const query = useLocalizedQuery([Queries.Account, user], getCurrentInvestor, {
-    // Creates the conditional to only fetch the data if the user is a investor user
-    enabled: user?.role === UserRoles.Investor,
-    ...staticDataQueryOptions,
-  });
-
-  return useMemo(
-    () => ({
-      ...query,
-      investor: query.data,
-    }),
-    [query]
-  );
-};
 
 /** Hook with mutation that handle favorite state. If favorite is false, creates a POST request to set favorite to true, and if favorite is true, creates a DELETE request that set favorite to false. */
 export const useFavoriteInvestor = () => {

--- a/frontend/services/project-developers/projectDevelopersService.ts
+++ b/frontend/services/project-developers/projectDevelopersService.ts
@@ -1,12 +1,6 @@
 import { useMemo } from 'react';
 
-import {
-  UseQueryResult,
-  useMutation,
-  useQueryClient,
-  UseQueryOptions,
-  QueryFunction,
-} from 'react-query';
+import { UseQueryResult, useMutation, useQueryClient, UseQueryOptions } from 'react-query';
 
 import { useRouter } from 'next/router';
 
@@ -112,31 +106,6 @@ export function useProjectDeveloper(
     [query]
   );
 }
-
-const getCurrentProjectDeveloper: QueryFunction<ProjectDeveloper> = async () =>
-  await API.get<ResponseData<ProjectDeveloper>>('/api/v1/account/project_developer').then(
-    (response) => response.data.data
-  );
-/** Get the Current Project Developer if the UserRole is project_developer */
-export const useCurrentProjectDeveloper = (user?: User) => {
-  const query = useLocalizedQuery<ProjectDeveloper, any, ProjectDeveloper, any>(
-    [Queries.ProjectDeveloper, user],
-    getCurrentProjectDeveloper,
-    {
-      // Creates the conditional to only fetch the data if the user is a project developer user
-      enabled: !user || user?.role === UserRoles.ProjectDeveloper,
-      ...staticDataQueryOptions,
-    }
-  );
-
-  return useMemo<UseQueryResult<ProjectDeveloper> & { projectDeveloper: ProjectDeveloper }>(
-    () => ({
-      ...query,
-      projectDeveloper: query.data,
-    }),
-    [query]
-  );
-};
 
 /** Hook with mutation that handle favorite state. If favorite is false, creates a POST request to set favorite to true, and if favorite is true, creates a DELETE request that set favorite to false. */
 export const useFavoriteProjectDeveloper = () => {


### PR DESCRIPTION
## Description

This PR adds the possibility of editing ProjectDeveloper and Investor account details in the account's original language. In addition, it fixes a bug where when editing projects, the `locale=` query param was still being sent, causing the endpoint to update the project in the UI language instead of the project one. 

&nbsp; 

**In this PR:**  

- Removed `useCurrentProjectDeveloper` from `projectDeveloperService`  
  _In favor of a `useProjectDeveloper`_ in `services/accounts`, to match the location of the account's `useInvestor` and `useProject`  


- Refactored several services/hooks to be able to support a `params` parameter:   
  _Where we can specify `includes`, but more importantly a `locale`. This allows us to set a `locale=null` where necessary, to retrieve/create/update data in the account/project original language. Updated the app where these services/hooks were used._
  - Account project developers
    - `getProjectDeveloper`
    - `useProjectDeveloper`
    - `updateProjectDeveloper`
    - `useUpdateProjectDeveloper`
  - Account investors  
    - `getInvestor`
    - `useInvestor`
    - `updateInvestor`
    - `useUpdateInvestor`
  - Account projects
    - `createProject`
    - `useCreateProject`
    - `updateProject`
    - `useUpdateProject`
    - `useAccount`

&nbsp;

- `projects/new`  
  Added a `locale: null` query param so that the project is created in the account's original language  

- `project/[id]:edit`  
  Added a `locale: null` query param so that the project is updated in the account's original language  

- `project-developers/edit`  
  Added a `locale: null` query param so that the project-developer is edited the account's original language  

- `investors/edit`  
  Added a `locale: null` query param so that the investor is edited the account's original language  

- `ProjectForm`  
  Removed the `useUpdateProject` in favour of the one passed via prop  
  _To match the logic in all other views/forms_   

&nbsp; 

**Others**  
  - Minor query invalidation improvements and cleanup  

&nbsp;

## Testing instructions



&nbsp;

### Using an Investor account

**Updating the profile does not send a `locale=` param**

1. Sign in into the app  
2. Visit Dashboard / Account Information
3. Set the UI language to a language different than the account one  
4. Edit your profile and submit  

Verify that the `PUT` request does not have a `locale=` query param set

&nbsp; 

### Using a Project Developer  account  

**Updating the profile does not send a `locale=` param**

1. Sign in into the app  
2. Visit Dashboard / Account Information
3. Set the UI language to a language different than the account one  
4. Edit your profile and submit  

Verify that the `PUT` request does not have a `locale=` query param set

&nbsp;

**Creating a project does not send a `locale=` param**  

1. Sign in into the app  
2. Visit Dashboard / Projects  
3. Set the UI language to a language different than the account one  
4. Create a project and submit  

Verify that the `POST` request does not have a `locale=` query param set

**Updating a project does not send a `locale=` param**  

1. Sign in into the app  
2. Visit Dashboard / Projects  
3. Set the UI language to a language different than the account one  
4. Edit a project and submit  

Verify that the `PUT` request does not have a `locale=` query param set

&nbsp;

## Tracking

[LET-811](https://vizzuality.atlassian.net/browse/LET-811)