### PR TITLE
Allow the user to delete all their favourites

### DIFF
--- a/frontend/enums/index.ts
+++ b/frontend/enums/index.ts
@@ -74,6 +74,12 @@ export enum Queries {
   FavoriteProjectsList = 'favorite_projects',
   /** Single project */
   Project = 'project',
+  /** List of projects */
+  OpenCallList = 'open_calls',
+  /** List of favorited projects */
+  FavoriteOpenCallsList = 'favorite_open_calls',
+  /** Single open call */
+  OpenCall = 'open_call',
   /** List of investors */
   InvestorList = 'investors',
   /** List of favorited investors */

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -644,6 +644,9 @@
   "DIrN6T": {
     "string": "Project developer features"
   },
+  "DQDJ8q": {
+    "string": "By publishing your project it will be publicly visible."
+  },
   "DQoGRx": {
     "string": "About the impact"
   },
@@ -870,6 +873,9 @@
   "IkUX0b": {
     "string": "How the money will be used"
   },
+  "Iu60EH": {
+    "string": "Are you sure you want to continue?"
+  },
   "J4SQjQ": {
     "string": "select"
   },
@@ -920,6 +926,9 @@
   },
   "JcS7oJ": {
     "string": "By priority landscapes"
+  },
+  "Jfw90a": {
+    "string": "Publish draft"
   },
   "JkLHGw": {
     "string": "Website"
@@ -2388,6 +2397,9 @@
   "sy+pv5": {
     "string": "Email"
   },
+  "syEQFE": {
+    "string": "Publish"
+  },
   "t39CQq": {
     "string": "What’s your mission?"
   },
@@ -2609,6 +2621,9 @@
   },
   "ygx9Jx": {
     "string": "Micro finance"
+  },
+  "yp8KtZ": {
+    "string": "Publish project?"
   },
   "yqJ5XD": {
     "string": "Select the amount of money that you need"

--- a/frontend/layouts/dashboard-favorites/component.tsx
+++ b/frontend/layouts/dashboard-favorites/component.tsx
@@ -93,7 +93,7 @@ export const DashboardFavoritesLayout: FC<DashboardFavoritesLayoutProps> = ({
       <Head title={intl.formatMessage({ defaultMessage: 'My favorites', id: '50bxrQ' })} />
       <DashboardLayout
         isLoading={loading}
-        sidebar={<Navigation className="-ml-6 -mb-14 md:mt-8 md:sticky md:top-16" stats={stats} />}
+        sidebar={<Navigation className="-ml-6 md:mt-8 md:sticky md:top-16" stats={stats} />}
       >
         <div className="relative">{childrenWithProps}</div>
       </DashboardLayout>

--- a/frontend/layouts/dashboard-favorites/navigation/component.tsx
+++ b/frontend/layouts/dashboard-favorites/navigation/component.tsx
@@ -1,11 +1,15 @@
-import { FC } from 'react';
+import { FC, useCallback } from 'react';
 
 import { useIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import { useRouter } from 'next/router';
 
 import BadgeNavigation from 'components/badge-navigation';
+import Button from 'components/button';
 import { Paths } from 'enums';
+
+import { useDeleteFavorites } from 'services/users/userService';
 
 import { NavigationProps } from './types';
 
@@ -44,15 +48,31 @@ export const Navigation: FC<NavigationProps> = ({ className, stats }: Navigation
   const activeId =
     navigationItems.find(({ link }) => asPath.startsWith(link))?.id ?? navigationItems[0]?.id;
 
+  const deleteFavorites = useDeleteFavorites();
+
+  const handleRemoveAllClick = useCallback(() => {
+    deleteFavorites.mutate();
+  }, [deleteFavorites]);
+
   return (
-    <BadgeNavigation
-      className={className}
-      orientation="vertical"
-      badgePosition="left"
-      theme="simple"
-      activeId={activeId}
-      items={navigationItems}
-    />
+    <>
+      <BadgeNavigation
+        className={className}
+        orientation="vertical"
+        badgePosition="left"
+        theme="simple"
+        activeId={activeId}
+        items={navigationItems}
+      />
+      <Button
+        size="smallest"
+        theme="naked"
+        className="mt-6 text-sm underline text-green-dark focus-visible:outline-green-dark"
+        onClick={handleRemoveAllClick}
+      >
+        <FormattedMessage defaultMessage="Remove all" id="jNai7b" />
+      </Button>
+    </>
   );
 };
 

--- a/frontend/pages/dashboard/favorites/investors.tsx
+++ b/frontend/pages/dashboard/favorites/investors.tsx
@@ -44,26 +44,12 @@ export const FavoritesInvestorsPage: PageComponent<
     favoriteInvestor.mutate({ id, isFavourite: true });
   };
 
-  const handleRemoveAllClick = () => {
-    console.log('unfavorite all investors');
-  };
-
   return (
     <>
       <div className="top-0 left-0 flex justify-between w-full pb-1 pr-2 mx-1 mb-4 md:pt-10 md:-mt-10 md:px-1 lg:z-20 lg:sticky bg-background-dark">
         <div className="font-medium">
           <FormattedMessage defaultMessage="Investors" id="zdIaHp" />{' '}
           {meta?.total && `(${meta?.total})`}
-        </div>
-        <div>
-          <Button
-            size="smallest"
-            theme="naked"
-            className="text-sm underline text-green-dark focus-visible:outline-green-dark"
-            onClick={handleRemoveAllClick}
-          >
-            <FormattedMessage defaultMessage="Remove all" id="jNai7b" />
-          </Button>
         </div>
       </div>
       <div className="flex flex-col pt-2 md:pl-1 md:-mr-1">

--- a/frontend/pages/dashboard/favorites/open-calls.tsx
+++ b/frontend/pages/dashboard/favorites/open-calls.tsx
@@ -32,26 +32,12 @@ export const FavoritesOpenCallsPage: PageComponent<
 > = ({ data: openCalls = [], meta }) => {
   const hasOpenCalls = openCalls?.length > 0;
 
-  const handleRemoveAllClick = () => {
-    console.log('unfavorite all open calls');
-  };
-
   return (
     <>
       <div className="top-0 left-0 flex justify-between w-full pb-1 pr-2 mx-1 mb-4 md:pt-10 md:-mt-10 md:px-1 lg:z-20 lg:sticky bg-background-dark">
         <div className="font-medium">
           <FormattedMessage defaultMessage="Open calls" id="OBhULP" />{' '}
           {/*meta?.total && `(${meta?.total})`*/}(0)
-        </div>
-        <div>
-          <Button
-            size="smallest"
-            theme="naked"
-            className="text-sm underline text-green-dark focus-visible:outline-green-dark"
-            onClick={handleRemoveAllClick}
-          >
-            <FormattedMessage defaultMessage="Remove all" id="jNai7b" />
-          </Button>
         </div>
       </div>
       <div className="flex flex-col pt-2 md:pl-1 md:-mr-1">

--- a/frontend/pages/dashboard/favorites/project-developers.tsx
+++ b/frontend/pages/dashboard/favorites/project-developers.tsx
@@ -44,26 +44,12 @@ export const FavoritesProjectDevelopersPage: PageComponent<
     favoriteProjectDeveloper.mutate({ id, isFavourite: true });
   };
 
-  const handleRemoveAllClick = () => {
-    console.log('unfavorite all project developers');
-  };
-
   return (
     <>
       <div className="top-0 left-0 flex justify-between w-full pb-1 pr-2 mx-1 mb-4 md:pt-10 md:-mt-10 md:px-1 lg:z-20 lg:sticky bg-background-dark">
         <div className="font-medium">
           <FormattedMessage defaultMessage="Project developers" id="0wBg9P" />{' '}
           {meta?.total && `(${meta?.total})`}
-        </div>
-        <div>
-          <Button
-            size="smallest"
-            theme="naked"
-            className="text-sm underline text-green-dark focus-visible:outline-green-dark"
-            onClick={handleRemoveAllClick}
-          >
-            <FormattedMessage defaultMessage="Remove all" id="jNai7b" />
-          </Button>
         </div>
       </div>
       <div className="flex flex-col pt-2 md:pl-1 md:-mr-1">

--- a/frontend/pages/dashboard/favorites/projects.tsx
+++ b/frontend/pages/dashboard/favorites/projects.tsx
@@ -44,26 +44,12 @@ export const FavoritesProjectsPage: PageComponent<
     favoriteProject.mutate({ id: slug, isFavourite: true });
   };
 
-  const handleRemoveAllClick = () => {
-    console.log('unfavorite all projects');
-  };
-
   return (
     <>
       <div className="top-0 flex justify-between px-2 pb-1 mb-4 -mx-2 md:pt-10 md:-mt-10 md:pl-3 md:pr-2 lg:z-20 lg:sticky bg-background-dark">
         <div className="font-medium">
           <FormattedMessage defaultMessage="Projects" id="UxTJRa" />{' '}
           {meta?.total && `(${meta?.total})`}
-        </div>
-        <div>
-          <Button
-            size="smallest"
-            theme="naked"
-            className="text-sm underline text-green-dark focus-visible:outline-green-dark"
-            onClick={handleRemoveAllClick}
-          >
-            <FormattedMessage defaultMessage="Remove all" id="jNai7b" />
-          </Button>
         </div>
       </div>
       <div className="flex flex-col gap-2 pt-2 md:pl-1 md:-mr-1">

--- a/frontend/services/users/userService.ts
+++ b/frontend/services/users/userService.ts
@@ -1,7 +1,10 @@
-import { useMutation, UseMutationResult } from 'react-query';
+import { useMutation, UseMutationResult, useQueryClient } from 'react-query';
+
+import { useRouter } from 'next/router';
 
 import { AxiosResponse, AxiosError } from 'axios';
 
+import { Queries } from 'enums';
 import { SignupDto, User, ChangePassword } from 'types/user';
 
 import { ErrorResponse, ResponseData } from 'services/types';
@@ -42,4 +45,45 @@ export const useChangePassword = (): UseMutationResult<
   ChangePassword
 > => {
   return useMutation(changePassword);
+};
+
+export const deleteFavorites = () => {
+  return API.request({
+    method: 'DELETE',
+    url: '/api/v1/account/users/favourites',
+    data: {},
+  });
+};
+
+export const useDeleteFavorites = (): UseMutationResult<
+  AxiosResponse<any>,
+  ErrorResponse,
+  void
+> => {
+  const { locale } = useRouter();
+  const queryClient = useQueryClient();
+
+  return useMutation(deleteFavorites, {
+    onSuccess: (data) => {
+      queryClient.setQueryData([Queries.Project, locale], data);
+      queryClient.invalidateQueries([Queries.Project], {});
+      queryClient.invalidateQueries([Queries.ProjectList], {});
+      queryClient.invalidateQueries([Queries.FavoriteProjectsList, {}]);
+
+      queryClient.setQueryData([Queries.OpenCall, locale], data);
+      queryClient.invalidateQueries([Queries.OpenCall], {});
+      queryClient.invalidateQueries([Queries.OpenCallList], {});
+      queryClient.invalidateQueries([Queries.FavoriteOpenCallsList, {}]);
+
+      queryClient.setQueryData([Queries.ProjectDeveloper, locale], data);
+      queryClient.invalidateQueries([Queries.ProjectDeveloper], {});
+      queryClient.invalidateQueries([Queries.ProjectDeveloperList], {});
+      queryClient.invalidateQueries([Queries.FavoriteProjectDevelopersList, {}]);
+
+      queryClient.setQueryData([Queries.Investor, locale], data);
+      queryClient.invalidateQueries([Queries.Investor], {});
+      queryClient.invalidateQueries([Queries.InvestorList], {});
+      queryClient.invalidateQueries([Queries.FavoriteInvestorsList], {});
+    },
+  });
 };


### PR DESCRIPTION
This PR allows account users to delete all their favourites at once.

## Testing instructions

1. Create a bunch of favourites (projects, open calls, investors and PDs)
2. Go to your favourites in the Dashboard
3. Click the “Remove all” button in the sidebar

All your favourites should get deleted immediately.

## Tracking

[LET-861](https://vizzuality.atlassian.net/browse/LET-861).
