### PR TITLE
Add description of the 'Orinoquía' priority landscape to the 'for investors' page

### DIFF
--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -2109,6 +2109,9 @@
   "pHaFj5": {
     "string": "To create an Investor account you will need the following information."
   },
+  "pNNQA+": {
+    "string": "It is an ecoregion covered with savannahs of high floristic diversity and habitats representative of the evolutionary processes of the Guiana Shield. It includes both blackwater and whitewater rivers that feed the great Orinoco River, creating different types of seasonally flooded forests."
+  },
   "pONqz8": {
     "string": "First name"
   },

--- a/frontend/pages/for-investors.tsx
+++ b/frontend/pages/for-investors.tsx
@@ -95,8 +95,8 @@ const ForInvestorsPage: PageComponent<ForInvestorsPageProps, StaticPageLayoutPro
     ),
     orinoquia: (
       <FormattedMessage
-        defaultMessage="Helps to ensure connectivity between the Andean, Orinocean and Amazonian ecosystems, allowing the conservation of flora, fauna, scenic beauties, geomorphological complexes, historical or cultural manifestations, the conservation and regulation of water systems."
-        id="WJGIA3"
+        defaultMessage="It is an ecoregion covered with savannahs of high floristic diversity and habitats representative of the evolutionary processes of the Guiana Shield. It includes both blackwater and whitewater rivers that feed the great Orinoco River, creating different types of seasonally flooded forests."
+        id="pNNQA+"
       />
     ),
     'amazon-heart': (


### PR DESCRIPTION
## Description

This PR adds the description of the 'Orinoquía' priority landscape to the '/for-investors' page. 

## Testing instructions

Verify that the description of the _"Orinoquía"_ priority landscape in the `/for-investors` page matches the acceptance criteria. 

## Tracking

[LET-825](https://vizzuality.atlassian.net/browse/LET-825)

## Screenshot  
<img width="917" alt="Screenshot 2022-08-03 at 12 33 24" src="https://user-images.githubusercontent.com/6273795/182598093-ce894e48-94cc-4aab-9169-de9f712f279f.png">

