### PR TITLE
Allow investor users to launch, close and delete open calls from the Dashboard list

### DIFF
--- a/frontend/containers/dashboard/open-calls/table/cells/actions/component.tsx
+++ b/frontend/containers/dashboard/open-calls/table/cells/actions/component.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react';
+import { FC, useCallback, useState } from 'react';
 
 import { FormattedMessage, useIntl } from 'react-intl';
 
@@ -11,6 +11,7 @@ import ConfirmationPrompt from 'components/confirmation-prompt';
 import { Paths, OpenCallStatus } from 'enums';
 
 import { useDeleteAccountProject } from 'services/account';
+import { useUpdateOpenCall } from 'services/open-call/open-call-service';
 
 import { CellActionsProps } from './types';
 
@@ -25,11 +26,16 @@ export const CellActions: FC<CellActionsProps> = ({
   const router = useRouter();
 
   const deleteProjectMutation = useDeleteAccountProject();
+  const updateOpenCallMutation = useUpdateOpenCall();
 
   const [confirmDelete, setConfirmDelete] = useState<boolean>(false);
+  const [confirmLaunch, setConfirmLaunch] = useState(false);
 
   const handleRowMenuItemClick = (key: string) => {
     switch (key) {
+      case 'launch':
+        setConfirmLaunch(true);
+        return;
       // case 'edit':
       //   router.push(
       //     `${Paths.OpenCall}/${slug}/edit?returnPath=${encodeURIComponent(router.asPath)}`,
@@ -59,6 +65,17 @@ export const CellActions: FC<CellActionsProps> = ({
     );
   };
 
+  const handleLaunchOpenCall = useCallback(() => {
+    updateOpenCallMutation.mutate(
+      { id: slug, status: OpenCallStatus.Launched },
+      {
+        onSuccess: () => {
+          setConfirmLaunch(false);
+        },
+      }
+    );
+  }, [slug, updateOpenCallMutation]);
+
   return (
     <div className="flex items-center justify-center gap-3">
       <Link
@@ -70,6 +87,11 @@ export const CellActions: FC<CellActionsProps> = ({
         </a>
       </Link>
       <RowMenu direction="top" onAction={handleRowMenuItemClick}>
+        {status === OpenCallStatus.Draft && (
+          <RowMenuItem key="launch">
+            <FormattedMessage defaultMessage="Launch open call" id="c4HVkO" />
+          </RowMenuItem>
+        )}
         {/* <RowMenuItem key="edit">
           <FormattedMessage defaultMessage="Edit" id="wEQDC6" />
         </RowMenuItem>
@@ -107,6 +129,28 @@ export const CellActions: FC<CellActionsProps> = ({
             </p>
             <p>
               <FormattedMessage defaultMessage="You can't undo this action." id="k0xbVH" />
+            </p>
+          </>
+        }
+      />
+
+      <ConfirmationPrompt
+        open={confirmLaunch}
+        onAccept={handleLaunchOpenCall}
+        onDismiss={() => setConfirmLaunch(false)}
+        onRefuse={() => setConfirmLaunch(false)}
+        onConfirmText={intl.formatMessage({ defaultMessage: 'Launch', id: 'ewx2b7' })}
+        title={intl.formatMessage({ defaultMessage: 'Launch open call?', id: 'EgOO+m' })}
+        description={
+          <>
+            <p>
+              <FormattedMessage
+                defaultMessage="By launching your open call, it will be publicly visible and projects will be able to apply to it."
+                id="8UvQTx"
+              />
+            </p>
+            <p>
+              <FormattedMessage defaultMessage="Are you sure you want to continue?" id="Iu60EH" />
             </p>
           </>
         }

--- a/frontend/containers/dashboard/open-calls/table/cells/actions/component.tsx
+++ b/frontend/containers/dashboard/open-calls/table/cells/actions/component.tsx
@@ -10,8 +10,7 @@ import RowMenu, { RowMenuItem } from 'containers/dashboard/row-menu';
 import ConfirmationPrompt from 'components/confirmation-prompt';
 import { Paths, OpenCallStatus } from 'enums';
 
-import { useDeleteAccountProject } from 'services/account';
-import { useUpdateOpenCall } from 'services/open-call/open-call-service';
+import { useDeleteOpenCall, useUpdateOpenCall } from 'services/open-call/open-call-service';
 
 import { CellActionsProps } from './types';
 
@@ -25,7 +24,7 @@ export const CellActions: FC<CellActionsProps> = ({
   const intl = useIntl();
   const router = useRouter();
 
-  const deleteProjectMutation = useDeleteAccountProject();
+  const deleteOpenCallMutation = useDeleteOpenCall();
   const updateOpenCallMutation = useUpdateOpenCall();
 
   const [confirmDelete, setConfirmDelete] = useState<boolean>(false);
@@ -52,22 +51,19 @@ export const CellActions: FC<CellActionsProps> = ({
       case 'close':
         setConfirmClose(true);
         return;
-      // case 'delete':
-      //   setConfirmDelete(true);
-      //   return;
+      case 'delete':
+        setConfirmDelete(true);
+        return;
     }
   };
 
-  const handleDeleteProjectConfirmation = () => {
-    deleteProjectMutation.mutate(
-      { id: slug },
-      {
-        onSuccess: () => {
-          setConfirmDelete(false);
-        },
-      }
-    );
-  };
+  const handleDeleteOpenCall = useCallback(() => {
+    deleteOpenCallMutation.mutate(slug, {
+      onSuccess: () => {
+        setConfirmDelete(false);
+      },
+    });
+  }, [slug, deleteOpenCallMutation]);
 
   const handleLaunchOpenCall = useCallback(() => {
     updateOpenCallMutation.mutate(
@@ -124,14 +120,14 @@ export const CellActions: FC<CellActionsProps> = ({
             <FormattedMessage defaultMessage="Close open call" id="kdZTM0" />
           </RowMenuItem>
         )}
-        {/* <RowMenuItem key="delete">
+        <RowMenuItem key="delete">
           <FormattedMessage defaultMessage="Delete" id="K3r6DQ" />
-        </RowMenuItem> */}
+        </RowMenuItem>
       </RowMenu>
 
       <ConfirmationPrompt
         open={confirmDelete}
-        onAccept={handleDeleteProjectConfirmation}
+        onAccept={handleDeleteOpenCall}
         onDismiss={() => setConfirmDelete(false)}
         onRefuse={() => setConfirmDelete(false)}
         title={intl.formatMessage({ defaultMessage: 'Delete open call?', id: 'DsukuX' })}

--- a/frontend/containers/dashboard/open-calls/table/cells/actions/component.tsx
+++ b/frontend/containers/dashboard/open-calls/table/cells/actions/component.tsx
@@ -30,6 +30,7 @@ export const CellActions: FC<CellActionsProps> = ({
 
   const [confirmDelete, setConfirmDelete] = useState<boolean>(false);
   const [confirmLaunch, setConfirmLaunch] = useState(false);
+  const [confirmClose, setConfirmClose] = useState(false);
 
   const handleRowMenuItemClick = (key: string) => {
     switch (key) {
@@ -47,6 +48,9 @@ export const CellActions: FC<CellActionsProps> = ({
       //   return;
       case 'open':
         router.push(`${Paths.OpenCall}/${slug}`);
+        return;
+      case 'close':
+        setConfirmClose(true);
         return;
       // case 'delete':
       //   setConfirmDelete(true);
@@ -71,6 +75,17 @@ export const CellActions: FC<CellActionsProps> = ({
       {
         onSuccess: () => {
           setConfirmLaunch(false);
+        },
+      }
+    );
+  }, [slug, updateOpenCallMutation]);
+
+  const handleCloseOpenCall = useCallback(() => {
+    updateOpenCallMutation.mutate(
+      { id: slug, status: OpenCallStatus.Closed },
+      {
+        onSuccess: () => {
+          setConfirmClose(false);
         },
       }
     );
@@ -104,6 +119,11 @@ export const CellActions: FC<CellActionsProps> = ({
           <FormattedMessage defaultMessage="View open call page" id="7sVapx" />
         </RowMenuItem>
         {/* )} */}
+        {status === OpenCallStatus.Launched && (
+          <RowMenuItem key="close">
+            <FormattedMessage defaultMessage="Close open call" id="kdZTM0" />
+          </RowMenuItem>
+        )}
         {/* <RowMenuItem key="delete">
           <FormattedMessage defaultMessage="Delete" id="K3r6DQ" />
         </RowMenuItem> */}
@@ -151,6 +171,32 @@ export const CellActions: FC<CellActionsProps> = ({
             </p>
             <p>
               <FormattedMessage defaultMessage="Are you sure you want to continue?" id="Iu60EH" />
+            </p>
+          </>
+        }
+      />
+
+      <ConfirmationPrompt
+        open={confirmClose}
+        onAccept={handleCloseOpenCall}
+        onDismiss={() => setConfirmClose(false)}
+        onRefuse={() => setConfirmClose(false)}
+        onConfirmText={intl.formatMessage({ defaultMessage: 'Close', id: 'rbrahO' })}
+        title={intl.formatMessage({ defaultMessage: 'Close open call?', id: '0lKwqs' })}
+        description={
+          <>
+            <p>
+              <FormattedMessage
+                defaultMessage="Are you sure you want to close “<strong>{name}</strong>”?"
+                id="r2qqVX"
+                values={{
+                  name,
+                  strong: (chunk: string) => <span className="font-semibold">{chunk}</span>,
+                }}
+              />
+            </p>
+            <p>
+              <FormattedMessage defaultMessage="You can't undo this action." id="k0xbVH" />
             </p>
           </>
         }

--- a/frontend/containers/open-call-form/component.tsx
+++ b/frontend/containers/open-call-form/component.tsx
@@ -12,7 +12,7 @@ import MultiPageLayout, { OutroPage, Page } from 'containers/multi-page-layout';
 import Button from 'components/button';
 import Head from 'components/head';
 import { OpenCallStatus } from 'enums';
-import { OpenCallForm as OpenFormType, OpenCallDto } from 'types/open-calls';
+import { OpenCallForm as OpenFormType, OpenCallCreationPayload } from 'types/open-calls';
 import useOpenCallResolver, { formPageInputs } from 'validations/open-call';
 
 import {
@@ -60,7 +60,7 @@ export const OpenCallForm: FC<OpenCallFormTypes> = ({
   const isOutroPage = currentPage === totalPages;
 
   const handleMutate = useCallback(
-    (data: OpenCallDto) => {
+    (data: OpenCallCreationPayload) => {
       return mutation.mutate(
         { dto: data, locale: language },
         {

--- a/frontend/containers/open-call-form/types.ts
+++ b/frontend/containers/open-call-form/types.ts
@@ -13,7 +13,7 @@ import { AxiosError, AxiosResponse } from 'axios';
 
 import { Languages } from 'enums';
 import { Enum, GroupedEnums } from 'types/enums';
-import { OpenCall, OpenCallForm, OpenCallDto } from 'types/open-calls';
+import { OpenCall, OpenCallForm, OpenCallCreationPayload } from 'types/open-calls';
 
 import { ResponseData, ErrorResponse } from 'services/types';
 
@@ -23,7 +23,7 @@ export type OpenCallFormTypes = {
     OpenCall,
     AxiosError<ErrorResponse>,
     {
-      dto: OpenCallDto;
+      dto: OpenCallCreationPayload;
       locale: Languages;
     }
   >;

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -461,6 +461,9 @@
   "8SayhS": {
     "string": "{placeholder}"
   },
+  "8UvQTx": {
+    "string": "By launching your open call, it will be publicly visible and projects will be able to apply to it."
+  },
   "8WtyrD": {
     "string": "Spanish"
   },
@@ -749,6 +752,9 @@
   "Ec0M9T": {
     "string": "Please briefly describe the main groups of activities or components for the implementation of the project. It is not necessary to be very detailed, just a logical sequence of the general lines of action. These groups of activities should be used to define the estimated budget below. No more than three groups of activities or components"
   },
+  "EgOO+m": {
+    "string": "Launch open call?"
+  },
   "Ejc7dP": {
     "string": "tons of carbon are stored in the Amazon."
   },
@@ -926,6 +932,9 @@
   },
   "IkUX0b": {
     "string": "How the money will be used"
+  },
+  "IsC1uH": {
+    "string": "Create openCall"
   },
   "Iu60EH": {
     "string": "Are you sure you want to continue?"
@@ -1752,6 +1761,9 @@
   "c1m3Q7": {
     "string": "The project gallery will be the first thing other users will see on you page, it will help you to showcase you project."
   },
+  "c4HVkO": {
+    "string": "Launch open call"
+  },
   "c6KUQu": {
     "string": "Your account was successfully created, but you still need to be approved by our platform administrators."
   },
@@ -1874,6 +1886,9 @@
   },
   "eu+7Vl": {
     "string": "Do you have a project or a start-up business in the Colombian Amazon?"
+  },
+  "ewx2b7": {
+    "string": "Launch"
   },
   "f9DtLB": {
     "string": "max 36 months"

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -131,6 +131,9 @@
   "0iaD3T": {
     "string": "Total <span>{numProjects}</span> {numProjects, plural, one {project} other {projects}}"
   },
+  "0lKwqs": {
+    "string": "Close open call?"
+  },
   "0v43t3": {
     "string": "Note that all of this information will be visible in the Investor public profile page except questions."
   },
@@ -2151,6 +2154,9 @@
   "kaAF7K": {
     "string": "An open call is a call for projects made by a given investor. Open calls give investors the possibility to open specific opportunities in their topics of interest. All registered project developers have the possibility to submit their projects to an open call, if they match the open call criteria, and therefore apply to this particular funding."
   },
+  "kdZTM0": {
+    "string": "Close open call"
+  },
   "keWpuD": {
     "string": "In this data set, “tree cover” is defined as all vegetation greater than 5 meters in height, and may take the form of natural forests or plantations across a range of canopy densities. Tree cover loss is defined as “stand replacement disturbance,” or the complete removal of tree cover canopy at the Landsat pixel scale. Tree cover loss may be the result of human activities, including forestry practices such as timber harvesting or deforestation (the conversion of natural forest to other land uses), as well as natural causes such as disease or storm damage. Fire is another widespread cause of tree cover loss, and can be either natural or human-induced."
   },
@@ -2405,6 +2411,9 @@
   },
   "r/AN6W": {
     "string": "select investor/funder type"
+  },
+  "r2qqVX": {
+    "string": "Are you sure you want to close “<strong>{name}</strong>”?"
   },
   "rLzWx9": {
     "string": "{name} picture"

--- a/frontend/services/open-call/open-call-service.ts
+++ b/frontend/services/open-call/open-call-service.ts
@@ -1,13 +1,18 @@
 import { useMemo } from 'react';
 
-import { useMutation, UseMutationResult, UseQueryResult } from 'react-query';
+import { useMutation, UseMutationResult, useQueryClient, UseQueryResult } from 'react-query';
 
-import { AxiosError, AxiosRequestConfig } from 'axios';
+import { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
 
 import { useLocalizedQuery } from 'hooks/query';
 
 import { Languages, Queries } from 'enums';
-import { OpenCall, OpenCallDto, OpenCalParams } from 'types/open-calls';
+import {
+  OpenCall,
+  OpenCallCreationPayload,
+  OpenCallParams,
+  OpenCallUpdatePayload,
+} from 'types/open-calls';
 
 import API from 'services/api';
 import { ErrorResponse, ResponseData } from 'services/types';
@@ -15,7 +20,7 @@ import { ErrorResponse, ResponseData } from 'services/types';
 export const useCreateOpenCall = (): UseMutationResult<
   OpenCall,
   AxiosError<ErrorResponse>,
-  { dto: OpenCallDto; locale: Languages }
+  { dto: OpenCallCreationPayload; locale: Languages }
 > => {
   return useMutation(({ dto, locale }) =>
     API.post('/api/v1/account/open_calls', dto, { params: { locale } }).then(
@@ -24,11 +29,47 @@ export const useCreateOpenCall = (): UseMutationResult<
   );
 };
 
+export const updateOpenCall = async (
+  data: OpenCallUpdatePayload,
+  params?: {
+    locale?: string;
+  }
+): Promise<AxiosResponse<ResponseData<OpenCall>>> => {
+  const config: AxiosRequestConfig = {
+    url: `/api/v1/account/open_calls/${data.id}`,
+    method: 'PUT',
+    data: data,
+    params: params || {},
+  };
+
+  return await API(config);
+};
+
+export function useUpdateOpenCall(
+  params?: Parameters<typeof updateOpenCall>[1]
+): UseMutationResult<
+  AxiosResponse<ResponseData<OpenCall>>,
+  AxiosError<ErrorResponse>,
+  OpenCallUpdatePayload
+> {
+  const queryClient = useQueryClient();
+
+  return useMutation((data) => updateOpenCall(data, params), {
+    onSuccess: (result) => {
+      const { data } = result.data;
+      queryClient.invalidateQueries(Queries.OpenCall);
+      queryClient.invalidateQueries(Queries.OpenCallList);
+      queryClient.invalidateQueries(Queries.AccountOpenCallsList);
+      queryClient.setQueryData([Queries.OpenCall, data.id], data);
+    },
+  });
+}
+
 const getAccountOpenCallsList = async ({
   fields,
   filter,
   includes,
-}: OpenCalParams): Promise<OpenCall[]> => {
+}: OpenCallParams): Promise<OpenCall[]> => {
   const params = {
     'fields[open_call]': fields?.join(','),
     includes: includes?.join(','),
@@ -46,7 +87,7 @@ const getAccountOpenCallsList = async ({
 
 /** Hook to use the open calls list belonging to the current Investor account  */
 export const useAccountOpenCallList = (
-  params: OpenCalParams
+  params: OpenCallParams
 ): Omit<UseQueryResult, 'data'> & { openCalls: OpenCall[] } => {
   const { data, ...rest } = useLocalizedQuery<OpenCall[], ErrorResponse>(
     [Queries.AccountOpenCallsList, params],

--- a/frontend/services/open-call/open-call-service.ts
+++ b/frontend/services/open-call/open-call-service.ts
@@ -65,6 +65,34 @@ export function useUpdateOpenCall(
   });
 }
 
+export const deleteOpenCall = async (
+  id: OpenCall['id']
+): Promise<AxiosResponse<ResponseData<OpenCall>>> => {
+  const config: AxiosRequestConfig = {
+    url: `/api/v1/account/open_calls/${id}`,
+    method: 'DELETE',
+    data: { id },
+  };
+
+  return await API(config);
+};
+
+export function useDeleteOpenCall(): UseMutationResult<
+  AxiosResponse<ResponseData<OpenCall>>,
+  AxiosError<ErrorResponse>,
+  OpenCall['id']
+> {
+  const queryClient = useQueryClient();
+
+  return useMutation((id) => deleteOpenCall(id), {
+    onSuccess: () => {
+      queryClient.invalidateQueries(Queries.OpenCall);
+      queryClient.invalidateQueries(Queries.OpenCallList);
+      queryClient.invalidateQueries(Queries.AccountOpenCallsList);
+    },
+  });
+}
+
 const getAccountOpenCallsList = async ({
   fields,
   filter,

--- a/frontend/types/open-calls.ts
+++ b/frontend/types/open-calls.ts
@@ -1,5 +1,6 @@
 import { Languages, OpenCallStatus } from 'enums';
 import { Picture } from 'types';
+
 import { Locations } from './locations';
 
 export type OpenCall = {
@@ -47,11 +48,15 @@ export type OpenCallForm = {
   status: string;
 };
 
-export type OpenCallDto = Omit<OpenCallForm, 'closing_at'> & {
+export type OpenCallCreationPayload = Omit<OpenCallForm, 'closing_at'> & {
   closing_at: string;
 };
 
-export type OpenCalParams = {
+export type OpenCallUpdatePayload = Partial<OpenCallCreationPayload> & {
+  id: string;
+};
+
+export type OpenCallParams = {
   fields?: string[];
   includes?: string[];
   filter?: string;


### PR DESCRIPTION
This PR allows investor users to launch, close and delete open calls from the list on their Dashboard.

⚠️ This PR can't be merged until:

- https://github.com/Vizzuality/heco-invest/pull/477 is (this PR depends on it)
- [LET-700](https://vizzuality.atlassian.net/browse/LET-700), [LET-688](https://vizzuality.atlassian.net/browse/LET-688) and [LET-914](https://vizzuality.atlassian.net/browse/LET-914) have been merged (related back-end tasks, necessary for testing)

## Testing instructions

- Launch an open call
  - Create a draft open call and launch it from the Dashboard list
- Close an open call
  - Create an open call, launch it, and close it from the Dashboard list
- Delete an open call
  - Create an open call (draft or launched) and delete it from the Dashboard list    

## Tracking

- Launch an open call: [LET-894](https://vizzuality.atlassian.net/browse/LET-894)
- Close an open call: [LET-886](https://vizzuality.atlassian.net/browse/LET-886)
- Delete an open call: [LET-887](https://vizzuality.atlassian.net/browse/LET-887)
