### PR TITLE
fix: Adding correct FE link to reset password email

### DIFF
--- a/backend/app/controllers/concerns/api/errors.rb
+++ b/backend/app/controllers/concerns/api/errors.rb
@@ -15,6 +15,7 @@ module API
       base.rescue_from API::UnprocessableEntityError, with: :render_unprocessable_entity_error
       base.rescue_from ActiveRecord::RecordNotFound, with: :render_not_found_error
       base.rescue_from ActiveRecord::RecordInvalid, with: :render_validation_errors
+      base.rescue_from ActiveRecord::RecordNotUnique, with: :render_validation_errors
     end
 
     def render_error(exception)

--- a/backend/app/views/users/mailer/confirmation_instructions.html.erb
+++ b/backend/app/views/users/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,5 @@
-<p>Welcome <%= @email %>!</p>
+<p><%= t("devise.mailer.confirmation_instructions.greeting", recipient: @email) %></p>
 
-<p>You can confirm your account email through the link below:</p>
+<p><%= t("devise.mailer.confirmation_instructions.instruction") %></p>
 
-<p><%= link_to 'Confirm my account', api_v1_email_confirmation_url(confirmation_token: @token) %></p>
+<p><%= link_to t("devise.mailer.confirmation_instructions.action"), api_v1_email_confirmation_url(confirmation_token: @token) %></p>

--- a/backend/app/views/users/mailer/reset_password_instructions.html.erb
+++ b/backend/app/views/users/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,8 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= t("devise.mailer.reset_password_instructions.greeting", recipient: @resource.email) %></p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p><%= t("devise.mailer.reset_password_instructions.instruction") %></p>
 
-<p>As we don't have frontend page to reset password just displaing your token here: <%= @token %></p>
+<p><%= link_to t("devise.mailer.reset_password_instructions.action"), "#{ENV["FRONTEND_URL"]}/sign-in/reset-password?reset_password_token=#{@token}" %></p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p><%= t("devise.mailer.reset_password_instructions.instruction_2") %></p>
+<p><%= t("devise.mailer.reset_password_instructions.instruction_3") %></p>

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -105,8 +105,16 @@ zu:
     mailer:
       confirmation_instructions:
         subject: "Confirmation instructions"
+        greeting: "Welcome %{email}"
+        instruction: "You can confirm your account email through the link below"
+        action: "Confirm my account"
       reset_password_instructions:
         subject: "Reset password instructions"
+        greeting: "Hello %{recipient}"
+        instruction: "Someone has requested a link to change your password, and you can do this through the link below."
+        action: "Change my password"
+        instruction_2: "If you did not request this, please ignore this email."
+        instruction_3: "Your password will not change until you access the link above and create a new one."
       passwords:
         no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
         send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."


### PR DESCRIPTION
I am adding correct link to reset password email, which is `"#{ENV["FRONTEND_URL"]}/sign-in/reset-password?reset_password_token=#{@token}"`.

I have also seen that `user` devise emails (reset password and confirmation) have hardcoded text which is not at transifex yet, so I am adding it.

## Testing instructions

Via Rswag -- double check that reset password email contains new link to FE.

## Tracking

https://vizzuality.atlassian.net/browse/LET-677
