### PR TITLE
Fix project cards text alignment when project name spans multiple lines

### DIFF
--- a/frontend/containers/project-card/component.tsx
+++ b/frontend/containers/project-card/component.tsx
@@ -150,7 +150,7 @@ export const ProjectCard: FC<ProjectCardProps> = ({
           <div>
             {onClick ? (
               <button
-                className="text-xl font-semibold leading-tight outline-none"
+                className="text-xl font-semibold leading-tight text-left outline-none"
                 aria-label={intl.formatMessage(
                   {
                     defaultMessage: 'View {name} project details',


### PR DESCRIPTION
## Description

Quick fix for the project card's weird project name alignment, when the project name spans multiple lines

### Before
<img width="1680" alt="Screenshot 2022-08-04 at 16 44 20" src="https://user-images.githubusercontent.com/6273795/182890133-529fb711-411f-48b8-9f00-3b7a2f491104.png">

### After
<img width="1680" alt="Screenshot 2022-08-04 at 16 44 29" src="https://user-images.githubusercontent.com/6273795/182890158-5a3a158b-5213-4fc9-9858-b270ce280ff8.png">


## Testing instructions

N/A

## Tracking

N/A
