### PR TITLE
Remove duplicated menu items on discover pages

### DIFF
--- a/frontend/containers/layouts/navigation-menu-button/component.tsx
+++ b/frontend/containers/layouts/navigation-menu-button/component.tsx
@@ -5,6 +5,8 @@ import { FormattedMessage, useIntl } from 'react-intl';
 
 import { useRouter } from 'next/router';
 
+import { useBreakpoint } from 'hooks/use-breakpoint';
+
 import Button from 'components/button';
 import Menu, { MenuItem, MenuSection } from 'components/menu';
 import { Paths } from 'enums';
@@ -18,10 +20,13 @@ export const NavigationMenuButton: FC<NavigationMenuButtonProps> = ({
   className,
   theme = 'primary-white',
 }: NavigationMenuButtonProps) => {
-  const router = useRouter();
+  const { pathname, push } = useRouter();
+  const isSearchPage = pathname.includes(Paths.Discover);
   const intl = useIntl();
   const { user, userAccount: account } = useAccount();
   const signOut = useSignOut();
+  const breakpoint = useBreakpoint();
+  const isLg = breakpoint('lg');
 
   const [menuOpen, setMenuOpen] = useState(false);
 
@@ -33,18 +38,18 @@ export const NavigationMenuButton: FC<NavigationMenuButtonProps> = ({
             {},
             {
               onSuccess: () => {
-                router.push(Paths.Home);
+                push(Paths.Home);
               },
             }
           );
           break;
 
         default:
-          router.push(key);
+          push(key);
           break;
       }
     },
-    [router, signOut]
+    [push, signOut]
   );
 
   return (
@@ -72,9 +77,11 @@ export const NavigationMenuButton: FC<NavigationMenuButtonProps> = ({
           hiddenSections={{ 'user-section': 'sm' }}
         >
           <MenuSection>
-            <MenuItem key={Paths.Projects}>
-              <FormattedMessage defaultMessage="Search" id="xmcVZ0" />
-            </MenuItem>
+            {!isSearchPage && (
+              <MenuItem key={Paths.Projects}>
+                <FormattedMessage defaultMessage="Search" id="xmcVZ0" />
+              </MenuItem>
+            )}
             <MenuItem key={Paths.ForInvestors}>
               <FormattedMessage defaultMessage="For investors" id="MfCYKW" />
             </MenuItem>
@@ -117,8 +124,13 @@ export const NavigationMenuButton: FC<NavigationMenuButtonProps> = ({
               key="user-section-sign-in"
               title={intl.formatMessage({ defaultMessage: 'User', id: 'EwRIOm' })}
             >
-              <MenuItem key={Paths.SignIn}>
-                <FormattedMessage defaultMessage="Sign in" id="SQJto2" />
+              {(!isSearchPage || !isLg) && (
+                <MenuItem key={Paths.SignIn}>
+                  <FormattedMessage defaultMessage="Sign in" id="SQJto2" />
+                </MenuItem>
+              )}
+              <MenuItem key={Paths.SignUp}>
+                <FormattedMessage defaultMessage="Sign up" id="8HJxXG" />
               </MenuItem>
             </MenuSection>
           )}

--- a/frontend/layouts/discover-page/component.tsx
+++ b/frontend/layouts/discover-page/component.tsx
@@ -171,7 +171,7 @@ export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
         <div className="z-10">
           <Header />
           <LayoutContainer className="z-10 flex justify-center pt-1 mt-0 mb-2 pointer-events-none xl:hidden xl:mb-6 xl:mt-0 xl:left-0 xl:right-0 xl:h-20 xl:fixed xl:top-3">
-            <DiscoverSearch className="w-full max-w-3xl pointer-events-auto" />
+            <DiscoverSearch className="-z-10 w-full max-w-3xl pointer-events-auto" />
           </LayoutContainer>
         </div>
         <main className="z-0 flex flex-col flex-grow h-screen overflow-y-scroll">


### PR DESCRIPTION
This PR removes the duplicated items from the menu on discovery pages

## Description

As an HeCo visitor, I need that redundant items from "header menu" in search results page are removed, so that confusion is avoided and user experience improved

### Acceptance criteria

The option “Search” will not be displayed from the menu

The option “Sign in” will not be displayed from the menu

Applies only when the user is not logged in

## Testing instructions

### Signed in
1. Go to any discover page
2. Click on menu.
The menu should not display the search item

#### Large screens
<img width="523" alt="Screenshot 2022-07-27 at 19 27 24" src="https://user-images.githubusercontent.com/48164343/181311236-9dc05663-401d-4c5d-9322-752626169ada.png">

#### Small screens
<img width="432" alt="Screenshot 2022-07-27 at 19 27 49" src="https://user-images.githubusercontent.com/48164343/181311303-b4c4a15e-2302-4b6d-8cbd-8cc5cef1c9b2.png">


### Signed out
1. Go to any discover page
2. Click on menu.
The menu should not display the search or sign-in items

#### Large screens
<img width="523" alt="Screenshot 2022-07-27 at 19 25 24" src="https://user-images.githubusercontent.com/48164343/181310751-14667440-8a64-473b-a5d5-5719edb48906.png">

#### Small screens
<img width="523" alt="Screenshot 2022-07-27 at 19 24 44" src="https://user-images.githubusercontent.com/48164343/181310759-1185c65d-74a5-4b8d-a178-a65e6ba3b84d.png">


## Tracking

[LET-790](https://vizzuality.atlassian.net/browse/LET-790)

 