### PR TITLE
Reference priority landscapes by `code` instead of `id`

### DIFF
--- a/frontend/helpers/pages.ts
+++ b/frontend/helpers/pages.ts
@@ -13,11 +13,11 @@ import { AxiosError } from 'axios';
 import { EnumTypes, Languages, Paths } from 'enums';
 import languages from 'locales.config.json';
 import { Enum } from 'types/enums';
+import { Locations } from 'types/locations';
 import { Project, ProjectForm, ProjectUpdatePayload } from 'types/project';
 import { formPageInputs } from 'validations/project';
 
 import { ErrorResponse } from 'services/types';
-import { Locations } from 'types/locations';
 
 /** Uses the error messages received from the API and the input names of the form to get the fields and form pages with errors */
 export function getServiceErrors<FormValues>(
@@ -208,9 +208,9 @@ export const getProjectValues = (project: Project): ProjectUpdatePayload => {
   return projectUpload as ProjectUpdatePayload;
 };
 
-export const PRIORITY_LANDSCAPES_IDS = [
-  'b8eba9d3-1618-401c-b85c-c287941f6fe9',
-  '6f827753-3c27-4343-bc39-0c81a1875488',
-  '35490999-6962-4825-8ca4-1862c1a5e45d',
-  '135e49c7-0d29-455f-8700-33c573772b41',
+export const PRIORITY_LANDSCAPES_CODES = [
+  'priority-landscape-orinoquia',
+  'priority-landscape-amazon-heart',
+  'priority-landscape-amazonian-piedmont-massif',
+  'priority-landscape-orinoquia-transition',
 ];

--- a/frontend/pages/for-investors.tsx
+++ b/frontend/pages/for-investors.tsx
@@ -81,29 +81,29 @@ const ForInvestorsPage: PageComponent<ForInvestorsPageProps, StaticPageLayoutPro
   const isMd = breakpoint('sm');
   const isLg = breakpoint('lg');
 
-  const priorityLandscapesDescriptions = {
-    '35490999-6962-4825-8ca4-1862c1a5e45d': (
+  const priorityLandscapesDescriptionsByCode = {
+    'priority-landscape-amazonian-piedmont-massif': (
       <FormattedMessage
         defaultMessage="Being a point of transition and meeting between the two most biodiverse biomes on Earth, the Tropical Andes and the Amazon, the Mosaic foothills represents one of the regions with <n>the greatest biodiversity in the world</n>."
         id="RBIeR5"
         values={{
-          n: (chunk: string) => <span className="font-bold">{chunk}</span>,
+          n: (chunk: string) => <span className="font-semibold">{chunk}</span>,
         }}
       />
     ),
-    '135e49c7-0d29-455f-8700-33c573772b41': (
+    'priority-landscape-orinoquia-transition': (
       <FormattedMessage
         defaultMessage="Helps to ensure connectivity between the Andean, Orinocean and Amazonian ecosystems, allowing the conservation of flora, fauna, scenic beauties, geomorphological complexes, historical or cultural manifestations, the conservation and regulation of water systems."
         id="WJGIA3"
       />
     ),
-    'b8eba9d3-1618-401c-b85c-c287941f6fe9': (
+    'priority-landscape-orinoquia': (
       <FormattedMessage
         defaultMessage="It is an ecoregion covered with savannahs of high floristic diversity and habitats representative of the evolutionary processes of the Guiana Shield. It includes both blackwater and whitewater rivers that feed the great Orinoco River, creating different types of seasonally flooded forests."
         id="pNNQA+"
       />
     ),
-    '6f827753-3c27-4343-bc39-0c81a1875488': (
+    'priority-landscape-amazon-heart': (
       <FormattedMessage
         defaultMessage="It is an area with a number of attributes related to heterogeneity that maintain the structure and ecological processes that characterize it as the Heart of the Amazon, it is also one of the most unique natural and cultural heritages in the national territory due to its exuberant cultural diversity."
         id="QI4yO9"
@@ -297,8 +297,8 @@ const ForInvestorsPage: PageComponent<ForInvestorsPageProps, StaticPageLayoutPro
         </div>
 
         <div className="grid pb-6 md:pr-0 md:pl-0 overflow-x-auto md:grid-rows-[minmax(auto,_1fr)] grid-cols-auto-1fr gap-x-4 gap-y-14 md:gap-x-6 md:gap-y-6 md:overflow-x-hidden md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 md:place-content-end md:container md:mx-auto md:px-8">
-          {priorityLandscapes.map(({ id, name }, index) => {
-            const description = priorityLandscapesDescriptions[id];
+          {priorityLandscapes.map(({ id, name, code }, index) => {
+            const description = priorityLandscapesDescriptionsByCode[code];
             const projectsQuantity = projectsByPriorityLandscape[id]?.length || 0;
             return (
               <div

--- a/frontend/services/locations/locations.ts
+++ b/frontend/services/locations/locations.ts
@@ -6,7 +6,7 @@ import { groupBy } from 'lodash-es';
 
 import { useLocalizedQuery } from 'hooks/query';
 
-import { PRIORITY_LANDSCAPES_IDS } from 'helpers/pages';
+import { PRIORITY_LANDSCAPES_CODES } from 'helpers/pages';
 
 import { Queries, LocationsTypes } from 'enums';
 import { Locations, LocationsParams } from 'types/locations';
@@ -48,7 +48,7 @@ export const useGroupedLocations = (
 
 export const getPriorityLandscapes = async () => {
   const result = await getLocations({ 'filter[location_type]': LocationsTypes.PriorityLandscapes });
-  return result.filter(({ id }) => PRIORITY_LANDSCAPES_IDS.includes(id));
+  return result.filter(({ code }) => PRIORITY_LANDSCAPES_CODES.includes(code));
 };
 
 export const usePriorityLandscapes = () => {

--- a/frontend/types/locations.ts
+++ b/frontend/types/locations.ts
@@ -11,6 +11,7 @@ export type Locations = {
   id: string;
   type: 'location';
   name: string;
+  code?: string;
   location_type: LocationsTypes;
   parent: {
     id: string;


### PR DESCRIPTION
This PR removes any reference of priority landscapes by `id` and use the newly added `code` attribute instead. The `id` values are randomly generated and would differ on production.

## Testing instructions

Make sure the “For investors” page is still functional, as well as the PD form.

## Tracking

[LET-748](https://vizzuality.atlassian.net/browse/LET-748)
