### PR TITLE
Add change ownership functionality

### DIFF
--- a/frontend/components/confirmation-prompt/component.tsx
+++ b/frontend/components/confirmation-prompt/component.tsx
@@ -24,6 +24,7 @@ export const ConfirmationPrompt: FC<ConfirmationPromptProps> = ({
   onAcceptLoading = false,
   confirmationError,
   onConfirmDisabled = false,
+  onConfirmText,
 }: ConfirmationPromptProps) => (
   <Modal open={open} title={title} size="default" dismissable={dismissible} onDismiss={onDismiss}>
     <div className="flex flex-col items-center px-8 py-4">
@@ -62,7 +63,7 @@ export const ConfirmationPrompt: FC<ConfirmationPromptProps> = ({
         >
           <Loading className="mr-2" visible={onAcceptLoading} />
           {!confirmationError ? (
-            <FormattedMessage defaultMessage="Delete" id="K3r6DQ" />
+            onConfirmText || <FormattedMessage defaultMessage="Delete" id="K3r6DQ" />
           ) : (
             <FormattedMessage defaultMessage="Try again" id="FazwRl" />
           )}

--- a/frontend/components/confirmation-prompt/types.d.ts
+++ b/frontend/components/confirmation-prompt/types.d.ts
@@ -43,4 +43,6 @@ export interface ConfirmationPromptProps {
    * unset.
    */
   onDismiss: ModalProps['onDismiss'];
+  /** Text to show on the confirm button. Defaults to 'Delete' */
+  onConfirmText?: string;
 }

--- a/frontend/components/table/component.tsx
+++ b/frontend/components/table/component.tsx
@@ -23,6 +23,8 @@ export const Table: FC<TableProps> = ({
   manualSorting = false,
   pagination: paginationProps,
   onSortChange = noop,
+  isOwner,
+  accountName,
 }: TableProps) => {
   const DEFAULT_COLUMN = React.useMemo(
     () => ({
@@ -53,7 +55,8 @@ export const Table: FC<TableProps> = ({
       disableSortBy: !sortingEnabled,
       manualSortBy: manualSorting,
       disableMultiSort: true,
-
+      isOwner,
+      accountName,
       initialState: {
         ...initialState,
       },

--- a/frontend/components/table/types.d.ts
+++ b/frontend/components/table/types.d.ts
@@ -17,4 +17,8 @@ export interface TableProps {
   manualSorting?: boolean;
   /** Callback for when sorting changes */
   onSortChange?: ({ sortBy, sortOrder }: { sortBy?: string; sortOrder?: 'asc' | 'desc' }) => void;
+  /** Whether the current user is the account owner. Defaults to 'false */
+  isOwner?: boolean;
+  /** Current account name */
+  accountName?: string;
 }

--- a/frontend/containers/dashboard/row-menu/component.tsx
+++ b/frontend/containers/dashboard/row-menu/component.tsx
@@ -1,24 +1,46 @@
-import { FC } from 'react';
+import { FC, useState } from 'react';
 
-import { MoreVertical as MoreVerticalIcon } from 'react-feather';
+import { MoreVertical as MoreVerticalIcon, ChevronDown, ChevronUp } from 'react-feather';
 
 import Button from 'components/button';
-import Menu, { MenuItem } from 'components/menu';
+import Menu from 'components/menu';
 
 import { RowMenuProps } from './types';
 
-export const RowMenu: FC<RowMenuProps> = ({ onAction, children, direction }: RowMenuProps) => {
+export const RowMenu: FC<RowMenuProps> = ({
+  onAction,
+  children,
+  direction,
+  iconType = 'actions',
+}: RowMenuProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const menuIconOpenClose = () => {
+    const iconValue = (direction === 'top' ? 1 : 0) - (isOpen ? 1 : 0);
+    if (iconValue === 0) {
+      return <ChevronDown />;
+    } else {
+      return <ChevronUp />;
+    }
+  };
+
   return (
     <Menu
       Trigger={
         <Button size="smallest" theme="naked" className="focus-visible:outline-green-dark">
-          <MoreVerticalIcon className="w-6 h-6" />
+          {iconType === 'actions' ? (
+            <MoreVerticalIcon className="w-6 h-6" />
+          ) : (
+            iconType === 'open-close' && menuIconOpenClose()
+          )}
         </Button>
       }
       align="end"
       onAction={onAction}
       hiddenSections={{ 'user-section': 'sm' }}
       direction={direction}
+      onOpen={() => setIsOpen(true)}
+      onClose={() => setIsOpen(false)}
     >
       {children}
     </Menu>

--- a/frontend/containers/dashboard/row-menu/types.ts
+++ b/frontend/containers/dashboard/row-menu/types.ts
@@ -1,3 +1,5 @@
 import type { MenuProps } from 'components/menu/types';
 
-export type RowMenuProps = Pick<MenuProps, 'onAction' | 'children' | 'direction'>;
+export type RowMenuProps = Pick<MenuProps, 'onAction' | 'children' | 'direction'> & {
+  iconType?: 'actions' | 'open-close';
+};

--- a/frontend/containers/dashboard/users/table/cells/role/component.tsx
+++ b/frontend/containers/dashboard/users/table/cells/role/component.tsx
@@ -1,18 +1,112 @@
-import React from 'react';
+import { useState } from 'react';
 
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { useQueryClient } from 'react-query';
+
+import RowMenu, { RowMenuItem } from 'containers/dashboard/row-menu';
+
+import ConfirmationPrompt from 'components/confirmation-prompt';
+import { InvitationStatus, Queries } from 'enums';
+
+import { transferOwnership } from 'services/account';
 
 import { CellRoleProps } from './types';
 
-export const CellRole = ({ value }: CellRoleProps) => {
-  if (value === undefined) return null;
+export const CellRole = ({ value, row: { original }, isOwner, accountName }: CellRoleProps) => {
+  const { formatMessage } = useIntl();
+  const [isOpen, setIsOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string>();
+  const queryClient = useQueryClient();
+
+  if (value) {
+    return (
+      <p>
+        <FormattedMessage defaultMessage="Owner" id="zINlao" />
+      </p>
+    );
+  }
+
+  if (
+    !isOwner ||
+    (original.invitation !== InvitationStatus.Completed &&
+      (!original.approved || !original.confirmed))
+  ) {
+    return (
+      <p>
+        <FormattedMessage defaultMessage="User" id="EwRIOm" />
+      </p>
+    );
+  }
+
+  const handleChangeOwner = (key: string) => {
+    if (key === 'owner') {
+      setIsOpen(true);
+    }
+  };
+
+  const updateAccountOwner = async () => {
+    if (isOwner && original?.id) {
+      setIsLoading(true);
+      transferOwnership(original.id)
+        .then(() => {
+          queryClient.invalidateQueries(Queries.User);
+          queryClient.invalidateQueries(Queries.AccountUsersList);
+          setIsOpen(false);
+        })
+        .catch((err) => {
+          setError(
+            err?.message[0]?.title ||
+              formatMessage({
+                defaultMessage:
+                  'Something went wrong while trying to change the account ownership.',
+                id: 'P3pSke',
+              })
+          );
+        })
+        .finally(() => {
+          setIsLoading(false);
+        });
+    }
+  };
 
   return (
-    <div className="items-center">
-      <p>
-        {value && <FormattedMessage defaultMessage="Owner" id="zINlao" />}
-        {!value && <FormattedMessage defaultMessage="User" id="EwRIOm" />}
+    <div className="items-center flex">
+      <p className="mr-2">
+        <FormattedMessage defaultMessage="User" id="EwRIOm" />
       </p>
+      <RowMenu direction="top" onAction={handleChangeOwner} iconType="open-close">
+        <RowMenuItem key="user">
+          <FormattedMessage defaultMessage="User" id="EwRIOm" />
+        </RowMenuItem>
+        <RowMenuItem key="owner">
+          <FormattedMessage defaultMessage="Owner" id="zINlao" />
+        </RowMenuItem>
+      </RowMenu>
+      <ConfirmationPrompt
+        open={isOpen}
+        onAccept={updateAccountOwner}
+        title={formatMessage({ defaultMessage: 'Change account owner', id: 'Xcq/fH' })}
+        onDismiss={() => setIsOpen(false)}
+        onRefuse={() => setIsOpen(false)}
+        onConfirmText={formatMessage({ defaultMessage: 'Transfer ownership', id: '2AIlHB' })}
+        description={formatMessage(
+          {
+            defaultMessage:
+              'Are you sure you want to make <n>{userName}</n> the owner of <n>{accountName}</n> account? You cant undo this action.',
+            id: 'UD6OB+',
+          },
+          {
+            n: (chunk: string) => <span className="font-semibold">{chunk}</span>,
+            userName: original?.first_name
+              ? `${original?.first_name} ${original?.last_name}`
+              : original?.email,
+            accountName,
+          }
+        )}
+        confirmationError={error}
+        onAcceptLoading={isLoading}
+      />
     </div>
   );
 };

--- a/frontend/containers/dashboard/users/table/cells/role/types.ts
+++ b/frontend/containers/dashboard/users/table/cells/role/types.ts
@@ -1,3 +1,11 @@
+import { User } from 'types/user';
+
 export interface CellRoleProps {
   value: boolean;
+  /** Data from each row */
+  row: { original: User };
+  /** Whether the current user is the account owner. Defaults to 'false */
+  isOwner?: boolean;
+  /** Account name */
+  accountName?: string;
 }

--- a/frontend/containers/dashboard/users/table/component.tsx
+++ b/frontend/containers/dashboard/users/table/component.tsx
@@ -18,7 +18,7 @@ import User from './cells/user';
 
 import { UsersTableProps } from '.';
 
-export const UsersTable: FC<UsersTableProps> = ({ isOwner }) => {
+export const UsersTable: FC<UsersTableProps> = ({ isOwner, accountName }) => {
   const intl = useIntl();
 
   const queryOptions = { keepPreviousData: true, refetchOnMount: true };
@@ -67,6 +67,8 @@ export const UsersTable: FC<UsersTableProps> = ({ isOwner }) => {
     loading: isLoadingUsers || isFetchingUsers,
     sortingEnabled: true,
     manualSorting: false,
+    isOwner,
+    accountName,
   };
 
   const tablePropsWithPermissions = isOwner

--- a/frontend/containers/dashboard/users/table/types.ts
+++ b/frontend/containers/dashboard/users/table/types.ts
@@ -1,3 +1,6 @@
 export type UsersTableProps = {
-  isOwner: boolean;
+  /** Whether the current user is the account owner. Defaults to 'false */
+  isOwner?: boolean;
+  /** Current account name */
+  accountName?: string;
 };

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -164,6 +164,9 @@
   "25WwxF": {
     "string": "Don't have an account?"
   },
+  "2AIlHB": {
+    "string": "Transfer ownership"
+  },
   "2AZiFU": {
     "string": "Instrument size"
   },
@@ -1110,6 +1113,9 @@
   "P1f6hp": {
     "string": "Funding priorities"
   },
+  "P3pSke": {
+    "string": "Something went wrong while trying to change the account ownership."
+  },
   "P4T4Ib": {
     "string": "Discover projects that have impact in the Amazon region and get connected with investors and project developers."
   },
@@ -1293,6 +1299,9 @@
   "U98Mu/": {
     "string": "This layer shows the permanent and temporal wetlands of Colombia at a 1:100.000 reoslution"
   },
+  "UD6OB+": {
+    "string": "Are you sure you want to make <n>{userName}</n> the owner of <n>{accountName}</n> account? You cant undo this action."
+  },
   "UIQdVc": {
     "string": "Are you sure you want to delete “<strong>{projectName}</strong>”?"
   },
@@ -1448,6 +1457,9 @@
   },
   "XaFc9D": {
     "string": "Select HeCo priority landscapes on which you will have impact"
+  },
+  "Xcq/fH": {
+    "string": "Change account owner"
   },
   "Xf3dpi": {
     "string": "Toggle fullscreen mode"

--- a/frontend/pages/dashboard/users.tsx
+++ b/frontend/pages/dashboard/users.tsx
@@ -7,8 +7,6 @@ import { withLocalizedRequests } from 'hoc/locale';
 
 import { InferGetStaticPropsType } from 'next';
 
-import useMe from 'hooks/me';
-
 import { loadI18nMessages } from 'helpers/i18n';
 
 import UsersTable from 'containers/dashboard/users/table';
@@ -23,6 +21,8 @@ import NakedLayout from 'layouts/naked';
 import ProtectedPage from 'layouts/protected-page';
 import { PageComponent } from 'types';
 
+import { useAccount } from 'services/account';
+
 export const getStaticProps = withLocalizedRequests(async ({ locale }) => {
   return {
     props: {
@@ -36,7 +36,7 @@ type UsersPageProps = InferGetStaticPropsType<typeof getStaticProps>;
 export const UsersPage: PageComponent<UsersPageProps, DashboardLayoutProps> = () => {
   const [openInvitationModal, setOpenInvitationModal] = useState(false);
   const intl = useIntl();
-  const { user } = useMe();
+  const { user, userAccount } = useAccount();
 
   return (
     <ProtectedPage permissions={[UserRoles.ProjectDeveloper, UserRoles.Investor]}>
@@ -56,7 +56,7 @@ export const UsersPage: PageComponent<UsersPageProps, DashboardLayoutProps> = ()
         }
       >
         <div className="pt-4">
-          <UsersTable isOwner={user?.owner} />
+          <UsersTable accountName={userAccount?.name} isOwner={user?.owner} />
         </div>
       </DashboardLayout>
       <InviteUsersModal

--- a/frontend/services/account/index.ts
+++ b/frontend/services/account/index.ts
@@ -6,6 +6,7 @@ import {
   useQueryClient,
   UseQueryResult,
   UseQueryOptions,
+  useQuery,
 } from 'react-query';
 
 import { useRouter } from 'next/router';
@@ -413,4 +414,10 @@ export const useDeleteUser = (): UseMutationResult<{}, ErrorResponse> => {
     await API.delete(`/api/v1/account/users/${id}`, { data: {} });
 
   return useMutation(deleteUser);
+};
+
+export const transferOwnership = async (userId: string) => {
+  return await API.get('/api/v1/account/users/transfer_ownership', {
+    params: { user_id: userId },
+  });
 };

--- a/frontend/services/account/index.ts
+++ b/frontend/services/account/index.ts
@@ -417,7 +417,7 @@ export const useDeleteUser = (): UseMutationResult<{}, ErrorResponse> => {
 };
 
 export const transferOwnership = async (userId: string) => {
-  return await API.get('/api/v1/account/users/transfer_ownership', {
-    params: { user_id: userId },
+  return await API.post('/api/v1/account/users/transfer_ownership', {
+    user_id: userId,
   });
 };

--- a/frontend/types/user.ts
+++ b/frontend/types/user.ts
@@ -31,7 +31,7 @@ export interface User {
   account_language: Languages;
   confirmed: boolean;
   approved: boolean;
-  invitation: boolean;
+  invitation: InvitationStatus;
   owner: boolean;
   avatar: Picture;
 }


### PR DESCRIPTION
This PR adds the 'transfer account ownership" functionality

OBS: The BE will change the endpoint to change ownership. Now it's a GET, and it will be changed to POST. We can create a task for update the endpoint later

## Testing instructions

### Account owner user

1. Sign in as a account owner
2. Go to 'dashboard/users'
3. You should see a table with the account users, and the ones that have the 'role' **User** and 'invitation' **Accepted** should display an icon to open the menu. Clicking the icon should display a menu.
4. Click on 'owner' option of the menu
5. A modal should appear to confirm the action. 
6. Click 'transfer ownership'. The users list should be updated and the ownership changed

https://user-images.githubusercontent.com/48164343/182166174-1d9689c6-90ec-4075-a812-168b6f09339f.mov


### Account user (owner: false') 
1. Sign in as a account owner
2. Go to 'dashboard/users'
3. You should see a table with the account users, but you shouldn’t see any icon on the 'role' column.
<img width="961" alt="Screenshot 2022-08-01 at 16 08 43" src="https://user-images.githubusercontent.com/48164343/182166603-453ebc6a-f118-4331-92ab-b1badafb32fc.png">


## Tracking

[LET-823](https://vizzuality.atlassian.net/browse/LET-823)
