### PR TITLE
add faq href to existing faq links on pages

### DIFF
--- a/frontend/containers/account-pending-approval/component.tsx
+++ b/frontend/containers/account-pending-approval/component.tsx
@@ -3,6 +3,8 @@ import { FormattedMessage } from 'react-intl';
 import Image from 'next/image';
 import Link from 'next/link';
 
+import { FaqPaths } from 'hooks/useFaq';
+
 import Button from 'components/button';
 
 export const AccountPendingApproval = () => {
@@ -33,7 +35,7 @@ export const AccountPendingApproval = () => {
       <Button className="mt-6 mb-12" to="/discover">
         <FormattedMessage defaultMessage="Explore" id="7JlauX" />
       </Button>
-      <Link href="/faq#pending-approval" passHref>
+      <Link href={FaqPaths['why-is-my-account-pending-approval']} passHref>
         <a target="_blank" rel="noopener noreferrer" className="font-sans text-gray-600 underline">
           <FormattedMessage defaultMessage="Why is my profile pending approval?" id="Ftj+/t" />
         </a>

--- a/frontend/containers/account-pending-approval/component.tsx
+++ b/frontend/containers/account-pending-approval/component.tsx
@@ -3,7 +3,7 @@ import { FormattedMessage } from 'react-intl';
 import Image from 'next/image';
 import Link from 'next/link';
 
-import { FaqPaths } from 'hooks/useFaq';
+import { FaqPaths, FaqQuestions } from 'hooks/useFaq';
 
 import Button from 'components/button';
 
@@ -35,7 +35,7 @@ export const AccountPendingApproval = () => {
       <Button className="mt-6 mb-12" to="/discover">
         <FormattedMessage defaultMessage="Explore" id="7JlauX" />
       </Button>
-      <Link href={FaqPaths['why-is-my-account-pending-approval']} passHref>
+      <Link href={FaqPaths[FaqQuestions.WhyAccountIsPendingApproval]} passHref>
         <a target="_blank" rel="noopener noreferrer" className="font-sans text-gray-600 underline">
           <FormattedMessage defaultMessage="Why is my profile pending approval?" id="Ftj+/t" />
         </a>

--- a/frontend/containers/project-form/pages/pending-approval.tsx
+++ b/frontend/containers/project-form/pages/pending-approval.tsx
@@ -5,6 +5,8 @@ import { FormattedMessage } from 'react-intl';
 import Image from 'next/image';
 import Link from 'next/link';
 
+import { FaqPaths } from 'hooks/useFaq';
+
 import Button from 'components/button';
 import { Paths } from 'enums';
 
@@ -33,12 +35,12 @@ export const PendingApproval = ({ projectSlug }: { projectSlug: string }) => {
       <Button className="mt-6 mb-12" to={`${Paths.Project}/${projectSlug}`}>
         <FormattedMessage defaultMessage="Go to project page" id="mMReor" />
       </Button>
-      <Link href="/faq#pending-approval" passHref>
+      <Link href={FaqPaths['what-is-a-verification-badge']} passHref>
         <a target="_blank" rel="noopener noreferrer" className="font-sans text-gray-600 underline">
           <FormattedMessage defaultMessage="What is a verification badge?" id="qZPjW2" />
         </a>
       </Link>
-      <Link href="/faq#pending-approval" passHref>
+      <Link href={FaqPaths['when-will-the-project-have-the-verification-badge']} passHref>
         <a
           target="_blank"
           rel="noopener noreferrer"

--- a/frontend/containers/project-form/pages/pending-approval.tsx
+++ b/frontend/containers/project-form/pages/pending-approval.tsx
@@ -5,7 +5,7 @@ import { FormattedMessage } from 'react-intl';
 import Image from 'next/image';
 import Link from 'next/link';
 
-import { FaqPaths } from 'hooks/useFaq';
+import { FaqPaths, FaqQuestions } from 'hooks/useFaq';
 
 import Button from 'components/button';
 import { Paths } from 'enums';
@@ -35,12 +35,12 @@ export const PendingApproval = ({ projectSlug }: { projectSlug: string }) => {
       <Button className="mt-6 mb-12" to={`${Paths.Project}/${projectSlug}`}>
         <FormattedMessage defaultMessage="Go to project page" id="mMReor" />
       </Button>
-      <Link href={FaqPaths['what-is-a-verification-badge']} passHref>
+      <Link href={FaqPaths[FaqQuestions.WhatIsAVerificationBadge]} passHref>
         <a target="_blank" rel="noopener noreferrer" className="font-sans text-gray-600 underline">
           <FormattedMessage defaultMessage="What is a verification badge?" id="qZPjW2" />
         </a>
       </Link>
-      <Link href={FaqPaths['when-will-the-project-have-the-verification-badge']} passHref>
+      <Link href={FaqPaths[FaqQuestions.WhenWillTheProjectHaveTheVerificationBadge]} passHref>
         <a
           target="_blank"
           rel="noopener noreferrer"

--- a/frontend/hooks/useFaq.tsx
+++ b/frontend/hooks/useFaq.tsx
@@ -26,6 +26,10 @@ export enum FaqQuestions {
   ForWhoIsTheProjectFor = 'for-who-is-the-project-for',
   HowCanIFundAProject = 'how-can-i-fund-a-project',
   WhatInfoToCreateProject = 'what-information-do-i-need-to-create-a-project',
+  /** Verification Badges */
+  WhatIsAVerificationBadge = 'what-is-a-verification-badge',
+  WhenWillTheProjectHaveTheVerificationBadge = 'when-will-the-project-have-the-verification-badge',
+  WhenWillTheOpenCallHaveTheVerificationBadge = 'when-will-the-open-call-have-the-verification-badge',
 }
 
 export const FaqPaths = {
@@ -40,6 +44,9 @@ export const FaqPaths = {
   [FaqQuestions.ForWhoIsTheProjectFor]: `${Paths.FAQ}/${FaqSections.Projects}/${FaqQuestions.ForWhoIsTheProjectFor}`,
   [FaqQuestions.HowCanIFundAProject]: `${Paths.FAQ}/${FaqSections.Projects}/${FaqQuestions.HowCanIFundAProject}`,
   // [FaqQuestions.WhatInfoToCreateProject]: `${Paths.FAQ}/${FaqSections.Projects}/${FaqQuestions.WhatInfoToCreateProject}`,
+  [FaqQuestions.WhatIsAVerificationBadge]: `${Paths.FAQ}/${FaqSections.VerificationBadges}/${FaqQuestions.WhatIsAVerificationBadge}`,
+  [FaqQuestions.WhenWillTheProjectHaveTheVerificationBadge]: `${Paths.FAQ}/${FaqSections.VerificationBadges}/${FaqQuestions.WhenWillTheProjectHaveTheVerificationBadge}`,
+  // [FaqQuestions.WhenWillTheOpenCallHaveTheVerificationBadge]: `${Paths.FAQ}/${FaqSections.VerificationBadges}/${FaqQuestions.WhenWillTheOpenCallHaveTheVerificationBadge}`,
 };
 
 export const useFaq = () => {

--- a/frontend/layouts/static-page/footer/component.tsx
+++ b/frontend/layouts/static-page/footer/component.tsx
@@ -216,7 +216,7 @@ export const Footer: React.FC<FooterProps> = ({
                     </Link>
                   </li>
                   <li>
-                    <Link href="/faq">
+                    <Link href={Paths.FAQ}>
                       <a className="hover:underline">
                         <FormattedMessage defaultMessage="FAQ’s" id="qIvPIE" />
                       </a>

--- a/frontend/pages/invitation.tsx
+++ b/frontend/pages/invitation.tsx
@@ -12,6 +12,7 @@ import { withLocalizedRequests } from 'hoc/locale';
 import { InferGetStaticPropsType } from 'next';
 
 import useMe from 'hooks/me';
+import { FaqPaths } from 'hooks/useFaq';
 
 import { loadI18nMessages } from 'helpers/i18n';
 
@@ -97,7 +98,7 @@ const Invitation: PageComponent<InvitationProps> = () => {
         />
       </div>
       {invitedUserError || !query.invitation_token ? (
-        <div className="max-w-lg mt-20 text-center rounded-lg overflow-hidden">
+        <div className="max-w-lg mt-20 overflow-hidden text-center rounded-lg">
           <Alert withLayoutContainer>
             <p className="text-lg">
               <FormattedMessage defaultMessage="Invalid invitation token" id="XimHnV" />
@@ -144,7 +145,7 @@ const Invitation: PageComponent<InvitationProps> = () => {
                 : acceptInvitation.error?.message}
             </Alert>
           )}
-          <Link href={`${Paths.FAQ}#accounts`} passHref>
+          <Link href={FaqPaths['how-do-accounts-work']} passHref>
             <a className="text-base text-gray-700 underline">
               <FormattedMessage defaultMessage="How do accounts work?" id="/ITXlB" />
             </a>

--- a/frontend/pages/invitation.tsx
+++ b/frontend/pages/invitation.tsx
@@ -12,7 +12,7 @@ import { withLocalizedRequests } from 'hoc/locale';
 import { InferGetStaticPropsType } from 'next';
 
 import useMe from 'hooks/me';
-import { FaqPaths } from 'hooks/useFaq';
+import { FaqPaths, FaqQuestions } from 'hooks/useFaq';
 
 import { loadI18nMessages } from 'helpers/i18n';
 
@@ -145,7 +145,7 @@ const Invitation: PageComponent<InvitationProps> = () => {
                 : acceptInvitation.error?.message}
             </Alert>
           )}
-          <Link href={FaqPaths['how-do-accounts-work']} passHref>
+          <Link href={FaqPaths[FaqQuestions.HowDoAccountsWork]} passHref>
             <a className="text-base text-gray-700 underline">
               <FormattedMessage defaultMessage="How do accounts work?" id="/ITXlB" />
             </a>

--- a/frontend/pages/projects/pending.tsx
+++ b/frontend/pages/projects/pending.tsx
@@ -10,7 +10,7 @@ import { withLocalizedRequests } from 'hoc/locale';
 
 import { InferGetStaticPropsType } from 'next';
 
-import { FaqPaths } from 'hooks/useFaq';
+import { FaqPaths, FaqQuestions } from 'hooks/useFaq';
 
 import { loadI18nMessages } from 'helpers/i18n';
 
@@ -59,7 +59,7 @@ const Pending: PageComponent<PendingProjectProps, FormPageLayoutProps> = () => {
         <Button className="mt-6 mb-12" to={`${Paths.Project}/${query.project}`}>
           <FormattedMessage defaultMessage="Go to project page" id="mMReor" />
         </Button>
-        <Link href={FaqPaths['what-is-a-verification-badge']} passHref>
+        <Link href={FaqPaths[FaqQuestions.WhatIsAVerificationBadge]} passHref>
           <a
             target="_blank"
             rel="noopener noreferrer"
@@ -68,7 +68,7 @@ const Pending: PageComponent<PendingProjectProps, FormPageLayoutProps> = () => {
             <FormattedMessage defaultMessage="What is a verification badge?" id="qZPjW2" />
           </a>
         </Link>
-        <Link href={FaqPaths['when-will-the-project-have-the-verification-badge']} passHref>
+        <Link href={FaqPaths[FaqQuestions.WhenWillTheProjectHaveTheVerificationBadge]} passHref>
           <a
             target="_blank"
             rel="noopener noreferrer"

--- a/frontend/pages/projects/pending.tsx
+++ b/frontend/pages/projects/pending.tsx
@@ -10,6 +10,8 @@ import { withLocalizedRequests } from 'hoc/locale';
 
 import { InferGetStaticPropsType } from 'next';
 
+import { FaqPaths } from 'hooks/useFaq';
+
 import { loadI18nMessages } from 'helpers/i18n';
 
 import Button from 'components/button';
@@ -57,7 +59,7 @@ const Pending: PageComponent<PendingProjectProps, FormPageLayoutProps> = () => {
         <Button className="mt-6 mb-12" to={`${Paths.Project}/${query.project}`}>
           <FormattedMessage defaultMessage="Go to project page" id="mMReor" />
         </Button>
-        <Link href="/faq#pending-approval" passHref>
+        <Link href={FaqPaths['what-is-a-verification-badge']} passHref>
           <a
             target="_blank"
             rel="noopener noreferrer"
@@ -66,7 +68,7 @@ const Pending: PageComponent<PendingProjectProps, FormPageLayoutProps> = () => {
             <FormattedMessage defaultMessage="What is a verification badge?" id="qZPjW2" />
           </a>
         </Link>
-        <Link href="/faq#pending-approval" passHref>
+        <Link href={FaqPaths['when-will-the-project-have-the-verification-badge']} passHref>
           <a
             target="_blank"
             rel="noopener noreferrer"

--- a/frontend/pages/sign-in/index.tsx
+++ b/frontend/pages/sign-in/index.tsx
@@ -12,6 +12,7 @@ import { withLocalizedRequests } from 'hoc/locale';
 import { InferGetStaticPropsType } from 'next';
 
 import useMe from 'hooks/me';
+import { FaqPaths } from 'hooks/useFaq';
 
 import { loadI18nMessages } from 'helpers/i18n';
 
@@ -121,7 +122,7 @@ const SignIn: PageComponent<ProjectDeveloperProps, AuthPageLayoutProps> = () => 
             values={{
               accountName: invitedUser.account_name,
               a: (chunks: string) => (
-                <a className="underline" href={`${Paths.FAQ}#accounts`}>
+                <a className="underline" href={FaqPaths['how-do-accounts-work']}>
                   {chunks}
                 </a>
               ),

--- a/frontend/pages/sign-in/index.tsx
+++ b/frontend/pages/sign-in/index.tsx
@@ -12,7 +12,7 @@ import { withLocalizedRequests } from 'hoc/locale';
 import { InferGetStaticPropsType } from 'next';
 
 import useMe from 'hooks/me';
-import { FaqPaths } from 'hooks/useFaq';
+import { FaqPaths, FaqQuestions } from 'hooks/useFaq';
 
 import { loadI18nMessages } from 'helpers/i18n';
 
@@ -122,7 +122,7 @@ const SignIn: PageComponent<ProjectDeveloperProps, AuthPageLayoutProps> = () => 
             values={{
               accountName: invitedUser.account_name,
               a: (chunks: string) => (
-                <a className="underline" href={FaqPaths['how-do-accounts-work']}>
+                <a className="underline" href={FaqPaths[FaqQuestions.HowDoAccountsWork]}>
                   {chunks}
                 </a>
               ),

--- a/frontend/pages/sign-up/account-type.tsx
+++ b/frontend/pages/sign-up/account-type.tsx
@@ -5,6 +5,8 @@ import { useRouter } from 'next/router';
 
 import { withLocalizedRequests } from 'hoc/locale';
 
+import { FaqPaths } from 'hooks/useFaq';
+
 import { loadI18nMessages } from 'helpers/i18n';
 
 import AccountTypeSelector from 'containers/account-type-selector';
@@ -61,7 +63,7 @@ const SignUpAccountTypePage: PageComponent<{}, StaticPageLayoutProps> = () => {
               className="max-w-3xl mt-6"
               onAccountTypeSelected={handleAccountTypeSelected}
             />
-            <Link href={Paths.FAQ}>
+            <Link href={FaqPaths['how-do-accounts-work']}>
               <a className="mt-6 text-gray-600 underline transition-colors hover:text-green-dark active:text-green-dark outline-green-dark outline-rounded">
                 <FormattedMessage defaultMessage="How accounts work?" id="0hzVw6" />
               </a>

--- a/frontend/pages/sign-up/account-type.tsx
+++ b/frontend/pages/sign-up/account-type.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/router';
 
 import { withLocalizedRequests } from 'hoc/locale';
 
-import { FaqPaths } from 'hooks/useFaq';
+import { FaqPaths, FaqQuestions } from 'hooks/useFaq';
 
 import { loadI18nMessages } from 'helpers/i18n';
 
@@ -63,7 +63,7 @@ const SignUpAccountTypePage: PageComponent<{}, StaticPageLayoutProps> = () => {
               className="max-w-3xl mt-6"
               onAccountTypeSelected={handleAccountTypeSelected}
             />
-            <Link href={FaqPaths['how-do-accounts-work']}>
+            <Link href={FaqPaths[FaqQuestions.HowDoAccountsWork]}>
               <a className="mt-6 text-gray-600 underline transition-colors hover:text-green-dark active:text-green-dark outline-green-dark outline-rounded">
                 <FormattedMessage defaultMessage="How accounts work?" id="0hzVw6" />
               </a>

--- a/frontend/pages/sign-up/index.tsx
+++ b/frontend/pages/sign-up/index.tsx
@@ -11,6 +11,7 @@ import { withLocalizedRequests } from 'hoc/locale';
 import { InferGetStaticPropsType } from 'next';
 
 import useMe from 'hooks/me';
+import { FaqPaths } from 'hooks/useFaq';
 
 import { loadI18nMessages } from 'helpers/i18n';
 
@@ -120,7 +121,7 @@ const SignUp: PageComponent<SignUpPageProps, AuthPageLayoutProps> = () => {
             values={{
               accountName: invitedUser.account_name,
               a: (chunks: string) => (
-                <a className="underline" href={`${Paths.FAQ}#accounts`}>
+                <a className="underline" href={FaqPaths['how-do-accounts-work']}>
                   {chunks}
                 </a>
               ),

--- a/frontend/pages/sign-up/index.tsx
+++ b/frontend/pages/sign-up/index.tsx
@@ -11,7 +11,7 @@ import { withLocalizedRequests } from 'hoc/locale';
 import { InferGetStaticPropsType } from 'next';
 
 import useMe from 'hooks/me';
-import { FaqPaths } from 'hooks/useFaq';
+import { FaqPaths, FaqQuestions } from 'hooks/useFaq';
 
 import { loadI18nMessages } from 'helpers/i18n';
 
@@ -121,7 +121,7 @@ const SignUp: PageComponent<SignUpPageProps, AuthPageLayoutProps> = () => {
             values={{
               accountName: invitedUser.account_name,
               a: (chunks: string) => (
-                <a className="underline" href={FaqPaths['how-do-accounts-work']}>
+                <a className="underline" href={FaqPaths[FaqQuestions.HowDoAccountsWork]}>
                   {chunks}
                 </a>
               ),


### PR DESCRIPTION
This PQ adds the href to the FAQ links on pages

## Testing instructions

### Acceptance criteria

The page will be accessible from:

The “Pending approval” screen ([Figma](https://www.figma.com/file/KC49uMR9t1YARmFR0Sr6aN/HeCo---Work-in-progress?node-id=2586%3A33351))

The link should go directly to the section about account approval

This applies to the following pages:

- PD account creation
- Investor account creation
- Unapproved PD screen (screen shown after signing in when not approved yet)
- Unapproved investor screen (screen shown after signing in when not approved yet)
- The “Pending verification” screen ([Figma](https://www.figma.com/file/KC49uMR9t1YARmFR0Sr6aN/HeCo---Work-in-progress?node-id=2586%3A33431)) - The link should go directly to the section about the verification process

This applies to the following forms:

- Project creation
- Open call creation (not implemented yet)
- The account type selection screen ([Figma](https://www.figma.com/file/KC49uMR9t1YARmFR0Sr6aN/HeCo---Work-in-progress?node-id=788%3A14933))

The link should go directly to the “How do accounts work” section

- Footer

## Tracking

Link to the task(s), if any
