### PR TITLE
New instance variable to differentiate staging from production

### DIFF
--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -1,5 +1,6 @@
 SECRET_KEY_BASE=
 
+INSTANCE_ROLE=# staging|production, NOT the same as RAILS_ENV as that is "production" in staging as well
 IS_API_INSTANCE=true
 IS_JOBS_INSTANCE=true
 

--- a/backend/ENV_VARS.md
+++ b/backend/ENV_VARS.md
@@ -7,6 +7,9 @@ SECRET_KEY_BASE (generated with rake secret)
 Control if jobs routes are available (default false)
 IS_JOBS_INSTANCE
 
+staging|production, NOT the same as RAILS_ENV as that is "production" in staging as well
+INSTANCE_ROLE=
+
 BACKEND_URL (without protocol)
 RAILS_RELATIVE_URL_ROOT (if running backend application in sub url, like /backend)
 

--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -16,7 +16,7 @@ Rails.application.configure do
   config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
   # we want to allow non https localhost requests to staging, but not production
-  config.action_controller.forgery_protection_origin_check = (ENV["INSTANCE_ROLE"].present? && ENV["INSTANCE_ROLE"] == "production") || false
+  config.action_controller.forgery_protection_origin_check = false if ENV["INSTANCE_ROLE"] == "staging"
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).

--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -15,8 +15,8 @@ Rails.application.configure do
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
-  # TODO: fix this later, directupload is checkin it on staging but we want to allow non https localhost requests
-  config.action_controller.forgery_protection_origin_check = false
+  # we want to allow non https localhost requests to staging, but not production
+  config.action_controller.forgery_protection_origin_check = (ENV["INSTANCE_ROLE"].present? && ENV["INSTANCE_ROLE"] == "production") || false
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).

--- a/infrastructure/base/.terraform.lock.hcl
+++ b/infrastructure/base/.terraform.lock.hcl
@@ -2,42 +2,44 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/google" {
-  version     = "4.28.0"
+  version     = "4.26.0"
   constraints = "~> 4.20"
   hashes = [
-    "h1:jjNvhmeP9hf97J7C69ntwWEctx/1eJFK+fFZqzbosr0=",
-    "zh:17664192fbeb733d6d6cfa17fbd1c54e6f1614f635f48adfae17557e121b63eb",
-    "zh:2993a3ba417c576ca9c6adccb6a6e914b4dedd3f91a735fd14ab8910936d8c11",
-    "zh:452323359fd64dc0fbf96da8c1df1df57cacef72cf2615631662bdec1d73d94e",
-    "zh:492c1d1bfbd9bef2a30fab0096ae642ceeeee81499cf5aa9f4505a884b0855a3",
-    "zh:611875b0246bdbd8815f8e81e744e31466559fec3b4566c9d2f3d1fd54c20292",
-    "zh:63c5084e1ac50165da1feebf2f51af3c8a7b61f817861418850b2b59b010b604",
-    "zh:6efb784223405839aa22fc6e40e37e08dd7ba37310e327dea1731299e5c67104",
-    "zh:ac51b5555bfdee282885475831bdc336f42294687e887f91cd339f15a4f69bc1",
-    "zh:c98e971f99f43aea9e0363cdd478e3b19f79b4553357a089bb10ba7ab897a932",
-    "zh:e9c29205674657f7b31f352a680a17262a797150bcbe76b26939d5cb39d19199",
+    "h1:vrB5NhkzFu+dFiXcxGK1waeSYkqRFW4ZySgiq2js9Nk=",
+    "h1:xV+vg4tjH1G9GHYUkfuN3SVSC47G9NoQfQDbZmN2KCo=",
+    "zh:142ce66a1fd0f916d95eaaf3d8edbc818749bb7db1fe3fb9985b1150a01b6656",
+    "zh:17b9176fcf3109e64c57f61c32f98fc911777f4756da89f9c4bc2de9c0475592",
+    "zh:466ecc7451d859cbbbd25d251d7246bf813e168e26df843600c1c949f2bd6eaf",
+    "zh:57fcc1a9c26478356aee9ac34ba33b1a791f57d9dfd3409e421bedc94dbae938",
+    "zh:68750e29336e44d36facfdff6b0cd296b32e24e2aaded8cfeb8837ed1b706212",
+    "zh:8a2cf34a240c0bc0b04defc5bffc0bafabee323ec6d407f4ea0c12af171050e7",
+    "zh:91d9c9e8e3e961799691536565b6c33d1bc965f85c52913847f3a3fd8accecf6",
+    "zh:9a0c6b94467211f59d5069e3c79cb43dbb1d8fb0f61a9acfeccd24f5a0278918",
+    "zh:9a0df22fac3aecc2f0623e843c87680a07c460501508c4e32b0cc9f6e473ca2a",
+    "zh:bba9dfcf29f2ef541f9ae9cdc742e6c02f1262923f1d4c946c4b6e3d19e4346d",
+    "zh:e33d35fa18ba4effafdf0cf97794498cb4407a9a7c8edb2cec8a825ca94eb0f3",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
-    "zh:f968998e7690cd508c1f7847d7fa3ba2ae448d70e94414ada85c1cee81b3bcd9",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/google-beta" {
-  version     = "4.28.0"
+  version     = "4.26.0"
   constraints = "~> 4.20"
   hashes = [
-    "h1:kf7kz+xRgenx1f3ROvKxV9SSqkUhXBjIvJ0rmlmOSaY=",
-    "zh:02049634b3dd7928628145c1993e9a6772b8229e94c0466943dd8a192c7dcf43",
-    "zh:113664260f56d0559c9f4c5b912dd80ee966d09ff3723fe6ae1a71fa4915fdc9",
-    "zh:28de139a2db9ccf280a92fa18ed41f36ea5ef4269fda4124288751eec45b6907",
-    "zh:303dec5be87bd935351bf991da4edff71bab9909ce410a819b3dd0849a27df8b",
-    "zh:579b6cf837488a0e6335c1ca0b81ce0936d2ea29c24b4fb8ba54018e81a0cabb",
-    "zh:77cdb315e9144739241f9ea3e55502104dece33ce0acd9694469a3a5df4e3906",
-    "zh:837c37d168dc557b474b5dac3b850e134779a27ee9df3f49a4427c569d0eae44",
-    "zh:9359bf058b95fa6b9337a3b55168517fd380e6752c383c964fb776513621aca4",
-    "zh:cf3cdef5ed5d4a321ffd2cac070a00ff0f8cee7bfd6a2697c494a1d06937bb67",
-    "zh:e4f647bd336260fc477f7ab77e48e825d49f3d4ed1391bf232b5039cfc411760",
-    "zh:ec3a02205594beeeedd090dd6c831a988fc0ff58fb353cc78dc6395eedf19979",
+    "h1:/vQfEsILptD1/urOWC+TcQg89ifKDvI7weZEszGLI2E=",
+    "h1:uuLM13A87Zdpq/I1FV2PjWmXwZRBkwupc+nkiJx2LH8=",
+    "zh:0122996e6d27ee9c319bc7c90d61aa1365f3fbf30a39ed4ca48e12daad46a5f0",
+    "zh:14163b2309a689c1cd336e4b7d946f155220845216d4d548f0e655ba8f2fd5f9",
+    "zh:3c66947bc92c8eb9e44677d692ac42f28ad6a9279e7ae27a854278eb800c4097",
+    "zh:4b29c58e3580ec571477b93afc9a13f940340fa889f1d21ae3ae4a5d9cbebc35",
+    "zh:8557cff30ced68eb0d6c192f5209080c6c90c727d78eb36cbad61e1a37ff7a87",
+    "zh:b2d34ed618c371cb7145a9f842a6d6b1cd069963cfa38b83b0fb24dae755ad1d",
+    "zh:cbfcc05f7219d404986404b2a01633767d543fbe136e250a5e64dd48b56cb4d3",
+    "zh:eff6cdb15c459dc237419498e42477c26cb5c6082edf821a6fd1199548e9c4c2",
+    "zh:f495f6311dff0d908bad0e084ac09a11e8e45f67a5d85d196cb04dc43d270b9e",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f750e6c18cca47bac08f7998998b4c9df570cabd66c52dd0faa0439670c4df31",
+    "zh:fbca2a8537b2ea350761131e71ac529888b7949625055b2461a377f8838d3d98",
   ]
 }
 

--- a/infrastructure/base/main.tf
+++ b/infrastructure/base/main.tf
@@ -37,6 +37,7 @@ module "staging" {
   subdomain              = "staging"
   uptime_alert_email     = var.uptime_alert_email
   from_email_address     = var.from_email_address
+  instance_role          = "staging"
 }
 
 module "production" {
@@ -61,6 +62,7 @@ module "production" {
   redirect_dns_zone_name = module.redirect_dns.dns_zone_name
   uptime_alert_email     = var.uptime_alert_email
   from_email_address     = var.from_email_address
+  instance_role          = "production"
 }
 
 module "dns" {

--- a/infrastructure/base/modules/env/main.tf
+++ b/infrastructure/base/modules/env/main.tf
@@ -232,6 +232,10 @@ module "backend_cloudrun" {
     {
       name  = "GCP_REGION"
       value = var.gcp_region
+    },
+    {
+      name  = "INSTANCE_ROLE"
+      value = var.instance_role
     }
   ]
 }
@@ -339,6 +343,10 @@ module "jobs_cloudrun" {
     {
       name  = "GCP_REGION"
       value = var.gcp_region
+    },
+    {
+      name  = "INSTANCE_ROLE"
+      value = var.instance_role
     }
   ]
 }

--- a/infrastructure/base/modules/env/variables.tf
+++ b/infrastructure/base/modules/env/variables.tf
@@ -129,6 +129,6 @@ variable "from_email_address" {
 
 variable "instance_role" {
   type = string
-  default = ""
+  default = "production"
   description = "staging|production, NOT the same as RAILS_ENV as that is 'production' in staging as well"
 }

--- a/infrastructure/base/modules/env/variables.tf
+++ b/infrastructure/base/modules/env/variables.tf
@@ -126,3 +126,9 @@ variable "from_email_address" {
   type = string
   description = "Email address from which to send emails"
 }
+
+variable "instance_role" {
+  type = string
+  default = ""
+  description = "staging|production, NOT the same as RAILS_ENV as that is 'production' in staging as well"
+}


### PR DESCRIPTION
We're using "production" rails env in both staging and production, which is simpler than having 2 environments, but in some cases it's useful to know from the application which it is and this is now available as an env var `INSTANCE_ROLE`.

## Tracking

https://vizzuality.atlassian.net/browse/LET-426?atlOrigin=eyJpIjoiYmE1NGVkYWM4NjUzNDY0YzgxNmM1OWZlYWQ5NTcxMGMiLCJwIjoiaiJ9
