### PR TITLE
Fix edit project bugs

### DIFF
--- a/frontend/containers/project-form/helpers.ts
+++ b/frontend/containers/project-form/helpers.ts
@@ -19,7 +19,7 @@ export const useDefaultValues = (project: Project): Partial<ProjectForm> => {
       status: project.status,
       language: project.language,
       municipality_id: project.municipality?.id,
-      department_id: project.municipality.parent.id,
+      department_id: project.department?.id,
       country_id: project.country?.id,
       project_images_attributes: project.project_images?.map(({ cover, file, id }, index) => {
         const imageId = file.original.split('redirect/')[1].split('/')[0];

--- a/frontend/layouts/protected-page/component.tsx
+++ b/frontend/layouts/protected-page/component.tsx
@@ -71,7 +71,7 @@ const Protected: React.FC<ProtectedProps> = ({
 
   // If the ownership of the entity is needed and the user don't have it
   if (ownership?.allowOwner) {
-    if (!isOwner) {
+    if (isOwner === false) {
       // Redirect to dashboard
       router.push(Paths.Dashboard);
       return null;

--- a/frontend/pages/project/[id]/edit.tsx
+++ b/frontend/pages/project/[id]/edit.tsx
@@ -80,15 +80,13 @@ const EditProject: PageComponent<EditProjectProps, FormPageLayoutProps> = ({
     isFetching: isFetchingProject,
   } = useProject(router.query.id as string, PROJECT_QUERY_PARAMS, projectProp);
 
-  const updateProject = useUpdateProject({ locale: project.language });
+  const updateProject = useUpdateProject({ locale: project?.language });
 
   const getIsOwner = (_user: User, userAccount: ProjectDeveloper | Investor) => {
     // The user must be a the creator of the project to be allowed to edit it.
-    return (
-      project?.project_developer?.id &&
-      userAccount?.id &&
-      project.project_developer.id === userAccount.id
-    );
+    if (project?.project_developer?.id && userAccount?.id) {
+      return project.project_developer.id === userAccount.id;
+    }
   };
 
   const handleOnComplete = () => {

--- a/frontend/types/project.ts
+++ b/frontend/types/project.ts
@@ -47,16 +47,8 @@ export type ProjectBase = {
   target_groups: string[];
   ticket_size?: TicketSizes;
   language: Languages;
-  municipality: {
-    id: string;
-    location_type: 'municipality';
-    name: string;
-    parent: {
-      id: string;
-      location_type: 'department';
-      name: string;
-    };
-  };
+  municipality: Locations;
+  department: Locations;
   project_images: ProjectImageType[];
   trusted?: boolean;
   favourite?: boolean;


### PR DESCRIPTION
This PR fixes 2 bugs related to project edition page

## Testing instructions

### Bug 1
Description

A specific project crashes the app when you try to edit it.

Steps to reproduce:

1. Log in with the [susana.romao+pdapproved@vizzuality.com](mailto:susana.romao+pdapproved@vizzuality.com) account
2. Go to the projects list in the Dashboard
3. Click the “Edit” button of the “Awesome project (Edited)” project

The app will crash.

FIX: 
You will be sent to the project edit form

### Bug 2
Description

PD users may be unable to edit draft projects due to a FE crash.

Steps to reproduce

1. Log in with the [susana.romao+pdapproved@vizzuality.com](mailto:susana.romao+pdapproved@vizzuality.com) account
2. Go to the projects list in the Dashboard
3. Click the “Edit” button of the “Draft project - Clément” project

The app will crash.

FIX: 
You will be sent to the project edit form

## Tracking

BUG 1 - [LET-946](https://vizzuality.atlassian.net/browse/LET-946)
BUG 2- [LET-945](https://vizzuality.atlassian.net/browse/LET-945)