### PR TITLE
Add 'publish  draft' option to projects list

### DIFF
--- a/frontend/containers/dashboard/projects/table/cells/actions/types.ts
+++ b/frontend/containers/dashboard/projects/table/cells/actions/types.ts
@@ -1,10 +1,12 @@
 import { ProjectStatus } from 'enums';
+import { Project } from 'types/project';
 
 import { StatusTag } from '../status';
 
 export type CellActionsProps = {
   row: {
     original: {
+      data: Project;
       category: string;
       country: string;
       instrumentType: boolean;

--- a/frontend/containers/dashboard/projects/table/component.tsx
+++ b/frontend/containers/dashboard/projects/table/component.tsx
@@ -41,7 +41,7 @@ export const ProjectsTable: FC<ProjectsTableProps> = ({ onLoaded = noop }) => {
     isLoading: isLoadingProjects,
     isFetching: isFetchingProjects,
   } = useAccountProjectsList(
-    { ...queryParams, includes: ['municipality', 'country'] },
+    { ...queryParams, includes: ['municipality', 'department', 'country', 'project_images'] },
     queryOptions
   );
 
@@ -91,6 +91,7 @@ export const ProjectsTable: FC<ProjectsTableProps> = ({ onLoaded = noop }) => {
       },
     ],
     data: projects.map((project) => ({
+      data: project,
       slug: project.slug,
       name: project.name,
       status: project.status,


### PR DESCRIPTION
This PR adds the 'Publish draft' functionality

## Testing instructions

### Description

The users of a PD account will be able to publish a draft project directly from the projects list in the Dashboard. The users will have to confirm their action.

1. Sign-in as project developer
2. Go to dashboard/projects
3. On the projects table, choose one that has the 'status' 'draft', and click on the tree dots icon. It will display a menu. 
4. Click on  'Publish draft'. You should see a modal to confirm the action.
5. Click on 'publish'. The modal will close and the project status will change to 'Unverified'

## Tracking

[LET-884](https://vizzuality.atlassian.net/browse/LET-884)
