### PR TITLE
feat: List of the open calls at backoffice

### DIFF
--- a/backend/app/controllers/backoffice/open_calls_controller.rb
+++ b/backend/app/controllers/backoffice/open_calls_controller.rb
@@ -1,0 +1,19 @@
+module Backoffice
+  class OpenCallsController < BaseController
+    def index
+      @q = OpenCall.ransack params[:q]
+      @open_calls = @q.result.includes(:country, :municipality, :department, investor: [:account])
+
+      respond_to do |format|
+        format.html do
+          @pagy_object, @open_calls = pagy @open_calls, pagy_defaults
+        end
+        format.csv do
+          send_data Backoffice::CSV::OpenCallExporter.new(@open_calls).call,
+            filename: "open_calls.csv",
+            type: "text/csv; charset=utf-8"
+        end
+      end
+    end
+  end
+end

--- a/backend/app/models/open_call.rb
+++ b/backend/app/models/open_call.rb
@@ -13,6 +13,7 @@ class OpenCall < ApplicationRecord
   belongs_to :department, class_name: "Location", optional: true
 
   has_many :favourite_open_calls, dependent: :destroy
+  has_many :open_call_applications, dependent: :destroy
 
   has_one_attached :picture
 

--- a/backend/app/models/open_call_application.rb
+++ b/backend/app/models/open_call_application.rb
@@ -1,0 +1,11 @@
+class OpenCallApplication < ApplicationRecord
+  belongs_to :open_call, counter_cache: true
+  belongs_to :project_developer
+  belongs_to :project
+
+  translates :message
+
+  validates :language, inclusion: {in: Language::TYPES, allow_blank: true}, presence: true
+
+  validates_presence_of :message
+end

--- a/backend/app/models/project.rb
+++ b/backend/app/models/project.rb
@@ -17,6 +17,7 @@ class Project < ApplicationRecord
   has_many :favourite_projects, dependent: :destroy
   has_many :project_involvements, dependent: :destroy
   has_many :involved_project_developers, through: :project_involvements, source: :project_developer, dependent: :destroy
+  has_many :open_call_applications, dependent: :destroy
 
   translates :name,
     :description,

--- a/backend/app/models/project_developer.rb
+++ b/backend/app/models/project_developer.rb
@@ -9,6 +9,7 @@ class ProjectDeveloper < ApplicationRecord
   has_many :involved_projects, through: :project_involvements, source: :project, dependent: :destroy
   has_many :project_developer_priority_landscapes, dependent: :destroy
   has_many :priority_landscapes, through: :project_developer_priority_landscapes, source: :priority_landscape, dependent: :destroy
+  has_many :open_call_applications, dependent: :destroy
 
   validates :categories, array_inclusion: {in: Category::TYPES}, presence: true
   validates :impacts, array_inclusion: {in: Impact::TYPES}

--- a/backend/app/services/backoffice/csv/open_call_exporter.rb
+++ b/backend/app/services/backoffice/csv/open_call_exporter.rb
@@ -1,0 +1,17 @@
+module Backoffice
+  module CSV
+    class OpenCallExporter < BaseExporter
+      def call
+        generate_csv do
+          column(I18n.t("backoffice.open_calls.index.name")) { |r| r.name }
+          column(I18n.t("backoffice.common.investor")) { |r| r.investor.name }
+          column(I18n.t("backoffice.open_calls.index.location")) { |r| [r.municipality&.name, r.department&.name, r.country&.name].compact.join(", ") }
+          column(I18n.t("backoffice.open_calls.index.applications")) { |r| r.open_call_applications_count }
+          column(I18n.t("backoffice.common.status")) { |r|
+            r.trusted? ? I18n.t("backoffice.common.verified") : I18n.t("backoffice.common.unverified")
+          }
+        end
+      end
+    end
+  end
+end

--- a/backend/app/views/backoffice/base/_full_text_filter.html.erb
+++ b/backend/app/views/backoffice/base/_full_text_filter.html.erb
@@ -1,5 +1,7 @@
+<% filter_key = :filter_full_text if local_assigns[:filter_key].nil? %>
+
 <div class="inline-block relative w-60 mr-3">
-  <%= f.input :filter_full_text, placeholder: I18n.t("backoffice.common.search_placeholder"), required: false, label: false, input_html: { class:"z-20 pr-15", value: params.dig(:q, :filter_full_text) } %>
+  <%= f.input filter_key, as: :string, placeholder: I18n.t("backoffice.common.search_placeholder"), required: false, label: false, input_html: { class:"z-20 pr-15", value: params.dig(:q, filter_key) } %>
   <%= button_tag type: :submit, class: "absolute top-0 right-0 p-2.5 text-white bg-green-dark rounded-r-lg border border-solid border-beige" do %>
     <%= svg "search" %>
   <% end %>

--- a/backend/app/views/backoffice/base/_navigation.html.erb
+++ b/backend/app/views/backoffice/base/_navigation.html.erb
@@ -1,5 +1,6 @@
 <nav class="flex gap-4.5 py-3">
   <%= nav_link_to t("backoffice.layout.projects"), backoffice_projects_path %>
+  <%= nav_link_to t("backoffice.layout.open_calls"), backoffice_open_calls_path %>
   <%= nav_link_to t("backoffice.layout.investors"), backoffice_investors_path %>
   <%= nav_link_to t("backoffice.layout.project_developers"), backoffice_project_developers_path %>
   <%= nav_link_to t("backoffice.layout.users"), backoffice_users_path %>

--- a/backend/app/views/backoffice/open_calls/_filters.html.erb
+++ b/backend/app/views/backoffice/open_calls/_filters.html.erb
@@ -1,0 +1,7 @@
+<%= render "backoffice/base/filters", q: q do |f| %>
+  <%= render partial: "backoffice/base/full_text_filter", locals: { f: f, filter_key: :name_or_investor_account_name_or_country_name_or_department_name_or_municipality_name_i_cont } %>
+  <div class="w-30 inline-block mr-3">
+    <%= f.input :trusted_eq, as: :select, required: false, label: false, include_blank: I18n.t("backoffice.common.status"),
+                collection: [[t("backoffice.common.verified"), true], [t("backoffice.common.unverified"), false]] %>
+  </div>
+<% end %>

--- a/backend/app/views/backoffice/open_calls/index.html.erb
+++ b/backend/app/views/backoffice/open_calls/index.html.erb
@@ -1,0 +1,40 @@
+<div class="flex">
+  <%= render partial: "filters", locals: {q: @q} %>
+  <%= render partial: "backoffice/base/total_records" %>
+</div>
+
+<table class="backoffice-table">
+  <thead>
+  <tr>
+    <th>
+      <%= sort_link @q, :name, t("backoffice.open_calls.index.name") %>
+    </th>
+    <th>
+      <%= sort_link @q, :investor_account_name, t("backoffice.common.investor") %>
+    </th>
+    <th>
+      <%= sort_link @q, :municipality_name, [:municipality_name, :department_name, :country_name], t("backoffice.open_calls.index.location") %>
+    </th>
+    <th>
+      <%= sort_link @q, :open_call_applications_count, t("backoffice.open_calls.index.applications") %>
+    </th>
+    <th>
+      <%= sort_link @q, :trusted, t("backoffice.common.status") %>
+    </th>
+  </tr>
+  </thead>
+  <tbody>
+  <% @open_calls.each do |p| %>
+    <tr>
+      <td><%= p.name %></td>
+      <td><%= p.investor.name %></td>
+      <td><%= [p.municipality&.name, p.department&.name, p.country&.name].compact.join(", ") %></td>
+      <td><%= p.open_call_applications_count %></td>
+      <td>
+        <%= status_tag :verified, t('backoffice.common.verified') if p.trusted?  %>
+        <%= status_tag :unverified, t('backoffice.common.unverified') unless p.trusted?  %>
+      </td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -252,13 +252,18 @@ zu:
           not_valid_kml: This .kml/.kmz file does not have a valid XML syntax. Please try to validate it and resolve the issues.
           not_supported: This file is not supported. Please try uploading a different format.
           unable_to_parse: Unable to parse the file. Please try uploading a different format.
-
+    open_calls:
+      index:
+        name: Open Call name
+        location: Location
+        applications: Applications
     layout:
       header: Backoffice
       sign_out: Sign out
       project_developers: Project developers
       investors: Investors
       projects: Projects
+      open_calls: Open Calls
       users: Users
       admins: Administrators
   errors:

--- a/backend/config/routes/backoffice.rb
+++ b/backend/config/routes/backoffice.rb
@@ -19,6 +19,7 @@ namespace :backoffice do
   resources :investors, only: [:index, :edit, :update, :destroy]
   resources :project_developers, only: [:index, :edit, :update, :destroy]
   resources :projects, only: [:index, :edit, :update, :destroy]
+  resources :open_calls, only: [:index]
   resources :admins
   resources :users, only: [:index, :edit, :update, :destroy]
 end

--- a/backend/db/migrate/20220822094637_create_open_call_applications.rb
+++ b/backend/db/migrate/20220822094637_create_open_call_applications.rb
@@ -1,0 +1,15 @@
+class CreateOpenCallApplications < ActiveRecord::Migration[7.0]
+  def change
+    create_table :open_call_applications, id: :uuid do |t|
+      t.belongs_to :open_call, null: false, foreign_key: {on_delete: :cascade}, type: :uuid
+      t.belongs_to :project_developer, null: false, foreign_key: {on_delete: :cascade}, type: :uuid
+      t.belongs_to :project, null: false, foreign_key: {on_delete: :cascade}, type: :uuid
+      t.text :message_en
+      t.text :message_es
+      t.text :message_pt
+      t.string :language, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/migrate/20220822104832_add_open_call_applications_count_to_open_calls.rb
+++ b/backend/db/migrate/20220822104832_add_open_call_applications_count_to_open_calls.rb
@@ -1,0 +1,10 @@
+class AddOpenCallApplicationsCountToOpenCalls < ActiveRecord::Migration[7.0]
+  def self.up
+    add_column :open_calls, :open_call_applications_count, :integer, null: false, default: 0
+    OpenCall.find_each { |open_call| OpenCall.reset_counters(open_call.id, :open_call_applications) }
+  end
+
+  def self.down
+    remove_column :open_calls, :open_call_applications_count
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_19_092444) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_22_104832) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -210,6 +210,21 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_19_092444) do
     t.index ["parent_id"], name: "index_locations_on_parent_id"
   end
 
+  create_table "open_call_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "open_call_id", null: false
+    t.uuid "project_developer_id", null: false
+    t.uuid "project_id", null: false
+    t.text "message_en"
+    t.text "message_es"
+    t.text "message_pt"
+    t.string "language", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["open_call_id"], name: "index_open_call_applications_on_open_call_id"
+    t.index ["project_developer_id"], name: "index_open_call_applications_on_project_developer_id"
+    t.index ["project_id"], name: "index_open_call_applications_on_project_id"
+  end
+
   create_table "open_calls", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "investor_id", null: false
     t.text "name_en"
@@ -240,6 +255,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_19_092444) do
     t.text "funding_exclusions_pt"
     t.string "instrument_types", null: false, array: true
     t.integer "status", default: 1, null: false
+    t.integer "open_call_applications_count", default: 0, null: false
     t.index ["country_id"], name: "index_open_calls_on_country_id"
     t.index ["department_id"], name: "index_open_calls_on_department_id"
     t.index ["investor_id", "name_en"], name: "index_open_calls_on_investor_id_and_name_en", unique: true
@@ -437,6 +453,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_19_092444) do
   add_foreign_key "investors", "accounts", on_delete: :cascade
   add_foreign_key "location_geometries", "locations", on_delete: :cascade
   add_foreign_key "locations", "locations", column: "parent_id", on_delete: :cascade
+  add_foreign_key "open_call_applications", "open_calls", on_delete: :cascade
+  add_foreign_key "open_call_applications", "project_developers", on_delete: :cascade
+  add_foreign_key "open_call_applications", "projects", on_delete: :cascade
   add_foreign_key "open_calls", "investors", on_delete: :cascade
   add_foreign_key "open_calls", "locations", column: "country_id"
   add_foreign_key "open_calls", "locations", column: "department_id"

--- a/backend/spec/factories/open_call_applications.rb
+++ b/backend/spec/factories/open_call_applications.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :open_call_application do
+    open_call
+    project_developer
+    project
+
+    sequence(:message) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Lorem.paragraph(sentence_count: 4)
+    end
+
+    language { "en" }
+  end
+end

--- a/backend/spec/models/open_call_application_spec.rb
+++ b/backend/spec/models/open_call_application_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe OpenCallApplication, type: :model do
+  subject { build(:open_call_application) }
+
+  it { is_expected.to be_valid }
+
+  it "should not be valid without open_call" do
+    subject.open_call = nil
+    expect(subject).to have(1).errors_on(:open_call)
+  end
+
+  it "should not be valid without project" do
+    subject.project = nil
+    expect(subject).to have(1).errors_on(:project)
+  end
+
+  it "should not be valid without project_developer" do
+    subject.project_developer = nil
+    expect(subject).to have(1).errors_on(:project_developer)
+  end
+
+  it "should not be valid without message" do
+    subject.message = nil
+    expect(subject).to have(1).errors_on(:message)
+  end
+
+  it "should not be valid with wrong language" do
+    subject.language = "fr"
+    expect(subject).to have(1).errors_on(:language)
+  end
+
+  it "should not be valid without language" do
+    subject.language = nil
+    expect(subject).to have(1).errors_on(:language)
+  end
+end

--- a/backend/spec/services/backoffice/csv/open_call_exporter_spec.rb
+++ b/backend/spec/services/backoffice/csv/open_call_exporter_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe Backoffice::CSV::OpenCallExporter do
+  subject { described_class.new(query) }
+
+  let(:query) { create_list :open_call, 4, trusted: true }
+  let(:parsed_csv) { CSV.parse(subject.call) }
+
+  describe "#call" do
+    it "has correct headers at csv" do
+      expect(parsed_csv.first).to eq([
+        I18n.t("backoffice.open_calls.index.name"),
+        I18n.t("backoffice.common.investor"),
+        I18n.t("backoffice.open_calls.index.location"),
+        I18n.t("backoffice.open_calls.index.applications"),
+        I18n.t("backoffice.common.status")
+      ])
+    end
+
+    it "has correct data at csv" do
+      expect(parsed_csv.size).to eq(query.count + 1)
+      expect(parsed_csv.second).to eq([
+        query.first.name,
+        query.first.investor.name,
+        [query.first.municipality&.name, query.first.department&.name, query.first.country&.name].compact.join(", "),
+        query.first.open_call_applications_count.to_s,
+        I18n.t("backoffice.common.verified")
+      ])
+    end
+  end
+end

--- a/backend/spec/system/backoffice/open_calls_spec.rb
+++ b/backend/spec/system/backoffice/open_calls_spec.rb
@@ -1,0 +1,66 @@
+require "system_helper"
+
+RSpec.describe "Backoffice: Open Calls", type: :system do
+  let(:admin) { create(:admin, email: "admin@example.com", password: "SuperSecret6", first_name: "Admin", last_name: "Example") }
+  let!(:open_call) {
+    create(
+      :open_call,
+      name: "Open Call ultra name",
+      investor: create(:investor, account: create(:account, name: "Ultra investor name")),
+      trusted: true
+    )
+  }
+  let!(:open_calls) { create_list(:open_call, 4) }
+
+  before { sign_in admin }
+
+  describe "Index" do
+    before { visit "/backoffice/open_calls" }
+
+    it_behaves_like "with table pagination", expected_total: 5
+    it_behaves_like "with table sorting", columns: [
+      I18n.t("backoffice.open_calls.index.name"),
+      I18n.t("backoffice.common.investor"),
+      I18n.t("backoffice.open_calls.index.location"),
+      I18n.t("backoffice.open_calls.index.applications"),
+      I18n.t("backoffice.common.status")
+    ]
+    it_behaves_like "with csv export", file_name: "open_calls.csv"
+
+    it "shows open calls list" do
+      expect(page).to have_xpath(".//tbody/tr", count: 5)
+      within_row("Open Call ultra name") do
+        expect(page).to have_text("Ultra investor name")
+        expect(page).to have_text([open_call.municipality.name, open_call.department.name, open_call.country.name].join(", "))
+        expect(page).to have_text(open_call.open_call_applications_count)
+        expect(page).to have_text(I18n.t("backoffice.common.verified"))
+      end
+    end
+
+    context "when searching by ransack filter" do
+      context "when using full text" do
+        it "shows only found open calls" do
+          expect(page).to have_text(open_call.name)
+          open_calls.each { |o| expect(page).to have_text(o.name) }
+          fill_in :q_filter_full_text, with: open_call.name
+          find("form.open_call_search button").click
+          expect(page).to have_text(open_call.name)
+          open_calls.each { |o| expect(page).not_to have_text(o.name) }
+        end
+      end
+
+      context "when filtered by trusted flag" do
+        before { open_call.update! trusted: true }
+
+        it "returns records at correct state" do
+          expect(page).to have_text(open_call.name)
+          open_calls.each { |o| expect(page).to have_text(o.name) }
+          select t("backoffice.common.verified"), from: :q_trusted_eq
+          click_on t("backoffice.common.apply")
+          expect(page).to have_text(open_call.name)
+          open_calls.each { |o| expect(page).not_to have_text(o.name) }
+        end
+      end
+    end
+  end
+end

--- a/backend/spec/system/backoffice/open_calls_spec.rb
+++ b/backend/spec/system/backoffice/open_calls_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Backoffice: Open Calls", type: :system do
         it "shows only found open calls" do
           expect(page).to have_text(open_call.name)
           open_calls.each { |o| expect(page).to have_text(o.name) }
-          fill_in :q_filter_full_text, with: open_call.name
+          fill_in :q_name_or_investor_account_name_or_country_name_or_department_name_or_municipality_name_i_cont, with: open_call.name
           find("form.open_call_search button").click
           expect(page).to have_text(open_call.name)
           open_calls.each { |o| expect(page).not_to have_text(o.name) }


### PR DESCRIPTION
I am adding list of the Open Calls to Backoffice table. Table itself contains `Applications` so I have added `OpenCallApplications` model based on its design. Searching is done fully by ransack (no more `API::Filterer`) and it takes into account only table attributes.

![Screenshot 2022-08-22 at 13 57 07](https://user-images.githubusercontent.com/20660167/185917420-2f7b90d5-4ceb-47a8-afa0-9d4b79750ea6.png)

## Testing instructions

List can be checked via Backoffice ;). Please make sure that csv export works, filtering, pagination, total count.

## Tracking

https://vizzuality.atlassian.net/browse/LET-901
