### PR TITLE
Remove delete icon from owner on users list

### DIFF
--- a/frontend/containers/dashboard/users/table/cells/actions/component.tsx
+++ b/frontend/containers/dashboard/users/table/cells/actions/component.tsx
@@ -27,7 +27,7 @@ export const CellActions = ({ row }: CellActionsProps) => {
 
   if (!row) return null;
   const {
-    original: { id, invitation, first_name, last_name, email },
+    original: { id, invitation, first_name, last_name, email, owner },
   } = row;
   const displayName = first_name ? first_name + ' ' + last_name : email;
   const canResendInvitation =
@@ -45,12 +45,14 @@ export const CellActions = ({ row }: CellActionsProps) => {
   };
 
   const handleDeleteUser = (userId: string) => {
-    deleteUser.mutate(userId, {
-      onSuccess: () => {
-        queryClient.invalidateQueries(Queries.AccountUsersList);
-        setConfirmDelete(false);
-      },
-    });
+    if (!owner) {
+      deleteUser.mutate(userId, {
+        onSuccess: () => {
+          queryClient.invalidateQueries(Queries.AccountUsersList);
+          setConfirmDelete(false);
+        },
+      });
+    }
   };
 
   const handleDismiss = () => {
@@ -91,26 +93,28 @@ export const CellActions = ({ row }: CellActionsProps) => {
         </button>
       </Tooltip>
 
-      <Tooltip
-        placement="top"
-        arrow
-        arrowClassName="bg-black"
-        content={
-          <div className="max-w-xs p-2 font-sans text-sm font-normal text-white bg-black rounded-sm sm:max-w-md">
-            <FormattedMessage defaultMessage="Delete" id="K3r6DQ" />
-          </div>
-        }
-      >
-        <button
-          type="button"
-          onClick={() => setConfirmDelete(true)}
-          disabled={deleteUser.isLoading}
-          className="flex items-center justify-center w-8 h-8 border rounded-full hover:bg-green-light hover:bg-opacity-20 pointer border-green-dark"
+      {!owner && (
+        <Tooltip
+          placement="top"
+          arrow
+          arrowClassName="bg-black"
+          content={
+            <div className="max-w-xs p-2 font-sans text-sm font-normal text-white bg-black rounded-sm sm:max-w-md">
+              <FormattedMessage defaultMessage="Delete" id="K3r6DQ" />
+            </div>
+          }
         >
-          <Loading visible={deleteUser.isLoading} />
-          {!deleteUser.isLoading && <Icon className="w-5 h-5 text-green-dark" icon={TrashIcon} />}
-        </button>
-      </Tooltip>
+          <button
+            type="button"
+            onClick={() => setConfirmDelete(true)}
+            disabled={deleteUser.isLoading}
+            className="flex items-center justify-center w-8 h-8 border rounded-full hover:bg-green-light hover:bg-opacity-20 pointer border-green-dark"
+          >
+            <Loading visible={deleteUser.isLoading} />
+            {!deleteUser.isLoading && <Icon className="w-5 h-5 text-green-dark" icon={TrashIcon} />}
+          </button>
+        </Tooltip>
+      )}
 
       <ConfirmationPrompt
         open={confirmDelete}

--- a/frontend/containers/dashboard/users/table/cells/actions/types.ts
+++ b/frontend/containers/dashboard/users/table/cells/actions/types.ts
@@ -1,14 +1,7 @@
-import { InvitationStatus } from 'enums';
+import { User } from 'types/user';
 
 export interface CellActionsProps {
   row: {
-    original: {
-      id: string;
-      email: string;
-      confirmed: boolean;
-      first_name: string;
-      last_name: string;
-      invitation: InvitationStatus;
-    };
+    original: User;
   };
 }


### PR DESCRIPTION
This PR removes the delete option from account owner on the users table (dashboard/users)

The users should only be able to delete they own account from the page "/settings/information", and if the user is the account user he/she should transfer the ownership to other user first.

## Testing instructions

1. Sign in as an Investor or PD account owner.
2. Go to dashboard/users. 
3. You should see a table with the account users. All the last columns should have a 'trash' icon, to delete the user,  except the account owner.

<img width="986" alt="Screenshot 2022-08-08 at 18 12 27" src="https://user-images.githubusercontent.com/48164343/183463867-85992f9b-c714-48b5-b201-e1485b39d3ca.png">


## Tracking

[LET-882](https://vizzuality.atlassian.net/browse/LET-882)