### PR TITLE
Change search button text to 'search' when searching

### DIFF
--- a/frontend/containers/layouts/discover-search/component.tsx
+++ b/frontend/containers/layouts/discover-search/component.tsx
@@ -182,7 +182,11 @@ export const DiscoverSearch: FC<DiscoverSearchProps> = ({
                 </Button>
               </h3>
               <Button type="submit" className="h-full font-normal" theme="primary-orange">
-                {searchButtonText}
+                {searchInputValue ? (
+                  <FormattedMessage defaultMessage="Search" id="xmcVZ0" />
+                ) : (
+                  searchButtonText
+                )}
               </Button>
             </div>
           </form>


### PR DESCRIPTION
This PR fixes the search button text
When searching the text changes from 'See full catalogue' to 'Search' on the Home page
[issue](https://vizzuality.atlassian.net/browse/LET-634?focusedCommentId=18079)

## Testing instructions

Go to home page and type something on the search box. The text of the action button should change from 'See full catalogue' to 'Search' 

## Tracking

[LET-826](https://vizzuality.atlassian.net/browse/LET-826)
