### PR TITLE
Add FAQ page layout

### DIFF
--- a/frontend/components/expando/component.tsx
+++ b/frontend/components/expando/component.tsx
@@ -1,6 +1,7 @@
-import { FC, useState } from 'react';
+import { FC, useEffect, useState } from 'react';
 
 import { motion } from 'framer-motion';
+import { noop } from 'lodash-es';
 
 import type { ExpandoProps } from './types';
 
@@ -8,14 +9,20 @@ export const Expando: FC<ExpandoProps> = ({
   className,
   title,
   defaultOpen = true,
+  duration = 0.1,
+  onChange = noop,
   children,
 }: ExpandoProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(defaultOpen);
 
+  useEffect(() => {
+    onChange(isOpen);
+  }, [isOpen, onChange]);
+
   return (
     <div className={className}>
       <button
-        className="w-full rounded-full focus-visible:outline focus-visible:outline-green-dark focus-visible:outline-2 focus-visible:outline-offset-2"
+        className="w-full rounded focus-visible:outline focus-visible:outline-green-dark focus-visible:outline-2 focus-visible:outline-offset-2"
         type="button"
         onClick={() => setIsOpen(!isOpen)}
       >
@@ -25,7 +32,7 @@ export const Expando: FC<ExpandoProps> = ({
         className="px-2 -mx-2 overflow-hidden"
         initial={isOpen ? 'open' : 'closed'}
         animate={isOpen ? 'open' : 'closed'}
-        transition={{ bounce: 0, duration: 0.1 }}
+        transition={{ bounce: 0, duration }}
         variants={{
           open: { height: 'auto' },
           closed: { height: 0 },

--- a/frontend/components/expando/types.ts
+++ b/frontend/components/expando/types.ts
@@ -7,4 +7,8 @@ export type ExpandoProps = PropsWithChildren<{
   title: string | JSX.Element;
   /** Whether the expando defaults to an open state. Defaults to `true` */
   defaultOpen?: boolean;
+  /** Duration of the animation while expanding/collapsing. Defaults to 0.1 */
+  duration?: number;
+  /** Callback called when the expando changes open state */
+  onChange?: (isOpen: boolean) => void;
 }>;

--- a/frontend/containers/faq-page/faq-expando/component.tsx
+++ b/frontend/containers/faq-page/faq-expando/component.tsx
@@ -1,0 +1,60 @@
+import { FC, useState, useRef, useEffect, useCallback } from 'react';
+
+import { ChevronUp as ChevronUpIcon } from 'react-feather';
+
+import cx from 'classnames';
+
+import { useScrollToElement } from 'hooks/useScrollToElement';
+
+import Expando from 'components/expando';
+
+import type { FaqExpandoProps } from './types';
+
+export const FaqExpando: FC<FaqExpandoProps> = ({
+  className,
+  defaultOpen = false,
+  questionId: id,
+  question,
+  children: answer,
+}: FaqExpandoProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isOpen, setIsOpen] = useState<boolean>(defaultOpen);
+  const scrollToElement = useScrollToElement();
+
+  useEffect(() => {
+    if (defaultOpen) scrollToElement(containerRef, 96);
+  }, [defaultOpen, scrollToElement]);
+
+  return (
+    <div
+      key={id}
+      ref={containerRef}
+      className={cx({
+        'bg-white border-b border-bg-dark': true,
+        [className]: !!className,
+      })}
+    >
+      <Expando
+        defaultOpen={isOpen}
+        duration={0.4}
+        onChange={setIsOpen}
+        title={
+          <div className="flex items-center w-full px-6 py-5 text-left">
+            <span className="flex flex-grow text-lg font-semibold text-black">{question}</span>
+            <ChevronUpIcon
+              className={cx({
+                'w-6 h-6 transition-all duration-500': true,
+                'rotate-180': !isOpen,
+                'rotate-0': isOpen,
+              })}
+            />
+          </div>
+        }
+      >
+        <div className="px-6 pb-5">{answer}</div>
+      </Expando>
+    </div>
+  );
+};
+
+export default FaqExpando;

--- a/frontend/containers/faq-page/faq-expando/index.ts
+++ b/frontend/containers/faq-page/faq-expando/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { FaqExpandoProps } from './types';

--- a/frontend/containers/faq-page/faq-expando/types.ts
+++ b/frontend/containers/faq-page/faq-expando/types.ts
@@ -1,0 +1,14 @@
+import { PropsWithChildren } from 'react';
+
+import { FaqQuestions } from 'hooks/useFaq';
+
+export type FaqExpandoProps = PropsWithChildren<{
+  /** ClassNames to apply to the container */
+  className?: string;
+  /** Id of the question */
+  questionId: FaqQuestions;
+  /** Question for the FAQ Expando, displayed in the title */
+  question: string;
+  /** Whether the Expand defaults to open. Default: `false` */
+  defaultOpen?: boolean;
+}>;

--- a/frontend/hooks/useFaq.tsx
+++ b/frontend/hooks/useFaq.tsx
@@ -1,0 +1,145 @@
+import { useMemo } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import { Paths } from 'enums';
+
+/** FAQ Sections */
+export enum FaqSections {
+  Account = 'account',
+  Projects = 'projects',
+  OpenCalls = 'open-calls',
+  VerificationBadges = 'verification-badges',
+  HeCoPriorityLandscapes = 'heco-priority-landscapes',
+}
+
+/** FAQ Questions */
+export enum FaqQuestions {
+  /** Account */
+  HowDoAccountsWork = 'how-do-accounts-work',
+  CanIAddColleagues = 'can-i-add-colleagues-from-my-organization',
+  WhyAccountIsPendingApproval = 'why-is-my-account-pending-approval',
+  InfoNeededForPdAccount = 'what-information-do-i-need-to-create-a-project-developer-account',
+  InfoNeededForInvestorAccount = 'what-information-do-i-need-to-create-an-investor-account',
+  /** Projects */
+  WhatIsAProject = 'what-is-a-project',
+  ForWhoIsTheProjectFor = 'for-who-is-the-project-for',
+  HowCanIFundAProject = 'how-can-i-fund-a-project',
+  WhatInfoToCreateProject = 'what-information-do-i-need-to-create-a-project',
+}
+
+export const FaqPaths = {
+  /** Account */
+  [FaqQuestions.HowDoAccountsWork]: `${Paths.FAQ}/${FaqSections.Account}/${FaqQuestions.HowDoAccountsWork}`,
+  [FaqQuestions.CanIAddColleagues]: `${Paths.FAQ}/${FaqSections.Account}/${FaqQuestions.CanIAddColleagues}`,
+  [FaqQuestions.WhyAccountIsPendingApproval]: `${Paths.FAQ}/${FaqSections.Account}/${FaqQuestions.WhyAccountIsPendingApproval}`,
+  // [FaqQuestions.InfoNeededForPdAccount]: `${Paths.FAQ}/${FaqSections.Account}/${FaqQuestions.InfoNeededForPdAccount}`,
+  // [FaqQuestions.InfoNeededForInvestorAccount]: `${Paths.FAQ}/${FaqSections.Account}/${FaqQuestions.InfoNeededForInvestorAccount}`,
+  /** Projects */
+  [FaqQuestions.WhatIsAProject]: `${Paths.FAQ}/${FaqSections.Projects}/${FaqQuestions.WhatIsAProject}`,
+  [FaqQuestions.ForWhoIsTheProjectFor]: `${Paths.FAQ}/${FaqSections.Projects}/${FaqQuestions.ForWhoIsTheProjectFor}`,
+  [FaqQuestions.HowCanIFundAProject]: `${Paths.FAQ}/${FaqSections.Projects}/${FaqQuestions.HowCanIFundAProject}`,
+  // [FaqQuestions.WhatInfoToCreateProject]: `${Paths.FAQ}/${FaqSections.Projects}/${FaqQuestions.WhatInfoToCreateProject}`,
+};
+
+export const useFaq = () => {
+  const { formatMessage } = useIntl();
+
+  const faq = useMemo(
+    () => [
+      {
+        sectionId: FaqSections.Account,
+        name: formatMessage({ defaultMessage: 'Account', id: 'TwyMau' }),
+        items: [
+          {
+            questionId: FaqQuestions.HowDoAccountsWork,
+            question: formatMessage({ defaultMessage: 'How do accounts work?', id: '/ITXlB' }),
+            answer: formatMessage({
+              defaultMessage:
+                'To be part of the HeCo Invest platform your organization, institution or business must create an account. An account is your organization profile and it contains all the basic information to describe it. There are two types of accounts HeCo Invest: one for organizations developing projects - Project Developers - and one for organizations investing in projects - Investors. Each account will have at least one contact: the account owner.',
+              id: '+8XJbK',
+            }),
+          },
+          {
+            questionId: FaqQuestions.CanIAddColleagues,
+            question: formatMessage({
+              defaultMessage: 'Can I add colleagues from my organization to the account?',
+              id: 'tDM2u5',
+            }),
+            answer: formatMessage({
+              defaultMessage:
+                'The account owner can invite other colleagues to the account. These will receive an invitation by email to join the account. Each email can only be associated with one account. Once you are set as an account user, you can manage the account. However, adding or removing other account users can only be managed by account owners.',
+              id: 'OJfOvp',
+            }),
+          },
+          {
+            questionId: FaqQuestions.WhyAccountIsPendingApproval,
+            question: formatMessage({
+              defaultMessage: 'Why is my account pending approval?',
+              id: 'I2yxwP',
+            }),
+            answer: formatMessage({
+              defaultMessage:
+                'Every new account created will need to be approved by the HeCo Invest staff - platform administrator. This approval process allows for the verification of each organization, institution or business that applies to the HeCo Invest platform, guaranteeing that only trustworthy organizations will present their projects or investment opportunities. Therefore, your account will only be visible on the HeCo Invest platform after the platform administrator completes this approval step.',
+              id: 'Fg5HOn',
+            }),
+          },
+        ],
+      },
+      {
+        sectionId: FaqSections.Projects,
+        name: formatMessage({ defaultMessage: 'Projects', id: 'UxTJRa' }),
+        items: [
+          {
+            questionId: FaqQuestions.WhatIsAProject,
+            question: formatMessage({ defaultMessage: 'What is a project?', id: 'yP7Lrl' }),
+            answer: formatMessage({
+              defaultMessage:
+                'A project is an enterprise or initiative carefully planned and run by project developers in a given region with the objective of contributing to its environmental conservation. Projects are set up whenever a project developer is seeking visibility or needing investment.',
+              id: 'XwmxKZ',
+            }),
+          },
+          {
+            questionId: FaqQuestions.ForWhoIsTheProjectFor,
+            question: formatMessage({
+              defaultMessage: 'For who is the project for?',
+              id: 'etdw49',
+            }),
+            answer: formatMessage({
+              defaultMessage:
+                'Projects target investors. They are set up whenever a project developer is seeking visibility or needing investment. The project is intended to contribute to the environmental conservation of a specific region and benefit nature and people.',
+              id: 'Vi/HrX',
+            }),
+          },
+          {
+            questionId: FaqQuestions.HowCanIFundAProject,
+            question: formatMessage({
+              defaultMessage: 'How can I invest/fund a project?',
+              id: 'caaGgO',
+            }),
+            answer: formatMessage({
+              defaultMessage:
+                'The HeCo Invest platform connects governments, investors, donors, and philanthropists with selected investment opportunities and projects in high-priority areas for Herencia Colombia. If you find a project that matches your investment goals you can contact its project developer. The contact details will only be available for platform registered users. So if you want to reach out to a project developer, you first need to create an account or join an existing account. The beta version of the HeCo Invest platform does not include the actual attainment of the business deals. To fund a project, investors must carry out all business procedures outside the platform.',
+              id: 'FVcGqA',
+            }),
+          },
+        ],
+      },
+      {
+        sectionId: FaqSections.OpenCalls,
+        name: formatMessage({ defaultMessage: 'Open Calls', id: 'wpyHb9' }),
+      },
+      {
+        sectionId: FaqSections.VerificationBadges,
+        name: formatMessage({ defaultMessage: 'Verification badges', id: 'AGwIKZ' }),
+      },
+      {
+        sectionId: FaqSections.HeCoPriorityLandscapes,
+        name: formatMessage({ defaultMessage: 'HeCo Priority landscapes', id: 'BTFkyB' }),
+      },
+    ],
+    [formatMessage]
+  );
+
+  return faq;
+};

--- a/frontend/hooks/useScrollToElement.ts
+++ b/frontend/hooks/useScrollToElement.ts
@@ -1,0 +1,19 @@
+export const useScrollToElement = () => {
+  const scrollToElement = (
+    elementRef,
+    offsetY = 0
+  ): { elementRef: HTMLDivElement; offsetY: number } => {
+    const element = elementRef?.current;
+    if (!element || !window) return;
+
+    const position = element.getBoundingClientRect()?.top;
+    const offset = position + window.pageYOffset - offsetY;
+
+    window.scrollTo({
+      top: offset,
+      behavior: 'smooth',
+    });
+  };
+
+  return scrollToElement;
+};

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -642,6 +642,9 @@
   "IBlTCs": {
     "string": "The image is larger than {maxSize}MB"
   },
+  "IQTULX": {
+    "string": "We are here to help you"
+  },
   "ITdmlJ": {
     "string": "Contact information"
   },
@@ -872,6 +875,9 @@
   },
   "Q8Qw5B": {
     "string": "Description"
+  },
+  "QA1wrZ": {
+    "string": "Frequently Asked Questions"
   },
   "QDj3j7": {
     "string": "Inter-American Development Bank Lab"
@@ -1475,6 +1481,9 @@
   },
   "jKdvln": {
     "string": "Relevant links (optional)"
+  },
+  "jN8Kad": {
+    "string": "Browse thought the most frequently asked questions."
   },
   "jUgR7w": {
     "string": "Stage of development or maturity of the project"

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -1,4 +1,7 @@
 {
+  "+8XJbK": {
+    "string": "To be part of the HeCo Invest platform your organization, institution or business must create an account. An account is your organization profile and it contains all the basic information to describe it. There are two types of accounts HeCo Invest: one for organizations developing projects - Project Developers - and one for organizations investing in projects - Investors. Each account will have at least one contact: the account owner."
+  },
   "+JVDMC": {
     "string": "Know more"
   },
@@ -383,6 +386,9 @@
   "ADBj6Y": {
     "string": "What type of financing are you looking for to implement your project or solution?"
   },
+  "AGwIKZ": {
+    "string": "Verification badges"
+  },
   "APjPYs": {
     "string": "I want to write my content in"
   },
@@ -406,6 +412,9 @@
   },
   "BSFsv6": {
     "string": "Tree biomass density"
+  },
+  "BTFkyB": {
+    "string": "HeCo Priority landscapes"
   },
   "BY6k/1": {
     "string": "Riverine flood risk measures the percentage of population expected to be affected by Riverine flooding in an average year, accounting for existing flood-protection standards. Flood risk is assessed using hazard (inundation caused by river overflow), exposure (population in flood zone), and vulnerability.16 The existing level of flood protection is also incorporated into the risk calculation. It is important to note that this indicator represents flood risk not in terms of maximum possible impact but rather as average annual impact. The impacts from infrequent, extreme flood years are averaged with more common, less newsworthy flood years to produce the “expected annual affected population.” Higher values indicate that a greater proportion of the population is expected to be impacted by Riverine floods on average."
@@ -542,8 +551,14 @@
   "FN+0yY": {
     "string": "Unable to parse the file. Please try uploading a different format."
   },
+  "FVcGqA": {
+    "string": "The HeCo Invest platform connects governments, investors, donors, and philanthropists with selected investment opportunities and projects in high-priority areas for Herencia Colombia. If you find a project that matches your investment goals you can contact its project developer. The contact details will only be available for platform registered users. So if you want to reach out to a project developer, you first need to create an account or join an existing account. The beta version of the HeCo Invest platform does not include the actual attainment of the business deals. To fund a project, investors must carry out all business procedures outside the platform."
+  },
   "FazwRl": {
     "string": "Try again"
+  },
+  "Fg5HOn": {
+    "string": "Every new account created will need to be approved by the HeCo Invest staff - platform administrator. This approval process allows for the verification of each organization, institution or business that applies to the HeCo Invest platform, guaranteeing that only trustworthy organizations will present their projects or investment opportunities. Therefore, your account will only be visible on the HeCo Invest platform after the platform administrator completes this approval step."
   },
   "Ftj+/t": {
     "string": "Why is my profile pending approval?"
@@ -617,6 +632,9 @@
   },
   "I2VJMv": {
     "string": "Complete your profile with relevant information to make your relationship with project developers as precise as possible. For example the very particular topics you are interested in or the activities and items you definitely do not finance or invest in."
+  },
+  "I2yxwP": {
+    "string": "Why is my account pending approval?"
   },
   "I9iCt5": {
     "string": "From which investor or funder? (optional)"
@@ -798,6 +816,9 @@
   "OChccW": {
     "string": "Investor / Funder"
   },
+  "OJfOvp": {
+    "string": "The account owner can invite other colleagues to the account. These will receive an invitation by email to join the account. Each email can only be associated with one account. Once you are set as an account user, you can manage the account. However, adding or removing other account users can only be managed by account owners."
+  },
   "OSAxiC": {
     "string": "The solution or opportunity proposed"
   },
@@ -948,6 +969,9 @@
   "ToXG99": {
     "string": "View project page"
   },
+  "TwyMau": {
+    "string": "Account"
+  },
   "U1OBY8": {
     "string": "options {options}, selected."
   },
@@ -998,6 +1022,9 @@
   },
   "Vge+RX": {
     "string": "Footer"
+  },
+  "Vi/HrX": {
+    "string": "Projects target investors. They are set up whenever a project developer is seeking visibility or needing investment. The project is intended to contribute to the environmental conservation of a specific region and benefit nature and people."
   },
   "ViF88C": {
     "string": "Tell us about your work and impact priorities."
@@ -1088,6 +1115,9 @@
   },
   "XkF/qg": {
     "string": "Profile picture of {name}"
+  },
+  "XwmxKZ": {
+    "string": "A project is an enterprise or initiative carefully planned and run by project developers in a given region with the objective of contributing to its environmental conservation. Projects are set up whenever a project developer is seeking visibility or needing investment."
   },
   "Y2HapG": {
     "string": "The dataset represents a series of vectorized polygon layers that depict sub-basin boundaries at a global scale. An important characteristic of any sub-basin delineation is the sub-basin breakdown. At its highest level of sub-basin breakdown, each basin has been divided into two sub-basins at every location where two river branches meet which each have an individual upstream area of at least 100 km². A second critical feature of sub-basin delineations is the way the sub-basins are grouped or coded to allow for the creation of nested sub-basins at different scales, or to navigate within the sub-basin network from up- to downstream. To support these functionalities and topological concepts, the ‘Pfafstetter’ coding system has been implemented, offering 12 hierarchically nested sub-basin breakdowns globally."
@@ -1221,6 +1251,9 @@
   "cT6b2H": {
     "string": "WWF"
   },
+  "caaGgO": {
+    "string": "How can I invest/fund a project?"
+  },
   "ccXLVi": {
     "string": "Category"
   },
@@ -1298,6 +1331,9 @@
   },
   "et2m37": {
     "string": "insert URL"
+  },
+  "etdw49": {
+    "string": "For who is the project for?"
   },
   "eu+7Vl": {
     "string": "Do you have a project or a start-up business in the Colombian Amazon?"
@@ -1731,6 +1767,9 @@
   "t7lNU8": {
     "string": "Start making an impact now"
   },
+  "tDM2u5": {
+    "string": "Can I add colleagues from my organization to the account?"
+  },
   "tGAYL2": {
     "string": "Select an option"
   },
@@ -1889,6 +1928,9 @@
   },
   "yJVljq": {
     "string": "Through accessing <span>ARIES</span> (Artificial Intelligence for Environmental Sustainability) and using Machine Reasoning modelling algorithms, this platform accesses the most relevant information to inform you on project and investment potential impact along four key dimensions: <span>Biodiversity</span>, <span>Climate</span>, <span>Community</span> and <span>Water</span>."
+  },
+  "yP7Lrl": {
+    "string": "What is a project?"
   },
   "yQ7bY1": {
     "string": "You can upload a maximum of {maxFiles} files"

--- a/frontend/layouts/static-page/footer/component.tsx
+++ b/frontend/layouts/static-page/footer/component.tsx
@@ -216,9 +216,11 @@ export const Footer: React.FC<FooterProps> = ({
                     </Link>
                   </li>
                   <li>
-                    <a className="text-gray-400 disabled:pointer-events-none">
-                      <FormattedMessage defaultMessage="FAQ’s" id="qIvPIE" />
-                    </a>
+                    <Link href="/faq">
+                      <a className="hover:underline">
+                        <FormattedMessage defaultMessage="FAQ’s" id="qIvPIE" />
+                      </a>
+                    </Link>
                   </li>
                   <li>
                     <a className="text-gray-400 disabled:pointer-events-none">

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -69,6 +69,14 @@ module.exports = {
         source: '/project/:id/preview',
         destination: '/project/:id?preview=true',
       },
+      {
+        source: '/faq/:sectionId',
+        destination: '/faq',
+      },
+      {
+        source: '/faq/:sectionId/:questionId',
+        destination: '/faq',
+      },
     ];
   },
   async redirects() {

--- a/frontend/pages/faq.tsx
+++ b/frontend/pages/faq.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useRef } from 'react';
+
+import { FormattedMessage, useIntl } from 'react-intl';
+
+import cx from 'classnames';
+
+import { useRouter } from 'next/router';
+
+import { withLocalizedRequests } from 'hoc/locale';
+
+import { motion } from 'framer-motion';
+
+import { useFaq, FaqSections, FaqQuestions } from 'hooks/useFaq';
+import { useScrollToElement } from 'hooks/useScrollToElement';
+
+import { loadI18nMessages } from 'helpers/i18n';
+
+import FaqExpando from 'containers/faq-page/faq-expando';
+
+import Button from 'components/button';
+import Head from 'components/head';
+import LayoutContainer from 'components/layout-container';
+import { StaticPageLayoutProps } from 'layouts/static-page';
+import { PageComponent } from 'types';
+
+export const getServerSideProps = withLocalizedRequests(async (context) => {
+  // Property 'query' does not exist on type 'GetStaticPropsContext<ParsedUrlQuery, PreviewData>'
+  /** @ts-ignore */
+  const { locale, query } = context;
+  const { sectionId, questionId } = query;
+
+  const sectionExists = Object.values(FaqSections).includes(sectionId as FaqSections);
+  const questionExists = Object.values(FaqQuestions).includes(questionId as FaqQuestions);
+
+  if (!!sectionId && !sectionExists) {
+    return { notFound: true };
+  }
+
+  if (!!questionId && !questionExists) {
+    return { notFound: true };
+  }
+
+  return {
+    props: {
+      intlMessages: await loadI18nMessages({ locale }),
+    },
+  };
+});
+
+type FaqPageProps = {};
+
+const FaqPage: PageComponent<FaqPageProps, StaticPageLayoutProps> = () => {
+  const intl = useIntl();
+  const router = useRouter();
+  const containerRef = useRef(null);
+  const faqs = useFaq();
+  const scrollToElement = useScrollToElement();
+
+  const { sectionId, questionId } = router.query;
+
+  // Default to 'Account' if there is no sectionId in the url
+  const activeSection = sectionId ?? Object.values(FaqSections)[0];
+
+  const faqItems = faqs.find(({ sectionId: id }) => activeSection === id)?.items || [];
+
+  const animationVariants = {
+    initial: { opacity: 0 },
+    animate: { opacity: 1 },
+    exit: { opacity: 0 },
+  };
+
+  // We need to ensure that, when the user changes sections, it can see the "top" of the
+  // expandos section at the very least. If they can't, we scroll them up to the top of
+  // the FAQ aside/main container. Not scrolling to the very top of the page because at
+  // this point the user has already read it and scrolled past to it.
+  // The reason for this check is that, without this, the user could be at the very bottom
+  // of a section, or looking at the footer, and upon clicking to change sections they'd still
+  // be stuck at the bottom of the view. .
+  useEffect(() => {
+    const container = containerRef?.current;
+
+    if (!container || !window) return;
+
+    const positionY = container?.getBoundingClientRect()?.top;
+    const windowH = window.innerHeight;
+    const shouldScroll = !(positionY - 96 >= 0 && positionY <= windowH);
+
+    if (!shouldScroll) return;
+
+    scrollToElement(containerRef, 96);
+  }, [scrollToElement, sectionId]);
+
+  return (
+    <>
+      <Head
+        title={intl.formatMessage({ defaultMessage: 'Frequently Asked Questions', id: 'QA1wrZ' })}
+      />
+
+      <LayoutContainer className="mt-8 mb-32 bg-background-light">
+        <h1 className="font-serif text-3xl font-semibold md:text-4xl">
+          <FormattedMessage defaultMessage="We are here to help you" id="IQTULX" />
+        </h1>
+        <p className="my-3 text-lg text-gray-600 md:my-8">
+          <FormattedMessage
+            defaultMessage="Browse thought the most frequently asked questions."
+            id="jN8Kad"
+          />
+        </p>
+
+        <hr className="my-8 border-t-background-dark" />
+
+        <div ref={containerRef} className="relative flex flex-col gap-8 mt-8 md:gap-20 lg:flex-row">
+          <aside className="justify-start md:sticky md:self-start md:top-32">
+            {faqs.map(({ sectionId: id, name }) => (
+              <Button
+                key={id}
+                theme="naked"
+                onClick={() => {
+                  router.push(`/faq/${id}`, undefined, { shallow: true });
+                }}
+                className={cx({
+                  'whitespace-nowrap text-sm text-left focus-visible:outline-green-dark': true,
+                  'text-green-dark': activeSection === id,
+                })}
+              >
+                {name}
+              </Button>
+            ))}
+          </aside>
+          <motion.main key={sectionId as string} {...animationVariants}>
+            <div className="border-t border-l border-r rounded-lg shadow-sm border-bg-dark">
+              {faqItems.map(({ questionId: id, question, answer }, index) => (
+                <FaqExpando
+                  className={cx({
+                    'rounded-t-lg': index === 0,
+                    'rounded-b-lg': index === faqItems.length - 1,
+                  })}
+                  key={id}
+                  defaultOpen={(questionId as FaqQuestions) === id}
+                  questionId={id}
+                  question={question}
+                >
+                  {answer}
+                </FaqExpando>
+              ))}
+            </div>
+          </motion.main>
+        </div>
+      </LayoutContainer>
+    </>
+  );
+};
+
+FaqPage.layout = {
+  props: {
+    footerProps: {
+      className: 'mt-0',
+    },
+  },
+};
+
+export default FaqPage;

--- a/frontend/pages/faq.tsx
+++ b/frontend/pages/faq.tsx
@@ -96,7 +96,7 @@ const FaqPage: PageComponent<FaqPageProps, StaticPageLayoutProps> = () => {
         title={intl.formatMessage({ defaultMessage: 'Frequently Asked Questions', id: 'QA1wrZ' })}
       />
 
-      <LayoutContainer className="mt-8 mb-32 bg-background-light">
+      <LayoutContainer className="mt-8 mb-20 lg:mb-32 bg-background-light">
         <h1 className="font-serif text-3xl font-semibold md:text-4xl">
           <FormattedMessage defaultMessage="We are here to help you" id="IQTULX" />
         </h1>
@@ -109,8 +109,11 @@ const FaqPage: PageComponent<FaqPageProps, StaticPageLayoutProps> = () => {
 
         <hr className="my-8 border-t-background-dark" />
 
-        <div ref={containerRef} className="relative flex flex-col gap-8 mt-8 md:gap-20 lg:flex-row">
-          <aside className="justify-start md:sticky md:self-start md:top-32">
+        <div
+          ref={containerRef}
+          className="relative flex flex-col gap-8 mt-8 md:gap-20 lg:gap-32 xl:gap-48 lg:flex-row"
+        >
+          <aside className="justify-start w-full md:sticky md:self-start md:top-32">
             {faqs.map(({ sectionId: id, name }) => (
               <Button
                 key={id}


### PR DESCRIPTION
## Description

**In this PR:** 

- Added a `FaqExpando` component  
  - Customizes the `components/Expando` one to match the FAQ page's design.
  - Responsible to scroll the page to itself when its `defaultOpen` prop is set
    _This is set in the FAQ page when a user has linked to the respective question directly_
- Added a couple props to the `components/Expando` component
  _So we can specify an animation duration as well as have a callback for when it changes states_
- Added a `useScrollToElement` hook  
  _To facilitate scrolling to an element by its ref._
  _Currently used by the `FaqExpando`, and in the `FAQ` page itself to scroll to the top of the main container when the user changes sections_
- Added a `useFaq` hook 
  _In a similar pattern used in the `useLayers` hook, it stores which sections, paths, questions (and answers) we have, in order to simplify the page code_  
- Added a `pages/faq` page  
  _The whole "FAQ" is handled by a single page, but supports urls in the `/faq/:sectionId/:questionId` format._
  - It includes a transition when the user changes sections  
  - It features a sticky sidebar so that the sections' links are always visible  
  - It can scroll to the beginning of the questions automatically when the user changes sections
    _Currently only if not visible_  
  - It supports linking directly to a particular question
    _It'll auto-scroll to the question and auto-expand it_
  - URLs pointing to a non-existing section and/or question will return a `404`
  - The base url `/faq` defaults to the `Account` section  
- Enabled the footer's link to the FAQ page  
  _To facilitate testing_  

**Note:**  

Adding content will be addressed in [LET-781](https://vizzuality.atlassian.net/browse/LET-781), and adding links to the FAQ will be addressed in [LET-782](https://vizzuality.atlassian.net/browse/LET-782). Nevertheless, I added _some_ content so that we can minimally test the layout; chances are as we add the remaining content some changes will have to be made. 

**Figma:**

[Link](https://www.figma.com/file/KC49uMR9t1YARmFR0Sr6aN/HeCo---Work-in-progress?node-id=6091%3A102968)

## Testing instructions

**Restart the next server**
_This PR contains changes to `next.config.js`_

**Verify that:**  
- `/faq` displays the FAQ, and it defaults to the `Account` section  
- The left navigation works
  _And the active section is highlighted in dark green_  
  _Note that only the `Account` and `Projects` sections have content for testing. Nevertheless, the other ones should not crash the app_
- Section urls load the correct section
  _(eg: `/faq/projects`)_  
- Linking to a question directly works correctly
  _(eg: `faq/projects/for-who-is-the-project-for`)_  
  - The correct section is shown/highlighted  
  - The corresponding section expando is open  
  - The user is scrolled to the expand
    _We don't have content, so the scrolling may appear a bit weird. But the question should be visible_
- Linking to non-existing sections triggers the 404 page
  _(eg: `faq/section-that-doesnt-exist`)_  
- Linking to non-existing questions triggers the 404 page
  _(eg: `faq/projects/this-question-doesnt-exist`)_
- Linking to non-existing-subpages triggers the 404 page
  _(eg: `faq/projects/for-who-is-the-project-for/the-question-exists-but-theres-no-sub-page`)_


## Tracking

[LET-780](https://vizzuality.atlassian.net/browse/LET-780)

## Screenshot
<img width="1680" alt="Screenshot 2022-07-27 at 15 10 02" src="https://user-images.githubusercontent.com/6273795/181268642-531ff769-43b1-436b-813b-e05a514f7a75.png">

## Screen recording

https://user-images.githubusercontent.com/6273795/181269373-4174e15d-42e0-48b4-b9b9-8e064a6e2d85.mp4


