### PR TITLE
feat: All endpoints which returns list of favourites

### DIFF
--- a/backend/app/controllers/api/v1/accounts/open_calls_controller.rb
+++ b/backend/app/controllers/api/v1/accounts/open_calls_controller.rb
@@ -1,0 +1,24 @@
+module API
+  module V1
+    module Accounts
+      class OpenCallsController < BaseController
+        include API::Pagination
+
+        load_and_authorize_resource
+
+        def favourites
+          @open_calls = @open_calls.includes(:investor).order(created_at: :desc)
+          pagy_object, @open_calls = pagy(@open_calls, page: current_page, items: per_page)
+          render json: OpenCallSerializer.new(
+            @open_calls,
+            include: included_relationships,
+            fields: sparse_fieldset,
+            links: pagination_links(:api_v1_open_calls_path, pagy_object),
+            meta: pagination_meta(pagy_object),
+            params: {current_user: current_user}
+          ).serializable_hash
+        end
+      end
+    end
+  end
+end

--- a/backend/app/models/ability.rb
+++ b/backend/app/models/ability.rb
@@ -66,5 +66,11 @@ class Ability
     can :manage, FavouriteProject, user_id: user.id
     can :manage, FavouriteProjectDeveloper, user_id: user.id
     can :manage, FavouriteInvestor, user_id: user.id
+    can :manage, FavouriteOpenCall, user_id: user.id
+
+    can %i[favourites], Project, favourite_projects: {user_id: user.id}
+    can %i[favourites], ProjectDeveloper, favourite_project_developers: {user_id: user.id}
+    can %i[favourites], Investor, favourite_investors: {user_id: user.id}
+    can %i[favourites], OpenCall, favourite_open_calls: {user_id: user.id}
   end
 end

--- a/backend/app/models/favourite_open_call.rb
+++ b/backend/app/models/favourite_open_call.rb
@@ -1,0 +1,6 @@
+class FavouriteOpenCall < ApplicationRecord
+  belongs_to :user
+  belongs_to :open_call
+
+  validates_uniqueness_of :open_call, scope: :user_id
+end

--- a/backend/app/models/open_call.rb
+++ b/backend/app/models/open_call.rb
@@ -7,6 +7,8 @@ class OpenCall < ApplicationRecord
 
   belongs_to :investor, counter_cache: true
 
+  has_many :favourite_open_calls, dependent: :destroy
+
   validates :instrument_type, inclusion: {in: InstrumentType::TYPES, allow_blank: true}, presence: true
   validates :ticket_size, inclusion: {in: TicketSize::TYPES, allow_blank: true}, presence: true
   validates :sdgs, array_inclusion: {in: Sdg::TYPES}

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -11,6 +11,8 @@ class User < ApplicationRecord
   has_many :project_developers, through: :favourite_project_developers
   has_many :favourite_investors, dependent: :destroy
   has_many :investors, through: :favourite_investors
+  has_many :favourite_open_calls, dependent: :destroy
+  has_many :open_calls, through: :favourite_open_calls
   has_one :owner_account, class_name: "Account", foreign_key: "owner_id", dependent: :restrict_with_error
 
   has_one_attached :avatar

--- a/backend/config/routes/api.rb
+++ b/backend/config/routes/api.rb
@@ -41,8 +41,27 @@ namespace :api, format: "json" do
 
     namespace :account, module: :accounts do
       resource :project_developer, only: [:create, :update, :show]
+      resources :project_developers, only: [] do
+        collection do
+          get :favourites
+        end
+      end
       resource :investor, only: [:create, :update, :show]
-      resources :projects, only: [:index, :create, :update, :destroy]
+      resources :investors, only: [] do
+        collection do
+          get :favourites
+        end
+      end
+      resources :projects, only: [:index, :create, :update, :destroy] do
+        collection do
+          get :favourites
+        end
+      end
+      resources :open_calls, only: [] do
+        collection do
+          get :favourites
+        end
+      end
       resources :users, only: [:index, :destroy] do
         collection do
           get :transfer_ownership

--- a/backend/db/migrate/20220727083258_create_favourite_open_calls.rb
+++ b/backend/db/migrate/20220727083258_create_favourite_open_calls.rb
@@ -1,0 +1,12 @@
+class CreateFavouriteOpenCalls < ActiveRecord::Migration[7.0]
+  def change
+    create_table :favourite_open_calls, id: :uuid do |t|
+      t.belongs_to :user, foreign_key: {on_delete: :cascade}, type: :uuid, null: false
+      t.belongs_to :open_call, foreign_key: {on_delete: :cascade}, type: :uuid, null: false
+
+      t.index [:user_id, :open_call_id], unique: true, name: "favourite_open_call_id_on_user_id"
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_25_074544) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_27_083258) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -108,6 +108,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_25_074544) do
     t.index ["investor_id"], name: "index_favourite_investors_on_investor_id"
     t.index ["user_id", "investor_id"], name: "index_favourite_investors_on_user_id_and_investor_id", unique: true
     t.index ["user_id"], name: "index_favourite_investors_on_user_id"
+  end
+
+  create_table "favourite_open_calls", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "user_id", null: false
+    t.uuid "open_call_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["open_call_id"], name: "index_favourite_open_calls_on_open_call_id"
+    t.index ["user_id", "open_call_id"], name: "favourite_open_call_id_on_user_id", unique: true
+    t.index ["user_id"], name: "index_favourite_open_calls_on_user_id"
   end
 
   create_table "favourite_project_developers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -398,6 +408,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_25_074544) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "favourite_investors", "investors", on_delete: :cascade
   add_foreign_key "favourite_investors", "users", on_delete: :cascade
+  add_foreign_key "favourite_open_calls", "open_calls", on_delete: :cascade
+  add_foreign_key "favourite_open_calls", "users", on_delete: :cascade
   add_foreign_key "favourite_project_developers", "project_developers", on_delete: :cascade
   add_foreign_key "favourite_project_developers", "users", on_delete: :cascade
   add_foreign_key "favourite_projects", "projects", on_delete: :cascade

--- a/backend/spec/factories/account.rb
+++ b/backend/spec/factories/account.rb
@@ -24,6 +24,10 @@ FactoryBot.define do
       project_developer
     end
 
+    factory :account_investor do
+      investor
+    end
+
     trait :unapproved do
       review_status { "unapproved" }
     end

--- a/backend/spec/factories/favourite_open_calls.rb
+++ b/backend/spec/factories/favourite_open_calls.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :favourite_open_call do
+    user
+    open_call
+  end
+end

--- a/backend/spec/factories/user.rb
+++ b/backend/spec/factories/user.rb
@@ -28,6 +28,12 @@ FactoryBot.define do
       account factory: :account_project_developer
     end
 
+    factory :user_investor do
+      role { "investor" }
+
+      account factory: :account_investor
+    end
+
     trait :project_developer do
       role { "project_developer" }
     end

--- a/backend/spec/fixtures/snapshots/api/v1/account/investors-favourites-include-relationships.json
+++ b/backend/spec/fixtures/snapshots/api/v1/account/investors-favourites-include-relationships.json
@@ -1,0 +1,51 @@
+{
+  "data": [
+    {
+      "id": "7a8105a2-b84e-459c-9539-327c84bf4846",
+      "type": "investor",
+      "attributes": {
+        "instagram": "https://instagram.com/bartoletti-and-sons",
+        "facebook": "https://facebook.com/bartoletti-and-sons"
+      },
+      "relationships": {
+      }
+    }
+  ],
+  "included": [
+    {
+      "id": "ff39ea8f-3369-47e1-8631-88857feb53ec",
+      "type": "user",
+      "attributes": {
+        "first_name": "Raymon",
+        "last_name": "Runte",
+        "email": "runte_raymon@example.org",
+        "role": "light",
+        "created_at": "2022-07-27T08:22:36.841Z",
+        "ui_language": "en",
+        "account_language": "en",
+        "confirmed": true,
+        "approved": true,
+        "invitation": null,
+        "owner": true,
+        "avatar": {
+          "small": null,
+          "medium": null,
+          "original": null
+        }
+      }
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "per_page": 10,
+    "from": 1,
+    "to": 1,
+    "total": 1,
+    "pages": 1
+  },
+  "links": {
+    "first": "/api/v1/investors?page%5Bsize%5D=10",
+    "self": "/api/v1/investors?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+    "last": "/api/v1/investors?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+  }
+}

--- a/backend/spec/fixtures/snapshots/api/v1/account/investors-favourites-sparse-fieldset.json
+++ b/backend/spec/fixtures/snapshots/api/v1/account/investors-favourites-sparse-fieldset.json
@@ -1,0 +1,27 @@
+{
+  "data": [
+    {
+      "id": "29567055-2843-46c5-889e-4326abfe463c",
+      "type": "investor",
+      "attributes": {
+        "instagram": "https://instagram.com/bartoletti-and-sons",
+        "facebook": "https://facebook.com/bartoletti-and-sons"
+      },
+      "relationships": {
+      }
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "per_page": 10,
+    "from": 1,
+    "to": 1,
+    "total": 1,
+    "pages": 1
+  },
+  "links": {
+    "first": "/api/v1/investors?page%5Bsize%5D=10",
+    "self": "/api/v1/investors?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+    "last": "/api/v1/investors?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+  }
+}

--- a/backend/spec/fixtures/snapshots/api/v1/account/investors-favourites.json
+++ b/backend/spec/fixtures/snapshots/api/v1/account/investors-favourites.json
@@ -1,0 +1,77 @@
+{
+  "data": [
+    {
+      "id": "e41dfd26-4db1-4af9-8c06-7fbc450d7a63",
+      "type": "investor",
+      "attributes": {
+        "name": "Bartoletti and Sons",
+        "slug": "bartoletti-and-sons",
+        "about": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
+        "website": "https://bartoletti-and-sons.com",
+        "instagram": "https://instagram.com/bartoletti-and-sons",
+        "facebook": "https://facebook.com/bartoletti-and-sons",
+        "linkedin": "https://linkedin.com/bartoletti-and-sons",
+        "twitter": "https://twitter.com/bartoletti-and-sons",
+        "mission": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
+        "prioritized_projects_description": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
+        "other_information": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
+        "investor_type": "angel-investor",
+        "categories": [
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
+        ],
+        "ticket_sizes": [
+          "validation",
+          "scaling"
+        ],
+        "instrument_types": [
+          "grant",
+          "loan"
+        ],
+        "impacts": [
+          "climate",
+          "water"
+        ],
+        "sdgs": [
+          1,
+          4,
+          5
+        ],
+        "previously_invested": true,
+        "language": "en",
+        "account_language": "en",
+        "review_status": "approved",
+        "created_at": "2022-07-27T08:22:36.055Z",
+        "contact_email": "contact@example.com",
+        "contact_phone": "+57-1-xxx-xx-xx",
+        "picture": {
+          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoWm1FNE1UWm1NQzFtWVRNM0xUUmxaVEl0WVRjd1l5MWpZakZpWlRZek1USmtZamtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2c623186d398170ec412800b307f81f14eaa804b/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg",
+          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoWm1FNE1UWm1NQzFtWVRNM0xUUmxaVEl0WVRjd1l5MWpZakZpWlRZek1USmtZamtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2c623186d398170ec412800b307f81f14eaa804b/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg",
+          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoWm1FNE1UWm1NQzFtWVRNM0xUUmxaVEl0WVRjd1l5MWpZakZpWlRZek1USmtZamtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2c623186d398170ec412800b307f81f14eaa804b/picture.jpg"
+        },
+        "favourite": true
+      },
+      "relationships": {
+        "owner": {
+          "data": {
+            "id": "7ca20b0e-2356-4fb4-998e-922a0bb9cc98",
+            "type": "user"
+          }
+        }
+      }
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "per_page": 10,
+    "from": 1,
+    "to": 1,
+    "total": 1,
+    "pages": 1
+  },
+  "links": {
+    "first": "/api/v1/investors?page%5Bsize%5D=10",
+    "self": "/api/v1/investors?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+    "last": "/api/v1/investors?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+  }
+}

--- a/backend/spec/fixtures/snapshots/api/v1/account/open-calls-favourites-include-relationships.json
+++ b/backend/spec/fixtures/snapshots/api/v1/account/open-calls-favourites-include-relationships.json
@@ -1,0 +1,110 @@
+{
+  "data": [
+    {
+      "id": "553f0437-3a33-4f61-8c1f-2a07f89dcfcd",
+      "type": "open_call",
+      "attributes": {
+        "name": "Open call 1",
+        "slug": "hane-lehner-and-goyette-open-call-1",
+        "description": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
+        "ticket_size": "scaling",
+        "instrument_type": "loan",
+        "sdgs": [
+          1,
+          4,
+          5
+        ],
+        "money_distribution": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
+        "impact_description": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
+        "closing_at": "2023-05-27T08:55:06.231Z",
+        "language": "en",
+        "account_language": "en",
+        "trusted": false,
+        "created_at": "2022-07-27T08:55:06.239Z"
+      },
+      "relationships": {
+        "investor": {
+          "data": {
+            "id": "470e8504-f4bb-4466-b2c9-07e07705411c",
+            "type": "investor"
+          }
+        }
+      }
+    }
+  ],
+  "included": [
+    {
+      "id": "470e8504-f4bb-4466-b2c9-07e07705411c",
+      "type": "investor",
+      "attributes": {
+        "name": "Hane, Lehner and Goyette",
+        "slug": "hane-lehner-and-goyette",
+        "about": "Et quaerat omnis. Harum voluptas atque. Quo nesciunt voluptas. Suscipit ex cum.",
+        "website": "https://hane-lehner-and-goyette.com",
+        "instagram": "https://instagram.com/hane-lehner-and-goyette",
+        "facebook": "https://facebook.com/hane-lehner-and-goyette",
+        "linkedin": "https://linkedin.com/hane-lehner-and-goyette",
+        "twitter": "https://twitter.com/hane-lehner-and-goyette",
+        "mission": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
+        "prioritized_projects_description": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
+        "other_information": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
+        "investor_type": "angel-investor",
+        "categories": [
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
+        ],
+        "ticket_sizes": [
+          "validation",
+          "scaling"
+        ],
+        "instrument_types": [
+          "grant",
+          "loan"
+        ],
+        "impacts": [
+          "climate",
+          "water"
+        ],
+        "sdgs": [
+          1,
+          4,
+          5
+        ],
+        "previously_invested": true,
+        "language": "en",
+        "account_language": "en",
+        "review_status": "approved",
+        "created_at": "2022-07-27T08:55:06.211Z",
+        "contact_email": "contact@example.com",
+        "contact_phone": "+57-1-xxx-xx-xx",
+        "picture": {
+          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0TVRNd01qVTVOeTAxWWpobExUUm1Nall0WWpnellTMHdOemhoTTJVd1pESm1NRGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ab12eb8aae52edf193d5cf2369bb80648022fff0/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg",
+          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0TVRNd01qVTVOeTAxWWpobExUUm1Nall0WWpnellTMHdOemhoTTJVd1pESm1NRGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ab12eb8aae52edf193d5cf2369bb80648022fff0/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg",
+          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0TVRNd01qVTVOeTAxWWpobExUUm1Nall0WWpnellTMHdOemhoTTJVd1pESm1NRGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ab12eb8aae52edf193d5cf2369bb80648022fff0/picture.jpg"
+        },
+        "favourite": false
+      },
+      "relationships": {
+        "owner": {
+          "data": {
+            "id": "4ab853d8-d6ea-4e1a-9c99-bcdb9d6a9393",
+            "type": "user"
+          }
+        }
+      }
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "per_page": 10,
+    "from": 1,
+    "to": 1,
+    "total": 1,
+    "pages": 1
+  },
+  "links": {
+    "first": "/api/v1/open_calls?page%5Bsize%5D=10",
+    "self": "/api/v1/open_calls?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+    "last": "/api/v1/open_calls?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+  }
+}

--- a/backend/spec/fixtures/snapshots/api/v1/account/open-calls-favourites-sparse-fieldset.json
+++ b/backend/spec/fixtures/snapshots/api/v1/account/open-calls-favourites-sparse-fieldset.json
@@ -1,0 +1,48 @@
+{
+  "data": [
+    {
+      "id": "ed5efee6-02e3-486b-91e1-3592c4e8ebee",
+      "type": "open_call",
+      "attributes": {
+        "name": "Open call 1",
+        "slug": "hane-lehner-and-goyette-open-call-1",
+        "description": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
+        "ticket_size": "scaling",
+        "instrument_type": "loan",
+        "sdgs": [
+          1,
+          4,
+          5
+        ],
+        "money_distribution": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
+        "impact_description": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
+        "closing_at": "2023-05-27T08:55:05.546Z",
+        "language": "en",
+        "account_language": "en",
+        "trusted": false,
+        "created_at": "2022-07-27T08:55:05.550Z"
+      },
+      "relationships": {
+        "investor": {
+          "data": {
+            "id": "c1836268-bd85-4506-9458-d1800d58b597",
+            "type": "investor"
+          }
+        }
+      }
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "per_page": 10,
+    "from": 1,
+    "to": 1,
+    "total": 1,
+    "pages": 1
+  },
+  "links": {
+    "first": "/api/v1/open_calls?page%5Bsize%5D=10",
+    "self": "/api/v1/open_calls?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+    "last": "/api/v1/open_calls?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+  }
+}

--- a/backend/spec/fixtures/snapshots/api/v1/account/open-calls-favourites.json
+++ b/backend/spec/fixtures/snapshots/api/v1/account/open-calls-favourites.json
@@ -1,0 +1,48 @@
+{
+  "data": [
+    {
+      "id": "00625275-657f-4929-a489-c0526bbe1faf",
+      "type": "open_call",
+      "attributes": {
+        "name": "Open call 1",
+        "slug": "hane-lehner-and-goyette-open-call-1",
+        "description": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
+        "ticket_size": "scaling",
+        "instrument_type": "loan",
+        "sdgs": [
+          1,
+          4,
+          5
+        ],
+        "money_distribution": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
+        "impact_description": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
+        "closing_at": "2023-05-27T08:55:03.974Z",
+        "language": "en",
+        "account_language": "en",
+        "trusted": false,
+        "created_at": "2022-07-27T08:55:04.009Z"
+      },
+      "relationships": {
+        "investor": {
+          "data": {
+            "id": "696a14d5-386a-4402-8d83-655c9bae2406",
+            "type": "investor"
+          }
+        }
+      }
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "per_page": 10,
+    "from": 1,
+    "to": 1,
+    "total": 1,
+    "pages": 1
+  },
+  "links": {
+    "first": "/api/v1/open_calls?page%5Bsize%5D=10",
+    "self": "/api/v1/open_calls?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+    "last": "/api/v1/open_calls?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+  }
+}

--- a/backend/spec/fixtures/snapshots/api/v1/account/project-developers-favourites-include-relationships.json
+++ b/backend/spec/fixtures/snapshots/api/v1/account/project-developers-favourites-include-relationships.json
@@ -1,0 +1,34 @@
+{
+  "data": [
+    {
+      "id": "bf92da19-bbe1-4ca2-aed8-977f7c511e22",
+      "type": "project_developer",
+      "attributes": {
+        "instagram": "https://instagram.com/bartoletti-and-sons"
+      },
+      "relationships": {
+        "involved_projects": {
+          "data": [
+
+          ]
+        }
+      }
+    }
+  ],
+  "included": [
+
+  ],
+  "meta": {
+    "page": 1,
+    "per_page": 10,
+    "from": 1,
+    "to": 1,
+    "total": 1,
+    "pages": 1
+  },
+  "links": {
+    "first": "/api/v1/project_developers?page%5Bsize%5D=10",
+    "self": "/api/v1/project_developers?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+    "last": "/api/v1/project_developers?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+  }
+}

--- a/backend/spec/fixtures/snapshots/api/v1/account/project-developers-favourites-sparse-fieldset.json
+++ b/backend/spec/fixtures/snapshots/api/v1/account/project-developers-favourites-sparse-fieldset.json
@@ -1,0 +1,27 @@
+{
+  "data": [
+    {
+      "id": "4df3969a-8f55-427b-8654-ca3f3700bbd3",
+      "type": "project_developer",
+      "attributes": {
+        "instagram": "https://instagram.com/bartoletti-and-sons",
+        "facebook": "https://facebook.com/bartoletti-and-sons"
+      },
+      "relationships": {
+      }
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "per_page": 10,
+    "from": 1,
+    "to": 1,
+    "total": 1,
+    "pages": 1
+  },
+  "links": {
+    "first": "/api/v1/project_developers?page%5Bsize%5D=10",
+    "self": "/api/v1/project_developers?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+    "last": "/api/v1/project_developers?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+  }
+}

--- a/backend/spec/fixtures/snapshots/api/v1/account/project-developers-favourites.json
+++ b/backend/spec/fixtures/snapshots/api/v1/account/project-developers-favourites.json
@@ -1,0 +1,76 @@
+{
+  "data": [
+    {
+      "id": "92140535-41ea-47de-851c-faa108b78d81",
+      "type": "project_developer",
+      "attributes": {
+        "name": "Bartoletti and Sons",
+        "slug": "bartoletti-and-sons",
+        "about": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
+        "website": "https://bartoletti-and-sons.com",
+        "instagram": "https://instagram.com/bartoletti-and-sons",
+        "facebook": "https://facebook.com/bartoletti-and-sons",
+        "linkedin": "https://linkedin.com/bartoletti-and-sons",
+        "twitter": "https://twitter.com/bartoletti-and-sons",
+        "mission": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
+        "project_developer_type": "ngo",
+        "categories": [
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
+        ],
+        "impacts": [
+          "climate",
+          "water"
+        ],
+        "language": "en",
+        "account_language": "en",
+        "entity_legal_registration_number": "564823570",
+        "review_status": "approved",
+        "mosaics": [
+          "amazon-heart",
+          "amazonian-piedmont-massif"
+        ],
+        "created_at": "2022-07-27T08:57:48.498Z",
+        "contact_email": "contact@example.com",
+        "contact_phone": "+57-1-xxx-xx-xx",
+        "picture": {
+          "small": "http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTW1RMk1EQXhOeTAyTnpJd0xUUXlNelV0T0dZd1l5MDBPVE5pWTJFd05UUm1OallHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e74228896e3f76369594969e330e1af86f10107e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg",
+          "medium": "http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTW1RMk1EQXhOeTAyTnpJd0xUUXlNelV0T0dZd1l5MDBPVE5pWTJFd05UUm1OallHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e74228896e3f76369594969e330e1af86f10107e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg",
+          "original": "http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTW1RMk1EQXhOeTAyTnpJd0xUUXlNelV0T0dZd1l5MDBPVE5pWTJFd05UUm1OallHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e74228896e3f76369594969e330e1af86f10107e/picture.jpg"
+        },
+        "favourite": true
+      },
+      "relationships": {
+        "owner": {
+          "data": {
+            "id": "4449c638-2e87-4fa7-bbff-5b30d6377376",
+            "type": "user"
+          }
+        },
+        "projects": {
+          "data": [
+
+          ]
+        },
+        "involved_projects": {
+          "data": [
+
+          ]
+        }
+      }
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "per_page": 10,
+    "from": 1,
+    "to": 1,
+    "total": 1,
+    "pages": 1
+  },
+  "links": {
+    "first": "/api/v1/project_developers?page%5Bsize%5D=10",
+    "self": "/api/v1/project_developers?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+    "last": "/api/v1/project_developers?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+  }
+}

--- a/backend/spec/fixtures/snapshots/api/v1/account/projects-favourites-include-relationships.json
+++ b/backend/spec/fixtures/snapshots/api/v1/account/projects-favourites-include-relationships.json
@@ -1,0 +1,96 @@
+{
+  "data": [
+    {
+      "id": "7e65e06d-f372-474e-a7a6-21eefdbbe08e",
+      "type": "project",
+      "attributes": {
+        "name": "Project 1"
+      },
+      "relationships": {
+        "project_developer": {
+          "data": {
+            "id": "011f80bd-edab-43e7-ab5f-f730ab208549",
+            "type": "project_developer"
+          }
+        }
+      }
+    }
+  ],
+  "included": [
+    {
+      "id": "011f80bd-edab-43e7-ab5f-f730ab208549",
+      "type": "project_developer",
+      "attributes": {
+        "name": "Hane, Lehner and Goyette",
+        "slug": "hane-lehner-and-goyette",
+        "about": "Et quaerat omnis. Harum voluptas atque. Quo nesciunt voluptas. Suscipit ex cum.",
+        "website": "https://hane-lehner-and-goyette.com",
+        "instagram": "https://instagram.com/hane-lehner-and-goyette",
+        "facebook": "https://facebook.com/hane-lehner-and-goyette",
+        "linkedin": "https://linkedin.com/hane-lehner-and-goyette",
+        "twitter": "https://twitter.com/hane-lehner-and-goyette",
+        "mission": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
+        "project_developer_type": "ngo",
+        "categories": [
+          "forestry-and-agroforestry",
+          "non-timber-forest-production"
+        ],
+        "impacts": [
+          "climate",
+          "water"
+        ],
+        "language": "en",
+        "account_language": "en",
+        "entity_legal_registration_number": "564823570",
+        "review_status": "approved",
+        "mosaics": [
+          "amazon-heart",
+          "amazonian-piedmont-massif"
+        ],
+        "created_at": "2022-07-27T07:56:07.183Z",
+        "contact_email": "contact@example.com",
+        "contact_phone": "+57-1-xxx-xx-xx",
+        "picture": {
+          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTWpNeE9ESTJaaTFtWVRBMExUUmxNR1V0T0RaaE9DMWhOakJrT1dVek1qUTBabUlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--91d576bef96e08fc86331afdd8bf8cc776db27af/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg",
+          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTWpNeE9ESTJaaTFtWVRBMExUUmxNR1V0T0RaaE9DMWhOakJrT1dVek1qUTBabUlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--91d576bef96e08fc86331afdd8bf8cc776db27af/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg",
+          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTWpNeE9ESTJaaTFtWVRBMExUUmxNR1V0T0RaaE9DMWhOakJrT1dVek1qUTBabUlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--91d576bef96e08fc86331afdd8bf8cc776db27af/picture.jpg"
+        },
+        "favourite": false
+      },
+      "relationships": {
+        "owner": {
+          "data": {
+            "id": "4b1fd7bc-7f83-45ee-8116-0ed61f5dbc79",
+            "type": "user"
+          }
+        },
+        "projects": {
+          "data": [
+            {
+              "id": "7e65e06d-f372-474e-a7a6-21eefdbbe08e",
+              "type": "project"
+            }
+          ]
+        },
+        "involved_projects": {
+          "data": [
+
+          ]
+        }
+      }
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "per_page": 10,
+    "from": 1,
+    "to": 1,
+    "total": 1,
+    "pages": 1
+  },
+  "links": {
+    "first": "/api/v1/projects?page%5Bsize%5D=10",
+    "self": "/api/v1/projects?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+    "last": "/api/v1/projects?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+  }
+}

--- a/backend/spec/fixtures/snapshots/api/v1/account/projects-favourites-sparse-fieldset.json
+++ b/backend/spec/fixtures/snapshots/api/v1/account/projects-favourites-sparse-fieldset.json
@@ -1,0 +1,27 @@
+{
+  "data": [
+    {
+      "id": "249bf39d-9df0-4a55-b748-ef79dd404cdb",
+      "type": "project",
+      "attributes": {
+        "name": "Project 1",
+        "description": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo."
+      },
+      "relationships": {
+      }
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "per_page": 10,
+    "from": 1,
+    "to": 1,
+    "total": 1,
+    "pages": 1
+  },
+  "links": {
+    "first": "/api/v1/projects?page%5Bsize%5D=10",
+    "self": "/api/v1/projects?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+    "last": "/api/v1/projects?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+  }
+}

--- a/backend/spec/fixtures/snapshots/api/v1/account/projects-favourites.json
+++ b/backend/spec/fixtures/snapshots/api/v1/account/projects-favourites.json
@@ -1,0 +1,129 @@
+{
+  "data": [
+    {
+      "id": "a15a8d1d-e1c3-4ea4-b3e8-48913678cbc8",
+      "type": "project",
+      "attributes": {
+        "name": "Project 1",
+        "status": "published",
+        "slug": "hane-lehner-and-goyette-project-1",
+        "description": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
+        "development_stage": "scaling-up",
+        "estimated_duration_in_months": 13,
+        "target_groups": [
+          "urban-populations",
+          "indigenous-peoples"
+        ],
+        "impact_areas": [
+          "pollutants-reduction",
+          "carbon-emission-reduction"
+        ],
+        "category": "forestry-and-agroforestry",
+        "sdgs": [
+          1,
+          4,
+          5
+        ],
+        "involved_project_developer_not_listed": false,
+        "problem": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
+        "solution": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
+        "expected_impact": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
+        "looking_for_funding": true,
+        "ticket_size": "scaling",
+        "instrument_types": [
+          "grant",
+          "loan"
+        ],
+        "funding_plan": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
+        "sustainability": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
+        "replicability": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
+        "progress_impact_tracking": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
+        "received_funding": true,
+        "received_funding_amount_usd": "3000.0",
+        "received_funding_investor": "Kutch-Spencer",
+        "relevant_links": null,
+        "language": "en",
+        "account_language": "en",
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            1.0,
+            2.0
+          ]
+        },
+        "trusted": false,
+        "created_at": "2022-07-27T07:56:04.885Z",
+        "municipality_biodiversity_impact": null,
+        "municipality_climate_impact": null,
+        "municipality_water_impact": null,
+        "municipality_community_impact": null,
+        "municipality_total_impact": null,
+        "hydrobasin_biodiversity_impact": null,
+        "hydrobasin_climate_impact": null,
+        "hydrobasin_water_impact": null,
+        "hydrobasin_community_impact": null,
+        "hydrobasin_total_impact": null,
+        "priority_landscape_biodiversity_impact": null,
+        "priority_landscape_climate_impact": null,
+        "priority_landscape_water_impact": null,
+        "priority_landscape_community_impact": null,
+        "priority_landscape_total_impact": null,
+        "latitude": 2.0,
+        "longitude": 1.0,
+        "favourite": true
+      },
+      "relationships": {
+        "project_developer": {
+          "data": {
+            "id": "d7d6216e-9f22-4442-ae95-900dad692018",
+            "type": "project_developer"
+          }
+        },
+        "country": {
+          "data": {
+            "id": "68fc2f6b-6ba3-42a2-9f6c-905cd8ac69a0",
+            "type": "location"
+          }
+        },
+        "municipality": {
+          "data": {
+            "id": "399e76c8-5008-4555-be6f-d76dfa74da75",
+            "type": "location"
+          }
+        },
+        "department": {
+          "data": {
+            "id": "dac3fce5-eeaf-48da-a6ee-28df56e251cf",
+            "type": "location"
+          }
+        },
+        "priority_landscape": {
+          "data": null
+        },
+        "involved_project_developers": {
+          "data": [
+
+          ]
+        },
+        "project_images": {
+          "data": [
+
+          ]
+        }
+      }
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "per_page": 10,
+    "from": 1,
+    "to": 1,
+    "total": 1,
+    "pages": 1
+  },
+  "links": {
+    "first": "/api/v1/projects?page%5Bsize%5D=10",
+    "self": "/api/v1/projects?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+    "last": "/api/v1/projects?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+  }
+}

--- a/backend/spec/models/favourite_open_call_spec.rb
+++ b/backend/spec/models/favourite_open_call_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe FavouriteOpenCall, type: :model do
+  subject { build(:favourite_open_call) }
+
+  it { is_expected.to be_valid }
+
+  it "should not be valid without user" do
+    subject.user = nil
+    expect(subject).to have(1).errors_on(:user)
+  end
+
+  it "should not be valid without open_call" do
+    subject.open_call = nil
+    expect(subject).to have(1).errors_on(:open_call)
+  end
+
+  it "should not be valid when open_call is already favourite" do
+    favourite_open_call = create :favourite_open_call
+    subject.assign_attributes favourite_open_call.attributes
+    expect(subject).to have(1).errors_on(:open_call)
+  end
+end

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -23,7 +23,7 @@ RSpec.configure do |config|
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
   config.request_snapshots_dir = "spec/fixtures/snapshots"
   # adding dynamic attributes for snapshots, small medium original are for active storage links
-  config.request_snapshots_dynamic_attributes = %w[id created_at updated_at small medium original]
+  config.request_snapshots_dynamic_attributes = %w[id created_at updated_at small medium original closing_at]
   config.request_snapshots_ignore_order = %w[included]
 
   config.include ActiveSupport::Testing::TimeHelpers

--- a/backend/spec/requests/api/v1/accounts/investors_spec.rb
+++ b/backend/spec/requests/api/v1/accounts/investors_spec.rb
@@ -242,4 +242,60 @@ RSpec.describe "API V1 Account Investors", type: :request do
       end
     end
   end
+
+  path "/api/v1/account/investors/favourites" do
+    get "Returns list of investors marked as favourite" do
+      tags "Investors"
+      consumes "application/json"
+      produces "application/json"
+      security [csrf: [], cookie_auth: []]
+      parameter name: "page[number]", in: :query, type: :integer, description: "Page number. Default: 1", required: false
+      parameter name: "page[size]", in: :query, type: :integer, description: "Per page items. Default: 10", required: false
+      parameter name: "fields[investor]", in: :query, type: :string, description: "Get only required fields. Use comma to separate multiple fields", required: false
+      parameter name: :includes, in: :query, type: :string, description: "Include relationships. Use comma to separate multiple fields", required: false
+
+      it_behaves_like "with not authorized error", csrf: true
+      it_behaves_like "with forbidden error", csrf: true, user: -> { create(:user, account: create(:account, :unapproved)) }
+
+      response "200", :success do
+        schema type: :object, properties: {
+          data: {type: :array, items: {"$ref" => "#/components/schemas/investor"}},
+          meta: {"$ref" => "#/components/schemas/pagination_meta"},
+          links: {"$ref" => "#/components/schemas/pagination_links"}
+        }
+
+        let("X-CSRF-TOKEN") { get_csrf_token }
+        let(:user) { create :user, account: create(:account, :approved) }
+        let!(:favourite_investor) { create :favourite_investor, user: user }
+        let!(:favourite_investor_of_different_user) { create :favourite_investor }
+        let!(:investor_not_marked_as_favourite) { create :investor }
+
+        before { sign_in user }
+
+        run_test!
+
+        it "matches snapshot", generate_swagger_example: true do
+          expect(response.body).to match_snapshot("api/v1/account/investors-favourites")
+          expect(response_json["data"].pluck("id")).to eq([favourite_investor.investor_id])
+        end
+
+        context "with sparse fieldset" do
+          let("fields[investor]") { "instagram,facebook,nonexisting" }
+
+          it "matches snapshot" do
+            expect(response.body).to match_snapshot("api/v1/account/investors-favourites-sparse-fieldset")
+          end
+        end
+
+        context "with relationships" do
+          let("fields[investor]") { "instagram,facebook,nonexisting" }
+          let(:includes) { "owner" }
+
+          it "matches snapshot" do
+            expect(response.body).to match_snapshot("api/v1/account/investors-favourites-include-relationships")
+          end
+        end
+      end
+    end
+  end
 end

--- a/backend/spec/requests/api/v1/accounts/open_calls_spec.rb
+++ b/backend/spec/requests/api/v1/accounts/open_calls_spec.rb
@@ -1,0 +1,60 @@
+require "swagger_helper"
+
+RSpec.describe "API V1 Account Open Calls", type: :request do
+  let(:user) { create :user_investor }
+
+  path "/api/v1/account/open_calls/favourites" do
+    get "Returns list of open calls marked as favourite" do
+      tags "Open Calls"
+      consumes "application/json"
+      produces "application/json"
+      security [csrf: [], cookie_auth: []]
+      parameter name: "page[number]", in: :query, type: :integer, description: "Page number. Default: 1", required: false
+      parameter name: "page[size]", in: :query, type: :integer, description: "Per page items. Default: 10", required: false
+      parameter name: "fields[open_calls]", in: :query, type: :string, description: "Get only required fields. Use comma to separate multiple fields", required: false
+      parameter name: :includes, in: :query, type: :string, description: "Include relationships. Use comma to separate multiple fields", required: false
+
+      it_behaves_like "with not authorized error", csrf: true
+      it_behaves_like "with forbidden error", csrf: true, user: -> { create(:user, account: create(:account, :unapproved)) }
+
+      response "200", :success do
+        schema type: :object, properties: {
+          data: {type: :array, items: {"$ref" => "#/components/schemas/open_call"}},
+          meta: {"$ref" => "#/components/schemas/pagination_meta"},
+          links: {"$ref" => "#/components/schemas/pagination_links"}
+        }
+
+        let("X-CSRF-TOKEN") { get_csrf_token }
+        let!(:favourite_open_call) { create :favourite_open_call, user: user }
+        let!(:favourite_open_call_of_different_user) { create :favourite_open_call }
+        let!(:open_call_not_marked_as_favourite) { create :open_call }
+
+        before { sign_in user }
+
+        run_test!
+
+        it "matches snapshot", generate_swagger_example: true do
+          expect(response.body).to match_snapshot("api/v1/account/open-calls-favourites")
+          expect(response_json["data"].pluck("id")).to eq([favourite_open_call.open_call_id])
+        end
+
+        context "with sparse fieldset" do
+          let("fields[open_call]") { "name,description,nonexisting" }
+
+          it "matches snapshot" do
+            expect(response.body).to match_snapshot("api/v1/account/open-calls-favourites-sparse-fieldset")
+          end
+        end
+
+        context "with relationships" do
+          let("fields[open_call]") { "name,investor" }
+          let(:includes) { "investor" }
+
+          it "matches snapshot" do
+            expect(response.body).to match_snapshot("api/v1/account/open-calls-favourites-include-relationships")
+          end
+        end
+      end
+    end
+  end
+end

--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -40,7 +40,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 1e2061e3-54db-4108-94cc-2c771c780e16
+                  id: 0f33acd9-8bad-490c-81a5-8038535565a4
                   type: investor
                   attributes:
                     name: Kutch-Spencer
@@ -79,18 +79,18 @@ paths:
                     language: en
                     account_language: en
                     review_status: approved
-                    created_at: '2022-07-21T12:29:27.329Z'
+                    created_at: '2022-07-27T08:57:35.034Z'
                     contact_email: contact@example.com
                     contact_phone: "+57-1-xxx-xx-xx"
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3WlRoaE1tRXdOQzAyWkRaaExUUmpPVEl0WW1FNFppMHhOek13WW1JeU1XRTBZVFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--00df29184997aa0c6e8712e1419d36353957e8ac/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3WlRoaE1tRXdOQzAyWkRaaExUUmpPVEl0WW1FNFppMHhOek13WW1JeU1XRTBZVFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--00df29184997aa0c6e8712e1419d36353957e8ac/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3WlRoaE1tRXdOQzAyWkRaaExUUmpPVEl0WW1FNFppMHhOek13WW1JeU1XRTBZVFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--00df29184997aa0c6e8712e1419d36353957e8ac/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTkRBM1pqSTJaQzB5WmprNExUUXlZVGt0WWpVd09DMHlOVGsxTXpNM1pUTTVOMlFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--1ed8d8bfa567d4ed3d8fe4d853f2c3fe68065f5f/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTkRBM1pqSTJaQzB5WmprNExUUXlZVGt0WWpVd09DMHlOVGsxTXpNM1pUTTVOMlFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--1ed8d8bfa567d4ed3d8fe4d853f2c3fe68065f5f/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTkRBM1pqSTJaQzB5WmprNExUUXlZVGt0WWpVd09DMHlOVGsxTXpNM1pUTTVOMlFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--1ed8d8bfa567d4ed3d8fe4d853f2c3fe68065f5f/picture.jpg
                     favourite: false
                   relationships:
                     owner:
                       data:
-                        id: 20e9c586-16ec-48c2-8759-93ee1f35f2be
+                        id: e2b90402-082e-4f3f-a498-2508e4778b92
                         type: user
               schema:
                 type: object
@@ -120,7 +120,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 6742a43c-d199-4758-bc10-9465d9b32947
+                  id: 42bf2aca-e4c7-4f96-8d53-414138c63339
                   type: investor
                   attributes:
                     name: Name
@@ -154,18 +154,18 @@ paths:
                     language: en
                     account_language: en
                     review_status: unapproved
-                    created_at: '2022-07-21T12:29:27.848Z'
+                    created_at: '2022-07-27T08:57:35.643Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6WkRWbVpUZzVNQzFrWXpBeUxUUXdZMkl0WW1RME9TMDVPREk1WmpZNVlXRmhaVE1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--b03c1b4f01ab49078d66ba90112c28426257e3af/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6WkRWbVpUZzVNQzFrWXpBeUxUUXdZMkl0WW1RME9TMDVPREk1WmpZNVlXRmhaVE1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--b03c1b4f01ab49078d66ba90112c28426257e3af/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6WkRWbVpUZzVNQzFrWXpBeUxUUXdZMkl0WW1RME9TMDVPREk1WmpZNVlXRmhaVE1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--b03c1b4f01ab49078d66ba90112c28426257e3af/test
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WVRjME4yUXpPQzA1WWprNExUUXlNMkV0T0RKbVppMDFObVE0WmpGaFptUmhZamNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--987e44ba7befddfa193090ad29e21b77854181ea/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WVRjME4yUXpPQzA1WWprNExUUXlNMkV0T0RKbVppMDFObVE0WmpGaFptUmhZamNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--987e44ba7befddfa193090ad29e21b77854181ea/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WVRjME4yUXpPQzA1WWprNExUUXlNMkV0T0RKbVppMDFObVE0WmpGaFptUmhZamNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--987e44ba7befddfa193090ad29e21b77854181ea/test
                     favourite: false
                   relationships:
                     owner:
                       data:
-                        id: 3018d157-f5b2-4df3-9443-c45d18fb51d4
+                        id: 02764664-c4a4-4da8-8eef-733323f55f5b
                         type: user
               schema:
                 type: object
@@ -335,7 +335,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 50aedb54-c8c5-4103-a3f9-ff53c573e266
+                  id: 6f8b3268-c120-433a-bcbd-5e817c6ffcd9
                   type: investor
                   attributes:
                     name: Name
@@ -369,18 +369,18 @@ paths:
                     language: en
                     account_language: en
                     review_status: approved
-                    created_at: '2022-07-21T12:29:28.524Z'
+                    created_at: '2022-07-27T08:57:36.633Z'
                     contact_email: contact@example.com
                     contact_phone: '123456789'
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtT0RNMlpqazJZeTAxTURReUxUUTFZakl0T0RrNE5pMDFNVEJpWlRjd09USTNPRGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--8bcf45710cc576f8076538f2610da62c3014ed08/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtT0RNMlpqazJZeTAxTURReUxUUTFZakl0T0RrNE5pMDFNVEJpWlRjd09USTNPRGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--8bcf45710cc576f8076538f2610da62c3014ed08/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtT0RNMlpqazJZeTAxTURReUxUUTFZakl0T0RrNE5pMDFNVEJpWlRjd09USTNPRGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--8bcf45710cc576f8076538f2610da62c3014ed08/test
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTldJMk1UY3pZUzB5T0ROaUxUUTNPV010T1RneFppMWxZV1JoTm1OaE9UWmhNak1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--d6a71c5507d1764661f6de2cff9330fa967bd305/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTldJMk1UY3pZUzB5T0ROaUxUUTNPV010T1RneFppMWxZV1JoTm1OaE9UWmhNak1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--d6a71c5507d1764661f6de2cff9330fa967bd305/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTldJMk1UY3pZUzB5T0ROaUxUUTNPV010T1RneFppMWxZV1JoTm1OaE9UWmhNak1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--d6a71c5507d1764661f6de2cff9330fa967bd305/test
                     favourite: false
                   relationships:
                     owner:
                       data:
-                        id: caaa5376-1b71-437b-8a59-34e6822cdf34
+                        id: cda89ef7-40fe-4e60-86e0-be9e44a68abe
                         type: user
               schema:
                 type: object
@@ -498,6 +498,243 @@ paths:
                     - 15
                     - 16
                     - 17
+  "/api/v1/account/investors/favourites":
+    get:
+      summary: Returns list of investors marked as favourite
+      tags:
+      - Investors
+      security:
+      - csrf: []
+        cookie_auth: []
+      parameters:
+      - name: page[number]
+        in: query
+        description: 'Page number. Default: 1'
+        required: false
+        schema:
+          type: integer
+      - name: page[size]
+        in: query
+        description: 'Per page items. Default: 10'
+        required: false
+        schema:
+          type: integer
+      - name: fields[investor]
+        in: query
+        description: Get only required fields. Use comma to separate multiple fields
+        required: false
+        schema:
+          type: string
+      - name: includes
+        in: query
+        description: Include relationships. Use comma to separate multiple fields
+        required: false
+        schema:
+          type: string
+      responses:
+        '401':
+          description: Authentication failed
+          content:
+            application/json:
+              example:
+                errors:
+                - title: You need to sign in or sign up before continuing.
+                  code:
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              example:
+                errors:
+                - title: You are not authorized to access this page.
+              schema:
+                "$ref": "#/components/schemas/errors"
+        '200':
+          description: success
+          content:
+            application/json:
+              example:
+                data:
+                - id: 7cb90229-44ba-417c-9ac1-31360a749adb
+                  type: investor
+                  attributes:
+                    name: Bartoletti and Sons
+                    slug: bartoletti-and-sons
+                    about: Placeat commodi libero. Quo recusandae repellat. Sunt commodi
+                      tempore. Voluptatem et corrupti.
+                    website: https://bartoletti-and-sons.com
+                    instagram: https://instagram.com/bartoletti-and-sons
+                    facebook: https://facebook.com/bartoletti-and-sons
+                    linkedin: https://linkedin.com/bartoletti-and-sons
+                    twitter: https://twitter.com/bartoletti-and-sons
+                    mission: Enim repellat pariatur. Earum modi eos. Libero tempora
+                      exercitationem. Qui dolorem quo.
+                    prioritized_projects_description: Enim repellat pariatur. Earum
+                      modi eos. Libero tempora exercitationem. Qui dolorem quo.
+                    other_information: Enim repellat pariatur. Earum modi eos. Libero
+                      tempora exercitationem. Qui dolorem quo.
+                    investor_type: angel-investor
+                    categories:
+                    - forestry-and-agroforestry
+                    - non-timber-forest-production
+                    ticket_sizes:
+                    - validation
+                    - scaling
+                    instrument_types:
+                    - grant
+                    - loan
+                    impacts:
+                    - climate
+                    - water
+                    sdgs:
+                    - 1
+                    - 4
+                    - 5
+                    previously_invested: true
+                    language: en
+                    account_language: en
+                    review_status: approved
+                    created_at: '2022-07-27T08:57:38.015Z'
+                    contact_email: contact@example.com
+                    contact_phone: "+57-1-xxx-xx-xx"
+                    picture:
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsTWpjMk5qUmtOUzFoTTJZeExUUTJaamd0WWpSaU1TMHdaR05rTWpJd1kyWXdabVFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--37f66a1a497599fd917a53cd1be7c2de8f3186de/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsTWpjMk5qUmtOUzFoTTJZeExUUTJaamd0WWpSaU1TMHdaR05rTWpJd1kyWXdabVFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--37f66a1a497599fd917a53cd1be7c2de8f3186de/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsTWpjMk5qUmtOUzFoTTJZeExUUTJaamd0WWpSaU1TMHdaR05rTWpJd1kyWXdabVFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--37f66a1a497599fd917a53cd1be7c2de8f3186de/picture.jpg
+                    favourite: true
+                  relationships:
+                    owner:
+                      data:
+                        id: 8adfe838-b9ff-41a6-a4ad-564c32fdb3aa
+                        type: user
+                meta:
+                  page: 1
+                  per_page: 10
+                  from: 1
+                  to: 1
+                  total: 1
+                  pages: 1
+                links:
+                  first: "/api/v1/investors?page%5Bsize%5D=10"
+                  self: "/api/v1/investors?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+                  last: "/api/v1/investors?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/investor"
+                  meta:
+                    "$ref": "#/components/schemas/pagination_meta"
+                  links:
+                    "$ref": "#/components/schemas/pagination_links"
+  "/api/v1/account/open_calls/favourites":
+    get:
+      summary: Returns list of open calls marked as favourite
+      tags:
+      - Open Calls
+      security:
+      - csrf: []
+        cookie_auth: []
+      parameters:
+      - name: page[number]
+        in: query
+        description: 'Page number. Default: 1'
+        required: false
+        schema:
+          type: integer
+      - name: page[size]
+        in: query
+        description: 'Per page items. Default: 10'
+        required: false
+        schema:
+          type: integer
+      - name: fields[open_calls]
+        in: query
+        description: Get only required fields. Use comma to separate multiple fields
+        required: false
+        schema:
+          type: string
+      - name: includes
+        in: query
+        description: Include relationships. Use comma to separate multiple fields
+        required: false
+        schema:
+          type: string
+      responses:
+        '401':
+          description: Authentication failed
+          content:
+            application/json:
+              example:
+                errors:
+                - title: You need to sign in or sign up before continuing.
+                  code:
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              example:
+                errors:
+                - title: You are not authorized to access this page.
+              schema:
+                "$ref": "#/components/schemas/errors"
+        '200':
+          description: success
+          content:
+            application/json:
+              example:
+                data:
+                - id: fbfec50f-e13f-463e-9c1f-d3e6da40c7cb
+                  type: open_call
+                  attributes:
+                    name: Open call 1
+                    slug: hane-lehner-and-goyette-open-call-1
+                    description: Enim repellat pariatur. Earum modi eos. Libero tempora
+                      exercitationem. Qui dolorem quo.
+                    ticket_size: scaling
+                    instrument_type: loan
+                    sdgs:
+                    - 1
+                    - 4
+                    - 5
+                    money_distribution: Enim repellat pariatur. Earum modi eos. Libero
+                      tempora exercitationem. Qui dolorem quo.
+                    impact_description: Enim repellat pariatur. Earum modi eos. Libero
+                      tempora exercitationem. Qui dolorem quo.
+                    closing_at: '2023-05-27T08:57:40.002Z'
+                    language: en
+                    account_language: en
+                    trusted: false
+                    created_at: '2022-07-27T08:57:40.009Z'
+                  relationships:
+                    investor:
+                      data:
+                        id: 2e0ee64a-8fb0-43f3-9f51-4502c1b2ac07
+                        type: investor
+                meta:
+                  page: 1
+                  per_page: 10
+                  from: 1
+                  to: 1
+                  total: 1
+                  pages: 1
+                links:
+                  first: "/api/v1/open_calls?page%5Bsize%5D=10"
+                  self: "/api/v1/open_calls?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+                  last: "/api/v1/open_calls?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/open_call"
+                  meta:
+                    "$ref": "#/components/schemas/pagination_meta"
+                  links:
+                    "$ref": "#/components/schemas/pagination_links"
   "/api/v1/account/project_developer":
     get:
       summary: Get current Project Developer
@@ -534,7 +771,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 10f1c049-000b-4e9f-92af-3c7439e3130b
+                  id: 162731fb-3f23-4304-bc0e-0f8cdebfa098
                   type: project_developer
                   attributes:
                     name: Kutch-Spencer
@@ -562,26 +799,26 @@ paths:
                     mosaics:
                     - amazon-heart
                     - amazonian-piedmont-massif
-                    created_at: '2022-07-21T12:29:30.250Z'
+                    created_at: '2022-07-27T08:57:45.149Z'
                     contact_email: contact@example.com
                     contact_phone: "+57-1-xxx-xx-xx"
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxWm1VNU5ETmpOUzA1TW1Fd0xUUmpOVEV0WVRNMVppMHlaR1l5T0RFeU4yUmxZV1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--32cbb06c9a19a00a70327fb31de87e2a8f125342/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxWm1VNU5ETmpOUzA1TW1Fd0xUUmpOVEV0WVRNMVppMHlaR1l5T0RFeU4yUmxZV1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--32cbb06c9a19a00a70327fb31de87e2a8f125342/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxWm1VNU5ETmpOUzA1TW1Fd0xUUmpOVEV0WVRNMVppMHlaR1l5T0RFeU4yUmxZV1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--32cbb06c9a19a00a70327fb31de87e2a8f125342/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTURBMU5EVmlNeTFrWkdZeExUUXlPRGt0WVRnMU55MW1PRFZsT1RNMVpHSTBZaklHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--3db14de473763827babad9c03e718fe2b0961b71/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTURBMU5EVmlNeTFrWkdZeExUUXlPRGt0WVRnMU55MW1PRFZsT1RNMVpHSTBZaklHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--3db14de473763827babad9c03e718fe2b0961b71/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTURBMU5EVmlNeTFrWkdZeExUUXlPRGt0WVRnMU55MW1PRFZsT1RNMVpHSTBZaklHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--3db14de473763827babad9c03e718fe2b0961b71/picture.jpg
                     favourite: false
                   relationships:
                     owner:
                       data:
-                        id: 52bd8f83-b94a-4a93-9604-e01355047662
+                        id: 3e12a3a6-0978-4131-b5f0-52414b512d71
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data:
-                      - id: 59f43c86-3b3d-4e9b-b830-a8587c4f69eb
+                      - id: 95b04e13-9214-4399-89af-89fc67287304
                         type: project
-                      - id: 24e8482f-d328-46ea-a850-6c1e3df954de
+                      - id: 95d33aac-2d6f-4c5b-ae87-ba8bd8fc4c08
                         type: project
               schema:
                 type: object
@@ -611,7 +848,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: d9218188-e7d1-4db9-a786-c21f2c3272ba
+                  id: 59ac9934-a3d8-480d-a876-076dbe019458
                   type: project_developer
                   attributes:
                     name: Name
@@ -636,18 +873,18 @@ paths:
                     review_status: unapproved
                     mosaics:
                     - amazon-heart
-                    created_at: '2022-07-21T12:29:31.380Z'
+                    created_at: '2022-07-27T08:57:46.203Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3TVdVek1UTTFaaTA1WW1SaExUUXpNR010WWpZNU1TMHlPVEptWkdJNFkyWmtNalVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e3eca2c7da7547b44a082915349689a14fae4427/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3TVdVek1UTTFaaTA1WW1SaExUUXpNR010WWpZNU1TMHlPVEptWkdJNFkyWmtNalVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e3eca2c7da7547b44a082915349689a14fae4427/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3TVdVek1UTTFaaTA1WW1SaExUUXpNR010WWpZNU1TMHlPVEptWkdJNFkyWmtNalVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e3eca2c7da7547b44a082915349689a14fae4427/test
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TVdJMFlUYzNNQzB4TkRabUxUUTJZV1l0WW1Oa09DMHpOamsxT1RFd1lqQTNaVFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--35a43ed16648d7a5c1f7a0c61b1eda4810adca33/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TVdJMFlUYzNNQzB4TkRabUxUUTJZV1l0WW1Oa09DMHpOamsxT1RFd1lqQTNaVFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--35a43ed16648d7a5c1f7a0c61b1eda4810adca33/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TVdJMFlUYzNNQzB4TkRabUxUUTJZV1l0WW1Oa09DMHpOamsxT1RFd1lqQTNaVFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--35a43ed16648d7a5c1f7a0c61b1eda4810adca33/test
                     favourite: false
                   relationships:
                     owner:
                       data:
-                        id: 96a21379-3a4b-4509-b56d-00e42dfbaf29
+                        id: 190199d2-a17d-4824-8aff-6959ea699cc9
                         type: user
                     projects:
                       data: []
@@ -782,7 +1019,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 34d7e9f9-ed68-49d2-bb79-eb5f6d699f00
+                  id: 7348e43a-3202-4af5-90cb-757d61985e1c
                   type: project_developer
                   attributes:
                     name: Name
@@ -807,18 +1044,18 @@ paths:
                     review_status: approved
                     mosaics:
                     - amazon-heart
-                    created_at: '2022-07-21T12:29:32.624Z'
+                    created_at: '2022-07-27T08:57:47.149Z'
                     contact_email: contact@example.com
                     contact_phone: "+57-1-xxx-xx-xx"
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5TlRGa1pESTRNeTAzTjJRekxUUTBOamd0T0dRNFppMWhaRGt4TlRkaVptUTBZelFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--9560d39d08ca36f8628cd207fd3b6d8acc015c09/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5TlRGa1pESTRNeTAzTjJRekxUUTBOamd0T0dRNFppMWhaRGt4TlRkaVptUTBZelFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--9560d39d08ca36f8628cd207fd3b6d8acc015c09/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5TlRGa1pESTRNeTAzTjJRekxUUTBOamd0T0dRNFppMWhaRGt4TlRkaVptUTBZelFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--9560d39d08ca36f8628cd207fd3b6d8acc015c09/test
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswT1dRNU56QXlaUzB5TlRkbUxUUXpOekV0T0RZd1pDMDVZekl3T1RKa01Ua3laallHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--9f0e6560b9ddaa49ffb9b10b3295ac2756d123f2/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswT1dRNU56QXlaUzB5TlRkbUxUUXpOekV0T0RZd1pDMDVZekl3T1RKa01Ua3laallHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--9f0e6560b9ddaa49ffb9b10b3295ac2756d123f2/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswT1dRNU56QXlaUzB5TlRkbUxUUXpOekV0T0RZd1pDMDVZekl3T1RKa01Ua3laallHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--9f0e6560b9ddaa49ffb9b10b3295ac2756d123f2/test
                     favourite: false
                   relationships:
                     owner:
                       data:
-                        id: 9ee23ccc-fd5e-42a6-b4bd-65985325f51c
+                        id: 1da17e64-8d54-46c6-8b1a-bddf34ff3d67
                         type: user
                     projects:
                       data: []
@@ -901,6 +1138,130 @@ paths:
                     - amazonian-piedmont-massif
                     - orinoquia-transition
                     - orinoquia
+  "/api/v1/account/project_developers/favourites":
+    get:
+      summary: Returns list of project developers marked as favourite
+      tags:
+      - Project Developers
+      security:
+      - csrf: []
+        cookie_auth: []
+      parameters:
+      - name: page[number]
+        in: query
+        description: 'Page number. Default: 1'
+        required: false
+        schema:
+          type: integer
+      - name: page[size]
+        in: query
+        description: 'Per page items. Default: 10'
+        required: false
+        schema:
+          type: integer
+      - name: fields[project_developer]
+        in: query
+        description: Get only required fields. Use comma to separate multiple fields
+        required: false
+        schema:
+          type: string
+      - name: includes
+        in: query
+        description: Include relationships. Use comma to separate multiple fields
+        required: false
+        schema:
+          type: string
+      responses:
+        '401':
+          description: Authentication failed
+          content:
+            application/json:
+              example:
+                errors:
+                - title: You need to sign in or sign up before continuing.
+                  code:
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              example:
+                errors:
+                - title: You are not authorized to access this page.
+              schema:
+                "$ref": "#/components/schemas/errors"
+        '200':
+          description: success
+          content:
+            application/json:
+              example:
+                data:
+                - id: 92140535-41ea-47de-851c-faa108b78d81
+                  type: project_developer
+                  attributes:
+                    name: Bartoletti and Sons
+                    slug: bartoletti-and-sons
+                    about: Placeat commodi libero. Quo recusandae repellat. Sunt commodi
+                      tempore. Voluptatem et corrupti.
+                    website: https://bartoletti-and-sons.com
+                    instagram: https://instagram.com/bartoletti-and-sons
+                    facebook: https://facebook.com/bartoletti-and-sons
+                    linkedin: https://linkedin.com/bartoletti-and-sons
+                    twitter: https://twitter.com/bartoletti-and-sons
+                    mission: Enim repellat pariatur. Earum modi eos. Libero tempora
+                      exercitationem. Qui dolorem quo.
+                    project_developer_type: ngo
+                    categories:
+                    - forestry-and-agroforestry
+                    - non-timber-forest-production
+                    impacts:
+                    - climate
+                    - water
+                    language: en
+                    account_language: en
+                    entity_legal_registration_number: '564823570'
+                    review_status: approved
+                    mosaics:
+                    - amazon-heart
+                    - amazonian-piedmont-massif
+                    created_at: '2022-07-27T08:57:48.498Z'
+                    contact_email: contact@example.com
+                    contact_phone: "+57-1-xxx-xx-xx"
+                    picture:
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTW1RMk1EQXhOeTAyTnpJd0xUUXlNelV0T0dZd1l5MDBPVE5pWTJFd05UUm1OallHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e74228896e3f76369594969e330e1af86f10107e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTW1RMk1EQXhOeTAyTnpJd0xUUXlNelV0T0dZd1l5MDBPVE5pWTJFd05UUm1OallHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e74228896e3f76369594969e330e1af86f10107e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTW1RMk1EQXhOeTAyTnpJd0xUUXlNelV0T0dZd1l5MDBPVE5pWTJFd05UUm1OallHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e74228896e3f76369594969e330e1af86f10107e/picture.jpg
+                    favourite: true
+                  relationships:
+                    owner:
+                      data:
+                        id: 4449c638-2e87-4fa7-bbff-5b30d6377376
+                        type: user
+                    projects:
+                      data: []
+                    involved_projects:
+                      data: []
+                meta:
+                  page: 1
+                  per_page: 10
+                  from: 1
+                  to: 1
+                  total: 1
+                  pages: 1
+                links:
+                  first: "/api/v1/project_developers?page%5Bsize%5D=10"
+                  self: "/api/v1/project_developers?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+                  last: "/api/v1/project_developers?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/project_developer"
+                  meta:
+                    "$ref": "#/components/schemas/pagination_meta"
+                  links:
+                    "$ref": "#/components/schemas/pagination_links"
   "/api/v1/account/projects":
     get:
       summary: Returns list of projects of User
@@ -943,7 +1304,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: 58d4804f-4144-4fef-b54b-232f2d361300
+                - id: 242eaf63-5441-4d58-aad0-d4e5dd2908c6
                   type: project
                   attributes:
                     name: Draft project
@@ -996,7 +1357,7 @@ paths:
                       - 1.0
                       - 2.0
                     trusted: false
-                    created_at: '2022-07-21T12:29:34.763Z'
+                    created_at: '2022-07-27T08:57:51.263Z'
                     municipality_biodiversity_impact:
                     municipality_climate_impact:
                     municipality_water_impact:
@@ -1018,19 +1379,19 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 6e4ce2d0-d6a4-47d4-925e-9f7565027bec
+                        id: 7479eae5-0a77-47ca-abbf-cd709d41512d
                         type: project_developer
                     country:
                       data:
-                        id: be425dab-cefd-48ef-ac55-6d907466500d
+                        id: f39fd1b7-50e9-46da-aff1-74b824c47de1
                         type: location
                     municipality:
                       data:
-                        id: 9b4c1dbc-3946-496c-afb8-64d714292f6e
+                        id: b2762723-3634-4066-a895-de0a3f877cb9
                         type: location
                     department:
                       data:
-                        id: 85cd4d98-d909-4fbb-b55e-56382e344c0b
+                        id: fee28db4-0746-4eb9-9168-0708c2a10506
                         type: location
                     priority_landscape:
                       data:
@@ -1038,7 +1399,7 @@ paths:
                       data: []
                     project_images:
                       data: []
-                - id: c3e4ad84-50e3-48ae-93d5-3cd81bd182c8
+                - id: 5bace564-6220-4bd3-8314-5c075da25189
                   type: project
                   attributes:
                     name: This PDs Project Amazing
@@ -1091,7 +1452,7 @@ paths:
                       - 1.0
                       - 2.0
                     trusted: false
-                    created_at: '2022-07-21T12:29:34.406Z'
+                    created_at: '2022-07-27T08:57:50.997Z'
                     municipality_biodiversity_impact:
                     municipality_climate_impact:
                     municipality_water_impact:
@@ -1113,19 +1474,19 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 6e4ce2d0-d6a4-47d4-925e-9f7565027bec
+                        id: 7479eae5-0a77-47ca-abbf-cd709d41512d
                         type: project_developer
                     country:
                       data:
-                        id: 8d8a6ab3-5628-432a-8090-e1fc50e2fc94
+                        id: b936d617-e870-4fa5-9e9e-30b876670910
                         type: location
                     municipality:
                       data:
-                        id: 4ed327ac-442a-4ecf-a674-83074b488fd4
+                        id: 26c3a568-1a16-4453-8da5-b4f49931081a
                         type: location
                     department:
                       data:
-                        id: 70b0fd18-4a1f-4d6b-98b2-df152aa2319e
+                        id: 404fc3d3-1c58-439f-bc45-e6a8c9674686
                         type: location
                     priority_landscape:
                       data:
@@ -1133,7 +1494,7 @@ paths:
                       data: []
                     project_images:
                       data: []
-                - id: 17da88d6-96ff-4a9f-8d8c-84100ffcc19d
+                - id: 70bfcd02-682c-4a3f-b349-e6154d155c39
                   type: project
                   attributes:
                     name: This PDs Project Awesome
@@ -1186,7 +1547,7 @@ paths:
                       - 1.0
                       - 2.0
                     trusted: false
-                    created_at: '2022-07-21T12:29:34.335Z'
+                    created_at: '2022-07-27T08:57:50.911Z'
                     municipality_biodiversity_impact:
                     municipality_climate_impact:
                     municipality_water_impact:
@@ -1208,19 +1569,19 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 6e4ce2d0-d6a4-47d4-925e-9f7565027bec
+                        id: 7479eae5-0a77-47ca-abbf-cd709d41512d
                         type: project_developer
                     country:
                       data:
-                        id: 50da0758-9c18-4e2c-8154-69b73a36f7ed
+                        id: 77fa395f-781d-4425-9a5b-4aef7682d9bc
                         type: location
                     municipality:
                       data:
-                        id: d1edb83b-cc04-4581-b714-7530736669b6
+                        id: 5e236c5d-2a83-45f8-8868-3a0cd380fc18
                         type: location
                     department:
                       data:
-                        id: 418e888f-4bec-434a-b449-bb5b5ae0b4dd
+                        id: 5a460ca0-2dd1-453d-9ca1-346638d6e72c
                         type: location
                     priority_landscape:
                       data:
@@ -1258,7 +1619,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 0c5b2fee-4f60-476b-b3e3-014b48303e17
+                  id: 35068440-8003-4d40-be37-a4e22c2a1551
                   type: project
                   attributes:
                     name: Project Name
@@ -1315,7 +1676,7 @@ paths:
                               - 1.5274297752414188
                         properties: {}
                     trusted: false
-                    created_at: '2022-07-21T12:29:38.066Z'
+                    created_at: '2022-07-27T08:57:54.633Z'
                     municipality_biodiversity_impact:
                     municipality_climate_impact:
                     municipality_water_impact:
@@ -1337,53 +1698,53 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 4cb212c3-19c6-405f-8bf1-a228dd2d5857
+                        id: 43b490c4-0efc-46e9-9a3e-23bc555256d6
                         type: project_developer
                     country:
                       data:
-                        id: 06d5f6f3-2378-4404-ae23-db03b4da1996
+                        id: c0ea99ec-939c-4eb8-971f-825e85a0c67c
                         type: location
                     municipality:
                       data:
-                        id: 7738de0a-a442-4781-ae19-1417fd492f4e
+                        id: da2827a6-0342-4393-be73-18b01e67c8ac
                         type: location
                     department:
                       data:
-                        id: 6acdb20a-831b-47d2-8378-bff023cbc714
+                        id: 89abba7a-c683-4035-b958-8a33baadfb61
                         type: location
                     priority_landscape:
                       data:
                     involved_project_developers:
                       data:
-                      - id: c4433dbc-58b5-4a39-8a87-fa7b8063b41d
+                      - id: 7d06c044-27cd-445d-8226-655c09b26ea0
                         type: project_developer
-                      - id: badbae9a-1228-4ab0-92a1-5dffbde5f7e2
+                      - id: 50d4a452-6ed1-4588-9264-1f47186d3e06
                         type: project_developer
                     project_images:
                       data:
-                      - id: f4948188-670f-4cff-8b7b-6538ddb06dab
+                      - id: 492a5fdf-fda5-441c-bc35-4e37e5a2fdb1
                         type: project_image
-                      - id: 25dfe3ea-5499-4ecb-8817-2c0d9f374579
+                      - id: b606f0a0-0220-49ea-852f-a0169de42825
                         type: project_image
                 included:
-                - id: f4948188-670f-4cff-8b7b-6538ddb06dab
+                - id: 492a5fdf-fda5-441c-bc35-4e37e5a2fdb1
                   type: project_image
                   attributes:
                     cover: true
-                    created_at: '2022-07-21T12:29:38.077Z'
+                    created_at: '2022-07-27T08:57:54.642Z'
                     file:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrTWpKa1l6STJZUzFsWVRjMExUUTVNbUV0WWpobU9DMHpOMlkyWkRFeE0yRmpOMklHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--782efc8406cc439231b834308dcd8cd59399ee2e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrTWpKa1l6STJZUzFsWVRjMExUUTVNbUV0WWpobU9DMHpOMlkyWkRFeE0yRmpOMklHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--782efc8406cc439231b834308dcd8cd59399ee2e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrTWpKa1l6STJZUzFsWVRjMExUUTVNbUV0WWpobU9DMHpOMlkyWkRFeE0yRmpOMklHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--782efc8406cc439231b834308dcd8cd59399ee2e/test
-                - id: 25dfe3ea-5499-4ecb-8817-2c0d9f374579
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWszTW1SaU5UWmxZUzAyTjJObExUUTJaR1V0T1dabU5DMW1NRGszTVRNek1EWXdaalFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2a9428052e04021dd1f2682084d42c2330d9e605/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWszTW1SaU5UWmxZUzAyTjJObExUUTJaR1V0T1dabU5DMW1NRGszTVRNek1EWXdaalFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2a9428052e04021dd1f2682084d42c2330d9e605/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWszTW1SaU5UWmxZUzAyTjJObExUUTJaR1V0T1dabU5DMW1NRGszTVRNek1EWXdaalFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2a9428052e04021dd1f2682084d42c2330d9e605/test
+                - id: b606f0a0-0220-49ea-852f-a0169de42825
                   type: project_image
                   attributes:
                     cover: false
-                    created_at: '2022-07-21T12:29:38.099Z'
+                    created_at: '2022-07-27T08:57:54.682Z'
                     file:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrTWpKa1l6STJZUzFsWVRjMExUUTVNbUV0WWpobU9DMHpOMlkyWkRFeE0yRmpOMklHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--782efc8406cc439231b834308dcd8cd59399ee2e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrTWpKa1l6STJZUzFsWVRjMExUUTVNbUV0WWpobU9DMHpOMlkyWkRFeE0yRmpOMklHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--782efc8406cc439231b834308dcd8cd59399ee2e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrTWpKa1l6STJZUzFsWVRjMExUUTVNbUV0WWpobU9DMHpOMlkyWkRFeE0yRmpOMklHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--782efc8406cc439231b834308dcd8cd59399ee2e/test
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWszTW1SaU5UWmxZUzAyTjJObExUUTJaR1V0T1dabU5DMW1NRGszTVRNek1EWXdaalFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2a9428052e04021dd1f2682084d42c2330d9e605/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3eU1EQjRNakF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--eecd42c95d4a671873063e8115ad147ca137769d/test
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWszTW1SaU5UWmxZUzAyTjJObExUUTJaR1V0T1dabU5DMW1NRGszTVRNek1EWXdaalFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2a9428052e04021dd1f2682084d42c2330d9e605/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lKYW5CbFp3WTZCa1ZVT2d0eVpYTnBlbVZKSWd3NE1EQjRPREF3QmpzR1ZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--7e1915aedd9d00d46843b05cad3232ede48b86eb/test
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWszTW1SaU5UWmxZUzAyTjJObExUUTJaR1V0T1dabU5DMW1NRGszTVRNek1EWXdaalFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2a9428052e04021dd1f2682084d42c2330d9e605/test
               schema:
                 type: object
                 properties:
@@ -1625,7 +1986,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 5dc5ab6a-6d98-4800-b085-5fb454fdb08d
+                  id: 52a8dd99-649e-4ccd-8a65-7dc704d7186f
                   type: project
                   attributes:
                     name: Updated Project Name
@@ -1669,7 +2030,7 @@ paths:
                       - 1
                       - 2
                     trusted: false
-                    created_at: '2022-07-21T12:29:44.828Z'
+                    created_at: '2022-07-27T08:58:02.661Z'
                     municipality_biodiversity_impact:
                     municipality_climate_impact:
                     municipality_water_impact:
@@ -1691,31 +2052,31 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: aa569d63-8dc1-4645-96bb-3aac3f7e0a3b
+                        id: b5825fa4-ab14-4aae-bdcb-3359fc01b5c9
                         type: project_developer
                     country:
                       data:
-                        id: b63437fd-f471-45a4-acd4-c988db0fb2c0
+                        id: 4035b50e-eeb5-468c-8766-56241c0f12d3
                         type: location
                     municipality:
                       data:
-                        id: 37dc3212-647f-4cd8-8d90-11c902bb35b8
+                        id: 2d8c29fe-b3d1-43f1-9f64-25a9a24de034
                         type: location
                     department:
                       data:
-                        id: 11797b22-0832-49fc-a605-2405164aa7d7
+                        id: 2f2e6046-8784-4183-888a-afb31a0a6aac
                         type: location
                     priority_landscape:
                       data:
                     involved_project_developers:
                       data:
-                      - id: b9800c4a-9973-4f2b-9ddc-253ddfd154cb
+                      - id: 8ac1d64e-1861-4c46-9011-c9e272a3e2e9
                         type: project_developer
-                      - id: d83330db-f16d-41d0-9c62-36121fd628d3
+                      - id: 0afd5ee7-b9b9-419a-afd2-093d7da95cb0
                         type: project_developer
                     project_images:
                       data:
-                      - id: f99c835d-fb0b-4344-ba21-e88bf6e42fbd
+                      - id: 988c96e5-3c32-4321-ad75-e368e66e83f1
                         type: project_image
               schema:
                 type: object
@@ -1955,6 +2316,180 @@ paths:
           application/json:
             schema:
               type: object
+  "/api/v1/account/projects/favourites":
+    get:
+      summary: Returns list of projects marked as favourite
+      tags:
+      - Projects
+      security:
+      - csrf: []
+        cookie_auth: []
+      parameters:
+      - name: page[number]
+        in: query
+        description: 'Page number. Default: 1'
+        required: false
+        schema:
+          type: integer
+      - name: page[size]
+        in: query
+        description: 'Per page items. Default: 10'
+        required: false
+        schema:
+          type: integer
+      - name: fields[project]
+        in: query
+        description: Get only required fields. Use comma to separate multiple fields
+        required: false
+        schema:
+          type: string
+      - name: includes
+        in: query
+        description: Include relationships. Use comma to separate multiple fields
+        required: false
+        schema:
+          type: string
+      responses:
+        '401':
+          description: Authentication failed
+          content:
+            application/json:
+              example:
+                errors:
+                - title: You need to sign in or sign up before continuing.
+                  code:
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              example:
+                errors:
+                - title: You are not authorized to access this page.
+              schema:
+                "$ref": "#/components/schemas/errors"
+        '200':
+          description: success
+          content:
+            application/json:
+              example:
+                data:
+                - id: 8a224305-79c2-4648-ba08-39097eca75dc
+                  type: project
+                  attributes:
+                    name: Project 1
+                    status: published
+                    slug: hane-lehner-and-goyette-project-1
+                    description: Enim repellat pariatur. Earum modi eos. Libero tempora
+                      exercitationem. Qui dolorem quo.
+                    development_stage: scaling-up
+                    estimated_duration_in_months: 13
+                    target_groups:
+                    - urban-populations
+                    - indigenous-peoples
+                    impact_areas:
+                    - pollutants-reduction
+                    - carbon-emission-reduction
+                    category: forestry-and-agroforestry
+                    sdgs:
+                    - 1
+                    - 4
+                    - 5
+                    involved_project_developer_not_listed: false
+                    problem: Enim repellat pariatur. Earum modi eos. Libero tempora
+                      exercitationem. Qui dolorem quo.
+                    solution: Enim repellat pariatur. Earum modi eos. Libero tempora
+                      exercitationem. Qui dolorem quo.
+                    expected_impact: Enim repellat pariatur. Earum modi eos. Libero
+                      tempora exercitationem. Qui dolorem quo.
+                    looking_for_funding: true
+                    ticket_size: scaling
+                    instrument_types:
+                    - grant
+                    - loan
+                    funding_plan: Enim repellat pariatur. Earum modi eos. Libero tempora
+                      exercitationem. Qui dolorem quo.
+                    sustainability: Enim repellat pariatur. Earum modi eos. Libero
+                      tempora exercitationem. Qui dolorem quo.
+                    replicability: Enim repellat pariatur. Earum modi eos. Libero
+                      tempora exercitationem. Qui dolorem quo.
+                    progress_impact_tracking: Enim repellat pariatur. Earum modi eos.
+                      Libero tempora exercitationem. Qui dolorem quo.
+                    received_funding: true
+                    received_funding_amount_usd: '3000.0'
+                    received_funding_investor: Kutch-Spencer
+                    relevant_links:
+                    language: en
+                    account_language: en
+                    geometry:
+                      type: Point
+                      coordinates:
+                      - 1.0
+                      - 2.0
+                    trusted: false
+                    created_at: '2022-07-27T08:58:18.121Z'
+                    municipality_biodiversity_impact:
+                    municipality_climate_impact:
+                    municipality_water_impact:
+                    municipality_community_impact:
+                    municipality_total_impact:
+                    hydrobasin_biodiversity_impact:
+                    hydrobasin_climate_impact:
+                    hydrobasin_water_impact:
+                    hydrobasin_community_impact:
+                    hydrobasin_total_impact:
+                    priority_landscape_biodiversity_impact:
+                    priority_landscape_climate_impact:
+                    priority_landscape_water_impact:
+                    priority_landscape_community_impact:
+                    priority_landscape_total_impact:
+                    latitude: 2.0
+                    longitude: 1.0
+                    favourite: true
+                  relationships:
+                    project_developer:
+                      data:
+                        id: 3fbcdfe1-a995-4361-a7ca-acf4610aa7ca
+                        type: project_developer
+                    country:
+                      data:
+                        id: 84b85017-b251-40e8-ba2b-5437039863a2
+                        type: location
+                    municipality:
+                      data:
+                        id: 0e7ea593-dee9-4084-b529-128a769f75ec
+                        type: location
+                    department:
+                      data:
+                        id: f60f0e0c-b043-4800-a328-5695d6a61ac3
+                        type: location
+                    priority_landscape:
+                      data:
+                    involved_project_developers:
+                      data: []
+                    project_images:
+                      data: []
+                meta:
+                  page: 1
+                  per_page: 10
+                  from: 1
+                  to: 1
+                  total: 1
+                  pages: 1
+                links:
+                  first: "/api/v1/projects?page%5Bsize%5D=10"
+                  self: "/api/v1/projects?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+                  last: "/api/v1/projects?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/project"
+                  meta:
+                    "$ref": "#/components/schemas/pagination_meta"
+                  links:
+                    "$ref": "#/components/schemas/pagination_links"
   "/api/v1/account/users":
     get:
       summary: Get current account users
@@ -1985,14 +2520,14 @@ paths:
             application/json:
               example:
                 data:
-                - id: f03c38a4-6723-477a-bf53-0fb340f54a06
+                - id: 48588b9a-e6ff-4330-b09d-65f7a7fce283
                   type: user
                   attributes:
                     first_name: Dawna
                     last_name: Block
                     email: dawna.block@example.org
                     role: light
-                    created_at: '2022-07-21T12:29:58.333Z'
+                    created_at: '2022-07-27T08:58:20.374Z'
                     ui_language: en
                     account_language: en
                     confirmed: true
@@ -2003,14 +2538,14 @@ paths:
                       small:
                       medium:
                       original:
-                - id: 970f8ea2-5e7b-4af3-add2-4ff001d9e4c5
+                - id: 5cac2ddb-eb89-4669-9daa-f0c149086f1b
                   type: user
                   attributes:
                     first_name: Desmond
                     last_name: Herzog
                     email: desmond_herzog@example.org
                     role: light
-                    created_at: '2022-07-21T12:29:58.375Z'
+                    created_at: '2022-07-27T08:58:20.427Z'
                     ui_language: en
                     account_language: en
                     confirmed: true
@@ -2021,14 +2556,14 @@ paths:
                       small:
                       medium:
                       original:
-                - id: 4afe30c6-6cfa-4f31-847b-03707b27d52d
+                - id: '0812732e-742f-48c4-a62a-90388bb3d09b'
                   type: user
                   attributes:
                     first_name: Raymon
                     last_name: Runte
                     email: runte_raymon@example.org
                     role: light
-                    created_at: '2022-07-21T12:29:58.385Z'
+                    created_at: '2022-07-27T08:58:20.439Z'
                     ui_language: en
                     account_language:
                     confirmed: true
@@ -2121,14 +2656,14 @@ paths:
             application/json:
               example:
                 data:
-                  id: 85ebed5b-1e3e-4557-b784-f711e312017a
+                  id: 39470558-3811-42e5-bf2e-cfdb904590d6
                   type: user
                   attributes:
                     first_name: Desmond
                     last_name: Herzog
                     email: desmond_herzog@example.org
                     role: light
-                    created_at: '2022-07-21T12:30:01.061Z'
+                    created_at: '2022-07-27T08:58:24.206Z'
                     ui_language: en
                     account_language: en
                     confirmed: true
@@ -2150,7 +2685,7 @@ paths:
             application/json:
               example:
                 errors:
-                - title: Couldn't find User with 'id'=f27d3ac1-6a3e-465a-873c-4f6a09f3795d
+                - title: Couldn't find User with 'id'=b9848197-e6dd-431f-ab4d-02ac57098caa
                     [WHERE "users"."account_id" = $1]
               schema:
                 "$ref": "#/components/schemas/errors"
@@ -2208,7 +2743,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: 4410cc35-91a2-4173-ba8e-b9700e45c19e
+                - id: '098b8ff8-585e-4dbf-af23-7f87677c4181'
                   type: background_job_event
                   attributes:
                     status: enqueued
@@ -2218,9 +2753,9 @@ paths:
                     priority:
                     executions: 1
                     message:
-                    created_at: '2022-07-11T12:30:01.469Z'
-                    updated_at: '2022-07-21T12:30:01.470Z'
-                - id: 9ee034e7-eb2f-4e8f-8f9b-b66d495ec8c7
+                    created_at: '2022-07-17T08:58:24.649Z'
+                    updated_at: '2022-07-27T08:58:24.649Z'
+                - id: 885a65dc-6c28-4522-af93-0fb41751fbc4
                   type: background_job_event
                   attributes:
                     status: crashed
@@ -2230,8 +2765,8 @@ paths:
                     priority:
                     executions: 1
                     message:
-                    created_at: '2022-07-21T12:30:01.465Z'
-                    updated_at: '2022-07-21T12:30:01.465Z'
+                    created_at: '2022-07-27T08:58:24.643Z'
+                    updated_at: '2022-07-27T08:58:24.643Z'
                 meta:
                   page: 1
                   per_page: 10
@@ -2292,14 +2827,14 @@ paths:
             application/json:
               example:
                 data:
-                  id: db18d885-79c8-444f-b5c2-3957e3ea18bd
+                  id: 2735e21b-ae20-4267-be99-e5fa560739a0
                   type: user
                   attributes:
                     first_name: Dawna
                     last_name: Block
                     email: user@example.com
                     role: light
-                    created_at: '2022-07-21T12:30:02.984Z'
+                    created_at: '2022-07-27T08:58:25.257Z'
                     ui_language: en
                     account_language:
                     confirmed: true
@@ -3132,7 +3667,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: 340208c3-6300-4988-bace-81cf38446ca9
+                - id: 358760ec-3e8c-4403-b3dd-6823ccb2cec2
                   type: investor
                   attributes:
                     name: Bartoletti and Sons
@@ -3170,20 +3705,20 @@ paths:
                     language: en
                     account_language: en
                     review_status: approved
-                    created_at: '2022-07-21T12:30:10.529Z'
+                    created_at: '2022-07-27T08:58:33.400Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrWm1RNE1EYzVZaTA1TmpZeExUUmlZVGd0WWpZME5TMDFNVGhsTnpreU5XRmxZbVVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--be90a0d1605da095e2f2319c4d3813a9fb477b08/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrWm1RNE1EYzVZaTA1TmpZeExUUmlZVGd0WWpZME5TMDFNVGhsTnpreU5XRmxZbVVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--be90a0d1605da095e2f2319c4d3813a9fb477b08/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrWm1RNE1EYzVZaTA1TmpZeExUUmlZVGd0WWpZME5TMDFNVGhsTnpreU5XRmxZbVVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--be90a0d1605da095e2f2319c4d3813a9fb477b08/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0WW1KbFlURXhOaTFpTURoakxUUTFZemN0T0RObE5DMWlNRGs0WkRReVpXVXpPVGdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--d98e7f7f104babb7c382b6929af85ea8f0bed768/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0WW1KbFlURXhOaTFpTURoakxUUTFZemN0T0RObE5DMWlNRGs0WkRReVpXVXpPVGdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--d98e7f7f104babb7c382b6929af85ea8f0bed768/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0WW1KbFlURXhOaTFpTURoakxUUTFZemN0T0RObE5DMWlNRGs0WkRReVpXVXpPVGdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--d98e7f7f104babb7c382b6929af85ea8f0bed768/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: b2c5ad86-f760-447b-b332-9dc7bb31f9ce
+                        id: 6934f0d8-4def-4842-831b-e847b5091427
                         type: user
-                - id: 292949cb-0bb7-47db-ba09-0e539b1f6968
+                - id: fa4a3818-78d3-4341-ae18-2984f072e4d6
                   type: investor
                   attributes:
                     name: Becker LLC
@@ -3221,20 +3756,20 @@ paths:
                     language: en
                     account_language: en
                     review_status: approved
-                    created_at: '2022-07-21T12:30:10.909Z'
+                    created_at: '2022-07-27T08:58:33.785Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWW1FNFlXRTFOeTFoWWpZNUxUUTROR0V0WWpWaVppMDFOR0ZrTXpsbU5XSTBaRFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--b653a9b86109533fb5a472094db451f6c080068a/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWW1FNFlXRTFOeTFoWWpZNUxUUTROR0V0WWpWaVppMDFOR0ZrTXpsbU5XSTBaRFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--b653a9b86109533fb5a472094db451f6c080068a/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWW1FNFlXRTFOeTFoWWpZNUxUUTROR0V0WWpWaVppMDFOR0ZrTXpsbU5XSTBaRFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--b653a9b86109533fb5a472094db451f6c080068a/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5TVRrNU1USTBaQzB6TkdaaExUUXlOemt0WVRZM055MWpaR1l4TWpNMVpEbGpZek1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--677a7343b7678ecb607562b9f1a18512439a52a5/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5TVRrNU1USTBaQzB6TkdaaExUUXlOemt0WVRZM055MWpaR1l4TWpNMVpEbGpZek1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--677a7343b7678ecb607562b9f1a18512439a52a5/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5TVRrNU1USTBaQzB6TkdaaExUUXlOemt0WVRZM055MWpaR1l4TWpNMVpEbGpZek1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--677a7343b7678ecb607562b9f1a18512439a52a5/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: edc7f55c-925d-4983-b9e3-c4c6022413d2
+                        id: 79d7006a-8558-4c40-925e-67b8d914382b
                         type: user
-                - id: 9cd2508b-841f-494a-ae9a-469c71031539
+                - id: 2defd266-7695-400c-9a65-d3ad2f7155c5
                   type: investor
                   attributes:
                     name: Gleichner-Bartoletti
@@ -3268,23 +3803,23 @@ paths:
                     - 1
                     - 5
                     previously_invested: true
-                    language: en
+                    language: pt
                     account_language: pt
                     review_status: approved
-                    created_at: '2022-07-21T12:30:11.179Z'
+                    created_at: '2022-07-27T08:58:34.028Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3WW1RNVlXRTBNUzA0WkdRMUxUUTRaamN0WW1Oak1TMDFNRFV4TnpJd016SXlOamdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--fa6fe12abad97262def6948c35c01e30fc310486/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3WW1RNVlXRTBNUzA0WkdRMUxUUTRaamN0WW1Oak1TMDFNRFV4TnpJd016SXlOamdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--fa6fe12abad97262def6948c35c01e30fc310486/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3WW1RNVlXRTBNUzA0WkdRMUxUUTRaamN0WW1Oak1TMDFNRFV4TnpJd016SXlOamdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--fa6fe12abad97262def6948c35c01e30fc310486/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrTkdabVlUWmhNUzA1WkdJekxUUmtNVGt0WWpJMk5pMWpPV1JsTkRsaE9UYzFOVE1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--97a83fc006b473fb7560b0bacc8ffd147601aedc/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrTkdabVlUWmhNUzA1WkdJekxUUmtNVGt0WWpJMk5pMWpPV1JsTkRsaE9UYzFOVE1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--97a83fc006b473fb7560b0bacc8ffd147601aedc/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrTkdabVlUWmhNUzA1WkdJekxUUmtNVGt0WWpJMk5pMWpPV1JsTkRsaE9UYzFOVE1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--97a83fc006b473fb7560b0bacc8ffd147601aedc/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 3051f1f4-ffc0-401f-8b24-0a942d9515aa
+                        id: a358e03f-4884-4609-8483-315b0100346c
                         type: user
-                - id: cd38b142-a84b-4c7d-82f5-2795fb64ad53
+                - id: b2553b48-444c-458c-b289-556121d6f57e
                   type: investor
                   attributes:
                     name: Hane, Lehner and Goyette
@@ -3322,20 +3857,20 @@ paths:
                     language: en
                     account_language: en
                     review_status: approved
-                    created_at: '2022-07-21T12:30:10.619Z'
+                    created_at: '2022-07-27T08:58:33.475Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswT0RRd05ESmhPQzB5TmpSbUxUUmlaR1V0WVRnNE5pMDVOekkyTm1aaE5UUmhPRGtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--3043ee07257bfb6dbdb0e21b2caa4e8d5ed7230a/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswT0RRd05ESmhPQzB5TmpSbUxUUmlaR1V0WVRnNE5pMDVOekkyTm1aaE5UUmhPRGtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--3043ee07257bfb6dbdb0e21b2caa4e8d5ed7230a/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswT0RRd05ESmhPQzB5TmpSbUxUUmlaR1V0WVRnNE5pMDVOekkyTm1aaE5UUmhPRGtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--3043ee07257bfb6dbdb0e21b2caa4e8d5ed7230a/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoTkRBMllXUmtaQzFsWlRnM0xUUXdZMlV0WW1Jd1pDMDJaRGhsWkRsaU4yTTJNV1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5879af8956b2553258464a2fd3ac4600ec9afd3a/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoTkRBMllXUmtaQzFsWlRnM0xUUXdZMlV0WW1Jd1pDMDJaRGhsWkRsaU4yTTJNV1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5879af8956b2553258464a2fd3ac4600ec9afd3a/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoTkRBMllXUmtaQzFsWlRnM0xUUXdZMlV0WW1Jd1pDMDJaRGhsWkRsaU4yTTJNV1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5879af8956b2553258464a2fd3ac4600ec9afd3a/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: a880213d-84f2-4942-b402-465e7338f09a
+                        id: 662899d7-acc8-404b-a6ab-b0a9243d2be5
                         type: user
-                - id: 7d28d46d-b0de-4336-bb94-3b7c3d8e308c
+                - id: 87a6810d-0c3a-49da-8215-b6ca8c88a205
                   type: investor
                   attributes:
                     name: Hilpert, Waters and Johnston
@@ -3373,20 +3908,20 @@ paths:
                     language: en
                     account_language: en
                     review_status: approved
-                    created_at: '2022-07-21T12:30:10.680Z'
+                    created_at: '2022-07-27T08:58:33.558Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWkRCak9ETmlPUzB5TW1GaUxUUmhNalF0WVdZM015MHdNVFpqTXpneE5XWTNPV1FHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4777b365963542ccf4477917d3d9463477a10036/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWkRCak9ETmlPUzB5TW1GaUxUUmhNalF0WVdZM015MHdNVFpqTXpneE5XWTNPV1FHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4777b365963542ccf4477917d3d9463477a10036/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWkRCak9ETmlPUzB5TW1GaUxUUmhNalF0WVdZM015MHdNVFpqTXpneE5XWTNPV1FHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4777b365963542ccf4477917d3d9463477a10036/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TkRobE5UQm1NUzB3TjJReExUUTNNemN0WVdObE55MWhNMlZtWkdWak9EaGlPVEVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--582e8eeb7a2f60d0be99f78820e86c082fdaf0ea/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TkRobE5UQm1NUzB3TjJReExUUTNNemN0WVdObE55MWhNMlZtWkdWak9EaGlPVEVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--582e8eeb7a2f60d0be99f78820e86c082fdaf0ea/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TkRobE5UQm1NUzB3TjJReExUUTNNemN0WVdObE55MWhNMlZtWkdWak9EaGlPVEVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--582e8eeb7a2f60d0be99f78820e86c082fdaf0ea/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 9932382f-fe92-4eed-b61d-01a5fc5c6d7e
+                        id: 3b2cf548-b4a7-435a-874b-b3294337de3c
                         type: user
-                - id: 0c8d4898-14cb-4dd4-97ef-e9f7966422e6
+                - id: 8437441b-7e30-47c1-8095-5082f8ae0682
                   type: investor
                   attributes:
                     name: Jacobson, Fritsch and Stanton
@@ -3424,20 +3959,20 @@ paths:
                     language: en
                     account_language: en
                     review_status: approved
-                    created_at: '2022-07-21T12:30:10.758Z'
+                    created_at: '2022-07-27T08:58:33.626Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTW1ZeE0yUmxPUzB4TUROakxUUXdNVEV0WW1VNVlpMDBNV1V3TTJWaE5HSTFOV0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2c9707a6ff1cd8d7ccb5a69969c4e0f7d21753b4/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTW1ZeE0yUmxPUzB4TUROakxUUXdNVEV0WW1VNVlpMDBNV1V3TTJWaE5HSTFOV0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2c9707a6ff1cd8d7ccb5a69969c4e0f7d21753b4/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTW1ZeE0yUmxPUzB4TUROakxUUXdNVEV0WW1VNVlpMDBNV1V3TTJWaE5HSTFOV0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2c9707a6ff1cd8d7ccb5a69969c4e0f7d21753b4/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyWmpRNE5HSXhNQzFtTURabUxUUTVPRGt0T0dJMU1DMWpOelpqTnpBNE9XTmxNemtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--bdc3514e5a748d46d96ff10c000b4a23148afa99/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyWmpRNE5HSXhNQzFtTURabUxUUTVPRGt0T0dJMU1DMWpOelpqTnpBNE9XTmxNemtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--bdc3514e5a748d46d96ff10c000b4a23148afa99/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyWmpRNE5HSXhNQzFtTURabUxUUTVPRGt0T0dJMU1DMWpOelpqTnpBNE9XTmxNemtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--bdc3514e5a748d46d96ff10c000b4a23148afa99/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 3d1d28c9-ded9-4972-85c9-102bbd18a6c1
+                        id: 994ba2ed-2ee0-4d11-be66-3bdcf1910571
                         type: user
-                - id: 285f689d-7b20-481a-81ac-d13b94c8f251
+                - id: b1c6b408-1577-4cdb-bf35-e8a43cdd776f
                   type: investor
                   attributes:
                     name: Keebler, Kub and Zemlak
@@ -3475,20 +4010,20 @@ paths:
                     language: en
                     account_language: en
                     review_status: approved
-                    created_at: '2022-07-21T12:30:10.829Z'
+                    created_at: '2022-07-27T08:58:33.709Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TVdWaU5qQTRaQzAxWTJFNUxUUXpPR1F0T0RjMU1pMHdaREV4T0dJeU4yUXhOR0lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--850ed229029a58b80420040a663f97f02325348c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TVdWaU5qQTRaQzAxWTJFNUxUUXpPR1F0T0RjMU1pMHdaREV4T0dJeU4yUXhOR0lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--850ed229029a58b80420040a663f97f02325348c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1TVdWaU5qQTRaQzAxWTJFNUxUUXpPR1F0T0RjMU1pMHdaREV4T0dJeU4yUXhOR0lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--850ed229029a58b80420040a663f97f02325348c/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3TlROa1pUazRPQzFtTlRabUxUUXdORGt0T0Rrd05DMHdPR0kzWmpkaU5qRmpaVEFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2741cef00255d23d7d32cc69dab769d153b4a370/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3TlROa1pUazRPQzFtTlRabUxUUXdORGt0T0Rrd05DMHdPR0kzWmpkaU5qRmpaVEFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2741cef00255d23d7d32cc69dab769d153b4a370/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3TlROa1pUazRPQzFtTlRabUxUUXdORGt0T0Rrd05DMHdPR0kzWmpkaU5qRmpaVEFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2741cef00255d23d7d32cc69dab769d153b4a370/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: c1489b76-1bf4-411c-befd-9c6a1e13512f
+                        id: ddcc4596-faf4-46c6-8d6d-7a1eadd14815
                         type: user
-                - id: 6d870ee4-443d-498b-960b-b1791754fc63
+                - id: '04526976-3abb-429c-ae8c-b0f52f1a3325'
                   type: investor
                   attributes:
                     name: Kutch-Spencer
@@ -3526,18 +4061,18 @@ paths:
                     language: en
                     account_language: en
                     review_status: approved
-                    created_at: '2022-07-21T12:30:10.452Z'
+                    created_at: '2022-07-27T08:58:33.323Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTWpsa01UQXlPUzFpTURNMUxUUmtNamd0T1dOaU5DMDFNbVZrTTJZd1pqZGtPR1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--81c385a0ad0787ac959f25162329fa934758dc84/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTWpsa01UQXlPUzFpTURNMUxUUmtNamd0T1dOaU5DMDFNbVZrTTJZd1pqZGtPR1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--81c385a0ad0787ac959f25162329fa934758dc84/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTWpsa01UQXlPUzFpTURNMUxUUmtNamd0T1dOaU5DMDFNbVZrTTJZd1pqZGtPR1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--81c385a0ad0787ac959f25162329fa934758dc84/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TXpWalpUVTROeTB5TVdWaExUUmhPRFl0WVRFNU9DMHdNalU1WkdVM1pUVXpaVElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--bdd38f7bbb630344da745fe94fcb758d78b6c629/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TXpWalpUVTROeTB5TVdWaExUUmhPRFl0WVRFNU9DMHdNalU1WkdVM1pUVXpaVElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--bdd38f7bbb630344da745fe94fcb758d78b6c629/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TXpWalpUVTROeTB5TVdWaExUUmhPRFl0WVRFNU9DMHdNalU1WkdVM1pUVXpaVElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--bdd38f7bbb630344da745fe94fcb758d78b6c629/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 4853a05b-be30-4bee-b5d7-6f55246a9e05
+                        id: 594d5ccd-327e-43e2-a137-c43272c36e21
                         type: user
                 meta:
                   page: 1
@@ -3601,7 +4136,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 6d870ee4-443d-498b-960b-b1791754fc63
+                  id: '04526976-3abb-429c-ae8c-b0f52f1a3325'
                   type: investor
                   attributes:
                     name: Kutch-Spencer
@@ -3639,18 +4174,18 @@ paths:
                     language: en
                     account_language: en
                     review_status: approved
-                    created_at: '2022-07-21T12:30:10.452Z'
+                    created_at: '2022-07-27T08:58:33.323Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTWpsa01UQXlPUzFpTURNMUxUUmtNamd0T1dOaU5DMDFNbVZrTTJZd1pqZGtPR1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--81c385a0ad0787ac959f25162329fa934758dc84/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTWpsa01UQXlPUzFpTURNMUxUUmtNamd0T1dOaU5DMDFNbVZrTTJZd1pqZGtPR1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--81c385a0ad0787ac959f25162329fa934758dc84/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTWpsa01UQXlPUzFpTURNMUxUUmtNamd0T1dOaU5DMDFNbVZrTTJZd1pqZGtPR1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--81c385a0ad0787ac959f25162329fa934758dc84/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TXpWalpUVTROeTB5TVdWaExUUmhPRFl0WVRFNU9DMHdNalU1WkdVM1pUVXpaVElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--bdd38f7bbb630344da745fe94fcb758d78b6c629/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TXpWalpUVTROeTB5TVdWaExUUmhPRFl0WVRFNU9DMHdNalU1WkdVM1pUVXpaVElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--bdd38f7bbb630344da745fe94fcb758d78b6c629/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TXpWalpUVTROeTB5TVdWaExUUmhPRFl0WVRFNU9DMHdNalU1WkdVM1pUVXpaVElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--bdd38f7bbb630344da745fe94fcb758d78b6c629/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 4853a05b-be30-4bee-b5d7-6f55246a9e05
+                        id: 594d5ccd-327e-43e2-a137-c43272c36e21
                         type: user
               schema:
                 type: object
@@ -3782,16 +4317,16 @@ paths:
             application/json:
               example:
                 data:
-                  id: 8cacabdb-f2c9-4a9b-b95d-84f24ec72e63
+                  id: b838601c-0ba4-4080-9d46-fc0ea839dfe1
                   type: user
                   attributes:
                     first_name: Dawna
                     last_name: Block
                     email: dawna.block@example.org
                     role: light
-                    created_at: '2022-07-21T12:30:15.046Z'
-                    ui_language: en
-                    account_language: en
+                    created_at: '2022-07-27T08:58:37.089Z'
+                    ui_language: es
+                    account_language: pt
                     confirmed: true
                     approved: true
                     invitation: completed
@@ -3873,58 +4408,58 @@ paths:
             application/json:
               example:
                 data:
-                - id: 79ed31d9-a7c6-4f08-a54c-71962ddeb82e
+                - id: 9a1f32ce-4a26-4e92-b265-1927cf1d516d
                   type: location
                   attributes:
                     name: Canada
                     location_type: country
-                    created_at: '2022-07-21T12:30:15.691Z'
+                    created_at: '2022-07-27T08:58:37.769Z'
                   relationships:
                     parent:
                       data:
-                - id: 788ee1d1-0336-4a2b-97a3-fb722ffd6c12
+                - id: f5770daa-44a2-459a-91d9-84942c530156
                   type: location
                   attributes:
                     name: Papua New Guinea
                     location_type: department
-                    created_at: '2022-07-21T12:30:15.695Z'
+                    created_at: '2022-07-27T08:58:37.776Z'
                   relationships:
                     parent:
                       data:
-                        id: 79ed31d9-a7c6-4f08-a54c-71962ddeb82e
+                        id: 9a1f32ce-4a26-4e92-b265-1927cf1d516d
                         type: location
-                - id: 7c5795aa-4dfe-45df-ba3b-2a4dd3b9ec9e
+                - id: 45324002-b498-42c5-94f4-f864ce3d1ae3
                   type: location
                   attributes:
                     name: Jamaica
                     location_type: municipality
-                    created_at: '2022-07-21T12:30:15.699Z'
+                    created_at: '2022-07-27T08:58:37.784Z'
                   relationships:
                     parent:
                       data:
-                        id: 788ee1d1-0336-4a2b-97a3-fb722ffd6c12
+                        id: f5770daa-44a2-459a-91d9-84942c530156
                         type: location
-                - id: 52b8b132-1081-477f-9ce2-1f0c7c7aed45
+                - id: cc3efc3b-a2ab-4ad1-a805-34cd1f860466
                   type: location
                   attributes:
                     name: Libyan Arab Jamahiriya
                     location_type: municipality
-                    created_at: '2022-07-21T12:30:15.703Z'
+                    created_at: '2022-07-27T08:58:37.788Z'
                   relationships:
                     parent:
                       data:
-                        id: 788ee1d1-0336-4a2b-97a3-fb722ffd6c12
+                        id: f5770daa-44a2-459a-91d9-84942c530156
                         type: location
-                - id: 8d6129c1-97b8-45c0-a443-d9af73af54fb
+                - id: cc396411-81c8-4203-aec8-9224c13c5897
                   type: location
                   attributes:
                     name: India
                     location_type: municipality
-                    created_at: '2022-07-21T12:30:15.707Z'
+                    created_at: '2022-07-27T08:58:37.794Z'
                   relationships:
                     parent:
                       data:
-                        id: 788ee1d1-0336-4a2b-97a3-fb722ffd6c12
+                        id: f5770daa-44a2-459a-91d9-84942c530156
                         type: location
               schema:
                 type: object
@@ -3973,16 +4508,16 @@ paths:
             application/json:
               example:
                 data:
-                  id: 7c5795aa-4dfe-45df-ba3b-2a4dd3b9ec9e
+                  id: 45324002-b498-42c5-94f4-f864ce3d1ae3
                   type: location
                   attributes:
                     name: Jamaica
                     location_type: municipality
-                    created_at: '2022-07-21T12:30:15.699Z'
+                    created_at: '2022-07-27T08:58:37.784Z'
                   relationships:
                     parent:
                       data:
-                        id: 788ee1d1-0336-4a2b-97a3-fb722ffd6c12
+                        id: f5770daa-44a2-459a-91d9-84942c530156
                         type: location
               schema:
                 type: object
@@ -4067,7 +4602,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: 00ac9ba3-cd21-4bed-a152-067ed1255e4c
+                - id: 5f4ee694-0483-404f-b0db-242637009b41
                   type: open_call
                   attributes:
                     name: Open call 1
@@ -4084,17 +4619,17 @@ paths:
                       tempora exercitationem. Qui dolorem quo.
                     impact_description: Enim repellat pariatur. Earum modi eos. Libero
                       tempora exercitationem. Qui dolorem quo.
-                    closing_at: '2023-05-21T12:30:16.160Z'
+                    closing_at: '2023-05-27T08:58:38.140Z'
                     language: en
                     account_language: en
                     trusted: false
-                    created_at: '2022-07-21T12:30:16.276Z'
+                    created_at: '2022-07-27T08:58:38.146Z'
                   relationships:
                     investor:
                       data:
-                        id: 790e5903-e299-408e-9c30-8a86854c48f6
+                        id: 4fbf3005-960c-4f32-8c3f-4009f1704e52
                         type: investor
-                - id: 1d6ac1f9-273a-4317-9432-22594dfa4d13
+                - id: 1243c5e8-82c6-46f9-a124-f785977043e7
                   type: open_call
                   attributes:
                     name: Open call 2
@@ -4111,17 +4646,17 @@ paths:
                       Sunt commodi tempore. Voluptatem et corrupti.
                     impact_description: Placeat commodi libero. Quo recusandae repellat.
                       Sunt commodi tempore. Voluptatem et corrupti.
-                    closing_at: '2023-05-21T12:30:16.397Z'
+                    closing_at: '2023-05-27T08:58:38.234Z'
                     language: en
                     account_language: en
                     trusted: false
-                    created_at: '2022-07-21T12:30:16.404Z'
+                    created_at: '2022-07-27T08:58:38.237Z'
                   relationships:
                     investor:
                       data:
-                        id: fb5e8025-2aa3-4eec-ba72-d1825c4a36ae
+                        id: 40167a2e-8c62-4cda-85b8-4edb2425e1d3
                         type: investor
-                - id: 8b3220f1-dfb0-4e68-98a2-7a81cb20695f
+                - id: 0c3ca2e1-d658-435c-bfe2-6479e515e983
                   type: open_call
                   attributes:
                     name: Open call 3
@@ -4138,17 +4673,17 @@ paths:
                       nesciunt voluptas. Suscipit ex cum.
                     impact_description: Et quaerat omnis. Harum voluptas atque. Quo
                       nesciunt voluptas. Suscipit ex cum.
-                    closing_at: '2023-05-21T12:30:16.490Z'
+                    closing_at: '2023-05-27T08:58:38.332Z'
                     language: en
                     account_language: en
                     trusted: false
-                    created_at: '2022-07-21T12:30:16.494Z'
+                    created_at: '2022-07-27T08:58:38.335Z'
                   relationships:
                     investor:
                       data:
-                        id: 9d0913a2-bfd6-4ce6-8a51-bb28ac17f904
+                        id: d83abe93-6edc-4306-b9f5-623cb461853b
                         type: investor
-                - id: bc5f6e0d-070a-4be6-b866-f5f5ace9d3bc
+                - id: ee69ba62-92c3-40ae-b7dd-c6163b4faf32
                   type: open_call
                   attributes:
                     name: Open call 4
@@ -4165,17 +4700,17 @@ paths:
                       Sit neque eos. Expedita molestiae quia.
                     impact_description: Dolores fugiat nesciunt. Ut laborum dolores.
                       Sit neque eos. Expedita molestiae quia.
-                    closing_at: '2023-05-21T12:30:16.585Z'
+                    closing_at: '2023-05-27T08:58:38.446Z'
                     language: en
                     account_language: en
                     trusted: false
-                    created_at: '2022-07-21T12:30:16.590Z'
+                    created_at: '2022-07-27T08:58:38.449Z'
                   relationships:
                     investor:
                       data:
-                        id: e831f983-4747-4ec0-b8f9-467d51d4dc5d
+                        id: 195e0a60-441f-4878-8e4c-b07a8fcb37a5
                         type: investor
-                - id: 68604047-f77e-484a-995c-a0afeaad43d8
+                - id: c5184e3c-b770-427b-a547-5b2f1dfeb6fb
                   type: open_call
                   attributes:
                     name: Open call 5
@@ -4192,17 +4727,17 @@ paths:
                       recusandae eum. Eius ex est.
                     impact_description: Autem et et. Voluptatem neque quibusdam. Repellat
                       recusandae eum. Eius ex est.
-                    closing_at: '2023-05-21T12:30:16.673Z'
+                    closing_at: '2023-05-27T08:58:38.546Z'
                     language: en
                     account_language: en
                     trusted: false
-                    created_at: '2022-07-21T12:30:16.677Z'
+                    created_at: '2022-07-27T08:58:38.549Z'
                   relationships:
                     investor:
                       data:
-                        id: 73dd0010-521b-4a27-9596-a7c0ef200f6f
+                        id: a8972ca0-70f3-47e5-aa55-61a35f3a5517
                         type: investor
-                - id: 58a2fb97-1070-41b2-8a7d-5aa1143afc9d
+                - id: 8f11e3c4-8c0f-4df2-9e75-330fad9dd93b
                   type: open_call
                   attributes:
                     name: Open call 6
@@ -4219,17 +4754,17 @@ paths:
                       Eligendi sapiente voluptatem. Quas rerum officia.
                     impact_description: Porro soluta beatae. Quia ratione facilis.
                       Eligendi sapiente voluptatem. Quas rerum officia.
-                    closing_at: '2023-05-21T12:30:16.788Z'
+                    closing_at: '2023-05-27T08:58:38.647Z'
                     language: en
                     account_language: en
                     trusted: false
-                    created_at: '2022-07-21T12:30:16.793Z'
+                    created_at: '2022-07-27T08:58:38.650Z'
                   relationships:
                     investor:
                       data:
-                        id: b12900ba-e9e1-4ef4-83a7-ab4ae476bed7
+                        id: 9efb5a09-7879-4f80-919f-958d24fd5351
                         type: investor
-                - id: 608a85e4-8a06-4f98-a901-50dcc3f13d79
+                - id: 0f92d21f-897d-42c4-95f7-44f04b8c72f1
                   type: open_call
                   attributes:
                     name: Open call 7
@@ -4246,17 +4781,17 @@ paths:
                       laudantium et. Sed recusandae aut.
                     impact_description: Mollitia aut vel. Qui illum accusantium. Et
                       laudantium et. Sed recusandae aut.
-                    closing_at: '2023-05-21T12:30:16.887Z'
+                    closing_at: '2023-05-27T08:58:38.746Z'
                     language: en
                     account_language: en
                     trusted: false
-                    created_at: '2022-07-21T12:30:16.890Z'
+                    created_at: '2022-07-27T08:58:38.749Z'
                   relationships:
                     investor:
                       data:
-                        id: 3c4cc9f8-4674-4c10-afb0-8aab351fe1bc
+                        id: c7127d15-1335-406a-bc0c-745d48099dd6
                         type: investor
-                - id: 3380612d-a0fd-45f3-81ca-3a4ef8a96494
+                - id: 31b3aa5e-31e1-4f7f-8ed4-7067c2020499
                   type: open_call
                   attributes:
                     name: Open call 9
@@ -4272,15 +4807,15 @@ paths:
                       quia officiis. Non aut sit.
                     impact_description: Impedit animi eveniet. Quia illum aut. Dolore
                       quia officiis. Non aut sit.
-                    closing_at: '2023-05-21T12:30:17.297Z'
+                    closing_at: '2023-05-27T08:58:38.997Z'
                     language: en
                     account_language: pt
                     trusted: false
-                    created_at: '2022-07-21T12:30:17.301Z'
+                    created_at: '2022-07-27T08:58:39.000Z'
                   relationships:
                     investor:
                       data:
-                        id: b0b3a510-362b-4f18-a266-f332a2603777
+                        id: 1eb08e79-b2fe-42a4-b713-36de6a07d9a8
                         type: investor
                 meta:
                   page: 1
@@ -4344,7 +4879,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 00ac9ba3-cd21-4bed-a152-067ed1255e4c
+                  id: 5f4ee694-0483-404f-b0db-242637009b41
                   type: open_call
                   attributes:
                     name: Open call 1
@@ -4361,15 +4896,15 @@ paths:
                       tempora exercitationem. Qui dolorem quo.
                     impact_description: Enim repellat pariatur. Earum modi eos. Libero
                       tempora exercitationem. Qui dolorem quo.
-                    closing_at: '2023-05-21T12:30:16.160Z'
+                    closing_at: '2023-05-27T08:58:38.140Z'
                     language: en
                     account_language: en
                     trusted: false
-                    created_at: '2022-07-21T12:30:16.276Z'
+                    created_at: '2022-07-27T08:58:38.146Z'
                   relationships:
                     investor:
                       data:
-                        id: 790e5903-e299-408e-9c30-8a86854c48f6
+                        id: 4fbf3005-960c-4f32-8c3f-4009f1704e52
                         type: investor
               schema:
                 type: object
@@ -4454,7 +4989,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: 6479e4ba-153f-4aef-9213-5db45e44c89a
+                - id: 4cdbda30-334a-4e2c-a907-78225e36b627
                   type: project_developer
                   attributes:
                     name: Bartoletti and Sons
@@ -4482,26 +5017,26 @@ paths:
                     mosaics:
                     - amazon-heart
                     - amazonian-piedmont-massif
-                    created_at: '2022-07-21T12:30:18.267Z'
+                    created_at: '2022-07-27T08:58:39.699Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3TkRVMFltSmtOaTFpWVRrM0xUUm1ZbVl0T1dKaFpTMHpNMkV4Wm1FME5HVmtPV1VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--505074c3d72b8f700b7a28abb11634f0ad1c70f9/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3TkRVMFltSmtOaTFpWVRrM0xUUm1ZbVl0T1dKaFpTMHpNMkV4Wm1FME5HVmtPV1VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--505074c3d72b8f700b7a28abb11634f0ad1c70f9/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3TkRVMFltSmtOaTFpWVRrM0xUUm1ZbVl0T1dKaFpTMHpNMkV4Wm1FME5HVmtPV1VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--505074c3d72b8f700b7a28abb11634f0ad1c70f9/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsWXpGaU9ESm1NeTFsTkRVekxUUmtNV1V0T1dVM01TMHpOakprWW1Ga01tUXhaalFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e02870539db20c2ab1aa03c01c6944517b2527ea/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsWXpGaU9ESm1NeTFsTkRVekxUUmtNV1V0T1dVM01TMHpOakprWW1Ga01tUXhaalFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e02870539db20c2ab1aa03c01c6944517b2527ea/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsWXpGaU9ESm1NeTFsTkRVekxUUmtNV1V0T1dVM01TMHpOakprWW1Ga01tUXhaalFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e02870539db20c2ab1aa03c01c6944517b2527ea/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 7c1ac75d-cdd4-4a01-84c3-b8c948ccf26f
+                        id: 5eef7049-bad7-45b6-adc7-1b95e11fc180
                         type: user
                     projects:
                       data:
-                      - id: a4540bcb-dafa-4c24-99c6-c31284229c4a
+                      - id: 31c0d218-b898-4844-9bd5-d324b94157bb
                         type: project
                     involved_projects:
                       data: []
-                - id: 7f148f7b-875b-49d6-8c84-df2bd8193320
+                - id: 91e71d9f-67d6-4337-9d1d-f3d247e5f0ac
                   type: project_developer
                   attributes:
                     name: Becker LLC
@@ -4529,24 +5064,24 @@ paths:
                     mosaics:
                     - amazon-heart
                     - amazonian-piedmont-massif
-                    created_at: '2022-07-21T12:30:18.955Z'
+                    created_at: '2022-07-27T08:58:40.185Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WTJFeU56TTNOQzFtT0RaaExUUmhOamN0WWpobU5TMWhNV0k1TURObFlXUTRPREFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f7aa82265ff1dc877c5cd987be47b5c08a495b16/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WTJFeU56TTNOQzFtT0RaaExUUmhOamN0WWpobU5TMWhNV0k1TURObFlXUTRPREFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f7aa82265ff1dc877c5cd987be47b5c08a495b16/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WTJFeU56TTNOQzFtT0RaaExUUmhOamN0WWpobU5TMWhNV0k1TURObFlXUTRPREFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f7aa82265ff1dc877c5cd987be47b5c08a495b16/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrWmpBeFptUmhZUzB5WkdKaUxUUTNPV010WW1FNVppMHpZelV6TURsa09UUmtabVVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--75298bd420cd6fa751867d97a31ec745a455e1d7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrWmpBeFptUmhZUzB5WkdKaUxUUTNPV010WW1FNVppMHpZelV6TURsa09UUmtabVVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--75298bd420cd6fa751867d97a31ec745a455e1d7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrWmpBeFptUmhZUzB5WkdKaUxUUTNPV010WW1FNVppMHpZelV6TURsa09UUmtabVVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--75298bd420cd6fa751867d97a31ec745a455e1d7/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: '0418b0b0-9bda-4099-8534-5e69f76fa2d0'
+                        id: ae8b3ced-85a9-470c-9f86-c8ecccc95f62
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data: []
-                - id: 6741a513-771a-474a-84c0-aea993bdbe38
+                - id: f9dc1e77-2f3b-4580-be25-9ad61649e23a
                   type: project_developer
                   attributes:
                     name: Hane, Lehner and Goyette
@@ -4574,26 +5109,26 @@ paths:
                     mosaics:
                     - amazon-heart
                     - amazonian-piedmont-massif
-                    created_at: '2022-07-21T12:30:18.399Z'
+                    created_at: '2022-07-27T08:58:39.837Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWszTXpBNVlqSmtNeTB3TXpaakxUUTJaREF0WWpoa1ppMHdOMk01TUdWa016ZGlZemNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2328e5e9993ac13e619e5901926e5ca670982750/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWszTXpBNVlqSmtNeTB3TXpaakxUUTJaREF0WWpoa1ppMHdOMk01TUdWa016ZGlZemNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2328e5e9993ac13e619e5901926e5ca670982750/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWszTXpBNVlqSmtNeTB3TXpaakxUUTJaREF0WWpoa1ppMHdOMk01TUdWa016ZGlZemNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2328e5e9993ac13e619e5901926e5ca670982750/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WXpWbFpqSXdNUzFsTWpVeExUUTJORFV0WVdWak5pMDFabUU1TTJZNE56QTVORGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c4bfe8cef462ce638201060a02fb0a7907452dd1/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WXpWbFpqSXdNUzFsTWpVeExUUTJORFV0WVdWak5pMDFabUU1TTJZNE56QTVORGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c4bfe8cef462ce638201060a02fb0a7907452dd1/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WXpWbFpqSXdNUzFsTWpVeExUUTJORFV0WVdWak5pMDFabUU1TTJZNE56QTVORGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c4bfe8cef462ce638201060a02fb0a7907452dd1/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 78af7b61-ccae-41f7-9d08-3ae9edc697ac
+                        id: 52751522-38b0-4312-b373-e42db5a72b7b
                         type: user
                     projects:
                       data:
-                      - id: 18391105-5dff-4225-80e0-4216cf30cb2f
+                      - id: e9c38b65-4245-43f0-80f6-bbbb3992dbbe
                         type: project
                     involved_projects:
                       data: []
-                - id: af9c6100-0768-4913-8b8f-3776411cea09
+                - id: f9ca417e-1ff7-4e82-9dd0-b54e4ff373f6
                   type: project_developer
                   attributes:
                     name: Hilpert, Waters and Johnston
@@ -4621,24 +5156,24 @@ paths:
                     mosaics:
                     - amazon-heart
                     - amazonian-piedmont-massif
-                    created_at: '2022-07-21T12:30:18.586Z'
+                    created_at: '2022-07-27T08:58:39.990Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WVRVek9UZ3dZaTFrWmpJMUxUUXpabVl0T1dSbVppMHpOekkyTVRsaU1ESmpaV0lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5d804be6a9e1387d46563965e022d9164ea7bbac/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WVRVek9UZ3dZaTFrWmpJMUxUUXpabVl0T1dSbVppMHpOekkyTVRsaU1ESmpaV0lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5d804be6a9e1387d46563965e022d9164ea7bbac/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WVRVek9UZ3dZaTFrWmpJMUxUUXpabVl0T1dSbVppMHpOekkyTVRsaU1ESmpaV0lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5d804be6a9e1387d46563965e022d9164ea7bbac/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpWW1JME9HUmpPQzB3WTJVd0xUUmxOMlV0WWprMll5MHpZV0ZoWldKaE1ERmhNekFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--10078d567d91cbdd4ea516be934613f69b024f6a/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpWW1JME9HUmpPQzB3WTJVd0xUUmxOMlV0WWprMll5MHpZV0ZoWldKaE1ERmhNekFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--10078d567d91cbdd4ea516be934613f69b024f6a/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpWW1JME9HUmpPQzB3WTJVd0xUUmxOMlV0WWprMll5MHpZV0ZoWldKaE1ERmhNekFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--10078d567d91cbdd4ea516be934613f69b024f6a/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 2174bd59-ca8d-4b78-b767-7a7952e81201
+                        id: fb9635b8-806b-464a-a335-d6a1f318a9e0
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data: []
-                - id: f14dcdfb-1d45-45a2-9b67-e8bc8df0431c
+                - id: 492aca89-1a5c-491f-b348-095fe6e7cc4f
                   type: project_developer
                   attributes:
                     name: Jacobson, Fritsch and Stanton
@@ -4666,24 +5201,24 @@ paths:
                     mosaics:
                     - amazon-heart
                     - amazonian-piedmont-massif
-                    created_at: '2022-07-21T12:30:18.656Z'
+                    created_at: '2022-07-27T08:58:40.056Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTWpaaVkyTmtaaTB4WWpJMkxUUm1ZalV0WWpreU5pMWlNbU0wTW1JNVpUWmxPVFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a47f4f0b8f9cb12e926cfd40fdb5c7ad8a91f258/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTWpaaVkyTmtaaTB4WWpJMkxUUm1ZalV0WWpreU5pMWlNbU0wTW1JNVpUWmxPVFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a47f4f0b8f9cb12e926cfd40fdb5c7ad8a91f258/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTWpaaVkyTmtaaTB4WWpJMkxUUm1ZalV0WWpreU5pMWlNbU0wTW1JNVpUWmxPVFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a47f4f0b8f9cb12e926cfd40fdb5c7ad8a91f258/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6T0RrMlltWmlaaTB6TVRVMkxUUm1Nakl0T0RjME5pMHlZVFl6WkRrMlpUa3pNV1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2dff2db0dd0c5d9ca15d1f2c431a10ad9ba8e6d0/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6T0RrMlltWmlaaTB6TVRVMkxUUm1Nakl0T0RjME5pMHlZVFl6WkRrMlpUa3pNV1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2dff2db0dd0c5d9ca15d1f2c431a10ad9ba8e6d0/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6T0RrMlltWmlaaTB6TVRVMkxUUm1Nakl0T0RjME5pMHlZVFl6WkRrMlpUa3pNV1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2dff2db0dd0c5d9ca15d1f2c431a10ad9ba8e6d0/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 68f8abe5-a5c7-41b0-8f08-80f891af338b
+                        id: 754de1fc-9366-438f-a92e-57fc116f3c0b
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data: []
-                - id: e64e0198-93c8-41ec-a6b0-68cb490e5714
+                - id: bd7bdacd-95a3-4e99-a820-6d65bad3bc0a
                   type: project_developer
                   attributes:
                     name: Keebler, Kub and Zemlak
@@ -4711,24 +5246,24 @@ paths:
                     mosaics:
                     - amazon-heart
                     - amazonian-piedmont-massif
-                    created_at: '2022-07-21T12:30:18.715Z'
+                    created_at: '2022-07-27T08:58:40.121Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrTnpZeE56TTJOaTAyTVdRNExUUm1NbUV0WW1VeU5pMDRPVFEzWkdZek1ETTNOalFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ab79dac71b75376563696d4c378676985b23ac9d/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrTnpZeE56TTJOaTAyTVdRNExUUm1NbUV0WW1VeU5pMDRPVFEzWkdZek1ETTNOalFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ab79dac71b75376563696d4c378676985b23ac9d/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrTnpZeE56TTJOaTAyTVdRNExUUm1NbUV0WW1VeU5pMDRPVFEzWkdZek1ETTNOalFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ab79dac71b75376563696d4c378676985b23ac9d/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0TlRrd09XUTRNeTAyTTJKbUxUUmxNemd0T1RWaVl5MDBZbUUwWVRVMVpqUTJNVFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--af1b980dd7aa00d13d432fc55c41eac42c52d2dd/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0TlRrd09XUTRNeTAyTTJKbUxUUmxNemd0T1RWaVl5MDBZbUUwWVRVMVpqUTJNVFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--af1b980dd7aa00d13d432fc55c41eac42c52d2dd/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0TlRrd09XUTRNeTAyTTJKbUxUUmxNemd0T1RWaVl5MDBZbUUwWVRVMVpqUTJNVFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--af1b980dd7aa00d13d432fc55c41eac42c52d2dd/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 10837066-77b8-450d-80eb-4a232192a486
+                        id: 16dbc16e-5e5e-4734-ab6c-833ef397a755
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data: []
-                - id: 1d68eb39-225a-480b-9bcc-38e88c74b643
+                - id: f89015dd-73de-45f8-a083-2c82d3834dcb
                   type: project_developer
                   attributes:
                     name: Kutch-Spencer
@@ -4755,28 +5290,28 @@ paths:
                     mosaics:
                     - amazon-heart
                     - amazonian-piedmont-massif
-                    created_at: '2022-07-21T12:30:18.499Z'
+                    created_at: '2022-07-27T08:58:39.922Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TlRFMk4yTTFZaTA1TXpVekxUUTFOR1l0WVRWa05DMHhNMlJqTkRBMVl6VXlNRGdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a5cd28a4730ba63c593f088b01ba5a91468aad5c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TlRFMk4yTTFZaTA1TXpVekxUUTFOR1l0WVRWa05DMHhNMlJqTkRBMVl6VXlNRGdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a5cd28a4730ba63c593f088b01ba5a91468aad5c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TlRFMk4yTTFZaTA1TXpVekxUUTFOR1l0WVRWa05DMHhNMlJqTkRBMVl6VXlNRGdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a5cd28a4730ba63c593f088b01ba5a91468aad5c/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5WVdZM09XUmxZeTFtTUdNekxUUXpObVF0T1RWaVl5MDBPVEptTURrek56UXhZbUlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6639267eb063664a8d317147887d6bf9b4814f81/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5WVdZM09XUmxZeTFtTUdNekxUUXpObVF0T1RWaVl5MDBPVEptTURrek56UXhZbUlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6639267eb063664a8d317147887d6bf9b4814f81/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5WVdZM09XUmxZeTFtTUdNekxUUXpObVF0T1RWaVl5MDBPVEptTURrek56UXhZbUlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6639267eb063664a8d317147887d6bf9b4814f81/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 17bfe1b2-1e72-440f-9a1f-4d6439c684b0
+                        id: 64ad9ea3-8151-4fc0-8354-a83dfca30a6e
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data:
-                      - id: a4540bcb-dafa-4c24-99c6-c31284229c4a
+                      - id: 31c0d218-b898-4844-9bd5-d324b94157bb
                         type: project
-                      - id: 18391105-5dff-4225-80e0-4216cf30cb2f
+                      - id: e9c38b65-4245-43f0-80f6-bbbb3992dbbe
                         type: project
-                - id: b9c48115-9386-4850-924e-c4208889ab9f
+                - id: dc3492cb-ef67-4add-9e25-33c38a9f1c53
                   type: project_developer
                   attributes:
                     name: Lind, Langworth and Gottlieb
@@ -4796,31 +5331,31 @@ paths:
                     impacts:
                     - climate
                     - water
-                    language: en
+                    language: pt
                     account_language: pt
                     entity_legal_registration_number: '564823570'
                     review_status: approved
                     mosaics:
                     - amazon-heart
                     - amazonian-piedmont-massif
-                    created_at: '2022-07-21T12:30:19.396Z'
+                    created_at: '2022-07-27T08:58:40.551Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsTTJNeU1UWTNPQzB4WXpCbUxUUmhNV0V0WW1NM1ppMWtZak5pWXpFMVlUUmpabVVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--b899e507fce897e182463ed2415176782bc5a51a/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsTTJNeU1UWTNPQzB4WXpCbUxUUmhNV0V0WW1NM1ppMWtZak5pWXpFMVlUUmpabVVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--b899e507fce897e182463ed2415176782bc5a51a/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsTTJNeU1UWTNPQzB4WXpCbUxUUmhNV0V0WW1NM1ppMWtZak5pWXpFMVlUUmpabVVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--b899e507fce897e182463ed2415176782bc5a51a/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3TmpjMk1qTTFOaTB6TUdVNUxUUXdaamt0T0RBelpTMDBNalkxTXpCaE1USTBNelFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2a02777015f5a5dfac41b2cfac60948915fe1b27/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3TmpjMk1qTTFOaTB6TUdVNUxUUXdaamt0T0RBelpTMDBNalkxTXpCaE1USTBNelFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2a02777015f5a5dfac41b2cfac60948915fe1b27/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3TmpjMk1qTTFOaTB6TUdVNUxUUXdaamt0T0RBelpTMDBNalkxTXpCaE1USTBNelFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2a02777015f5a5dfac41b2cfac60948915fe1b27/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 376d4f9d-664e-4a29-83b0-b169f7a1a8df
+                        id: a504e001-9102-4d9b-b120-d285db29342e
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data: []
-                - id: '060823ac-33b8-4cbe-b44d-43578e14d2e8'
+                - id: c378a570-1198-4eca-8ae6-79c3c1502b34
                   type: project_developer
                   attributes:
                     name: Ritchie, Glover and Ward
@@ -4848,24 +5383,24 @@ paths:
                     mosaics:
                     - amazon-heart
                     - amazonian-piedmont-massif
-                    created_at: '2022-07-21T12:30:19.125Z'
+                    created_at: '2022-07-27T08:58:40.321Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1Tnpjd016WTVaaTAyTW1NMUxUUTRZbVl0T0dRMk5TMDNabVJoTUdFME5qRXdPRElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--459f8214d2bc1d19b5d8e7a59530cd4b73ec08de/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1Tnpjd016WTVaaTAyTW1NMUxUUTRZbVl0T0dRMk5TMDNabVJoTUdFME5qRXdPRElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--459f8214d2bc1d19b5d8e7a59530cd4b73ec08de/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1Tnpjd016WTVaaTAyTW1NMUxUUTRZbVl0T0dRMk5TMDNabVJoTUdFME5qRXdPRElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--459f8214d2bc1d19b5d8e7a59530cd4b73ec08de/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1T0Rnd1pUTXlaQzAwTmpJM0xUUmhZVEV0T0dReFlpMWpaR1k1WVdWbVltUTFNR01HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c5191c1c31e233e0a20db9ee5722eb8e24f3b7bc/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1T0Rnd1pUTXlaQzAwTmpJM0xUUmhZVEV0T0dReFlpMWpaR1k1WVdWbVltUTFNR01HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c5191c1c31e233e0a20db9ee5722eb8e24f3b7bc/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1T0Rnd1pUTXlaQzAwTmpJM0xUUmhZVEV0T0dReFlpMWpaR1k1WVdWbVltUTFNR01HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c5191c1c31e233e0a20db9ee5722eb8e24f3b7bc/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 816addc7-b9cf-45be-8130-8c5f06f4bef7
+                        id: 87647520-b6ff-4646-8543-c87a9d19b027
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data: []
-                - id: 2f7deaa4-19ec-440f-b0a7-4e18b15b145e
+                - id: 9222e002-cc12-474d-8272-82e9b2473359
                   type: project_developer
                   attributes:
                     name: Runolfsson and Sons
@@ -4893,18 +5428,18 @@ paths:
                     mosaics:
                     - amazon-heart
                     - amazonian-piedmont-massif
-                    created_at: '2022-07-21T12:30:19.041Z'
+                    created_at: '2022-07-27T08:58:40.253Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TTJOak9UTTJOUzFqTVRFeUxUUmxaREF0T1dGaVlpMHpORFUxTnpVM1lXSm1ZemtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--b72939a2703a7271a0dea956a3c8d5681f59f786/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TTJOak9UTTJOUzFqTVRFeUxUUmxaREF0T1dGaVlpMHpORFUxTnpVM1lXSm1ZemtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--b72939a2703a7271a0dea956a3c8d5681f59f786/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TTJOak9UTTJOUzFqTVRFeUxUUmxaREF0T1dGaVlpMHpORFUxTnpVM1lXSm1ZemtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--b72939a2703a7271a0dea956a3c8d5681f59f786/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TW1FeU5EazBOQzA0WVRFMExUUmhaak10WVdSalpTMW1aV05tTWpnMVptUTVPVElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--af1f55c6a2c6c56ede67583a1cadd8323c8bc7bd/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TW1FeU5EazBOQzA0WVRFMExUUmhaak10WVdSalpTMW1aV05tTWpnMVptUTVPVElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--af1f55c6a2c6c56ede67583a1cadd8323c8bc7bd/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TW1FeU5EazBOQzA0WVRFMExUUmhaak10WVdSalpTMW1aV05tTWpnMVptUTVPVElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--af1f55c6a2c6c56ede67583a1cadd8323c8bc7bd/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 8503a676-1ab3-490a-8109-959949fd93d1
+                        id: 90268715-0c2f-4411-be19-a132c03e4212
                         type: user
                     projects:
                       data: []
@@ -4978,7 +5513,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 1d68eb39-225a-480b-9bcc-38e88c74b643
+                  id: f89015dd-73de-45f8-a083-2c82d3834dcb
                   type: project_developer
                   attributes:
                     name: Kutch-Spencer
@@ -5005,26 +5540,26 @@ paths:
                     mosaics:
                     - amazon-heart
                     - amazonian-piedmont-massif
-                    created_at: '2022-07-21T12:30:18.499Z'
+                    created_at: '2022-07-27T08:58:39.922Z'
                     contact_email:
                     contact_phone:
                     picture:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TlRFMk4yTTFZaTA1TXpVekxUUTFOR1l0WVRWa05DMHhNMlJqTkRBMVl6VXlNRGdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a5cd28a4730ba63c593f088b01ba5a91468aad5c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TlRFMk4yTTFZaTA1TXpVekxUUTFOR1l0WVRWa05DMHhNMlJqTkRBMVl6VXlNRGdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a5cd28a4730ba63c593f088b01ba5a91468aad5c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TlRFMk4yTTFZaTA1TXpVekxUUTFOR1l0WVRWa05DMHhNMlJqTkRBMVl6VXlNRGdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a5cd28a4730ba63c593f088b01ba5a91468aad5c/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5WVdZM09XUmxZeTFtTUdNekxUUXpObVF0T1RWaVl5MDBPVEptTURrek56UXhZbUlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6639267eb063664a8d317147887d6bf9b4814f81/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5WVdZM09XUmxZeTFtTUdNekxUUXpObVF0T1RWaVl5MDBPVEptTURrek56UXhZbUlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6639267eb063664a8d317147887d6bf9b4814f81/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5WVdZM09XUmxZeTFtTUdNekxUUXpObVF0T1RWaVl5MDBPVEptTURrek56UXhZbUlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6639267eb063664a8d317147887d6bf9b4814f81/picture.jpg
                     favourite:
                   relationships:
                     owner:
                       data:
-                        id: 17bfe1b2-1e72-440f-9a1f-4d6439c684b0
+                        id: 64ad9ea3-8151-4fc0-8354-a83dfca30a6e
                         type: user
                     projects:
                       data: []
                     involved_projects:
                       data:
-                      - id: 18391105-5dff-4225-80e0-4216cf30cb2f
+                      - id: 31c0d218-b898-4844-9bd5-d324b94157bb
                         type: project
-                      - id: a4540bcb-dafa-4c24-99c6-c31284229c4a
+                      - id: e9c38b65-4245-43f0-80f6-bbbb3992dbbe
                         type: project
               schema:
                 type: object
@@ -5086,49 +5621,49 @@ paths:
             application/json:
               example:
                 data:
-                - id: 489126d9-0775-4998-a1c6-9dfae88b38c2
+                - id: a8bb750a-9387-47f7-a4ab-522c3a936536
                   type: project_map
                   attributes:
                     trusted: false
                     category: forestry-and-agroforestry
                     latitude: 2.0
                     longitude: 1.0
-                - id: 89af165c-9881-4ba3-b75d-d1baf2228767
+                - id: 1b69fe53-fbfd-4542-9e0a-1c4aa2acd2f8
                   type: project_map
                   attributes:
                     trusted: false
                     category: forestry-and-agroforestry
                     latitude: 2.0
                     longitude: 1.0
-                - id: d5ddbc4d-6e85-4b61-a1de-a99f0226b534
+                - id: 144c5c4a-88bc-458b-a3f8-08fe9ae3645a
                   type: project_map
                   attributes:
                     trusted: false
                     category: forestry-and-agroforestry
                     latitude: 2.0
                     longitude: 1.0
-                - id: 3c4a6662-5096-4519-92c9-748c98f1abb3
+                - id: 93250448-c061-4a52-93cb-f7d5bb99e90e
                   type: project_map
                   attributes:
                     trusted: false
                     category: forestry-and-agroforestry
                     latitude: 2.0
                     longitude: 1.0
-                - id: 2e422b1d-1575-4e43-a31f-e283f84f2bd5
+                - id: f58edfdd-8fe8-47a9-8fc5-3814c37b4809
                   type: project_map
                   attributes:
                     trusted: false
                     category: forestry-and-agroforestry
                     latitude: 2.0
                     longitude: 1.0
-                - id: 68c25b9f-ef91-46da-aad9-5adc38fd80b5
+                - id: c35a6043-93e0-4c6e-9590-5ca4459fe363
                   type: project_map
                   attributes:
                     trusted: false
                     category: forestry-and-agroforestry
                     latitude: 2.0
                     longitude: 1.0
-                - id: ca120a41-dc89-42a8-af59-07740459b60c
+                - id: 9d016ef8-136f-4eec-8560-ed9c8b61ca75
                   type: project_map
                   attributes:
                     trusted: false
@@ -5266,7 +5801,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: 41ca1668-5303-48e1-92b4-b58e50471136
+                - id: 98f9c029-56df-4c31-8fbc-d03f536e20c1
                   type: project
                   attributes:
                     name: Project 1
@@ -5319,7 +5854,7 @@ paths:
                       - 1.0
                       - 2.0
                     trusted: false
-                    created_at: '2022-07-21T12:30:23.457Z'
+                    created_at: '2022-07-27T08:58:44.373Z'
                     municipality_biodiversity_impact:
                     municipality_climate_impact:
                     municipality_water_impact:
@@ -5341,35 +5876,35 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: e7316980-fa17-477e-a590-b9b7d956e136
+                        id: f371443f-094f-4c9e-9a50-a52e407ab08e
                         type: project_developer
                     country:
                       data:
-                        id: a8670e9c-222b-4d80-91c7-ceac098fc4a4
+                        id: 383bf073-e986-44eb-b0d9-5b534da69564
                         type: location
                     municipality:
                       data:
-                        id: 036dc570-365b-4147-8dc4-e05509ae67c1
+                        id: cf1f1cb1-bc27-487c-8e9e-a9ace2b15867
                         type: location
                     department:
                       data:
-                        id: a407a727-89a8-42c6-b230-846e2b57a487
+                        id: a98c1e46-8778-459b-adc3-89462b97ee97
                         type: location
                     priority_landscape:
                       data:
                     involved_project_developers:
                       data:
-                      - id: ce3f527b-d637-41ec-84a3-c005bacd4500
+                      - id: 79294bb6-694f-43fa-9336-7ebde12c5729
                         type: project_developer
-                      - id: 295430d3-3640-446b-94af-2f0018cf0db6
+                      - id: 60751dd0-0370-4842-916f-610097bd5cd2
                         type: project_developer
                     project_images:
                       data:
-                      - id: 64e05487-e7ec-48d2-aac2-c240fb1542c8
+                      - id: 92f46908-7d11-494b-a555-a0ff45d9e5b1
                         type: project_image
-                      - id: 2d5a0aaa-d2e5-453f-acc4-2b369bc40436
+                      - id: d8922039-33d4-40b4-925a-c16386cf79ae
                         type: project_image
-                - id: 9726789c-4167-4e6e-a03f-f22d1e6af5b7
+                - id: 0ac36e5e-a84a-4a9f-a1d0-df94e4c7aab2
                   type: project
                   attributes:
                     name: Project 10
@@ -5421,7 +5956,7 @@ paths:
                       - 1.0
                       - 2.0
                     trusted: false
-                    created_at: '2022-07-21T12:30:24.794Z'
+                    created_at: '2022-07-27T08:58:45.703Z'
                     municipality_biodiversity_impact:
                     municipality_climate_impact:
                     municipality_water_impact:
@@ -5443,19 +5978,19 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: d0b687aa-fe16-4c8e-9bc0-2bea34e35541
+                        id: 8e0602f6-2778-4414-82e1-d71ddaaf0406
                         type: project_developer
                     country:
                       data:
-                        id: 6f0929a4-1868-4b61-b7bb-4d07eabd6318
+                        id: 52c09700-bdc5-4985-a5a2-cfa3b453b19d
                         type: location
                     municipality:
                       data:
-                        id: 3b8c9fe1-e0cf-4c89-8b8f-57d3dcf3c57b
+                        id: 4a66314b-580d-4b44-97ef-55865dba9569
                         type: location
                     department:
                       data:
-                        id: c7ce587d-6c28-4024-9ea3-70e89344d34f
+                        id: fe2fe1d1-3b7f-4917-ad19-371af2e5e77f
                         type: location
                     priority_landscape:
                       data:
@@ -5463,7 +5998,7 @@ paths:
                       data: []
                     project_images:
                       data: []
-                - id: 63a7b9e1-fd66-4e4c-a183-07512fcbd6cd
+                - id: b54292cc-5f89-45f7-9e43-b5432395f8e4
                   type: project
                   attributes:
                     name: Project 2
@@ -5516,7 +6051,7 @@ paths:
                       - 1.0
                       - 2.0
                     trusted: false
-                    created_at: '2022-07-21T12:30:23.663Z'
+                    created_at: '2022-07-27T08:58:44.557Z'
                     municipality_biodiversity_impact:
                     municipality_climate_impact:
                     municipality_water_impact:
@@ -5538,19 +6073,19 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: '0892f161-0d70-4dc9-8e6c-3175bf59ee04'
+                        id: 4021fddf-f72b-4a32-8523-ad12448fa846
                         type: project_developer
                     country:
                       data:
-                        id: 2312ca99-4e5f-41c1-bcde-1495a175e080
+                        id: 070b235a-96ab-4f6c-a392-289a8f29000c
                         type: location
                     municipality:
                       data:
-                        id: ef247f6e-26e4-41c9-a63d-ade3e25c6f0e
+                        id: 50c4de6a-0f86-42f4-9fa2-50ad2b7b0366
                         type: location
                     department:
                       data:
-                        id: 25027af2-4890-475c-83d2-4950fb3004b8
+                        id: f604d183-8931-4ba9-98d1-d7c31908047b
                         type: location
                     priority_landscape:
                       data:
@@ -5558,7 +6093,7 @@ paths:
                       data: []
                     project_images:
                       data: []
-                - id: 20a7c2ef-bc9c-44fb-b268-d4b7081331f4
+                - id: 00255d56-8f66-4a20-9975-bb66a6319503
                   type: project
                   attributes:
                     name: Project 3
@@ -5611,7 +6146,7 @@ paths:
                       - 1.0
                       - 2.0
                     trusted: false
-                    created_at: '2022-07-21T12:30:23.795Z'
+                    created_at: '2022-07-27T08:58:44.685Z'
                     municipality_biodiversity_impact:
                     municipality_climate_impact:
                     municipality_water_impact:
@@ -5633,19 +6168,19 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 981e2b3a-47ae-4e99-8cb5-e3faca4ebe1e
+                        id: 5ceac3e9-1c93-4070-ac2a-9edbc0f1e589
                         type: project_developer
                     country:
                       data:
-                        id: 80ff3b8d-9860-4645-aea4-438532a34910
+                        id: a6794078-5de0-40b4-8aab-d3199a8fd272
                         type: location
                     municipality:
                       data:
-                        id: ace304e5-da0e-4578-a60a-cd7a966fae3e
+                        id: 2b8f12e2-058f-4a29-9948-34a50c06c22a
                         type: location
                     department:
                       data:
-                        id: 23b16fda-14a3-4947-b2de-0db97a2ca55a
+                        id: '038834f3-1f07-4275-8b68-d2d22ada0501'
                         type: location
                     priority_landscape:
                       data:
@@ -5653,7 +6188,7 @@ paths:
                       data: []
                     project_images:
                       data: []
-                - id: eef64909-497a-4e5e-8d81-87e1994bea4d
+                - id: 6c299e06-3c8a-4503-86cc-c0e36aa81aeb
                   type: project
                   attributes:
                     name: Project 4
@@ -5706,7 +6241,7 @@ paths:
                       - 1.0
                       - 2.0
                     trusted: false
-                    created_at: '2022-07-21T12:30:23.914Z'
+                    created_at: '2022-07-27T08:58:44.812Z'
                     municipality_biodiversity_impact:
                     municipality_climate_impact:
                     municipality_water_impact:
@@ -5728,19 +6263,19 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 11dd4a12-b320-4a2d-9521-80e02c0977b8
+                        id: bae6706e-d7f3-4b37-b6dc-d355ff8351ce
                         type: project_developer
                     country:
                       data:
-                        id: 87ea52dd-65dd-47f3-9b96-4bcad8e7b079
+                        id: 80a117c9-8525-4fc0-8fd4-b25a341d6c5a
                         type: location
                     municipality:
                       data:
-                        id: 5568f244-e68d-4730-8a2d-362ba1b0aff7
+                        id: e598e163-3031-4211-8486-68645a7ef1b1
                         type: location
                     department:
                       data:
-                        id: 185c83fb-15ac-4a05-a41f-18f1ca91f882
+                        id: 816e91fa-1595-472a-806f-f1bfa9f73b0d
                         type: location
                     priority_landscape:
                       data:
@@ -5748,7 +6283,7 @@ paths:
                       data: []
                     project_images:
                       data: []
-                - id: f47125cb-f908-4adf-ab96-29fa5a514414
+                - id: 1be66b24-4e98-4979-b9a6-0b98fe30512a
                   type: project
                   attributes:
                     name: Project 5
@@ -5801,7 +6336,7 @@ paths:
                       - 1.0
                       - 2.0
                     trusted: false
-                    created_at: '2022-07-21T12:30:24.051Z'
+                    created_at: '2022-07-27T08:58:44.945Z'
                     municipality_biodiversity_impact:
                     municipality_climate_impact:
                     municipality_water_impact:
@@ -5823,19 +6358,19 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: d5ed3721-1ab2-4eb9-ae26-0aaf430b9544
+                        id: 1de35b74-4785-4060-be07-75e1952f0927
                         type: project_developer
                     country:
                       data:
-                        id: 74ab60a5-da66-403d-a6e2-55ea9a9c13ab
+                        id: 077702a8-5c4f-417e-ba88-0005ba08605c
                         type: location
                     municipality:
                       data:
-                        id: 53314e3f-a4d8-4f2e-94b0-7febe76da5b2
+                        id: a000cac9-9e9a-4f7a-b3c5-8d088fb95161
                         type: location
                     department:
                       data:
-                        id: 36ee17ac-8a9f-4434-bef7-dff25a6ed1a1
+                        id: 0a166680-73d8-4b8f-8b21-490ef30f0c71
                         type: location
                     priority_landscape:
                       data:
@@ -5843,7 +6378,7 @@ paths:
                       data: []
                     project_images:
                       data: []
-                - id: 4306a7c2-3580-4d1c-b417-8883a48c487e
+                - id: 17e6d1fc-6cb2-4e07-9b6b-f60ed1091c1c
                   type: project
                   attributes:
                     name: Project 6
@@ -5896,7 +6431,7 @@ paths:
                       - 1.0
                       - 2.0
                     trusted: false
-                    created_at: '2022-07-21T12:30:24.190Z'
+                    created_at: '2022-07-27T08:58:45.070Z'
                     municipality_biodiversity_impact:
                     municipality_climate_impact:
                     municipality_water_impact:
@@ -5918,19 +6453,19 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 10146e8a-4c26-4114-904c-4a215082c856
+                        id: 0314aea8-7305-4883-a374-7d3f48253915
                         type: project_developer
                     country:
                       data:
-                        id: e96e2852-eab4-4b0a-b815-7ad7a393259d
+                        id: 938d8fea-0d03-405f-8dbe-9c9c0ce45531
                         type: location
                     municipality:
                       data:
-                        id: 9ea6ed43-0939-4749-bf68-e5e82c891d7f
+                        id: e22491ff-7c3d-4752-b09a-6cce173baf17
                         type: location
                     department:
                       data:
-                        id: 35f07a2f-2540-4133-836d-78aefcc5b799
+                        id: 9d35c089-5455-43eb-9330-d1ac1ad9fc5c
                         type: location
                     priority_landscape:
                       data:
@@ -5938,7 +6473,7 @@ paths:
                       data: []
                     project_images:
                       data: []
-                - id: a2baa0d9-01cc-442b-8c11-87b711fa9554
+                - id: 1b2f5a0b-9e58-438d-b27a-84aa0fed8b52
                   type: project
                   attributes:
                     name: Project 7
@@ -5991,7 +6526,7 @@ paths:
                       - 1.0
                       - 2.0
                     trusted: false
-                    created_at: '2022-07-21T12:30:24.318Z'
+                    created_at: '2022-07-27T08:58:45.196Z'
                     municipality_biodiversity_impact:
                     municipality_climate_impact:
                     municipality_water_impact:
@@ -6013,19 +6548,19 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: 1d5da739-73a6-4128-8858-0672b58a2f5a
+                        id: 8c890c36-4822-415a-9d67-1c7866b71319
                         type: project_developer
                     country:
                       data:
-                        id: 61594832-c45b-403b-b20c-5c94ae29da98
+                        id: 7b30b67e-6ef2-4110-b650-951798a1281a
                         type: location
                     municipality:
                       data:
-                        id: 2efe1da4-dd82-4cb7-8bc3-24a3c4ccbbab
+                        id: 60558d6a-74fa-4ffb-8bc6-1c0bff65883f
                         type: location
                     department:
                       data:
-                        id: 22f9e045-0d93-4b86-84fc-b329bdbb7426
+                        id: 40cb189c-b58a-4e8d-86c7-3c568d03a8ce
                         type: location
                     priority_landscape:
                       data:
@@ -6101,7 +6636,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 41ca1668-5303-48e1-92b4-b58e50471136
+                  id: 98f9c029-56df-4c31-8fbc-d03f536e20c1
                   type: project
                   attributes:
                     name: Project 1
@@ -6154,7 +6689,7 @@ paths:
                       - 1.0
                       - 2.0
                     trusted: false
-                    created_at: '2022-07-21T12:30:23.457Z'
+                    created_at: '2022-07-27T08:58:44.373Z'
                     municipality_biodiversity_impact:
                     municipality_climate_impact:
                     municipality_water_impact:
@@ -6176,33 +6711,33 @@ paths:
                   relationships:
                     project_developer:
                       data:
-                        id: e7316980-fa17-477e-a590-b9b7d956e136
+                        id: f371443f-094f-4c9e-9a50-a52e407ab08e
                         type: project_developer
                     country:
                       data:
-                        id: a8670e9c-222b-4d80-91c7-ceac098fc4a4
+                        id: 383bf073-e986-44eb-b0d9-5b534da69564
                         type: location
                     municipality:
                       data:
-                        id: 036dc570-365b-4147-8dc4-e05509ae67c1
+                        id: cf1f1cb1-bc27-487c-8e9e-a9ace2b15867
                         type: location
                     department:
                       data:
-                        id: a407a727-89a8-42c6-b230-846e2b57a487
+                        id: a98c1e46-8778-459b-adc3-89462b97ee97
                         type: location
                     priority_landscape:
                       data:
                     involved_project_developers:
                       data:
-                      - id: ce3f527b-d637-41ec-84a3-c005bacd4500
+                      - id: 79294bb6-694f-43fa-9336-7ebde12c5729
                         type: project_developer
-                      - id: 295430d3-3640-446b-94af-2f0018cf0db6
+                      - id: 60751dd0-0370-4842-916f-610097bd5cd2
                         type: project_developer
                     project_images:
                       data:
-                      - id: 64e05487-e7ec-48d2-aac2-c240fb1542c8
+                      - id: 92f46908-7d11-494b-a555-a0ff45d9e5b1
                         type: project_image
-                      - id: 2d5a0aaa-d2e5-453f-acc4-2b369bc40436
+                      - id: d8922039-33d4-40b4-925a-c16386cf79ae
                         type: project_image
               schema:
                 type: object
@@ -6250,14 +6785,14 @@ paths:
             application/json:
               example:
                 data:
-                  id: bf83c155-d561-4a38-85c9-c69177436a47
+                  id: 6494357c-fe4b-453b-8d5c-1929bb77deb0
                   type: user
                   attributes:
                     first_name: Dawna
                     last_name: Block
                     email: user@example.com
                     role: light
-                    created_at: '2022-07-21T12:30:26.743Z'
+                    created_at: '2022-07-27T08:58:47.617Z'
                     ui_language: en
                     account_language:
                     confirmed: true
@@ -6311,14 +6846,14 @@ paths:
             application/json:
               example:
                 data:
-                  id: 39f64d68-2aed-415d-b85e-9f83e5020fe2
+                  id: 99295393-9175-4180-938c-a741ef511f58
                   type: user
                   attributes:
                     first_name: Dawna
                     last_name: Block
                     email: user@example.com
                     role: light
-                    created_at: '2022-07-21T12:30:27.004Z'
+                    created_at: '2022-07-27T08:58:47.929Z'
                     ui_language: en
                     account_language:
                     confirmed: true
@@ -6448,14 +6983,14 @@ paths:
             application/json:
               example:
                 data:
-                  id: 450620f0-ca12-443d-9cff-aed5d1db3f99
+                  id: 580754e9-21d7-4f1a-ac34-ce540ec57f4f
                   type: user
                   attributes:
                     first_name: Jan
                     last_name: Kowalski
                     email: jankowalski@example.com
                     role: light
-                    created_at: '2022-07-21T12:30:27.933Z'
+                    created_at: '2022-07-27T08:58:48.906Z'
                     ui_language: en
                     account_language:
                     confirmed: true
@@ -6538,14 +7073,14 @@ paths:
             application/json:
               example:
                 data:
-                  id: 9754757c-7731-4c10-8c3b-4bd7855e8d5d
+                  id: e4402b8f-033c-4781-990c-47e119c4f151
                   type: user
                   attributes:
                     first_name: Dawna
                     last_name: Block
                     email: user@example.com
                     role: light
-                    created_at: '2022-07-21T12:30:27.661Z'
+                    created_at: '2022-07-27T08:58:48.598Z'
                     ui_language: en
                     account_language:
                     confirmed: true
@@ -6553,9 +7088,9 @@ paths:
                     invitation:
                     owner: false
                     avatar:
-                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3TURCa05HVXdaUzFqT1dVMUxUUTFNell0WW1Oa015MDJNV000TmpsbU1UWTROVFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--80e5eec3a2f8bab5d8d033059217a5bd7766dba0/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
-                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3TURCa05HVXdaUzFqT1dVMUxUUTFNell0WW1Oa015MDJNV000TmpsbU1UWTROVFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--80e5eec3a2f8bab5d8d033059217a5bd7766dba0/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
-                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3TURCa05HVXdaUzFqT1dVMUxUUTFNell0WW1Oa015MDJNV000TmpsbU1UWTROVFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--80e5eec3a2f8bab5d8d033059217a5bd7766dba0/picture.jpg
+                      small: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTm1VeVkySTBOaTA0T1Rrd0xUUmhaREF0WWpBeFlTMHhPR0kyWkdVNE1USTFNalVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--75636054c29a0784f3da68a6c6df529ca5610383/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--f7523a0d05ddde23c99aa6cff8205483f9bdcc69/picture.jpg
+                      medium: http://localhost:4000/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTm1VeVkySTBOaTA0T1Rrd0xUUmhaREF0WWpBeFlTMHhPR0kyWkdVNE1USTFNalVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--75636054c29a0784f3da68a6c6df529ca5610383/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1d7560c2ca237061922fe1e35b43f845e8a5689a/picture.jpg
+                      original: http://localhost:4000/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTm1VeVkySTBOaTA0T1Rrd0xUUmhaREF0WWpBeFlTMHhPR0kyWkdVNE1USTFNalVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--75636054c29a0784f3da68a6c6df529ca5610383/picture.jpg
               schema:
                 type: object
                 properties:
@@ -6627,19 +7162,19 @@ paths:
           content:
             application/json:
               example:
-                id: d60f1d4c-7cb1-49a8-858c-fbd0302b324b
-                key: isobhxq8ac768q5hqrhw62dme6ww
+                id: 871aaf29-ee9d-4c34-af3d-f5e35fcd8026
+                key: jia1hzv2rgv4baix6g7mbru8shjp
                 filename: test.jpg
                 content_type: image/jpeg
                 metadata: {}
                 service_name: test
                 byte_size: 32326
                 checksum: QYeLAwqIj9HrwITqtTYaEw==
-                created_at: '2022-07-21T12:30:28.742Z'
-                signed_id: eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrTmpCbU1XUTBZeTAzWTJJeExUUTVZVGd0T0RVNFl5MW1ZbVF3TXpBeVlqTXlOR0lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5da314e1020afad08ca6064b5bb8914423be9930
-                attachable_sgid: BAh7CEkiCGdpZAY6BkVUSSJWZ2lkOi8vYmFja2VuZC9BY3RpdmVTdG9yYWdlOjpCbG9iL2Q2MGYxZDRjLTdjYjEtNDlhOC04NThjLWZiZDAzMDJiMzI0Yj9leHBpcmVzX2luBjsAVEkiDHB1cnBvc2UGOwBUSSIPYXR0YWNoYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--fc5eb26b19495e2b28272ad49ead7ae1933ab3ff
+                created_at: '2022-07-27T08:58:50.058Z'
+                signed_id: eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0TnpGaFlXWXlPUzFsWlRsa0xUUmpNelF0WVdZelpDMW1OV1V6TldaalpEZ3dNallHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--8ec19062e3b62d7c914fc4ba15a4aac97e9d0ece
+                attachable_sgid: BAh7CEkiCGdpZAY6BkVUSSJWZ2lkOi8vYmFja2VuZC9BY3RpdmVTdG9yYWdlOjpCbG9iLzg3MWFhZjI5LWVlOWQtNGMzNC1hZjNkLWY1ZTM1ZmNkODAyNj9leHBpcmVzX2luBjsAVEkiDHB1cnBvc2UGOwBUSSIPYXR0YWNoYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--49db45f7c3cfb2dc7c5bf5025ff62093bc74186c
                 direct_upload:
-                  url: http://www.example.com/backend/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDam9JYTJWNVNTSWhhWE52WW1oNGNUaGhZemMyT0hFMWFIRnlhSGMyTW1SdFpUWjNkd1k2QmtWVU9oRmpiMjUwWlc1MFgzUjVjR1ZKSWc5cGJXRm5aUzlxY0dWbkJqc0dWRG9UWTI5dWRHVnVkRjlzWlc1bmRHaHBBa1orT2cxamFHVmphM04xYlVraUhWRlpaVXhCZDNGSmFqbEljbmRKVkhGMFZGbGhSWGM5UFFZN0JsUTZFWE5sY25acFkyVmZibUZ0WlRvSmRHVnpkQT09IiwiZXhwIjoiMjAyMi0wNy0yMVQxMjozNToyOC43NDVaIiwicHVyIjoiYmxvYl90b2tlbiJ9fQ==--f66989babdc0638300a4e3eac5f2f0cd6136b35e
+                  url: http://www.example.com/backend/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDam9JYTJWNVNTSWhhbWxoTVdoNmRqSnlaM1kwWW1GcGVEWm5OMjFpY25VNGMyaHFjQVk2QmtWVU9oRmpiMjUwWlc1MFgzUjVjR1ZKSWc5cGJXRm5aUzlxY0dWbkJqc0dWRG9UWTI5dWRHVnVkRjlzWlc1bmRHaHBBa1orT2cxamFHVmphM04xYlVraUhWRlpaVXhCZDNGSmFqbEljbmRKVkhGMFZGbGhSWGM5UFFZN0JsUTZFWE5sY25acFkyVmZibUZ0WlRvSmRHVnpkQT09IiwiZXhwIjoiMjAyMi0wNy0yN1QwOTowMzo1MC4wNjJaIiwicHVyIjoiYmxvYl90b2tlbiJ9fQ==--4d50b97fcd59eeb297d288bd0e1666d83f2a78da
                   headers:
                     Content-Type: image/jpeg
               schema:


### PR DESCRIPTION
I am adding new API endpoints which returns list of favourites for all entities.
```
GET /api/v1/account/investors/favourites
GET /api/v1/account/project_developers/favourites
GET /api/v1/account/projects/favourites
GET /api/v1/account/open_calls/favourites
```
These endpoints are available only for users with approved account. I have decided to keep endpoints separate (one per entity type) so It follows same approach as rest of our API. 

It took me some time till I have decided if these new endpoints should be part of for example `Account/ProjectsController/favourites` or if it would be better to have them at `FavouriteProjectsController/index` action. In second case, path would be `GET /api/v1/projects/favourite_projects`. I have tried to implement both approaches and first one which I have chosen in the end looks better, code is cleaner.

## Testing instructions

Via Rswag

## Tracking

https://vizzuality.atlassian.net/browse/LET-765
