### PR TITLE
Users can unfavorite projects, project developers and investors from dashboard/favorites

### DIFF
--- a/frontend/pages/dashboard/favorites/investors.tsx
+++ b/frontend/pages/dashboard/favorites/investors.tsx
@@ -17,6 +17,8 @@ import DashboardFavoritesLayout, {
 import { PageComponent } from 'types';
 import { Investor as InvestorType } from 'types/investor';
 
+import { useFavoriteInvestor } from 'services/investors/investorsService';
+
 export const getStaticProps = withLocalizedRequests(async ({ locale }) => {
   return {
     props: {
@@ -36,8 +38,10 @@ export const FavoritesInvestorsPage: PageComponent<
 > = ({ data: investors = [], meta }) => {
   const hasInvestors = investors?.length > 0;
 
-  const handleRemoveClick = (slug: string) => {
-    console.log('unfavorite', slug);
+  const favoriteInvestor = useFavoriteInvestor();
+
+  const handleRemoveClick = (id: string) => {
+    favoriteInvestor.mutate({ id, isFavourite: true });
   };
 
   const handleRemoveAllClick = () => {
@@ -65,8 +69,8 @@ export const FavoritesInvestorsPage: PageComponent<
       <div className="flex flex-col pt-2 md:pl-1 md:-mr-1">
         {hasInvestors ? (
           <div className="grid grid-cols-1 gap-6 p-1 2xl:grid-cols-2">
-            {investors.map(({ investor_type, name, about, slug, picture, impacts }) => (
-              <CardHoverToDelete key={slug} onClick={() => handleRemoveClick(slug)}>
+            {investors.map(({ id, investor_type, name, about, slug, picture, impacts }) => (
+              <CardHoverToDelete key={slug} onClick={() => handleRemoveClick(id)}>
                 <ProfileCard
                   className="h-full"
                   profileType="investor"

--- a/frontend/pages/dashboard/favorites/project-developers.tsx
+++ b/frontend/pages/dashboard/favorites/project-developers.tsx
@@ -17,6 +17,8 @@ import DashboardFavoritesLayout, {
 import { PageComponent } from 'types';
 import { ProjectDeveloper as ProjectDeveloperType } from 'types/projectDeveloper';
 
+import { useFavoriteProjectDeveloper } from 'services/project-developers/projectDevelopersService';
+
 export const getStaticProps = withLocalizedRequests(async ({ locale }) => {
   return {
     props: {
@@ -36,8 +38,10 @@ export const FavoritesProjectDevelopersPage: PageComponent<
 > = ({ data: projectDevelopers = [], meta }) => {
   const hasProjectDevelopers = projectDevelopers?.length > 0;
 
-  const handleRemoveClick = (slug: string) => {
-    console.log('unfavorite', slug);
+  const favoriteProjectDeveloper = useFavoriteProjectDeveloper();
+
+  const handleRemoveClick = (id: string) => {
+    favoriteProjectDeveloper.mutate({ id, isFavourite: true });
   };
 
   const handleRemoveAllClick = () => {
@@ -66,8 +70,8 @@ export const FavoritesProjectDevelopersPage: PageComponent<
         {hasProjectDevelopers ? (
           <div className="grid grid-cols-1 gap-6 p-1 2xl:grid-cols-2">
             {projectDevelopers.map(
-              ({ slug, name, project_developer_type, about, picture, impacts }) => (
-                <CardHoverToDelete key={slug} onClick={() => handleRemoveClick(slug)}>
+              ({ id, slug, name, project_developer_type, about, picture, impacts }) => (
+                <CardHoverToDelete key={slug} onClick={() => handleRemoveClick(id)}>
                   <ProfileCard
                     className="h-full"
                     profileType="project-developer"

--- a/frontend/pages/dashboard/favorites/projects.tsx
+++ b/frontend/pages/dashboard/favorites/projects.tsx
@@ -17,6 +17,8 @@ import DashboardFavoritesLayout, {
 import { PageComponent } from 'types';
 import { Project as ProjectType } from 'types/project';
 
+import { useFavoriteProject } from 'services/projects/projectService';
+
 export const getStaticProps = withLocalizedRequests(async ({ locale }) => {
   return {
     props: {
@@ -36,8 +38,10 @@ export const FavoritesProjectsPage: PageComponent<
 > = ({ data: projects = [], meta }) => {
   const hasProjects = projects?.length > 0;
 
-  const handleRemoveClick = (id: string) => {
-    console.log('unfavorite', id);
+  const favoriteProject = useFavoriteProject();
+
+  const handleRemoveClick = (slug: string) => {
+    favoriteProject.mutate({ id: slug, isFavourite: true });
   };
 
   const handleRemoveAllClick = () => {
@@ -66,7 +70,7 @@ export const FavoritesProjectsPage: PageComponent<
         {hasProjects ? (
           <>
             {projects.map((project) => (
-              <CardHoverToDelete key={project.slug} onClick={() => handleRemoveClick(project.slug)}>
+              <CardHoverToDelete key={project.id} onClick={() => handleRemoveClick(project.id)}>
                 <ProjectCard className="" project={project} />
               </CardHoverToDelete>
             ))}


### PR DESCRIPTION
## Description

This PR adds the ability to remove Projects, Project developers, and Investors from the favorites via the `dashboard/favorites` section. In order to do so, the user hovers a card and clicks the Trash can icon. 

**Notes:** 
- _"Remove all"_ to be implemented later, and tracked by [LET-861](https://vizzuality.atlassian.net/browse/LET-861)  
  _The endpoints to batch unfavorite are not yet available_
- The "hover to see trashcan icon" was implemented in #445


## Testing instructions

Verify that by hovering a Project card and PD/Investor card and clicking on the trash can icon, the item gets removed from the favorites  

## Tracking

[LET-854](https://vizzuality.atlassian.net/browse/LET-854)
