### PR TITLE
Let 774 fe user reset password

### DIFF
--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -455,6 +455,9 @@
   "D5RCKi": {
     "string": "Project name"
   },
+  "D7hbFB": {
+    "string": "Back to Sign in"
+  },
   "DCAMZh": {
     "string": "Choose the field to sort by"
   },
@@ -490,6 +493,9 @@
   },
   "E80WrK": {
     "string": "Information"
+  },
+  "EGMX38": {
+    "string": "Please insert your new password."
   },
   "EKOV4Z": {
     "string": "Contextual Layers"
@@ -571,6 +577,9 @@
   },
   "GgNMmS": {
     "string": "National Wetlands Map of Colombia"
+  },
+  "GhrkT+": {
+    "string": "confirm password"
   },
   "GtP2gp": {
     "string": "Find opportunities that have the greatest impact on challenges like <b>biodiversity, climate, community</b> and <b>water</b>."
@@ -1110,6 +1119,9 @@
   "YjuFXX": {
     "string": "Herencia Colombia priority landscapes"
   },
+  "Yy/yDL": {
+    "string": "Reset password"
+  },
   "Z8971h": {
     "string": "Verified"
   },
@@ -1295,6 +1307,9 @@
   },
   "fMrPOR": {
     "string": "Go to last page"
+  },
+  "fTHhSB": {
+    "string": "New password"
   },
   "fUM67k": {
     "string": "Open project"
@@ -1520,6 +1535,9 @@
   },
   "n0nU+Y": {
     "string": "Illustration of a person looking at a list of cards"
+  },
+  "n4Y/RH": {
+    "string": "insert new passowrd"
   },
   "n6KNWj": {
     "string": "Pending verification"

--- a/frontend/pages/sign-in/forgot-password.tsx
+++ b/frontend/pages/sign-in/forgot-password.tsx
@@ -19,10 +19,10 @@ import Label from 'components/forms/label';
 import Loading from 'components/loading';
 import AuthPageLayout, { AuthPageLayoutProps } from 'layouts/auth-page';
 import { PageComponent } from 'types';
-import { ResetPassword } from 'types/sign-in';
+import { ForgotPassword } from 'types/sign-in';
 import { useForgotPasswordResolver } from 'validations/sign-in';
 
-import { useResetPassword } from 'services/users/userService';
+import { useForgotPassword } from 'services/reset-password/reset-password-service';
 
 export const getStaticProps = withLocalizedRequests(async ({ locale }) => {
   return {
@@ -36,17 +36,17 @@ type ForgotPasswordPageProps = InferGetStaticPropsType<typeof getStaticProps>;
 
 const ForgotPassword: PageComponent<ForgotPasswordPageProps, AuthPageLayoutProps> = () => {
   const intl = useIntl();
-  const resetPassword = useResetPassword();
+  const resetPassword = useForgotPassword();
   const resolver = useForgotPasswordResolver();
   const {
     register,
     formState: { errors },
     handleSubmit,
-  } = useForm<ResetPassword>({ resolver, shouldUseNativeValidation: true });
+  } = useForm<ForgotPassword>({ resolver, shouldUseNativeValidation: true });
   const { push } = useRouter();
 
   const handleResetPassword = useCallback(
-    (data: ResetPassword) =>
+    (data: ForgotPassword) =>
       resetPassword.mutate(data, {
         onSuccess: () => {
           push('/sign-in');
@@ -54,8 +54,7 @@ const ForgotPassword: PageComponent<ForgotPasswordPageProps, AuthPageLayoutProps
       }),
     [resetPassword, push]
   );
-
-  const onSubmit: SubmitHandler<ResetPassword> = handleResetPassword;
+  const onSubmit: SubmitHandler<ForgotPassword> = handleResetPassword;
 
   return (
     <div className="flex flex-col justify-center w-full h-full max-w-xl m-auto">

--- a/frontend/pages/sign-in/reset-password.tsx
+++ b/frontend/pages/sign-in/reset-password.tsx
@@ -1,0 +1,160 @@
+import { useEffect } from 'react';
+
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { useQueryClient } from 'react-query';
+
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+import { withLocalizedRequests } from 'hoc/locale';
+
+import { InferGetServerSidePropsType } from 'next';
+
+import useMe from 'hooks/me';
+
+import { loadI18nMessages } from 'helpers/i18n';
+
+import Alert from 'components/alert';
+import Button from 'components/button';
+import ErrorMessage from 'components/forms/error-message';
+import Input from 'components/forms/input';
+import Label from 'components/forms/label';
+import Loading from 'components/loading';
+import { Paths, Queries } from 'enums';
+import AuthPageLayout, { AuthPageLayoutProps } from 'layouts/auth-page';
+import { PageComponent } from 'types';
+import { ResetPassword } from 'types/sign-in';
+import { useResetPasswordResolver } from 'validations/sign-in';
+
+import { useResetPassword } from 'services/reset-password/reset-password-service';
+
+export const getServerSideProps = withLocalizedRequests(async ({ locale, query }: any) => {
+  if (!query.reset_password_token) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      intlMessages: await loadI18nMessages({ locale }),
+    },
+  };
+});
+
+type ResetPasswordPageProps = InferGetServerSidePropsType<typeof getServerSideProps>;
+
+const ResetPasswordPage: PageComponent<ResetPasswordPageProps, AuthPageLayoutProps> = () => {
+  const { query, push } = useRouter();
+  const intl = useIntl();
+  const resetPassword = useResetPassword();
+  const { user } = useMe();
+  const queryClient = useQueryClient();
+  const resolver = useResetPasswordResolver();
+  const {
+    handleSubmit,
+    register,
+    formState: { errors },
+  } = useForm<ResetPassword>({
+    resolver,
+    shouldUseNativeValidation: true,
+    defaultValues: { reset_password_token: query.reset_password_token as string },
+  });
+
+  const onSubmit: SubmitHandler<ResetPassword> = (values) => {
+    resetPassword.mutate(values, {
+      onSuccess: () => {
+        queryClient.invalidateQueries(Queries.User);
+      },
+    });
+  };
+
+  useEffect(() => {
+    if (user) {
+      push(Paths.Dashboard);
+    }
+  }, [user, push]);
+
+  return (
+    <div className="flex flex-col justify-center w-full h-full max-w-xl m-auto">
+      <h1 className="mb-2.5 font-serif text-4xl font-semibold text-green-dark">
+        <FormattedMessage defaultMessage="Reset password" id="Yy/yDL" />
+      </h1>
+      <p className="mb-6.5 font-sans text-base text-gray-600">
+        <FormattedMessage defaultMessage="Please insert your new password." id="EGMX38" />
+      </p>
+      <form onSubmit={handleSubmit(onSubmit)} noValidate>
+        {resetPassword.isError && (
+          <Alert type="warning" className="mb-4.5" withLayoutContainer>
+            {Array.isArray(resetPassword.error.message)
+              ? resetPassword.error.message[0].title
+              : resetPassword.error.message}
+          </Alert>
+        )}
+        <div className="w-full">
+          <Label htmlFor="email">
+            <FormattedMessage defaultMessage="New password" id="fTHhSB" />
+          </Label>
+          <Input
+            type="password"
+            name="password"
+            id="password"
+            placeholder={intl.formatMessage({
+              defaultMessage: 'insert new passowrd',
+              id: 'n4Y/RH',
+            })}
+            aria-describedby="email-error"
+            register={register}
+            className="mt-2.5 mb-2"
+          />
+          <ErrorMessage id="email-error" errorText={errors.password?.message} />
+        </div>
+        <div className="w-full mt-4.5">
+          <Label htmlFor="password_confirmation">
+            <FormattedMessage defaultMessage="Confirm password" id="8HimVK" />
+          </Label>
+          <Input
+            type="password"
+            name="password_confirmation"
+            id="password_confirmation"
+            placeholder={intl.formatMessage({
+              defaultMessage: 'confirm password',
+              id: 'GhrkT+',
+            })}
+            aria-describedby="email-error"
+            register={register}
+            className="mt-2.5 mb-2"
+          />
+          <ErrorMessage id="email-error" errorText={errors.password_confirmation?.message} />
+        </div>
+
+        <div className="flex flex-col items-center justify-center mt-15">
+          <Button type="submit" disabled={resetPassword.isLoading}>
+            <Loading visible={resetPassword.isLoading} className="mr-2.5" />
+            <FormattedMessage defaultMessage="Reset password" id="Yy/yDL" />
+          </Button>
+          <Link href={Paths.SignIn} passHref>
+            <a className="mt-5 text-sm text-green-dark">
+              <FormattedMessage defaultMessage="Back to Sign in" id="D7hbFB" />
+            </a>
+          </Link>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+ResetPasswordPage.layout = {
+  Component: AuthPageLayout,
+  props: {
+    headerProps: {
+      pageType: 'forgot-password',
+    },
+    asideProps: {
+      photo: 'side-02',
+    },
+  },
+};
+
+export default ResetPasswordPage;

--- a/frontend/services/reset-password/reset-password-service.ts
+++ b/frontend/services/reset-password/reset-password-service.ts
@@ -1,0 +1,30 @@
+import { UseMutationResult, useMutation } from 'react-query';
+
+import { AxiosResponse, AxiosError } from 'axios';
+
+import { ForgotPassword, ResetPassword } from 'types/sign-in';
+import { User } from 'types/user';
+
+import API from 'services/api';
+import { ResponseData } from 'services/types';
+
+/** Sends an email to the user with the reset-passord link */
+export const useForgotPassword = (): UseMutationResult<
+  AxiosResponse,
+  AxiosError,
+  ForgotPassword
+> => {
+  const forgotPassword = async (dto: ForgotPassword) =>
+    await API.post('/api/v1/reset_password', dto);
+  return useMutation(forgotPassword);
+};
+
+/** Creates a new password using a reset_password token */
+export const useResetPassword = (): UseMutationResult<
+  AxiosResponse<ResponseData<User>>,
+  AxiosError,
+  ResetPassword
+> => {
+  const resetPassword = async (dto: ResetPassword) => await API.put('/api/v1/reset_password', dto);
+  return useMutation(resetPassword);
+};

--- a/frontend/services/users/userService.ts
+++ b/frontend/services/users/userService.ts
@@ -1,11 +1,8 @@
 import { useMutation, UseMutationResult, useQueryClient } from 'react-query';
 
-import { useRouter } from 'next/router';
-
 import { AxiosResponse, AxiosError } from 'axios';
 
 import { Queries } from 'enums';
-import { ResetPassword } from 'types/sign-in';
 import { SignupDto, User } from 'types/user';
 
 import { ErrorResponse, ResponseData } from 'services/types';
@@ -25,11 +22,6 @@ export function useSignup(): UseMutationResult<
     return data;
   };
   return useMutation(signup);
-}
-
-export function useResetPassword(): UseMutationResult<AxiosResponse, AxiosError, ResetPassword> {
-  const resetPassword = async (dto: ResetPassword) => await API.post('/api/v1/reset_password', dto);
-  return useMutation(resetPassword);
 }
 
 /** Get the logged user */

--- a/frontend/types/sign-in.ts
+++ b/frontend/types/sign-in.ts
@@ -3,6 +3,12 @@ export type SignIn = {
   password: string;
 };
 
-export type ResetPassword = {
+export type ForgotPassword = {
   email: string;
+};
+
+export type ResetPassword = {
+  password: string;
+  password_confirmation: string;
+  reset_password_token: string;
 };

--- a/frontend/validations/sign-in.ts
+++ b/frontend/validations/sign-in.ts
@@ -1,9 +1,9 @@
 import { useIntl } from 'react-intl';
 
 import { yupResolver } from '@hookform/resolvers/yup';
-import { SchemaOf, object, string } from 'yup';
+import { SchemaOf, object, string, ref } from 'yup';
 
-import { ResetPassword, SignIn } from 'types/sign-in';
+import { ResetPassword, ForgotPassword, SignIn } from 'types/sign-in';
 
 export const useSignInResolver = () => {
   const { formatMessage } = useIntl();
@@ -36,7 +36,7 @@ export const useSignInResolver = () => {
 export const useForgotPasswordResolver = () => {
   const { formatMessage } = useIntl();
 
-  const schema: SchemaOf<ResetPassword> = object().shape({
+  const schema: SchemaOf<ForgotPassword> = object().shape({
     email: string()
       .required(
         formatMessage({
@@ -50,6 +50,41 @@ export const useForgotPasswordResolver = () => {
           id: '05q+7T',
         })
       ),
+  });
+
+  return yupResolver(schema);
+};
+
+export const useResetPasswordResolver = () => {
+  const { formatMessage } = useIntl();
+
+  const schema: SchemaOf<ResetPassword> = object().shape({
+    password: string()
+      .required(
+        formatMessage({
+          defaultMessage: 'You need to enter a password.',
+          id: 'zeCjLr',
+        })
+      )
+      .matches(/^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[a-zA-Z]).{12,}$/, {
+        message: formatMessage({
+          defaultMessage:
+            'The password must contain at least 12 characters, with at least one uppercase letter, one lowercase letter and a number.',
+          id: 'rJnXTe',
+        }),
+      }),
+    password_confirmation: string()
+      .oneOf(
+        [ref('password'), null],
+        formatMessage({ defaultMessage: "The passwords don't match.", id: 'weOT3A' })
+      )
+      .required(
+        formatMessage({
+          defaultMessage: 'You need to confirm the password.',
+          id: '+UvbBR',
+        })
+      ),
+    reset_password_token: string(),
   });
 
   return yupResolver(schema);


### PR DESCRIPTION
This PR adds the reset password page

## Acceptance criteria

On the sign in page, the user is able to reset their password

There is a link to reset the password

Once the link is clicked, the user fills in their email address ([Figma](https://www.figma.com/file/KC49uMR9t1YARmFR0Sr6aN/HeCo---Work-in-progress?node-id=742%3A17781))

After asking to reset their password, the user receives an email with a link to a reset password form

The form asks the user:

1. Their new password
2. A confirmation of their new password

Once the form is submitted, the user may get signed in automatically or redirected to the sign in page

Check with the BE team to see which approach they prefer and with Andreia 

- The endpoint signs in the user automatically 

[The form follows the design](https://www.figma.com/file/KC49uMR9t1YARmFR0Sr6aN/HeCo---Work-in-progress?node-id=6589%3A95676) 

## Testing instructions

1. Go to sign-in and click on forgot password link
2. You will be redirected to the forgot-password page. Fill the email and click 'send email'. You will receive an email with the reset_password_token.
3. Go to /sign-in/reset-password?reset_password_token= and paste the token on the query value.
4. You should see the reset password form. Fill the form and click 'reset password' button.
5. After the request is done you should be signed-in and redirected to the dashboard

- If the reset_password_token doesn’t exist the page must be 404
- The new password must be valid with the correct pattern and length (min 12 characters, min 1 uppercase, min 1 number)
- If the token is not valid (expired or already used) the API error should be shown 

## Tracking

[LET-774](https://vizzuality.atlassian.net/browse/LET-774)

## Screenshot 
<img width="1172" alt="Screenshot 2022-07-27 at 13 20 39" src="https://user-images.githubusercontent.com/48164343/181235067-902172b8-e2e9-46f9-85c1-82d1ecc2148e.png">


