### PR TITLE
Create settings/info page and allow delete own user

### DIFF
--- a/frontend/components/confirmation-prompt/component.tsx
+++ b/frontend/components/confirmation-prompt/component.tsx
@@ -23,6 +23,7 @@ export const ConfirmationPrompt: FC<ConfirmationPromptProps> = ({
   onRefuse,
   onAcceptLoading = false,
   confirmationError,
+  onConfirmDisabled = false,
 }: ConfirmationPromptProps) => (
   <Modal open={open} title={title} size="default" dismissable={dismissible} onDismiss={onDismiss}>
     <div className="flex flex-col items-center px-8 py-4">
@@ -57,7 +58,7 @@ export const ConfirmationPrompt: FC<ConfirmationPromptProps> = ({
           size="small"
           className="flex-shrink-0 sm:mr-5"
           onClick={onAccept}
-          disabled={onAcceptLoading}
+          disabled={onConfirmDisabled || onAcceptLoading}
         >
           <Loading className="mr-2" visible={onAcceptLoading} />
           {!confirmationError ? (

--- a/frontend/components/confirmation-prompt/types.d.ts
+++ b/frontend/components/confirmation-prompt/types.d.ts
@@ -32,6 +32,8 @@ export interface ConfirmationPromptProps {
   onAcceptLoading?: boolean;
   /** Message of the error triggered by the confirmation the action. */
   confirmationError?: string;
+  /** Disables the onConfirm action button. Defaults to 'false' */
+  onConfirmDisabled?: boolean;
   /**
    * Callback executed when the user refuses the action
    */

--- a/frontend/enums/index.ts
+++ b/frontend/enums/index.ts
@@ -39,6 +39,8 @@ export enum Paths {
   Invitation = '/invitation',
   ForInvestors = '/for-investors',
   ForProjectDevelopers = '/for-project-developers',
+  UserInformation = '/settings/information',
+  UserPassword = '/settings/password',
 }
 
 export enum UserRoles {

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -146,6 +146,9 @@
   "39AHJm": {
     "string": "Sign Up"
   },
+  "3T3umg": {
+    "string": "If you are the owner of the account, please transfer the ownership before continuing."
+  },
   "3dEg+E": {
     "string": "{start} of {end}"
   },
@@ -181,6 +184,9 @@
   },
   "4YJHut": {
     "string": "Clear search"
+  },
+  "4iPaIz": {
+    "string": "Update information"
   },
   "4iXh64": {
     "string": "Your account has not been approved, your profile is not publicly visible."
@@ -370,6 +376,9 @@
   },
   "A4UTjl": {
     "string": "Portuguese"
+  },
+  "A775MJ": {
+    "string": "You are currently the account owner. Please transfer the ownership before continuing."
   },
   "A8lXv/": {
     "string": "Global estimate of human population density and distribution."
@@ -1296,6 +1305,9 @@
   "fX9u5/": {
     "string": "Contribute to addressing the effects of climate change through investments to reduce CO2 emissions and conserve or restore forest-related carbon sinks. <br></br><br></br> Nature based solutions have been estimated to have the potential of contributing to compensate for up to 30% of global emissions."
   },
+  "fZpvTQ": {
+    "string": "Delete my user"
+  },
   "ff0+bt": {
     "string": "The platform will use the most advanced technologies and Artificial Intelligence applications to provide in one place data and tools to connect investors, donors and philanthropists with carefully selected projects in high priority locations defined by Heremcia Colombia."
   },
@@ -1647,6 +1659,9 @@
   "rLzWx9": {
     "string": "{name} picture"
   },
+  "rPwLb7": {
+    "string": "By deleting your user, you will be removed from the account <n>accountName</n> and you no longer will have access to HeCo Invest Platform."
+  },
   "rPwaWt": {
     "string": "A great name is short, crisp, and easily understood."
   },
@@ -1670,6 +1685,9 @@
   },
   "s07dAT": {
     "string": "Project image"
+  },
+  "s63oNj": {
+    "string": "Are you sure you want to delete your user? You can't undo this action and you will lose your access to the platform."
   },
   "sFn7MX": {
     "string": "Integration of project impact in each dimension (climate, biodiversity, water community) into a single score, ranging from 0 to 100."

--- a/frontend/layouts/settings/component.tsx
+++ b/frontend/layouts/settings/component.tsx
@@ -1,0 +1,66 @@
+import { FC, useRef } from 'react';
+
+import useMe from 'hooks/me';
+
+import LayoutContainer from 'components/layout-container';
+import Loading from 'components/loading';
+import { UserRoles } from 'enums';
+import ProtectedPage from 'layouts/protected-page';
+
+import AccountPicture from '../dashboard/account-picture';
+import Header from '../dashboard/header';
+
+import Navigation from './navigation';
+import { SettingsLayoutProps } from './types';
+
+export const SettingsLayout: FC<SettingsLayoutProps> = ({
+  isLoading = false,
+  children,
+  buttons,
+}: SettingsLayoutProps) => {
+  const mainContainerRef = useRef(null);
+
+  const { user } = useMe();
+
+  return (
+    <ProtectedPage permissions={[UserRoles.ProjectDeveloper, UserRoles.Investor]}>
+      <div className="min-h-screen bg-background-dark">
+        <div className="flex flex-col lg:h-screen ">
+          <div className="z-10 flex flex-col bg-radial-green-dark bg-green-dark lg:backdrop-blur-sm">
+            <Header />
+            <LayoutContainer className="mt-18 lg:mt-0">
+              <div className="flex flex-col w-full text-white lg:flex-row">
+                <div className="flex flex-grow gap-8">
+                  <div className="lg:translate-y-5">
+                    <AccountPicture name={user?.first_name} picture={user?.avatar.small} />
+                  </div>
+                  <div className="flex flex-col justify-end pb-2 mt-5 lg:mt-0">
+                    <p className="text-sm leading-5 text-gray-600">
+                      {user?.first_name} {user?.last_name}
+                    </p>
+                    <Navigation className="hidden lg:flex" userRole={user?.role} />
+                  </div>
+                </div>
+                <Navigation className="flex mt-2 lg:hidden" userRole={user?.role} />
+                <div className="flex items-end justify-center">
+                  <div className="flex gap-2 my-4 lg:my-0 lg:translate-y-5">{buttons}</div>
+                </div>
+              </div>
+            </LayoutContainer>
+          </div>
+          <main ref={mainContainerRef} className="h-full overflow-y-scroll bg-background-dark">
+            {isLoading ? (
+              <div className="absolute flex items-center justify-center bg-background-dark top-px bottom-px left-px bg-opacity-20 right-px rounded-2xl backdrop-blur-sm">
+                <Loading visible={true} iconClassName="w-10 h-10" />
+              </div>
+            ) : (
+              <LayoutContainer className="py-8">{children}</LayoutContainer>
+            )}
+          </main>
+        </div>
+      </div>
+    </ProtectedPage>
+  );
+};
+
+export default SettingsLayout;

--- a/frontend/layouts/settings/index.ts
+++ b/frontend/layouts/settings/index.ts
@@ -1,0 +1,2 @@
+export type { SettingsLayoutProps } from './types';
+export { default } from './component';

--- a/frontend/layouts/settings/navigation/component.tsx
+++ b/frontend/layouts/settings/navigation/component.tsx
@@ -1,0 +1,76 @@
+import { FC, useMemo } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import cx from 'classnames';
+
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+import { Paths, UserRoles } from 'enums';
+
+import { NavigationProps } from './types';
+
+export const Navigation: FC<NavigationProps> = ({ className, userRole }: NavigationProps) => {
+  const intl = useIntl();
+  const { asPath } = useRouter();
+
+  const links = useMemo(
+    () => [
+      {
+        id: Paths.UserInformation,
+        name: intl.formatMessage({ defaultMessage: 'Information', id: 'E80WrK' }),
+        restricted: UserRoles.ProjectDeveloper,
+      },
+      {
+        id: Paths.UserPassword,
+        name: intl.formatMessage({ defaultMessage: 'Password', id: '5sg7KC' }),
+        restricted: UserRoles.ProjectDeveloper,
+      },
+    ],
+    [intl]
+  );
+
+  const activeLinkId = useMemo(
+    () => links.find(({ id }) => asPath.startsWith(id))?.id,
+    [asPath, links]
+  );
+
+  return (
+    <div className={className}>
+      <nav>
+        <ol className="flex flex-wrap -mx-2 gap-y-2 gap-x-4 whitespace-nowrap">
+          {links.map(({ id, name, restricted }) => {
+            const roles = (Array.isArray(restricted) ? restricted : [restricted]).filter(
+              (role) => !!role
+            );
+
+            if (roles.length && !roles.includes(userRole)) return;
+
+            const isActive = id === activeLinkId;
+
+            return (
+              <li key={id} className="transition-all">
+                <Link key={id} href={id}>
+                  <a
+                    className={cx({
+                      'px-2 rounded-full transition-all': true,
+                      'focus-visible:outline focus-visible:outline-green-dark focus-visible:outline-2 focus-visible:outline-offset-2':
+                        true,
+                      'font-semibold': isActive,
+                    })}
+                    aria-current={isActive ? 'location' : false}
+                  >
+                    {name}
+                  </a>
+                </Link>
+              </li>
+            );
+          })}
+        </ol>
+      </nav>
+    </div>
+  );
+};
+
+export default Navigation;

--- a/frontend/layouts/settings/navigation/index.ts
+++ b/frontend/layouts/settings/navigation/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { NavigationProps } from './types';

--- a/frontend/layouts/settings/navigation/types.ts
+++ b/frontend/layouts/settings/navigation/types.ts
@@ -1,0 +1,8 @@
+import { UserRoles } from 'enums';
+
+export type NavigationProps = {
+  /** Classes to apply to the container */
+  className?: string;
+  /** Role of the user to display a navigation for */
+  userRole: UserRoles;
+};

--- a/frontend/layouts/settings/types.ts
+++ b/frontend/layouts/settings/types.ts
@@ -1,0 +1,14 @@
+import { PropsWithChildren } from 'react';
+
+import { HeaderProps } from '../dashboard/header';
+
+export type SettingsLayoutProps = PropsWithChildren<
+  HeaderProps & {
+    /** Whether the loading spinner should be shown. Defaults to `false` */
+    isLoading?: boolean;
+    /** Whether the main container should auto scroll up on query. Defaults to `true` */
+    scrollOnQuery?: boolean;
+    /** Buttons to show in the header */
+    buttons?: JSX.Element;
+  }
+>;

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -70,6 +70,11 @@ module.exports = {
         destination: '/discover/projects',
         permanent: true,
       },
+      {
+        source: '/settings',
+        destination: '/settings/information',
+        permanent: true,
+      },
     ];
   },
 };

--- a/frontend/pages/settings/information.tsx
+++ b/frontend/pages/settings/information.tsx
@@ -1,0 +1,135 @@
+import { useState } from 'react';
+
+import { FormattedMessage, useIntl } from 'react-intl';
+import { useQueryClient } from 'react-query';
+
+import { useRouter } from 'next/router';
+
+import { withLocalizedRequests } from 'hoc/locale';
+
+import { InferGetStaticPropsType } from 'next';
+
+import useMe from 'hooks/me';
+
+import { loadI18nMessages } from 'helpers/i18n';
+
+import Button from 'components/button';
+import ConfirmationPrompt from 'components/confirmation-prompt';
+import Head from 'components/head';
+import LayoutContainer from 'components/layout-container';
+import { Paths, UserRoles } from 'enums';
+import NakedLayout from 'layouts/naked';
+import ProtectedPage from 'layouts/protected-page';
+import SettingsLayout, { SettingsLayoutProps } from 'layouts/settings';
+import { PageComponent } from 'types';
+
+import { useDeleteUser } from 'services/account';
+
+export const getStaticProps = withLocalizedRequests(async ({ locale }) => {
+  return {
+    props: {
+      intlMessages: await loadI18nMessages({ locale }),
+    },
+  };
+});
+
+type InformationPageProps = InferGetStaticPropsType<typeof getStaticProps>;
+
+const Information: PageComponent<InformationPageProps, SettingsLayoutProps> = () => {
+  const { formatMessage } = useIntl();
+  const { push } = useRouter();
+  const { user } = useMe();
+  const queryClient = useQueryClient();
+  const deleteUser = useDeleteUser();
+  const [showConfirmation, setShowConfirmation] = useState(false);
+
+  const handleDeleteUser = () => {
+    if (user && !user.owner) {
+      deleteUser.mutate(user.id, {
+        onSuccess: async () => {
+          queryClient.removeQueries();
+          push(Paths.Home);
+        },
+      });
+    }
+  };
+
+  return (
+    <ProtectedPage permissions={[UserRoles.ProjectDeveloper, UserRoles.Investor, UserRoles.Light]}>
+      <Head title={formatMessage({ defaultMessage: 'Account information', id: 'CzsYIe' })} />
+      <SettingsLayout>
+        <LayoutContainer layout={'narrow'} className="flex flex-col gap-4">
+          <div className="p-6 bg-white rounded-lg">
+            <div className="flex text-sm">
+              <div className="flex-grow font-semibold">
+                <FormattedMessage defaultMessage="Update information" id="4iPaIz" />
+              </div>
+            </div>
+          </div>
+        </LayoutContainer>
+        <LayoutContainer layout={'narrow'} className="flex flex-col gap-4 mt-6">
+          <div className="p-6 bg-white rounded-lg">
+            <div className="">
+              <div className="flex-grow text-xl font-semibold text-red-700">
+                <FormattedMessage defaultMessage="Delete my user" id="fZpvTQ" />
+              </div>
+              <div className="p-4 mt-6 rounded-lg bg-red-50">
+                <p>
+                  <FormattedMessage
+                    defaultMessage="By deleting your user, you will be removed from the account <n>accountName</n> and you no longer will have access to HeCo Invest Platform."
+                    id="rPwLb7"
+                    values={{
+                      n: () => (
+                        <span className="font-semibold">
+                          {user?.first_name} {user?.last_name}
+                        </span>
+                      ),
+                    }}
+                  />
+                </p>
+                <p className="mt-4 font-semibold">
+                  <FormattedMessage
+                    defaultMessage="If you are the owner of the account, please transfer the ownership before continuing."
+                    id="3T3umg"
+                  />
+                </p>
+              </div>
+              <div className="flex justify-end mt-6">
+                <Button theme="primary-red" onClick={() => setShowConfirmation(true)}>
+                  <FormattedMessage defaultMessage="Delete" id="K3r6DQ" />
+                </Button>
+              </div>
+            </div>
+          </div>
+        </LayoutContainer>
+        <ConfirmationPrompt
+          onAccept={handleDeleteUser}
+          onDismiss={() => setShowConfirmation(false)}
+          onRefuse={() => setShowConfirmation(false)}
+          open={showConfirmation}
+          onConfirmDisabled={!user || user.owner}
+          title={formatMessage({ defaultMessage: 'Delete my user', id: 'fZpvTQ' })}
+          description={
+            user?.owner
+              ? formatMessage({
+                  defaultMessage:
+                    'You are currently the account owner. Please transfer the ownership before continuing.',
+                  id: 'A775MJ',
+                })
+              : formatMessage({
+                  defaultMessage:
+                    "Are you sure you want to delete your user? You can't undo this action and you will lose your access to the platform.",
+                  id: 's63oNj',
+                })
+          }
+        />
+      </SettingsLayout>
+    </ProtectedPage>
+  );
+};
+
+Information.layout = {
+  Component: NakedLayout,
+};
+
+export default Information;

--- a/frontend/pages/settings/information.tsx
+++ b/frontend/pages/settings/information.tsx
@@ -23,7 +23,7 @@ import ProtectedPage from 'layouts/protected-page';
 import SettingsLayout, { SettingsLayoutProps } from 'layouts/settings';
 import { PageComponent } from 'types';
 
-import { useDeleteUser } from 'services/account';
+import { useAccount, useDeleteUser } from 'services/account';
 
 export const getStaticProps = withLocalizedRequests(async ({ locale }) => {
   return {
@@ -38,7 +38,7 @@ type InformationPageProps = InferGetStaticPropsType<typeof getStaticProps>;
 const Information: PageComponent<InformationPageProps, SettingsLayoutProps> = () => {
   const { formatMessage } = useIntl();
   const { push } = useRouter();
-  const { user } = useMe();
+  const { user, userAccount } = useAccount();
   const queryClient = useQueryClient();
   const deleteUser = useDeleteUser();
   const [showConfirmation, setShowConfirmation] = useState(false);
@@ -79,11 +79,7 @@ const Information: PageComponent<InformationPageProps, SettingsLayoutProps> = ()
                     defaultMessage="By deleting your user, you will be removed from the account <n>accountName</n> and you no longer will have access to HeCo Invest Platform."
                     id="rPwLb7"
                     values={{
-                      n: () => (
-                        <span className="font-semibold">
-                          {user?.first_name} {user?.last_name}
-                        </span>
-                      ),
+                      n: () => <span className="font-semibold">{userAccount?.name}</span>,
                     }}
                   />
                 </p>

--- a/frontend/types/user.ts
+++ b/frontend/types/user.ts
@@ -1,4 +1,5 @@
-import { InvitationStatus, UserRoles } from 'enums';
+import { InvitationStatus, Languages, UserRoles } from 'enums';
+import { Picture } from 'types';
 
 export interface SignupFormI {
   first_name: string;
@@ -25,10 +26,14 @@ export interface User {
   last_name: string;
   email: string;
   role: UserRoles;
+  created_at: string;
+  ui_language: Languages;
+  account_language: Languages;
   confirmed: boolean;
   approved: boolean;
-  invitation?: InvitationStatus;
+  invitation: boolean;
   owner: boolean;
+  avatar: Picture;
 }
 
 export type UserAccount = {


### PR DESCRIPTION
This PR adds the page settings/information and the delete own account functionality 

## Description

The users should have a way to delete their own account.

There will be a new page ‘user-settings’

The page will display a button to delete the user account

A modal will be displayed to confirm the action

When the action is confirmed, the user will be logged-out and re directed to the home page


## Testing instructions

### Testing as a account user
1. Log in as a account user (not owner)
2. Go to settings. You will be redirected to settings/information
3. Click on 'delete' button on 'Delete my account' section. A confirmation modal should appear with a text explaining that you will lose your account and access to the platform.
4. Click on 'delete'. You should be signed out and redirected to the home page.

### Testing as account owner
1. Log in as a account owner
2. Go to settings. You will be redirected to settings/information
3. Click on 'delete' button on 'Delete my account' section. A confirmation modal should appear with a text explaining that you can't delete your account because you are the account owner.
5. The 'delete' button on the modal should be disabled.

## Tracking

[LET-808](https://vizzuality.atlassian.net/browse/LET-808)