### PR TITLE
Fix filters being cleared when using the discover pages' pagination

### DIFF
--- a/frontend/containers/layouts/discover-search/component.tsx
+++ b/frontend/containers/layouts/discover-search/component.tsx
@@ -7,7 +7,7 @@ import cx from 'classnames';
 
 import { useRouter } from 'next/router';
 
-import { useDiscoverPath, useQueryParams } from 'helpers/pages';
+import { cleanQueryParams, useDiscoverPath, useQueryParams } from 'helpers/pages';
 
 import Filters from 'containers/forms/filters';
 import { FilterForm, FilterParams } from 'containers/forms/filters/types';
@@ -58,11 +58,17 @@ export const DiscoverSearch: FC<DiscoverSearchProps> = ({
 
   const handleSearch = (searchInput: string, filtersInput: Partial<FilterParams>) => {
     push(
-      { query: { sorting, page: 1, search: searchInput, ...filtersInput }, pathname },
-      undefined,
       {
-        shallow: true,
-      }
+        query: cleanQueryParams({
+          page: null,
+          search: searchInput || null,
+          sorting: sorting || null,
+          ...filtersInput,
+        }),
+        pathname,
+      },
+      undefined,
+      { shallow: true }
     );
   };
 

--- a/frontend/helpers/pages.ts
+++ b/frontend/helpers/pages.ts
@@ -104,23 +104,9 @@ export const useDiscoverPath = () => {
 };
 
 /** Hook to get the query params of the discover pages */
-export const useQueryParams = (sortingState?: { sortBy: string; sortOrder: string }) => {
+export const useQueryParams = () => {
   const { query } = useRouter();
-  return useMemo(() => {
-    const { page, search, sorting, ...filters } = query;
-    return cleanQueryParams({
-      page: parseInt(query.page as string) || null,
-      search: (query.search as string) || '',
-      sorting:
-        // No need to decode URI component, next/router does it automatically
-        sorting
-          ? (sorting as string)
-          : sortingState?.sortBy
-          ? `${sortingState?.sortBy} ${sortingState?.sortOrder}`
-          : '',
-      ...filters,
-    });
-  }, [query, sortingState]);
+  return cleanQueryParams(query);
 };
 
 /** Hook that returns the search queries on string format */

--- a/frontend/helpers/pages.ts
+++ b/frontend/helpers/pages.ts
@@ -17,7 +17,7 @@ import { Locations } from 'types/locations';
 import { Project, ProjectForm, ProjectUpdatePayload } from 'types/project';
 import { formPageInputs } from 'validations/project';
 
-import { ErrorResponse } from 'services/types';
+import { PagedRequest, ErrorResponse } from 'services/types';
 
 /** Uses the error messages received from the API and the input names of the form to get the fields and form pages with errors */
 export function getServiceErrors<FormValues>(
@@ -103,18 +103,19 @@ export const useQueryParams = (sortingState?: { sortBy: string; sortOrder: strin
 };
 
 /** Hook that returns the search queries on string format */
-export const useQueryString = () => {
+export const useQueryString = (params: PagedRequest = {}) => {
   const { query } = useRouter();
   const queries = Object.entries(query);
   if (queries.length) {
     const queryString = new URLSearchParams();
     queries.forEach(([key, value]) => {
-      let queryValue = value;
-      if (Array.isArray(value)) {
-        queryValue = value.join(',');
+      let queryValue = params[key] || value;
+      if (Array.isArray(queryValue)) {
+        queryValue = queryValue.join(',');
       }
       queryString.append(key, queryValue as string);
     });
+
     return `?${queryString}`;
   }
   return '';

--- a/frontend/hooks/usePagination.ts
+++ b/frontend/hooks/usePagination.ts
@@ -2,6 +2,8 @@ import { useMemo, useState, useEffect } from 'react';
 
 import { useRouter } from 'next/router';
 
+import { useQueryParams } from 'helpers/pages';
+
 export const usePagination = (meta) => {
   const router = useRouter();
   const { query } = router;
@@ -20,13 +22,7 @@ export const usePagination = (meta) => {
     totalPages: undefined,
   });
 
-  const queryParams = useMemo(
-    () => ({
-      page: parseInt(query.page as string) || 1,
-      search: (query.search as string) || '',
-    }),
-    [query]
-  );
+  const queryParams = useQueryParams();
 
   useEffect(() => {
     if (!meta) return;

--- a/frontend/hooks/usePagination.ts
+++ b/frontend/hooks/usePagination.ts
@@ -22,7 +22,8 @@ export const usePagination = (meta) => {
     totalPages: undefined,
   });
 
-  const queryParams = useQueryParams();
+  let queryParams = useQueryParams();
+  delete queryParams['page'];
 
   useEffect(() => {
     if (!meta) return;
@@ -51,7 +52,7 @@ export const usePagination = (meta) => {
   }, [meta]);
 
   const handlePageClick = (page: number) => {
-    router.push({ query: { ...queryParams, page } });
+    router.push({ query: { ...queryParams, ...(page !== 1 && { page }) } });
   };
 
   if (!paginationProps) return null;

--- a/frontend/layouts/discover-page/component.tsx
+++ b/frontend/layouts/discover-page/component.tsx
@@ -47,12 +47,12 @@ export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
     if (pathname.startsWith(Paths.Projects)) return Queries.Project;
 
     if (sorting.sortBy !== 'name' && sorting.sortBy !== 'created_at') {
-      setSorting({ ...sorting, sortBy: 'name' });
+      setSorting(defaultSorting);
     }
-  }, [pathname, sorting]) as SortingByTargetType;
+  }, [defaultSorting, pathname, sorting]) as SortingByTargetType;
 
   const sortingOptions = useSortingByOptions(sortingOptionsTarget);
-  const queryParams = useQueryParams(sorting);
+  const queryParams = useQueryParams();
 
   const queryOptions = { keepPreviousData: true };
 

--- a/frontend/layouts/discover-page/component.tsx
+++ b/frontend/layouts/discover-page/component.tsx
@@ -6,7 +6,7 @@ import cx from 'classnames';
 
 import { useRouter } from 'next/router';
 
-import { useQueryParams } from 'helpers/pages';
+import { cleanQueryParams, useQueryParams } from 'helpers/pages';
 
 import DiscoverSearch from 'containers/layouts/discover-search';
 
@@ -52,7 +52,6 @@ export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
   }, [pathname, sorting]) as SortingByTargetType;
 
   const sortingOptions = useSortingByOptions(sortingOptionsTarget);
-
   const queryParams = useQueryParams(sorting);
 
   const queryOptions = { keepPreviousData: false };
@@ -91,8 +90,11 @@ export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
   }, [pathname, projects, projectDevelopers, investors, openCalls]) || { data: [], meta: [] };
 
   useEffect(() => {
-    const [sortBy, sortOrder]: any = queryParams.sorting.split(' ');
-    setSorting(sortBy && sortOrder ? { sortBy, sortOrder } : defaultSorting);
+    const [sortBy, sortOrder]: any = queryParams?.sorting?.split(' ') || [
+      defaultSorting.sortBy,
+      defaultSorting.sortOrder,
+    ];
+    setSorting({ sortBy, sortOrder });
   }, [defaultSorting, queryParams.sorting]);
 
   const handleSorting = ({
@@ -103,10 +105,10 @@ export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
     sortOrder: SortingOrderType;
   }) => {
     push({
-      query: {
+      query: cleanQueryParams({
         ...queryParams,
         sorting: `${sortBy || sorting.sortBy} ${sortOrder || sorting.sortOrder}`,
-      },
+      }),
     });
   };
 

--- a/frontend/layouts/discover-page/component.tsx
+++ b/frontend/layouts/discover-page/component.tsx
@@ -54,7 +54,7 @@ export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
   const sortingOptions = useSortingByOptions(sortingOptionsTarget);
   const queryParams = useQueryParams(sorting);
 
-  const queryOptions = { keepPreviousData: false };
+  const queryOptions = { keepPreviousData: true };
 
   const projects = useProjectsList(
     { ...queryParams, includes: ['project_developer', 'involved_project_developers'] },

--- a/frontend/layouts/discover-page/navigation/component.tsx
+++ b/frontend/layouts/discover-page/navigation/component.tsx
@@ -15,8 +15,8 @@ export const Navigation: FC<NavigationProps> = ({ stats }: NavigationProps) => {
   const intl = useIntl();
   const { asPath } = useRouter();
 
-  // Pick the query params we want to preserve in the navigation links (search, filters, sorting)
-  const queryString = useQueryString();
+  // Pick the the query params we want to preserve in the navigation links (search, filters, sorting)
+  const queryString = useQueryString({ page: 1 });
 
   const navigationItems = [
     {

--- a/frontend/layouts/discover-page/navigation/component.tsx
+++ b/frontend/layouts/discover-page/navigation/component.tsx
@@ -16,7 +16,7 @@ export const Navigation: FC<NavigationProps> = ({ stats }: NavigationProps) => {
   const { asPath } = useRouter();
 
   // Pick the the query params we want to preserve in the navigation links (search, filters, sorting)
-  const queryString = useQueryString({ page: 1 });
+  const queryString = useQueryString({ page: null });
 
   const navigationItems = [
     {


### PR DESCRIPTION
## Description

This PR aims to fix a couple issues with the Discover/Search pages:  
- Using the pagination clears the filters  
- Pagination does not reset to the first page when changing tabs  

Extra:  
- Clearing the search term from the input clears it from the URL  
- Clearing the filters clears them from the URL  
- When page is `1`, it'll be cleared from the URL  
- Fix discover/projects list not displaying the loading spinner

Not done here:  
- Sorting does not reset when changing tabs  
  _eg: while searching for projects, if the user is sorting by impact score, then clicks on another tab, sorting does not get reset_


## Testing instructions

Verify that:  
1. Using the pagination does not clear enabled filters   
    - Visit `discover/projects`
    - Select the `Biodiversity` filter
    - Click on another tab
    - Verify that the filter does not get cleared
2. When changing tabs, pagination gets reset to the first page  
    - Visit `discover/projects`  
    - Click to move to page 3  
    - Click on another tab  
    - Verify that the currently selected page is page 1  

## Tracking

N/A
