### PR TITLE
fix: Account can be deleted via Backoffice

### DIFF
--- a/backend/app/controllers/backoffice/investors_controller.rb
+++ b/backend/app/controllers/backoffice/investors_controller.rb
@@ -40,7 +40,7 @@ module Backoffice
     end
 
     def destroy
-      @investor.destroy!
+      @investor.account.destroy!
 
       redirect_to backoffice_investors_path, status: :see_other,
         notice: t("backoffice.messages.success_delete", model: t("backoffice.common.investor"))

--- a/backend/app/controllers/backoffice/project_developers_controller.rb
+++ b/backend/app/controllers/backoffice/project_developers_controller.rb
@@ -40,7 +40,7 @@ module Backoffice
     end
 
     def destroy
-      @project_developer.destroy!
+      @project_developer.account.destroy!
 
       redirect_to backoffice_project_developers_path, status: :see_other,
         notice: t("backoffice.messages.success_delete", model: t("backoffice.common.project_developer"))

--- a/backend/app/controllers/backoffice/users_controller.rb
+++ b/backend/app/controllers/backoffice/users_controller.rb
@@ -38,6 +38,8 @@ module Backoffice
     end
 
     def destroy
+      return redirect_to(backoffice_users_path, status: :see_other, alert: I18n.t("errors.messages.user.is_owner")) if @user.owner_account.present?
+
       if @user.destroy
         UserMailer.destroyed(@user.email, @user.full_name, @user.locale).deliver_later
         redirect_to backoffice_users_path, status: :see_other,

--- a/backend/app/models/account.rb
+++ b/backend/app/models/account.rb
@@ -7,10 +7,10 @@ class Account < ApplicationRecord
 
   belongs_to :owner, class_name: "User"
 
-  has_many :users
+  has_many :users, dependent: :destroy
 
-  has_one :investor
-  has_one :project_developer
+  has_one :investor, dependent: :destroy
+  has_one :project_developer, dependent: :destroy
 
   has_one_attached :picture
 

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -13,7 +13,7 @@ class User < ApplicationRecord
   has_many :investors, through: :favourite_investors
   has_many :favourite_open_calls, dependent: :destroy
   has_many :open_calls, through: :favourite_open_calls
-  has_one :owner_account, class_name: "Account", foreign_key: "owner_id", dependent: :restrict_with_error
+  has_one :owner_account, class_name: "Account", foreign_key: "owner_id"
 
   has_one_attached :avatar
 

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -281,6 +281,7 @@ zu:
         multiple_accounts: User already have account!
         no_project_developer: User is not project developer!
         no_investor: User is not investor!
+        is_owner: User is owner of account and cannot be deleted now!
   user_mailer:
     greetings: Dear %{full_name},
     farewell_html: Best Regards,<br />Your HeCo Team

--- a/backend/spec/system/backoffice/investors_spec.rb
+++ b/backend/spec/system/backoffice/investors_spec.rb
@@ -306,6 +306,7 @@ RSpec.describe "Backoffice: Investors", type: :system do
           expect(page).to have_text(t("backoffice.messages.success_delete", model: t("backoffice.common.investor")))
           expect(current_path).to eql(backoffice_investors_path)
           expect(page).not_to have_text(approved_investor.name)
+          expect(Account.find_by(id: approved_investor.account_id)).to be_nil
         end
       end
     end

--- a/backend/spec/system/backoffice/project_developers_spec.rb
+++ b/backend/spec/system/backoffice/project_developers_spec.rb
@@ -263,6 +263,7 @@ RSpec.describe "Backoffice: Project Developers", type: :system do
         expect(page).to have_text(t("backoffice.messages.success_delete", model: t("backoffice.common.project_developer")))
         expect(current_path).to eql(backoffice_project_developers_path)
         expect(page).not_to have_text(approved_pd.name)
+        expect(Account.find_by(id: approved_pd.account_id)).to be_nil
       end
     end
   end


### PR DESCRIPTION
I am fixing Account deletion action at backoffice. It now deletes even `Account` record which triggers users deletion as well -- at past, just `Investor` or `ProjectDeveloper` record were destroyed, but `Account` didn't get deleted.

## Testing instructions

Delete Account (PD or Investor) via Backoffice and check that all users are destroyed as well

## Tracking

BugFix
