### PR TITLE
fix: Enforce account language for stuff created via API

### DIFF
--- a/backend/app/controllers/api/v1/accounts/investors_controller.rb
+++ b/backend/app/controllers/api/v1/accounts/investors_controller.rb
@@ -5,7 +5,8 @@ module API
         include API::Pagination
 
         before_action :require_investor!, except: %i[create favourites]
-        around_action(only: [:show]) { |_controller, action| set_locale(current_user&.account&.language, &action) }
+        around_action(only: %i[create]) { |_, action| set_locale(account_params[:language], &action) }
+        around_action(only: %i[update show]) { |_, action| set_locale(current_user&.account&.language, &action) }
         load_and_authorize_resource only: :favourites
 
         def create

--- a/backend/app/controllers/api/v1/accounts/open_calls_controller.rb
+++ b/backend/app/controllers/api/v1/accounts/open_calls_controller.rb
@@ -5,6 +5,7 @@ module API
         include API::Pagination
 
         before_action :fetch_open_call, only: [:update, :destroy]
+        around_action(only: %i[create update]) { |_, action| set_locale(current_user&.account&.language, &action) }
         load_and_authorize_resource
 
         def index

--- a/backend/app/controllers/api/v1/accounts/project_developers_controller.rb
+++ b/backend/app/controllers/api/v1/accounts/project_developers_controller.rb
@@ -5,7 +5,8 @@ module API
         include API::Pagination
 
         before_action :require_project_developer!, except: %i[create favourites]
-        around_action(only: [:show]) { |_controller, action| set_locale(current_user&.account&.language, &action) }
+        around_action(only: %i[create]) { |_, action| set_locale(account_params[:language], &action) }
+        around_action(only: %i[update show]) { |_, action| set_locale(current_user&.account&.language, &action) }
         load_and_authorize_resource only: :favourites
 
         def create

--- a/backend/app/controllers/api/v1/accounts/projects_controller.rb
+++ b/backend/app/controllers/api/v1/accounts/projects_controller.rb
@@ -5,6 +5,7 @@ module API
         include API::Pagination
 
         before_action :fetch_project, only: [:update, :destroy]
+        around_action(only: %i[create update]) { |_, action| set_locale(current_user&.account&.language, &action) }
         load_and_authorize_resource
 
         def index

--- a/backend/app/models/location.rb
+++ b/backend/app/models/location.rb
@@ -14,6 +14,8 @@ class Location < ApplicationRecord
 
   has_one :location_geometry, dependent: :destroy
 
+  translates :name
+
   LocationType::TYPES.each do |location_type|
     scope location_type, -> { where(location_type: location_type) }
   end
@@ -21,9 +23,7 @@ class Location < ApplicationRecord
   validates :location_type, inclusion: {in: LocationType::TYPES, allow_blank: true}, presence: true
   validates_presence_of :name
 
-  validates_uniqueness_of :name_en, scope: :location_type, if: -> { parent_id.blank? }
-
-  translates :name
+  validates_uniqueness_of [*locale_columns(:name)], scope: %i[location_type parent_id], case_sensitive: false, allow_blank: true
 
   generate_ransackers_for_translated_columns I18n.default_locale, db_column: false
 

--- a/backend/spec/fixtures/snapshots/api/v1/account/open-calls-create.json
+++ b/backend/spec/fixtures/snapshots/api/v1/account/open-calls-create.json
@@ -19,8 +19,8 @@
       "impact_description": "Open Call Impact Description",
       "maximum_funding_per_project": 100000,
       "closing_at": "2022-08-09T11:55:03.369Z",
-      "language": "en",
-      "account_language": "en",
+      "language": "es",
+      "account_language": "es",
       "trusted": false,
       "created_at": "2022-08-08T11:55:03.401Z",
       "picture": {

--- a/backend/spec/fixtures/snapshots/api/v1/account/open-calls-include-relationships.json
+++ b/backend/spec/fixtures/snapshots/api/v1/account/open-calls-include-relationships.json
@@ -130,8 +130,8 @@
           5
         ],
         "previously_invested": true,
-        "language": "en",
-        "account_language": "en",
+        "language": "es",
+        "account_language": "es",
         "review_status": "approved",
         "created_at": "2022-08-15T08:51:46.333Z",
         "contact_email": "contact@example.com",

--- a/backend/spec/fixtures/snapshots/api/v1/account/open-calls-update.json
+++ b/backend/spec/fixtures/snapshots/api/v1/account/open-calls-update.json
@@ -19,7 +19,7 @@
       "maximum_funding_per_project": 100000,
       "closing_at": "2022-08-19T09:52:12.167Z",
       "language": "en",
-      "account_language": "en",
+      "account_language": "es",
       "trusted": false,
       "created_at": "2022-08-09T09:52:12.069Z",
       "picture": {

--- a/backend/spec/fixtures/snapshots/api/v1/account/open-calls.json
+++ b/backend/spec/fixtures/snapshots/api/v1/account/open-calls.json
@@ -22,7 +22,7 @@
         "closing_at": "2023-06-15T08:51:40.739Z",
         "status": "launched",
         "language": "en",
-        "account_language": "en",
+        "account_language": "es",
         "trusted": false,
         "created_at": "2022-08-15T08:51:40.746Z",
         "picture": {
@@ -80,7 +80,7 @@
         "closing_at": "2023-06-15T08:51:40.659Z",
         "status": "launched",
         "language": "en",
-        "account_language": "en",
+        "account_language": "es",
         "trusted": false,
         "created_at": "2022-08-15T08:51:40.663Z",
         "picture": {
@@ -138,7 +138,7 @@
         "closing_at": "2023-06-15T08:51:40.584Z",
         "status": "launched",
         "language": "en",
-        "account_language": "en",
+        "account_language": "es",
         "trusted": false,
         "created_at": "2022-08-15T08:51:40.592Z",
         "picture": {
@@ -196,7 +196,7 @@
         "closing_at": "2023-06-15T08:51:40.519Z",
         "status": "launched",
         "language": "en",
-        "account_language": "en",
+        "account_language": "es",
         "trusted": false,
         "created_at": "2022-08-15T08:51:40.525Z",
         "picture": {
@@ -254,7 +254,7 @@
         "closing_at": "2023-06-15T08:51:40.421Z",
         "status": "launched",
         "language": "en",
-        "account_language": "en",
+        "account_language": "es",
         "trusted": false,
         "created_at": "2022-08-15T08:51:40.426Z",
         "picture": {
@@ -312,7 +312,7 @@
         "closing_at": "2023-06-15T08:51:40.349Z",
         "status": "draft",
         "language": "en",
-        "account_language": "en",
+        "account_language": "es",
         "trusted": false,
         "created_at": "2022-08-15T08:51:40.356Z",
         "picture": {

--- a/backend/spec/fixtures/snapshots/api/v1/account/projects-include-relationships.json
+++ b/backend/spec/fixtures/snapshots/api/v1/account/projects-include-relationships.json
@@ -69,7 +69,7 @@
           "climate",
           "water"
         ],
-        "language": "en",
+        "language": "es",
         "entity_legal_registration_number": "564823570",
         "review_status": "approved",
         "contact_email": "contact@example.com",
@@ -81,7 +81,7 @@
         },
         "favourite": false,
         "created_at": "2022-06-27T09:04:33.802Z",
-        "account_language": "en"
+        "account_language": "es"
       },
       "relationships": {
         "owner": {

--- a/backend/spec/fixtures/snapshots/api/v1/account/projects.json
+++ b/backend/spec/fixtures/snapshots/api/v1/account/projects.json
@@ -70,7 +70,7 @@
         "favourite": false,
         "created_at": "2022-06-27T09:04:33.005Z",
         "status": "draft",
-        "account_language": "en",
+        "account_language": "es",
         "impact_calculated": false
       },
       "relationships": {
@@ -183,7 +183,7 @@
         "favourite": false,
         "created_at": "2022-06-27T09:04:32.944Z",
         "status": "published",
-        "account_language": "en",
+        "account_language": "es",
         "impact_calculated": false
       },
       "relationships": {
@@ -296,7 +296,7 @@
         "latitude": 2.0,
         "longitude": 1.0,
         "favourite": false,
-        "account_language": "en",
+        "account_language": "es",
         "impact_calculated": false
       },
       "relationships": {

--- a/backend/spec/fixtures/snapshots/api/v1/accounts-investor-create.json
+++ b/backend/spec/fixtures/snapshots/api/v1/accounts-investor-create.json
@@ -33,7 +33,7 @@
         5
       ],
       "previously_invested": true,
-      "language": "en",
+      "language": "es",
       "review_status": "unapproved",
       "contact_email": null,
       "contact_phone": null,
@@ -46,7 +46,7 @@
       "prioritized_projects_description": "What type of projects are you prioritizing?",
       "favourite": false,
       "created_at": "2022-06-21T11:29:51.428Z",
-      "account_language": "en"
+      "account_language": "es"
     },
     "relationships": {
       "owner": {

--- a/backend/spec/fixtures/snapshots/api/v1/accounts-investor-update.json
+++ b/backend/spec/fixtures/snapshots/api/v1/accounts-investor-update.json
@@ -4,7 +4,7 @@
     "type": "investor",
     "attributes": {
       "name": "Name",
-      "slug": "kutch-spencer",
+      "slug": "galvez-y-banda",
       "about": "About",
       "website": "http://website.com",
       "instagram": "http://instagram.com",
@@ -33,7 +33,7 @@
         5
       ],
       "previously_invested": true,
-      "language": "en",
+      "language": "es",
       "review_status": "approved",
       "contact_email": "contact@example.com",
       "contact_phone": "123456789",
@@ -46,7 +46,7 @@
       "prioritized_projects_description": "What type of projects are you prioritizing?",
       "favourite": false,
       "created_at": "2022-06-21T11:29:50.603Z",
-      "account_language": "en"
+      "account_language": "es"
     },
     "relationships": {
       "owner": {

--- a/backend/spec/fixtures/snapshots/api/v1/accounts-project-create.json
+++ b/backend/spec/fixtures/snapshots/api/v1/accounts-project-create.json
@@ -38,7 +38,7 @@
       "received_funding_amount_usd": "1000000.0",
       "received_funding_investor": "Some Investor name",
       "relevant_links": "Here relevant links",
-      "language": "en",
+      "language": "es",
       "favourite": false,
       "geometry": {
         "type": "FeatureCollection",
@@ -98,7 +98,7 @@
       "priority_landscape_total_impact": null,
       "created_at": "2022-06-24T09:06:23.534Z",
       "status": "published",
-      "account_language": "en",
+      "account_language": "es",
       "impact_calculated": false
     },
     "relationships": {

--- a/backend/spec/fixtures/snapshots/api/v1/accounts-project-developer-create.json
+++ b/backend/spec/fixtures/snapshots/api/v1/accounts-project-developer-create.json
@@ -21,7 +21,7 @@
         "biodiversity",
         "climate"
       ],
-      "language": "en",
+      "language": "es",
       "entity_legal_registration_number": "564823570",
       "review_status": "unapproved",
       "picture": {
@@ -33,7 +33,7 @@
       "contact_phone": null,
       "favourite": false,
       "created_at": "2022-06-21T11:30:04.901Z",
-      "account_language": "en"
+      "account_language": "es"
     },
     "relationships": {
       "owner": {

--- a/backend/spec/fixtures/snapshots/api/v1/accounts-project-developer-update.json
+++ b/backend/spec/fixtures/snapshots/api/v1/accounts-project-developer-update.json
@@ -4,7 +4,7 @@
     "type": "project_developer",
     "attributes": {
       "name": "Name",
-      "slug": "kutch-spencer",
+      "slug": "galvez-y-banda",
       "about": "About",
       "website": "http://website.com",
       "instagram": "http://instagram.com",
@@ -21,7 +21,7 @@
         "biodiversity",
         "climate"
       ],
-      "language": "en",
+      "language": "es",
       "entity_legal_registration_number": "564823570",
       "review_status": "approved",
       "picture": {
@@ -33,7 +33,7 @@
       "contact_phone": "+57-1-xxx-xx-xx",
       "favourite": false,
       "created_at": "2022-06-21T11:30:04.521Z",
-      "account_language": "en"
+      "account_language": "es"
     },
     "relationships": {
       "owner": {

--- a/backend/spec/requests/api/v1/accounts/investors_spec.rb
+++ b/backend/spec/requests/api/v1/accounts/investors_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "API V1 Account Investors", type: :request do
       let(:user) { create :user }
       let(:investor_params) do
         {
-          language: "en",
+          language: "es",
           picture: blob.signed_id,
           name: "Name",
           about: "About",
@@ -117,6 +117,13 @@ RSpec.describe "API V1 Account Investors", type: :request do
 
         it "matches snapshot", generate_swagger_example: true do
           expect(response.body).to match_snapshot("api/v1/accounts-investor-create")
+        end
+
+        it "saves data to correct language" do
+          investor = Investor.find response_json["data"]["id"]
+          Investor.translatable_attributes.each do |attr|
+            expect(investor.public_send("#{attr}_#{investor_params[:language]}")).to eq(investor_params[attr])
+          end
         end
       end
 
@@ -170,7 +177,7 @@ RSpec.describe "API V1 Account Investors", type: :request do
         }
       }
 
-      let(:investor) { create :investor }
+      let(:investor) { I18n.with_locale(:es) { create :investor, language: :es } }
       let(:user) { create :user }
       let(:investor_params) do
         {
@@ -216,6 +223,13 @@ RSpec.describe "API V1 Account Investors", type: :request do
           expect(response.body).to match_snapshot("api/v1/accounts-investor-update")
         end
 
+        it "saves data to correct language" do
+          investor.reload
+          Investor.translatable_attributes.each do |attr|
+            expect(investor.public_send("#{attr}_#{investor.language}")).to eq(investor_params[attr])
+          end
+        end
+
         context "when updating just some attributes" do
           let(:investor_params) do
             {
@@ -236,7 +250,7 @@ RSpec.describe "API V1 Account Investors", type: :request do
           end
 
           it "keeps old language" do
-            expect(response_json["data"]["attributes"]["language"]).to eq("en")
+            expect(response_json["data"]["attributes"]["language"]).to eq("es")
           end
         end
       end

--- a/backend/spec/requests/api/v1/accounts/project_developers_spec.rb
+++ b/backend/spec/requests/api/v1/accounts/project_developers_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "API V1 Account Project Developers", type: :request do
       let(:user) { create :user }
       let(:project_developer_params) do
         {
-          language: "en",
+          language: "es",
           picture: blob.signed_id,
           name: "Name",
           about: "About",
@@ -109,6 +109,13 @@ RSpec.describe "API V1 Account Project Developers", type: :request do
 
         it "matches snapshot", generate_swagger_example: true do
           expect(response.body).to match_snapshot("api/v1/accounts-project-developer-create")
+        end
+
+        it "saves data to correct language" do
+          project_developer = ProjectDeveloper.find response_json["data"]["id"]
+          ProjectDeveloper.translatable_attributes.each do |attr|
+            expect(project_developer.public_send("#{attr}_#{project_developer_params[:language]}")).to eq(project_developer_params[attr])
+          end
         end
       end
 
@@ -158,7 +165,7 @@ RSpec.describe "API V1 Account Project Developers", type: :request do
         }
       }
 
-      let(:project_developer) { create :project_developer }
+      let(:project_developer) { I18n.with_locale(:es) { create :project_developer, language: :es } }
       let(:user) { create :user }
       let(:project_developer_params) do
         {
@@ -198,6 +205,13 @@ RSpec.describe "API V1 Account Project Developers", type: :request do
           expect(response.body).to match_snapshot("api/v1/accounts-project-developer-update")
         end
 
+        it "saves data to correct language" do
+          project_developer.reload
+          ProjectDeveloper.translatable_attributes.each do |attr|
+            expect(project_developer.public_send("#{attr}_#{project_developer.language}")).to eq(project_developer_params[attr])
+          end
+        end
+
         context "when updating just some attributes" do
           let(:project_developer_params) do
             {
@@ -218,7 +232,7 @@ RSpec.describe "API V1 Account Project Developers", type: :request do
           end
 
           it "keeps old language" do
-            expect(response_json["data"]["attributes"]["language"]).to eq("en")
+            expect(response_json["data"]["attributes"]["language"]).to eq("es")
           end
         end
       end


### PR DESCRIPTION
I am fixing translation mismatch during create and update of Project/Investor/PD/OpenCall. This mismatch happened when `locale` provided by FE was different than user account language. In such case language of new record corresponded to user account language, but data were saved under `locale` suffix. This PR fixes this bug by ignoring `locale` in these cases and ensuring that only account language is taken into account.

## Testing instructions

Should be possible via Rswag --> when creating/updating Project/Investor/PD/OpenCall, set `locale` param to different value then your account language is. All attributes should be saved under account language <-- can be checked by getting record via API with locale that corresponds to your account language.
When creating Invetor/PD, you can also sent `locale` which is different than `language` param. All data should be saved under `language` param in this case.

## Tracking

https://vizzuality.atlassian.net/browse/LET-956
