### PR TITLE
Add position to table menu

### DIFF
--- a/frontend/containers/dashboard/projects/table/cells/actions/component.tsx
+++ b/frontend/containers/dashboard/projects/table/cells/actions/component.tsx
@@ -17,7 +17,9 @@ import { CellActionsProps } from './types';
 export const CellActions: FC<CellActionsProps> = ({
   row: {
     original: { slug, name, status },
+    index,
   },
+  rows,
 }: CellActionsProps) => {
   const intl = useIntl();
   const router = useRouter();
@@ -57,6 +59,9 @@ export const CellActions: FC<CellActionsProps> = ({
     );
   };
 
+  // Used to change the position of the menu on the last row so that it is not hidden by the table's bottom
+  const isLast = rows?.length === index + 1;
+
   return (
     <div className="flex items-center justify-center gap-3">
       <Link
@@ -67,7 +72,7 @@ export const CellActions: FC<CellActionsProps> = ({
           <FormattedMessage defaultMessage="Edit" id="wEQDC6" />
         </a>
       </Link>
-      <RowMenu onAction={handleRowMenuItemClick}>
+      <RowMenu direction={isLast ? 'top' : 'bottom'} onAction={handleRowMenuItemClick}>
         <RowMenuItem key="edit">
           <FormattedMessage defaultMessage="Edit" id="wEQDC6" />
         </RowMenuItem>

--- a/frontend/containers/dashboard/projects/table/cells/actions/types.ts
+++ b/frontend/containers/dashboard/projects/table/cells/actions/types.ts
@@ -15,5 +15,8 @@ export type CellActionsProps = {
       ticketSize: string;
       statusTag: StatusTag;
     };
+    index: number;
   };
+  // Property that comes for each row
+  rows: any[];
 };

--- a/frontend/containers/dashboard/row-menu/component.tsx
+++ b/frontend/containers/dashboard/row-menu/component.tsx
@@ -7,7 +7,7 @@ import Menu, { MenuItem } from 'components/menu';
 
 import { RowMenuProps } from './types';
 
-export const RowMenu: FC<RowMenuProps> = ({ onAction, children }: RowMenuProps) => {
+export const RowMenu: FC<RowMenuProps> = ({ onAction, children, direction }: RowMenuProps) => {
   return (
     <Menu
       Trigger={
@@ -18,6 +18,7 @@ export const RowMenu: FC<RowMenuProps> = ({ onAction, children }: RowMenuProps) 
       align="end"
       onAction={onAction}
       hiddenSections={{ 'user-section': 'sm' }}
+      direction={direction}
     >
       {children}
     </Menu>

--- a/frontend/containers/dashboard/row-menu/types.ts
+++ b/frontend/containers/dashboard/row-menu/types.ts
@@ -1,3 +1,3 @@
 import type { MenuProps } from 'components/menu/types';
 
-export type RowMenuProps = Pick<MenuProps, 'onAction' | 'children'>;
+export type RowMenuProps = Pick<MenuProps, 'onAction' | 'children' | 'direction'>;


### PR DESCRIPTION
This pr fixes the table actions menu bug

## Acceptance criteria

The menu should not be cut off. 

![85502db3-445e-4499-8b2b-376eded0db8f](https://user-images.githubusercontent.com/48164343/181599806-2c33023a-9cce-44c2-8a54-3e3bffaaf949.png)

I couldn’t handle the bug with css, so I changed the menu position from 'bottom' to 'top' for the last row


## Testing instructions

The last table row action menu should not be hidden


## Screenshot
<img width="944" alt="Screenshot 2022-07-28 at 19 26 11" src="https://user-images.githubusercontent.com/48164343/181600101-8782e01b-937b-4d08-b702-efe791ac3615.png">


## Tracking

[LET-768](https://vizzuality.atlassian.net/browse/LET-768)
