### PR TITLE
fix: language mismatch - refactoring set_locale wrapper

### DIFF
--- a/backend/app/controllers/api/v1/accounts/investors_controller.rb
+++ b/backend/app/controllers/api/v1/accounts/investors_controller.rb
@@ -5,8 +5,9 @@ module API
         include API::Pagination
 
         before_action :require_investor!, except: %i[create favourites]
-        around_action(only: %i[create]) { |_, action| set_locale(account_params[:language], &action) }
-        around_action(only: %i[update show]) { |_, action| set_locale(current_user&.account&.language, &action) }
+        around_action(only: %i[create]) { |_, action| set_locale(language: account_params[:language], &action) }
+        around_action(only: %i[update]) { |_, action| set_locale(language: current_user&.account&.language, &action) }
+        around_action(only: %i[show]) { |_, action| set_locale(fallback_language: current_user&.account&.language, &action) }
         load_and_authorize_resource only: :favourites
 
         def create

--- a/backend/app/controllers/api/v1/accounts/open_calls_controller.rb
+++ b/backend/app/controllers/api/v1/accounts/open_calls_controller.rb
@@ -5,7 +5,7 @@ module API
         include API::Pagination
 
         before_action :fetch_open_call, only: [:update, :destroy]
-        around_action(only: %i[create update]) { |_, action| set_locale(current_user&.account&.language, &action) }
+        around_action(only: %i[create update]) { |_, action| set_locale(language: current_user&.account&.language, &action) }
         load_and_authorize_resource
 
         def index

--- a/backend/app/controllers/api/v1/accounts/project_developers_controller.rb
+++ b/backend/app/controllers/api/v1/accounts/project_developers_controller.rb
@@ -5,8 +5,9 @@ module API
         include API::Pagination
 
         before_action :require_project_developer!, except: %i[create favourites]
-        around_action(only: %i[create]) { |_, action| set_locale(account_params[:language], &action) }
-        around_action(only: %i[update show]) { |_, action| set_locale(current_user&.account&.language, &action) }
+        around_action(only: %i[create]) { |_, action| set_locale(language: account_params[:language], &action) }
+        around_action(only: %i[update]) { |_, action| set_locale(language: current_user&.account&.language, &action) }
+        around_action(only: %i[show]) { |_, action| set_locale(fallback_language: current_user&.account&.language, &action) }
         load_and_authorize_resource only: :favourites
 
         def create

--- a/backend/app/controllers/api/v1/accounts/projects_controller.rb
+++ b/backend/app/controllers/api/v1/accounts/projects_controller.rb
@@ -5,7 +5,7 @@ module API
         include API::Pagination
 
         before_action :fetch_project, only: [:update, :destroy]
-        around_action(only: %i[create update]) { |_, action| set_locale(current_user&.account&.language, &action) }
+        around_action(only: %i[create update]) { |_, action| set_locale(language: current_user&.account&.language, &action) }
         load_and_authorize_resource
 
         def index

--- a/backend/app/controllers/api/v1/investors_controller.rb
+++ b/backend/app/controllers/api/v1/investors_controller.rb
@@ -4,7 +4,7 @@ module API
       include API::Pagination
 
       before_action :fetch_investor, only: :show
-      around_action(only: [:show]) { |_controller, action| set_locale(@investor&.account&.language, &action) }
+      around_action(only: [:show]) { |_, action| set_locale(fallback_language: @investor&.account&.language, &action) }
       load_and_authorize_resource
 
       def index

--- a/backend/app/controllers/api/v1/open_calls_controller.rb
+++ b/backend/app/controllers/api/v1/open_calls_controller.rb
@@ -4,7 +4,7 @@ module API
       include API::Pagination
 
       before_action :fetch_open_call, only: [:show]
-      around_action(only: [:show]) { |_controller, action| set_locale(@open_call&.investor&.account&.language, &action) }
+      around_action(only: [:show]) { |_, action| set_locale(fallback_language: @open_call&.investor&.account&.language, &action) }
       load_and_authorize_resource
 
       def index

--- a/backend/app/controllers/api/v1/project_developers_controller.rb
+++ b/backend/app/controllers/api/v1/project_developers_controller.rb
@@ -4,7 +4,7 @@ module API
       include API::Pagination
 
       before_action :fetch_project_developer, only: :show
-      around_action(only: [:show]) { |_controller, action| set_locale(@project_developer&.account&.language, &action) }
+      around_action(only: [:show]) { |_, action| set_locale(fallback_language: @project_developer&.account&.language, &action) }
       load_and_authorize_resource
 
       def index

--- a/backend/app/controllers/api/v1/projects_controller.rb
+++ b/backend/app/controllers/api/v1/projects_controller.rb
@@ -4,7 +4,7 @@ module API
       include API::Pagination
 
       before_action :fetch_project, only: [:show]
-      around_action(only: [:show]) { |_controller, action| set_locale(@project&.project_developer&.account&.language, &action) }
+      around_action(only: [:show]) { |_, action| set_locale(fallback_language: @project&.project_developer&.account&.language, &action) }
       load_and_authorize_resource
 
       def index

--- a/backend/app/controllers/concerns/api/localization.rb
+++ b/backend/app/controllers/concerns/api/localization.rb
@@ -1,14 +1,16 @@
 module API
   module Localization
     def self.included(base)
-      base.around_action { |_controller, action| set_locale(nil, &action) }
+      base.around_action { |_controller, action| set_locale(&action) }
     end
 
-    def set_locale(language = nil, &action)
-      locale = if params[:locale].present? && Language::TYPES.include?(params[:locale])
-        params[:locale]
-      elsif language.present? && Language::TYPES.include?(language)
+    def set_locale(language: nil, fallback_language: nil, &action)
+      locale = if language.present? && Language::TYPES.include?(language)
         language
+      elsif params[:locale].present? && Language::TYPES.include?(params[:locale])
+        params[:locale]
+      elsif fallback_language.present? && Language::TYPES.include?(fallback_language)
+        fallback_language
       else
         I18n.default_locale.to_s
       end

--- a/backend/spec/requests/api/v1/accounts/investors_spec.rb
+++ b/backend/spec/requests/api/v1/accounts/investors_spec.rb
@@ -99,7 +99,8 @@ RSpec.describe "API V1 Account Investors", type: :request do
           impacts: ["biodiversity", "climate"],
           ticket_sizes: ["small-grants"],
           instrument_types: ["grant"],
-          sdgs: [1, 2, 5]
+          sdgs: [1, 2, 5],
+          locale: :en
         }
       end
 
@@ -200,7 +201,8 @@ RSpec.describe "API V1 Account Investors", type: :request do
           impacts: ["biodiversity", "climate"],
           ticket_sizes: ["small-grants"],
           instrument_types: ["grant"],
-          sdgs: [1, 2, 5]
+          sdgs: [1, 2, 5],
+          locale: :en
         }
       end
 

--- a/backend/spec/requests/api/v1/accounts/open_calls_spec.rb
+++ b/backend/spec/requests/api/v1/accounts/open_calls_spec.rb
@@ -160,7 +160,8 @@ RSpec.describe "API V1 Account Open Calls", type: :request do
           funding_exclusions: "Open Call Funding Exclusions",
           closing_at: 1.day.from_now,
           sdgs: [1, 2],
-          instrument_types: %w[loan grant]
+          instrument_types: %w[loan grant],
+          locale: :en
         }
       end
 
@@ -257,7 +258,8 @@ RSpec.describe "API V1 Account Open Calls", type: :request do
           funding_exclusions: "Updated Open Call Funding Exclusions",
           closing_at: 10.days.from_now,
           sdgs: [1, 8],
-          instrument_types: %w[grant]
+          instrument_types: %w[grant],
+          locale: :en
         }
       end
 

--- a/backend/spec/requests/api/v1/accounts/project_developers_spec.rb
+++ b/backend/spec/requests/api/v1/accounts/project_developers_spec.rb
@@ -91,7 +91,8 @@ RSpec.describe "API V1 Account Project Developers", type: :request do
           contact_email: "contact@example.com",
           categories: ["sustainable-agrosystems", "tourism-and-recreation"],
           impacts: ["biodiversity", "climate"],
-          priority_landscape_ids: [priority_landscape.id]
+          priority_landscape_ids: [priority_landscape.id],
+          locale: :en
         }
       end
 
@@ -182,7 +183,8 @@ RSpec.describe "API V1 Account Project Developers", type: :request do
           mission: "Mission",
           categories: ["sustainable-agrosystems", "tourism-and-recreation"],
           impacts: ["biodiversity", "climate"],
-          priority_landscape_ids: [priority_landscape.id]
+          priority_landscape_ids: [priority_landscape.id],
+          locale: :en
         }
       end
 

--- a/backend/spec/requests/api/v1/accounts/projects_spec.rb
+++ b/backend/spec/requests/api/v1/accounts/projects_spec.rb
@@ -170,7 +170,8 @@ RSpec.describe "API V1 Account Projects", type: :request do
             {file: blob.signed_id, cover: true},
             {file: blob.signed_id, cover: false}
           ],
-          includes: "project_images"
+          includes: "project_images",
+          locale: :en
         }
       end
 
@@ -287,7 +288,8 @@ RSpec.describe "API V1 Account Projects", type: :request do
           target_groups: %w[urban-populations indigenous-peoples],
           impact_areas: %w[restoration pollutants-reduction],
           sdgs: [2, 4, 5],
-          instrument_types: %w[grant]
+          instrument_types: %w[grant],
+          locale: :en
         }
       end
 


### PR DESCRIPTION
I have actually made mistake during implementing #484 . For whatever reason, I thought that method `set_locale` sets language to provided value, but it does so only when `locale` param is empty.

This PR tweaks `set_locale ` method so it distinguish between `fallback_language` and `language`. When app decides which language to use, it goes like this `language --> locale --> fallback_language --> default_locale`. This way, we have possibility to define language which we will fallback in case that `locale` is empty, but also possibility to enforce language which is used instead of `locale`.

I have also updated tests to make sure that this fix works ;) 

## Testing instructions

Via rswag

## Tracking

https://vizzuality.atlassian.net/browse/LET-956 - second round
