### PR TITLE
Remove IS_API_INSTANCE as API routes should be always available

### DIFF
--- a/backend/ENV_VARS.md
+++ b/backend/ENV_VARS.md
@@ -4,8 +4,7 @@ RACK_ENV
 RAILS_MAX_THREADS (say 10)
 SECRET_KEY_BASE (generated with rake secret)
 
-Control which routes are available for Rails instance - true / false
-IS_API_INSTANCE
+Control if jobs routes are available (default false)
 IS_JOBS_INSTANCE
 
 BACKEND_URL (without protocol)
@@ -13,7 +12,7 @@ RAILS_RELATIVE_URL_ROOT (if running backend application in sub url, like /backen
 
 GCP services config
 GCP_PROJECT_ID - Id of the GCP project
-GCP_REGION - GCP region where the project's GCP resources are hosted 
+GCP_REGION - GCP region where the project's GCP resources are hosted
 
 Cloud Tasks configuration
 CLOUDTASKER_PROCESSOR_HOST - with protocol, as available from outside the platform, e.g. https://your-public-domain.com

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     post "/rails/active_storage/direct_uploads", to: "active_storage/direct_uploads#create"
   end
 
-  draw :backoffice if ENV["IS_API_INSTANCE"].to_s == "true" || ENV["IS_JOBS_INSTANCE"].to_s == "true"
-  draw :api if ENV["IS_API_INSTANCE"].to_s == "true"
+  draw :backoffice
+  draw :api
   draw :jobs if ENV["IS_JOBS_INSTANCE"].to_s == "true"
 end

--- a/backend/docker-compose-test.yml
+++ b/backend/docker-compose-test.yml
@@ -13,7 +13,6 @@ services:
       - DATABASE_HOST=db
       - CLOUD_TASKS_TEST_QUEUE_NAME=test
       - FRONTEND_URL=http://localhost:4000
-      - IS_API_INSTANCE=true
       - IS_JOBS_INSTANCE=true
     depends_on:
       - db

--- a/infrastructure/base/modules/env/main.tf
+++ b/infrastructure/base/modules/env/main.tf
@@ -202,10 +202,6 @@ module "backend_cloudrun" {
       value = "email-test"
     },
     {
-      name  = "IS_API_INSTANCE"
-      value = true
-    },
-    {
       name  = "IS_JOBS_INSTANCE"
       value = false
     },
@@ -311,10 +307,6 @@ module "jobs_cloudrun" {
     {
       name  = "CLOUD_TASKS_TEST_QUEUE_NAME"
       value = "email-test"
-    },
-    {
-      name  = "IS_API_INSTANCE"
-      value = false
     },
     {
       name  = "IS_JOBS_INSTANCE"


### PR DESCRIPTION
Sending emails is not working on staging as it was moved to job instance. The problem was that job instance was not having API routes. I'm removing API_INSTANCE variable as it is not helpful with anything anymore.

## Testing instructions

After merge if sending emails works.

## Tracking

No tracking