### PR TITLE
Fix bug causing a table crash when canSort is set to false but a column accessor has not been set

### DIFF
--- a/frontend/components/table/component.tsx
+++ b/frontend/components/table/component.tsx
@@ -96,10 +96,7 @@ export const Table: FC<TableProps> = ({
 
                     // canSort is always true when manualSortBy is true
                     // See: https://github.com/TanStack/table/issues/2599
-                    const canSort =
-                      (sortingEnabled &&
-                        columns.find(({ accessor }) => accessor === id)?.canSort) ??
-                      true;
+                    const canSort = (sortingEnabled && column?.canSort) ?? true;
 
                     return (
                       <th


### PR DESCRIPTION
## Description

This PR fixes a bug in the Dashboard/Users table, where if the user clicks on the "actions" column header, the table will attempt to sort the column even though `canSort` is set to false for that particular column. 

**Screen recording of the bug:**
https://user-images.githubusercontent.com/6273795/182859480-f68fbeb9-b93a-43af-ab00-f7eae3c55d98.mp4

## Testing instructions

Verify that the bug no longer occurs. 

## Tracking

[LET-862](https://vizzuality.atlassian.net/browse/LET-862)
