### PR TITLE
Let 860 and 850 Fix texts

### DIFF
--- a/frontend/containers/account-pending-approval/component.tsx
+++ b/frontend/containers/account-pending-approval/component.tsx
@@ -37,7 +37,7 @@ export const AccountPendingApproval = () => {
       </Button>
       <Link href={FaqPaths[FaqQuestions.WhyAccountIsPendingApproval]} passHref>
         <a target="_blank" rel="noopener noreferrer" className="font-sans text-gray-600 underline">
-          <FormattedMessage defaultMessage="Why is my profile pending approval?" id="Ftj+/t" />
+          <FormattedMessage defaultMessage="Why is my account pending approval?" id="I2yxwP" />
         </a>
       </Link>
     </div>

--- a/frontend/containers/faq-page/answers/projects/project-info/component.tsx
+++ b/frontend/containers/faq-page/answers/projects/project-info/component.tsx
@@ -160,8 +160,8 @@ export const ProjectInfo: FC = () => {
           mandatory={true}
           validationType={ItemValidationTypes.SelectMultiple}
           title={formatMessage({
-            defaultMessage: 'Which of these topics/sector categories better describe your project?',
-            id: 'i2AgQl',
+            defaultMessage: 'Target group',
+            id: '0L/mZC',
           })}
           description={formatMessage({
             defaultMessage:

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -749,9 +749,6 @@
   "Fg5HOn": {
     "string": "Every new account created will need to be approved by the HeCo Invest staff - platform administrator. This approval process allows for the verification of each organization, institution or business that applies to the HeCo Invest platform, guaranteeing that only trustworthy organizations will present their projects or investment opportunities. Therefore, your account will only be visible on the HeCo Invest platform after the platform administrator completes this approval step."
   },
-  "Ftj+/t": {
-    "string": "Why is my profile pending approval?"
-  },
   "Fxekek": {
     "string": "Invite again"
   },


### PR DESCRIPTION
This PR changes the 'pending approval' text of FAQ's link

## Testing instructions

BUG 1:

After completing the account creation we should see the message “Why is my account pending approval?” instead we are seeing “Why is my profile pending approval?” Please change in the code and let us know to update the translations accordingly.

![57694905-27dd-4128-9896-750a311b9374](https://user-images.githubusercontent.com/48164343/183700281-9f0f7f5b-9372-452a-883b-4c85e81354e9.png)

FIX TEST
1. Sign up
2. Choose any account type
3. Fill the account form and complete the account creation
4. After finishing, you will see the 'Pending approval' page, and the FAQ's link text should be 'Why is my account pending approval?'

BUG 2:

Point 11 of “What information do I need to create a project” in the FAQ must say "Target group"
![5c182484-2daa-4dc6-8010-117d11b35f7e](https://user-images.githubusercontent.com/48164343/183703209-b5aea003-35ed-4aa1-bae8-4ba4c9aef5f9.png)

FIX TEST

1. Go to FAQ's / Projects / question 11
2. You should see the text 'Target group (select multiple) *'

## Tracking

[LET-860](https://vizzuality.atlassian.net/browse/LET-860)
[LET-850](https://vizzuality.atlassian.net/browse/LET-850)