### PR TITLE
Let 859 fe fix token invalid error when a user with a light account type is invited to the platform

### DIFF
--- a/frontend/pages/invitation.tsx
+++ b/frontend/pages/invitation.tsx
@@ -104,7 +104,7 @@ const Invitation: PageComponent<InvitationProps> = () => {
             </p>
           </Alert>
         </div>
-      ) : invitedUserLoading || userLoading ? (
+      ) : !invitedUser || invitedUserLoading || userLoading ? (
         <div className="flex flex-col items-center justify-center mt-20">
           <Loading visible iconClassName="w-16 h-16" />
         </div>

--- a/frontend/pages/invitation.tsx
+++ b/frontend/pages/invitation.tsx
@@ -42,7 +42,8 @@ const Invitation: PageComponent<InvitationProps> = () => {
     invitedUser,
     isError: invitedUserError,
     isLoading: invitedUserLoading,
-  } = useInvitedUser(query.invitation_token as string);
+  } = useInvitedUser((query.invitation_token as string) || 'INVALID_INVITATION_TOKEN');
+  //The useInvitedUser is only enabled when the query.invitation_token is not null, so we set it to any string to show an error if the query.invitation_token is null
   const { user, isError: userError, isLoading: userLoading } = useMe();
   const acceptInvitation = useAcceptInvitation();
   const signOut = useSignOut();
@@ -86,17 +87,9 @@ const Invitation: PageComponent<InvitationProps> = () => {
     });
   };
 
-  return (
-    <div className="flex flex-col items-center w-full min-h-[calc(100vh-100px)] lg:min-h-[calc(100vh-176px)]">
-      <div className="flex items-center justify-center rounded-full w-44 h-44 bg-background-middle">
-        <Image
-          src="/images/invitation.svg"
-          width={112}
-          height={97}
-          alt={formatMessage({ defaultMessage: 'Invitation mail', id: 'a+vAPa' })}
-        />
-      </div>
-      {invitedUserError || !query.invitation_token ? (
+  const InvitationContent = () => {
+    if (invitedUserError) {
+      return (
         <div className="max-w-lg mt-20 overflow-hidden text-center rounded-lg">
           <Alert withLayoutContainer>
             <p className="text-lg">
@@ -104,11 +97,11 @@ const Invitation: PageComponent<InvitationProps> = () => {
             </p>
           </Alert>
         </div>
-      ) : !invitedUser || invitedUserLoading || userLoading ? (
-        <div className="flex flex-col items-center justify-center mt-20">
-          <Loading visible iconClassName="w-16 h-16" />
-        </div>
-      ) : (
+      );
+    }
+
+    if (!!invitedUser && !!user) {
+      return (
         <div className="max-w-lg text-center">
           <h1 className="mb-6 font-serif text-3xl font-semibold mt-7 text-green-dark">
             <FormattedMessage
@@ -150,7 +143,27 @@ const Invitation: PageComponent<InvitationProps> = () => {
             </a>
           </Link>
         </div>
-      )}
+      );
+    }
+
+    return (
+      <div className="flex flex-col items-center justify-center mt-20">
+        <Loading visible iconClassName="w-16 h-16" />
+      </div>
+    );
+  };
+
+  return (
+    <div className="flex flex-col items-center w-full min-h-[calc(100vh-100px)] lg:min-h-[calc(100vh-176px)]">
+      <div className="flex items-center justify-center rounded-full w-44 h-44 bg-background-middle">
+        <Image
+          src="/images/invitation.svg"
+          width={112}
+          height={97}
+          alt={formatMessage({ defaultMessage: 'Invitation mail', id: 'a+vAPa' })}
+        />
+      </div>
+      <InvitationContent />
     </div>
   );
 };

--- a/frontend/pages/sign-in/index.tsx
+++ b/frontend/pages/sign-in/index.tsx
@@ -66,13 +66,6 @@ const SignIn: PageComponent<ProjectDeveloperProps, AuthPageLayoutProps> = () => 
     // Wait until user and inviteUser are loaded to be able to compare them
     if (!isUserLoading && !isInvitedUserLoading) {
       if (!!invitedUser) {
-        // If the user has an invitation and is signed in go to invitation page
-        if (!!user && user?.role === UserRoles.Light) {
-          replace({
-            pathname: Paths.Invitation,
-            query: { invitation_token: query.invitation_token },
-          });
-        }
         setValue('email', invitedUser.email);
       } else if (!!user) {
         // If is not a invited user and is already signed in


### PR DESCRIPTION
This PR fixes 2 bugs related to the invitation flow

## Testing instructions
BUG 1
Steps to reproduce 

- Register a user but DON’T start account creation. Just light sing in
- Log out
- Now log in with an investor account owner
- Invite the user you registered first
- Email is sent
- Click the invitation link
- As the user already exists, you will be asked to log in
- Log in

Expected results: I’m logged in and land at the account My Area page

Actual results: the screen says “token invalid”

Fixed results: you are redirected to dashboard (My Area page)


BUG 2
Invitation page flickering before redirect
Steps to reproduce 
- log out HeCo
- click on a invitation link
slowing down your internet connection to fast 3g, you will be more likely to reproduce the error

Expected results - You should see a loading icon and then be redirected to sign-in or sign-up
Actual results: You see the loading and then, for a moment, the 'invitation' page content before being redirected

Fixed results: You don't see the 'invitation' content before being redirected
 

Link to Jira comment: [LET-441: Investor account owners can see and add users to accountIN PROGRESS](https://vizzuality.atlassian.net/browse/LET-441?focusedCommentId=18223)


## Tracking
https://vizzuality.atlassian.net/browse/LET-859
https://vizzuality.atlassian.net/browse/LET-845
