### PR TITLE
fix: Backoffice sorting

### DIFF
--- a/backend/app/helpers/application_helper.rb
+++ b/backend/app/helpers/application_helper.rb
@@ -42,10 +42,6 @@ module ApplicationHelper
     link_to text, "#{url}?section=#{section}", class: classnames
   end
 
-  def localized_sort_link(q, key, *args, &block)
-    sort_link q, "#{key}_#{I18n.locale}", *args, &block
-  end
-
   def status_tag(key, text)
     return if text.blank?
 

--- a/backend/app/models/concerns/enum_model.rb
+++ b/backend/app/models/concerns/enum_model.rb
@@ -33,14 +33,5 @@ module EnumModel
     def find(slug)
       new(slug: slug)
     end
-
-    def select_index_sql(column_name = name.underscore)
-      sql = ["CASE"]
-      all.sort_by(&:name).each_with_index do |enum, index|
-        sql << "WHEN #{column_name} ='#{enum.slug}' THEN #{index}"
-      end
-      sql << "END"
-      sql.join(" ")
-    end
   end
 end

--- a/backend/app/models/project.rb
+++ b/backend/app/models/project.rb
@@ -2,6 +2,7 @@ class Project < ApplicationRecord
   extend FriendlyId
   include Translatable
   include Searchable
+  include ExtraRansackers
 
   friendly_id :project_developer_prefixed_name, use: :slugged
 
@@ -74,9 +75,8 @@ class Project < ApplicationRecord
 
   delegate :account_language, to: :project_developer, allow_nil: true
 
-  ransacker :category_index do
-    Arel.sql(Category.select_index_sql)
-  end
+  generate_ransackers_for_translated_columns
+  generate_localized_ransackers_for_static_types :category
 
   def project_developer_prefixed_name
     "#{project_developer&.name} #{original_name}"

--- a/backend/app/views/backoffice/investors/index.html.erb
+++ b/backend/app/views/backoffice/investors/index.html.erb
@@ -25,7 +25,7 @@
         <%= sort_link @q, :open_calls_count, t(".open_calls") %>
       </th>
       <th>
-        <%= sort_link @q, :language, t("backoffice.common.language") %>
+        <%= sort_link @q, :account_language, t("backoffice.common.language") %>
       </th>
       <th>
         <%= sort_link @q, :account_review_status, t("backoffice.common.status") %>

--- a/backend/app/views/backoffice/project_developers/index.html.erb
+++ b/backend/app/views/backoffice/project_developers/index.html.erb
@@ -25,7 +25,7 @@
         <%= sort_link @q, :projects_count, t(".projects") %>
       </th>
       <th>
-        <%= sort_link @q, :language, t("backoffice.common.language") %>
+        <%= sort_link @q, :account_language, t("backoffice.common.language") %>
       </th>
       <th>
         <%= sort_link @q, :account_review_status, t("backoffice.common.status") %>

--- a/backend/app/views/backoffice/projects/index.html.erb
+++ b/backend/app/views/backoffice/projects/index.html.erb
@@ -7,16 +7,16 @@
   <thead>
     <tr>
       <th>
-        <%= localized_sort_link @q, :name, t("backoffice.common.project_name") %>
+        <%= sort_link @q, :name, t("backoffice.common.project_name") %>
       </th>
       <th>
         <%= sort_link @q, :project_developer_account_name, t("backoffice.common.project_developer") %>
       </th>
       <th>
-        <%= sort_link @q, :category_index, t("backoffice.common.category") %>
+        <%= sort_link @q, :category_localized, t("backoffice.common.category") %>
       </th>
       <th>
-        <%= localized_sort_link @q, :priority_landscape_name, t("backoffice.projects.index.priority_landscape") %>
+        <%= sort_link @q, :priority_landscape_name, t("backoffice.projects.index.priority_landscape") %>
       </th>
       <th>
         <%= sort_link @q, :trusted, t("backoffice.common.status") %>

--- a/backend/spec/models/project_spec.rb
+++ b/backend/spec/models/project_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Project, type: :model do
 
   it_behaves_like :searchable
   it_behaves_like :translatable
+  it_behaves_like :with_ransacked_translations
+  it_behaves_like :with_ransacked_static_types, :category
 
   it { is_expected.to be_valid }
 

--- a/backend/spec/models/project_spec.rb
+++ b/backend/spec/models/project_spec.rb
@@ -309,13 +309,13 @@ RSpec.describe Project, type: :model do
       context "sort" do
         it "correctly by category name asc" do
           q = Project.ransack
-          q.sorts = "category_index asc"
+          q.sorts = "category_localized asc"
           expect(q.result.pluck(:category)).to eq(["forestry-and-agroforestry", "sustainable-agrosystems", "tourism-and-recreation"])
         end
 
         it "correctly by category name desc" do
           q = Project.ransack
-          q.sorts = "category_index desc"
+          q.sorts = "category_localized desc"
           expect(q.result.pluck(:category)).to eq(["tourism-and-recreation", "sustainable-agrosystems", "forestry-and-agroforestry"])
         end
       end


### PR DESCRIPTION
I am refactoring sorting at backoffice so it uses generated ransackers added by #475 . This have advantage of respecting translation fallbacks and also it adds ransackers for all attributes (no need to add extra stuff to model everytime).

Also, sorting by language was broken so I am fixing this one --> we show static type (`en`) instead of localized text (`English`) at backoffice table so I have not used one of these new ransackers for this (`language_localized`).

## Testing instructions

Via backoffice -- simple check if sorting used there still works

## Tracking

Fixes bug https://vizzuality.atlassian.net/browse/LET-851
