### PR TITLE
Allow serving images from localhost

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -6,7 +6,7 @@ module.exports = {
     defaultLocale: locales.find((locale) => locale.default).locale,
   },
   images: {
-    domains: ['hecoinvest.org', 'staging.hecoinvest.org'],
+    domains: ['hecoinvest.org', 'staging.hecoinvest.org', 'localhost'],
   },
   swcMinify: false,
   eslint: {


### PR DESCRIPTION
I wanted to test account ownership transfer locally with localhost backend as I was lazy to use API docs for doing that (wanted Buttons! :D). Unfortunately, that did not work as images served by localhost were blocked, this fixes that, not sure if there are any negative implications of changing that config or not (never used it).

## Testing instructions

What to test? How to do it?

## Tracking

No tracking