### PR TITLE
Add info to map layers tooltips

### DIFF
--- a/frontend/containers/discover-map/layer-tooltip/component.tsx
+++ b/frontend/containers/discover-map/layer-tooltip/component.tsx
@@ -38,7 +38,17 @@ export const LayerTooltip: FC<LayerTooltipProps> = ({ selectedLayer, closeToolti
               <FormattedMessage defaultMessage="Overview" id="9uOFF3" />
             )}
           </p>
-          <p className="text-xs text-gray-900">{selectedLayer?.overview}</p>
+          {Array.isArray(selectedLayer?.overview) ? (
+            <div className="flex flex-col gap-2">
+              {selectedLayer.overview.map((overview, index) => (
+                <p key={index} className="text-xs text-gray-900">
+                  {overview}
+                </p>
+              ))}
+            </div>
+          ) : (
+            <p className="text-xs text-gray-900">{selectedLayer?.overview}</p>
+          )}
         </div>
         <div>
           <p className="mt-4 mb-2 text-sm font-semibold text-gray-600">
@@ -48,7 +58,7 @@ export const LayerTooltip: FC<LayerTooltipProps> = ({ selectedLayer, closeToolti
           </p>
           {selectedLayer?.dataSourceUrl ? (
             <a
-              className="text-xs text-gray-900 hover:underline"
+              className="text-xs text-gray-900 underline"
               target="_blanc"
               rel="noopener noreferrer"
               href={selectedLayer?.dataSourceUrl}

--- a/frontend/containers/discover-map/map-layers-selector/types.ts
+++ b/frontend/containers/discover-map/map-layers-selector/types.ts
@@ -1,3 +1,5 @@
+import { string } from 'yup/lib/locale';
+
 export type MapLayersSelectorProps = {
   /** Classes to apply to the container */
   className?: string;
@@ -13,7 +15,7 @@ export type SelectedLayerTooltip = {
   id: string;
   name: string;
   description: string;
-  overview?: string;
+  overview?: string | string[];
   dataSource: string;
   dataSourceUrl: string;
 };

--- a/frontend/hooks/useLayers.ts
+++ b/frontend/hooks/useLayers.ts
@@ -68,7 +68,8 @@ export const useLayers = () => {
             id: 'Id5CnU',
           }),
           dataSource: 'Ministerio de Medio Ambiente y Desarrollo Sostenible de Colombia',
-          dataSourceUrl: '',
+          dataSourceUrl:
+            'https://www.arcgis.com/home/item.html?id=07bdb2d56b534039843a415995fc4447',
           specification: {
             type: 'vector',
             source: {
@@ -228,7 +229,7 @@ export const useLayers = () => {
           }),
           dataSource:
             'United Nations Environment World Conservation Monitoring Centre (UNEP-WCMC) and Natural History Museum',
-          dataSourceUrl: '',
+          dataSourceUrl: 'https://data.nhm.ac.uk/',
           specification: {
             type: 'raster',
             source: {
@@ -353,11 +354,18 @@ export const useLayers = () => {
             defaultMessage: 'Global estimate of human population density and distribution.',
             id: 'A8lXv/',
           }),
-          overview: formatMessage({
-            defaultMessage:
-              'The Global Human Settlement Layer (GHSL) Population Grid depicts the distribution and density of population, expressed as the number of people per cell, for 2015. While GFW uses only 2015 data, the GHSL is a multi-temporal population data set that employs new spatial data mining technologies. These methods enable the automatic processing and extraction of analytics and knowledge from different data sets: global, fine-scale satellite image data streams, census data, and crowd sources or volunteered geographic information sources. To produce this population density and distribution data set, researchers mapped global built-up areas, which are defined as all above ground constructions intended for human or animal sheltering or to produce economic goods. The locations of these built up areas was established using Landsat imagery analysis. An additional source used to compile this data set was the Gridded Population of the World (GPW) data set assembled by the Center for International Earth Science Information Network (CIESIN). The GPW data set consists of census population data and bolstered the built-up areas data by enabling researchers to estimate residential population. To present this data as grid cells, GPW data was disaggregated from census or administrative units.',
-            id: 'PIc+q2',
-          }),
+          overview: [
+            formatMessage({
+              defaultMessage:
+                'The Global Human Settlement Layer (GHSL) Population Grid depicts the distribution and density of population, expressed as the number of people per cell, for 2015. While GFW uses only 2015 data, the GHSL is a multi-temporal population data set that employs new spatial data mining technologies. These methods enable the automatic processing and extraction of analytics and knowledge from different data sets: global, fine-scale satellite image data streams, census data, and crowd sources or volunteered geographic information sources.',
+              id: 'VzuazJ',
+            }),
+            formatMessage({
+              defaultMessage:
+                'To produce this population density and distribution data set, researchers mapped global built-up areas, which are defined as all above ground constructions intended for human or animal sheltering or to produce economic goods. The locations of these built up areas was established using Landsat imagery analysis. An additional source used to compile this data set was the Gridded Population of the World (GPW) data set assembled by the Center for International Earth Science Information Network (CIESIN). The GPW data set consists of census population data and bolstered the built-up areas data by enabling researchers to estimate residential population. To present this data as grid cells, GPW data was disaggregated from census or administrative units.',
+              id: 'dKiARI',
+            }),
+          ],
           dataSource:
             'European Commission, Joint Research Centre (JRC); Columbia University, Center for International Earth Science Information Network - CIESIN',
           dataSourceUrl: 'https://data.jrc.ec.europa.eu/dataset/jrc-ghsl-ghs_pop_gpw4_globe_r2015a',
@@ -384,11 +392,18 @@ export const useLayers = () => {
               'Displays the Key Biodiversity Areas containing 95% or more of the remaining population of one or more species listed as Endangered or Critically Endangered on the International Union for Conservation of Nature (IUCN) Red List of Threatened Species.',
             id: '6vrfSY',
           }),
-          overview: formatMessage({
-            defaultMessage:
-              'The dataset represents the boundaries of sites containing 95% or more of the remaining population of one or more species listed as Endangered or Critically Endangered on the International Union for Conservation of Nature (IUCN) Red List of Threatened Species. The Alliance for Zero Extinction (AZE) originally created this dataset with a goal to prevent extinctions by identifying and safeguarding key sites. The 2019 March version of this dataset contains 859 sites, supporting 1483 Critically Endangered or Endangered species.',
-            id: 'UVJ5y2',
-          }),
+          overview: [
+            formatMessage({
+              defaultMessage:
+                'The dataset represents the boundaries of sites containing 95% or more of the remaining population of one or more species listed as Endangered or Critically Endangered on the International Union for Conservation of Nature (IUCN) Red List of Threatened Species.',
+              id: 'TYrWO2',
+            }),
+            formatMessage({
+              defaultMessage:
+                'The Alliance for Zero Extinction (AZE) originally created this dataset with a goal to prevent extinctions by identifying and safeguarding key sites. The 2019 March version of this dataset contains 859 sites, supporting 1483 Critically Endangered or Endangered species.',
+              id: 'tgYyOu',
+            }),
+          ],
           dataSource: 'Alliance for Zero Extinctions (AZE)',
           dataSourceUrl: 'https://www.keybiodiversityareas.org/kba-data/request',
           specification: {
@@ -444,11 +459,18 @@ export const useLayers = () => {
             defaultMessage: 'Identifies areas of gross tree cover loss.',
             id: 'rw2/NH',
           }),
-          overview: formatMessage({
-            defaultMessage:
-              'This data set, a collaboration between the Global Land Analysis & Discovery (GLAD) lab at the University of Maryland, Google, USGS, and NASA, measures areas of tree cover loss across all global land (except Antarctica and other Arctic islands) at approximately 30 × 30 meter resolution. The data were generated using multispectral satellite imagery from the Landsat 5 thematic mapper (TM), the Landsat 7 thematic mapper plus (ETM+), and the Landsat 8 Operational Land Imager (OLI) sensors. Over 1 million satellite images were processed and analyzed, including over 600,000 Landsat 7 images for the 2000-2012 interval, and more than 400,000 Landsat 5, 7, and 8 images for updates for the 2011-2021 interval. The clear land surface observations in the satellite images were assembled and a supervised learning algorithm was applied to identify per pixel tree cover loss. In this data set, “tree cover” is defined as all vegetation greater than 5 meters in height, and may take the form of natural forests or plantations across a range of canopy densities. Tree cover loss is defined as “stand replacement disturbance,” or the complete removal of tree cover canopy at the Landsat pixel scale. Tree cover loss may be the result of human activities, including forestry practices such as timber harvesting or deforestation (the conversion of natural forest to other land uses), as well as natural causes such as disease or storm damage. Fire is another widespread cause of tree cover loss, and can be either natural or human-induced.',
-            id: 'jJYv/7',
-          }),
+          overview: [
+            formatMessage({
+              defaultMessage:
+                'This data set, a collaboration between the Global Land Analysis & Discovery (GLAD) lab at the University of Maryland, Google, USGS, and NASA, measures areas of tree cover loss across all global land (except Antarctica and other Arctic islands) at approximately 30 × 30 meter resolution. The data were generated using multispectral satellite imagery from the Landsat 5 thematic mapper (TM), the Landsat 7 thematic mapper plus (ETM+), and the Landsat 8 Operational Land Imager (OLI) sensors. Over 1 million satellite images were processed and analyzed, including over 600,000 Landsat 7 images for the 2000-2012 interval, and more than 400,000 Landsat 5, 7, and 8 images for updates for the 2011-2021 interval. The clear land surface observations in the satellite images were assembled and a supervised learning algorithm was applied to identify per pixel tree cover loss.',
+              id: 'eE6uKi',
+            }),
+            formatMessage({
+              defaultMessage:
+                'In this data set, “tree cover” is defined as all vegetation greater than 5 meters in height, and may take the form of natural forests or plantations across a range of canopy densities. Tree cover loss is defined as “stand replacement disturbance,” or the complete removal of tree cover canopy at the Landsat pixel scale. Tree cover loss may be the result of human activities, including forestry practices such as timber harvesting or deforestation (the conversion of natural forest to other land uses), as well as natural causes such as disease or storm damage. Fire is another widespread cause of tree cover loss, and can be either natural or human-induced.',
+              id: 'keWpuD',
+            }),
+          ],
           dataSource: 'Hansen/UMD/Google/USGS/NASA',
           dataSourceUrl: 'https://glad.earthengine.app/view/global-forest-change',
           specification: {

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -825,9 +825,6 @@
   "PIZ1dD": {
     "string": "Search biodiversity"
   },
-  "PIc+q2": {
-    "string": "The Global Human Settlement Layer (GHSL) Population Grid depicts the distribution and density of population, expressed as the number of people per cell, for 2015. While GFW uses only 2015 data, the GHSL is a multi-temporal population data set that employs new spatial data mining technologies. These methods enable the automatic processing and extraction of analytics and knowledge from different data sets: global, fine-scale satellite image data streams, census data, and crowd sources or volunteered geographic information sources. To produce this population density and distribution data set, researchers mapped global built-up areas, which are defined as all above ground constructions intended for human or animal sheltering or to produce economic goods. The locations of these built up areas was established using Landsat imagery analysis. An additional source used to compile this data set was the Gridded Population of the World (GPW) data set assembled by the Center for International Earth Science Information Network (CIESIN). The GPW data set consists of census population data and bolstered the built-up areas data by enabling researchers to estimate residential population. To present this data as grid cells, GPW data was disaggregated from census or administrative units."
-  },
   "PR8FFs": {
     "string": "Create your organization's account as a project developer in the field or as an investor or funder and become part of the HeCo Invest community."
   },
@@ -936,6 +933,9 @@
   "TUFmRM": {
     "string": "Climate impact"
   },
+  "TYrWO2": {
+    "string": "The dataset represents the boundaries of sites containing 95% or more of the remaining population of one or more species listed as Endangered or Critically Endangered on the International Union for Conservation of Nature (IUCN) Red List of Threatened Species."
+  },
   "TfXhCr": {
     "string": "No projects"
   },
@@ -956,9 +956,6 @@
   },
   "URdlN+": {
     "string": "Invest in small, medium or big project opportunities."
-  },
-  "UVJ5y2": {
-    "string": "The dataset represents the boundaries of sites containing 95% or more of the remaining population of one or more species listed as Endangered or Critically Endangered on the International Union for Conservation of Nature (IUCN) Red List of Threatened Species. The Alliance for Zero Extinction (AZE) originally created this dataset with a goal to prevent extinctions by identifying and safeguarding key sites. The 2019 March version of this dataset contains 859 sites, supporting 1483 Critically Endangered or Endangered species."
   },
   "Ub+AGc": {
     "string": "Sign In"
@@ -1004,6 +1001,9 @@
   },
   "Vxcu91": {
     "string": "{name} account"
+  },
+  "VzuazJ": {
+    "string": "The Global Human Settlement Layer (GHSL) Population Grid depicts the distribution and density of population, expressed as the number of people per cell, for 2015. While GFW uses only 2015 data, the GHSL is a multi-temporal population data set that employs new spatial data mining technologies. These methods enable the automatic processing and extraction of analytics and knowledge from different data sets: global, fine-scale satellite image data streams, census data, and crowd sources or volunteered geographic information sources."
   },
   "W2JBdp": {
     "string": "Impact"
@@ -1239,6 +1239,9 @@
   "dHpDHe": {
     "string": "HeCo Invest will <n>benefit poor and vulnerable people</n> living in <n>HeCo priority landscapes in the Amazon region</n>."
   },
+  "dKiARI": {
+    "string": "To produce this population density and distribution data set, researchers mapped global built-up areas, which are defined as all above ground constructions intended for human or animal sheltering or to produce economic goods. The locations of these built up areas was established using Landsat imagery analysis. An additional source used to compile this data set was the Gridded Population of the World (GPW) data set assembled by the Center for International Earth Science Information Network (CIESIN). The GPW data set consists of census population data and bolstered the built-up areas data by enabling researchers to estimate residential population. To present this data as grid cells, GPW data was disaggregated from census or administrative units."
+  },
   "dPuc1g": {
     "string": "Slide {slideNumber}"
   },
@@ -1262,6 +1265,9 @@
   },
   "e0c9xF": {
     "string": "insert the name of the investor/funder"
+  },
+  "eE6uKi": {
+    "string": "This data set, a collaboration between the Global Land Analysis & Discovery (GLAD) lab at the University of Maryland, Google, USGS, and NASA, measures areas of tree cover loss across all global land (except Antarctica and other Arctic islands) at approximately 30 × 30 meter resolution. The data were generated using multispectral satellite imagery from the Landsat 5 thematic mapper (TM), the Landsat 7 thematic mapper plus (ETM+), and the Landsat 8 Operational Land Imager (OLI) sensors. Over 1 million satellite images were processed and analyzed, including over 600,000 Landsat 7 images for the 2000-2012 interval, and more than 400,000 Landsat 5, 7, and 8 images for updates for the 2011-2021 interval. The clear land surface observations in the satellite images were assembled and a supervised learning algorithm was applied to identify per pixel tree cover loss."
   },
   "eItis6": {
     "string": "Discover investors by budget/ticket size"
@@ -1428,9 +1434,6 @@
   "jHyKQ2": {
     "string": "Thanks to our <n>model ARIES</n>, an Artificial Intelligence tool, you can <n>reach investors</n> that are interested in your project and <n>learn how your activity impacts</n> the environment and your community."
   },
-  "jJYv/7": {
-    "string": "This data set, a collaboration between the Global Land Analysis & Discovery (GLAD) lab at the University of Maryland, Google, USGS, and NASA, measures areas of tree cover loss across all global land (except Antarctica and other Arctic islands) at approximately 30 × 30 meter resolution. The data were generated using multispectral satellite imagery from the Landsat 5 thematic mapper (TM), the Landsat 7 thematic mapper plus (ETM+), and the Landsat 8 Operational Land Imager (OLI) sensors. Over 1 million satellite images were processed and analyzed, including over 600,000 Landsat 7 images for the 2000-2012 interval, and more than 400,000 Landsat 5, 7, and 8 images for updates for the 2011-2021 interval. The clear land surface observations in the satellite images were assembled and a supervised learning algorithm was applied to identify per pixel tree cover loss. In this data set, “tree cover” is defined as all vegetation greater than 5 meters in height, and may take the form of natural forests or plantations across a range of canopy densities. Tree cover loss is defined as “stand replacement disturbance,” or the complete removal of tree cover canopy at the Landsat pixel scale. Tree cover loss may be the result of human activities, including forestry practices such as timber harvesting or deforestation (the conversion of natural forest to other land uses), as well as natural causes such as disease or storm damage. Fire is another widespread cause of tree cover loss, and can be either natural or human-induced."
-  },
   "jKdvln": {
     "string": "Relevant links (optional)"
   },
@@ -1484,6 +1487,9 @@
   },
   "kX7oGR": {
     "string": "Other information"
+  },
+  "keWpuD": {
+    "string": "In this data set, “tree cover” is defined as all vegetation greater than 5 meters in height, and may take the form of natural forests or plantations across a range of canopy densities. Tree cover loss is defined as “stand replacement disturbance,” or the complete removal of tree cover canopy at the Landsat pixel scale. Tree cover loss may be the result of human activities, including forestry practices such as timber harvesting or deforestation (the conversion of natural forest to other land uses), as well as natural causes such as disease or storm damage. Fire is another widespread cause of tree cover loss, and can be either natural or human-induced."
   },
   "ku+mDU": {
     "string": "State"
@@ -1739,6 +1745,9 @@
   },
   "tSCuG5": {
     "string": "Delete user?"
+  },
+  "tgYyOu": {
+    "string": "The Alliance for Zero Extinction (AZE) originally created this dataset with a goal to prevent extinctions by identifying and safeguarding key sites. The 2019 March version of this dataset contains 859 sites, supporting 1483 Critically Endangered or Endangered species."
   },
   "twK/jv": {
     "string": "Project developer profile"


### PR DESCRIPTION
This PR adds the missing information about the map layers to be displayed on the tooltips

## Testing instructions

The map layers tooltips should show the info according to the  [data layers doc](https://docs.google.com/spreadsheets/d/1XbiiS0pv5P3eLbO3HTFVD5R-nQ8C55iyfYIxhiC3uKk/edit#gid=1856162673)

Changes covered:

- Missing url for “Biodiversity intactness”
Note: the info in the document source had been wrongly changed by us on the 22nd of June. Checking cell history I found the correct info and is already ok. Please add

- Additionally, the overview of the following layers is not respecting the paragraph split
  1. Population Density
  2. Endangered Species and Critical Habitats
  3. Tree cover loss

## Tracking

[LET-827](https://vizzuality.atlassian.net/browse/LET-827)
