### PR TITLE
Allow investor users to edit their open calls

### DIFF
--- a/frontend/containers/forms/project-gallery/project-gallery-image/component.tsx
+++ b/frontend/containers/forms/project-gallery/project-gallery-image/component.tsx
@@ -28,7 +28,7 @@ export const ProjectGalleryImage = <FormValues extends FieldValues>({
 }: ProjectGalleryImageProps<FormValues>) => {
   const [invalid, setInvalid] = useState<boolean>(invalidProp);
   const { isFocusVisible, focusProps } = useFocusRing();
-  const { file, title, src } = image;
+  const { id, file, title, src } = image;
   const { formatMessage } = useIntl();
 
   useEffect(() => {
@@ -42,7 +42,6 @@ export const ProjectGalleryImage = <FormValues extends FieldValues>({
       })}
     >
       <Button
-        name={name}
         theme="primary-white"
         className="absolute right-0 z-10 justify-center w-6 h-6 px-0 py-0 mx-2 my-2 overflow-hidden text-red-600 transition-opacity ease-in opacity-0 group-hover:opacity-100 group-hover:text-red-600 focus-visible:opacity-100"
         title={formatMessage({ defaultMessage: 'Delete image', id: 'pWwsxm' })}
@@ -51,32 +50,8 @@ export const ProjectGalleryImage = <FormValues extends FieldValues>({
       >
         <Icon icon={Trash2} className="w-4" />
       </Button>
-      <Controller
-        name={name}
-        control={control}
-        render={({ field }) => (
-          <input
-            {...field}
-            name={name}
-            id={file}
-            type="radio"
-            className="sr-only peer"
-            value={file}
-            onInvalid={() => setInvalid(true)}
-            checked={defaultSelected}
-            {...focusProps}
-            {...rest}
-            onChange={onSelectCover}
-            aria-labelledby="select-cover-input"
-          />
-        )}
-      />
-      <label
-        id="select-cover-input"
-        htmlFor={file}
-        className="overflow-hidden rounded cursor-pointer"
-      >
-        <span className="sr-only">{image.title}</span>
+
+      {!onSelectCover && (
         <Image
           aria-hidden={true}
           className="z-0 rounded"
@@ -86,7 +61,43 @@ export const ProjectGalleryImage = <FormValues extends FieldValues>({
           layout="fill"
           objectFit="cover"
         />
-      </label>
+      )}
+
+      {!!onSelectCover && (
+        <>
+          <Controller
+            name={name}
+            control={control}
+            render={({ field }) => (
+              <input
+                {...field}
+                name={name}
+                id={id}
+                type="radio"
+                className="sr-only peer"
+                value={file}
+                onInvalid={() => setInvalid(true)}
+                checked={defaultSelected}
+                {...focusProps}
+                {...rest}
+                onChange={onSelectCover}
+              />
+            )}
+          />
+          <label htmlFor={id} className="overflow-hidden rounded cursor-pointer">
+            <span className="sr-only">{image.title}</span>
+            <Image
+              aria-hidden={true}
+              className="z-0 rounded"
+              src={src}
+              title={title}
+              alt={title}
+              layout="fill"
+              objectFit="cover"
+            />
+          </label>
+        </>
+      )}
 
       <span
         aria-hidden={true}

--- a/frontend/containers/forms/project-gallery/project-gallery-image/types.ts
+++ b/frontend/containers/forms/project-gallery/project-gallery-image/types.ts
@@ -30,5 +30,5 @@ export type ProjectGalleryImageProps<FormValues> = {
   /** handle remove an an image from images array */
   onDeleteImage: () => void;
   /** Callback to handle selecting a cover image */
-  onSelectCover: () => void;
+  onSelectCover?: () => void;
 };

--- a/frontend/containers/investor-form/component.tsx
+++ b/frontend/containers/investor-form/component.tsx
@@ -178,6 +178,7 @@ const InvestorForm: FC<InvestorFormProps> = ({
           <Impacts
             register={register}
             setError={setError}
+            getValues={getValues}
             setValue={setValue}
             errors={errors}
             impacts={enums?.impact}

--- a/frontend/containers/investor-form/pages/impacts.tsx
+++ b/frontend/containers/investor-form/pages/impacts.tsx
@@ -13,7 +13,14 @@ import TagGroup from 'components/forms/tag-group';
 
 import { ImpactProps } from '../types';
 
-export const Impact: FC<ImpactProps> = ({ register, errors, impacts, setValue, clearErrors }) => {
+export const Impact: FC<ImpactProps> = ({
+  register,
+  errors,
+  impacts,
+  getValues,
+  setValue,
+  clearErrors,
+}) => {
   return (
     <div>
       <h1 className="font-serif text-3xl font-semibold mb-2.5">
@@ -130,6 +137,7 @@ export const Impact: FC<ImpactProps> = ({ register, errors, impacts, setValue, c
               clearErrors={clearErrors}
               register={register}
               aria-describedby="sdgs-error"
+              defaultValues={getValues('sdgs')}
             />
           </fieldset>
           <ErrorMessage

--- a/frontend/containers/open-call-form/component.tsx
+++ b/frontend/containers/open-call-form/component.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
@@ -15,6 +15,9 @@ import { OpenCallStatus } from 'enums';
 import { OpenCallForm as OpenFormType, OpenCallCreationPayload } from 'types/open-calls';
 import useOpenCallResolver, { formPageInputs } from 'validations/open-call';
 
+import { useDefaultValues } from './helpers';
+import { BasicMutationType } from './types';
+
 import {
   OpenCallInformation,
   OpenCallExpectedImpact,
@@ -24,20 +27,23 @@ import {
   PendingVerification,
 } from '.';
 
-export const OpenCallForm: FC<OpenCallFormTypes> = ({
+export const OpenCallForm = <MutationType extends BasicMutationType>({
   title,
   initialValues: openCall,
   mutation,
   enums,
-  language,
+  locale,
   onComplete,
   leaveMessage,
-}) => {
+  isLoading,
+}: OpenCallFormTypes<MutationType>) => {
   const [currentPage, setCurrentPage] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
   const [showLeave, setShowLeave] = useState(false);
   const [slug, setSlug] = useState<string>();
   const resolver = useOpenCallResolver(currentPage);
+
+  const defaultValues = useDefaultValues(openCall);
 
   const {
     handleSubmit,
@@ -46,6 +52,7 @@ export const OpenCallForm: FC<OpenCallFormTypes> = ({
     formState: { errors },
     clearErrors,
     setValue,
+    getValues,
     setError,
     resetField,
   } = useForm<OpenFormType>({
@@ -53,37 +60,34 @@ export const OpenCallForm: FC<OpenCallFormTypes> = ({
     shouldUseNativeValidation: true,
     shouldFocusError: true,
     reValidateMode: 'onChange',
+    defaultValues,
   });
 
   const isLastPage = currentPage === totalPages - 1;
   const languageNames = useLanguageNames();
   const isOutroPage = currentPage === totalPages;
 
+  const alert = useGetAlert(mutation.error);
+
   const handleMutate = useCallback(
     (data: OpenCallCreationPayload) => {
-      return mutation.mutate(
-        { dto: data, locale: language },
-        {
-          onError: (error) => {
-            const { errorPages, fieldErrors } = getServiceErrors<OpenFormType>(
-              error,
-              formPageInputs
-            );
-            fieldErrors.forEach(({ fieldName, message }) => setError(fieldName, { message }));
-            if (errorPages.length) setCurrentPage(errorPages[0]);
-          },
-          onSuccess: (openCall) => {
-            if (openCall.trusted) {
-              onComplete();
-            } else {
-              setCurrentPage(currentPage + 1);
-              setSlug(openCall.slug);
-            }
-          },
-        }
-      );
+      return mutation.mutate(data, {
+        onError: (error) => {
+          const { errorPages, fieldErrors } = getServiceErrors<OpenFormType>(error, formPageInputs);
+          fieldErrors.forEach(({ fieldName, message }) => setError(fieldName, { message }));
+          if (errorPages.length) setCurrentPage(errorPages[0]);
+        },
+        onSuccess: (openCall) => {
+          if (openCall.trusted || data.status === OpenCallStatus.Draft) {
+            onComplete();
+          } else {
+            setCurrentPage(currentPage + 1);
+            setSlug(openCall.slug);
+          }
+        },
+      });
     },
-    [currentPage, language, mutation, onComplete, setError]
+    [currentPage, mutation, onComplete, setError]
   );
 
   const onSubmit: SubmitHandler<OpenFormType> = (values) => {
@@ -109,7 +113,16 @@ export const OpenCallForm: FC<OpenCallFormTypes> = ({
     await handleSubmit(onSubmit)();
   };
 
-  const alert = useGetAlert(mutation.error);
+  // This component may be mounted when `openCall` has not resolved yet (`isLoading` will be
+  // `true`). In that case, we want to make sure the form is populated with the default values.
+  // `useForm`'s `defaultValues` attribute is only read on mount.
+  useEffect(() => {
+    if (!isLoading && defaultValues) {
+      Object.entries(defaultValues).map(([key, value]) => {
+        setValue(key as keyof OpenFormType, value);
+      });
+    }
+  }, [isLoading, defaultValues, setValue]);
 
   return (
     <div>
@@ -118,7 +131,7 @@ export const OpenCallForm: FC<OpenCallFormTypes> = ({
         getTotalPages={(pages) => setTotalPages(pages)}
         layout="narrow"
         title={title}
-        locale={language}
+        locale={locale}
         autoNavigation={false}
         page={currentPage}
         alert={alert}
@@ -130,6 +143,7 @@ export const OpenCallForm: FC<OpenCallFormTypes> = ({
         showProgressBar
         onCloseClick={() => setShowLeave(true)}
         onSubmitClick={handleSubmitPublish}
+        isLoading={isLoading}
         footerElements={
           isLastPage &&
           (!openCall?.status || openCall.status === OpenCallStatus.Draft) && (
@@ -150,15 +164,17 @@ export const OpenCallForm: FC<OpenCallFormTypes> = ({
               defaultMessage="<span>Note:</span>The content of this open call should be written in {language}"
               id="SUQqz6"
               values={{
-                language: languageNames[language],
+                language: languageNames[locale],
                 span: (chunks: string) => <span className="mr-2 font-semibold">{chunks}</span>,
               }}
             />
           </ContentLanguageAlert>
           <OpenCallInformation
+            openCall={openCall}
             control={control}
             setError={setError}
             setValue={setValue}
+            getValues={getValues}
             register={register}
             errors={errors}
             clearErrors={clearErrors}
@@ -171,6 +187,7 @@ export const OpenCallForm: FC<OpenCallFormTypes> = ({
             setValue={setValue}
             errors={errors}
             register={register}
+            getValues={getValues}
           />
         </Page>
         <Page>
@@ -183,7 +200,7 @@ export const OpenCallForm: FC<OpenCallFormTypes> = ({
           />
         </Page>
         <Page>
-          <OpenCallClosingDate control={control} errors={errors} />
+          <OpenCallClosingDate control={control} errors={errors} getValues={getValues} />
         </Page>
         <OutroPage>
           <PendingVerification slug={slug} />

--- a/frontend/containers/open-call-form/helpers.ts
+++ b/frontend/containers/open-call-form/helpers.ts
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+
+import { pickBy } from 'lodash-es';
+
+import { OpenCall, OpenCallForm } from 'types/open-calls';
+import { formPageInputs } from 'validations/open-call';
+
+export const useDefaultValues = (openCall: OpenCall): Partial<OpenCallForm> => {
+  return useMemo(() => {
+    if (!openCall) return null;
+
+    const general = pickBy(openCall, (_, key: any) => formPageInputs.flat().includes(key));
+
+    return {
+      ...general,
+      id: openCall.id,
+      picture: openCall.picture?.original?.split('redirect/')[1].split('/')[0] ?? undefined,
+      country_id: openCall.country?.id,
+      department_id: openCall.department?.id,
+      municipality_id: openCall.municipality?.id,
+      closing_at: new Date(openCall.closing_at),
+    };
+  }, [openCall]);
+};

--- a/frontend/containers/open-call-form/pages/closing-date.tsx
+++ b/frontend/containers/open-call-form/pages/closing-date.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react';
+import { FC, useCallback, useState } from 'react';
 
 import { FormattedMessage } from 'react-intl';
 
@@ -9,19 +9,27 @@ import ErrorMessage from 'components/forms/error-message';
 
 import { OpenCallClosingDateProps } from '../types';
 
-export const OpenCallClosingDate: FC<OpenCallClosingDateProps> = ({ control, errors }) => {
-  const [totalDays, setTotalDays] = useState(0);
+const getDaysCountFromToday = (targetDate: Dayjs) => {
+  // In order to have a “ceil” value, we pass `true` as the last param to get a float
+  return Math.ceil(targetDate.diff(dayjs(), 'd', true)) + 1;
+};
 
-  const handleChangeDate = (event: any) => {
+export const OpenCallClosingDate: FC<OpenCallClosingDateProps> = ({
+  control,
+  errors,
+  getValues,
+}) => {
+  const [totalDays, setTotalDays] = useState(
+    getValues('closing_at') ? getDaysCountFromToday(dayjs(getValues('closing_at'))) : 0
+  );
+
+  const handleChangeDate = useCallback((event: any) => {
     const newDate: Dayjs = event.target.value;
-    // total days between now and the closing_date (the selected date)
-    // The 'true' on the last function param is to return a float value, so we use the Math.ceil to round up, and the + 1 is to add the current day
-    const total = newDate?.diff(dayjs(), 'd', true);
-    setTotalDays(total ? Math.ceil(total) + 1 : 0);
-  };
+    setTotalDays(newDate ? getDaysCountFromToday(newDate) : 0);
+  }, []);
 
   return (
-    <div className="max-w-[814px] m-auto">
+    <>
       <div className="mb-10">
         <h1 className="mb-2 font-serif text-3xl font-semibold">
           <FormattedMessage
@@ -59,6 +67,6 @@ export const OpenCallClosingDate: FC<OpenCallClosingDateProps> = ({ control, err
           />
         </p>
       </div>
-    </div>
+    </>
   );
 };

--- a/frontend/containers/open-call-form/pages/expected-impact.tsx
+++ b/frontend/containers/open-call-form/pages/expected-impact.tsx
@@ -16,6 +16,7 @@ export const OpenCallExpectedImpact: FC<OpenCallExpectedImpactProps> = ({
   errors,
   clearErrors,
   setValue,
+  getValues,
 }) => {
   const { formatMessage } = useIntl();
 
@@ -77,6 +78,7 @@ export const OpenCallExpectedImpact: FC<OpenCallExpectedImpactProps> = ({
               name="sdgs"
               register={register}
               setValue={setValue}
+              defaultValues={getValues('sdgs')}
               aria-describedby="sdgs-error"
             />
             <ErrorMessage id="sdgs-error" errorText={errors.sdgs?.[0]?.message} />

--- a/frontend/containers/open-call-form/types.ts
+++ b/frontend/containers/open-call-form/types.ts
@@ -2,6 +2,7 @@ import {
   Control,
   FieldErrors,
   UseFormClearErrors,
+  UseFormGetValues,
   UseFormRegister,
   UseFormResetField,
   UseFormSetError,
@@ -9,75 +10,87 @@ import {
 } from 'react-hook-form';
 import { UseMutationResult } from 'react-query';
 
-import { AxiosError, AxiosResponse } from 'axios';
+import { AxiosError } from 'axios';
 
 import { Languages } from 'enums';
 import { Enum, GroupedEnums } from 'types/enums';
-import { OpenCall, OpenCallForm, OpenCallCreationPayload } from 'types/open-calls';
+import { OpenCall, OpenCallForm } from 'types/open-calls';
 
-import { ResponseData, ErrorResponse } from 'services/types';
+import { ErrorResponse } from 'services/types';
 
-export type OpenCallFormTypes = {
+export type BasicMutationType = UseMutationResult<OpenCall, AxiosError<ErrorResponse>, {}, unknown>;
+
+export type OpenCallFormTypes<MutationType extends BasicMutationType> = {
+  /** Title of the Header and MultipageLayout */
   title: string;
-  mutation: UseMutationResult<
-    OpenCall,
-    AxiosError<ErrorResponse>,
-    {
-      dto: OpenCallCreationPayload;
-      locale: Languages;
-    }
-  >;
+  /** Mutation used when submitting the form */
+  mutation: MutationType;
+  /** Values of the open call when editing */
   initialValues?: OpenCall;
+  /** Enums data */
   enums: GroupedEnums;
-  language: Languages;
+  /** Locale of the content */
+  locale: Languages;
+  /** Callback to execute when form has been submitted successfully */
   onComplete: () => void;
+  /** Leave message to show when leaving the form */
   leaveMessage: string;
+  /** Whether the open call data is still being loaded/fetched */
+  isLoading?: boolean;
 };
 
 export type OpenCallInformationProps = {
-  /**  React-hook-form register function */
+  /** Open call (API data) */
+  openCall: OpenCall;
+  /** React-hook-form register function */
   register: UseFormRegister<OpenCallForm>;
-  /**  React-hook-form clearErrors function */
+  /** React-hook-form clearErrors function */
   clearErrors: UseFormClearErrors<OpenCallForm>;
-  /**  React-hook-form state - errors */
+  /** React-hook-form state - errors */
   errors: FieldErrors<OpenCallForm>;
-  /**  React-hook-form setError function */
+  /** React-hook-form setError function */
   setError: UseFormSetError<OpenCallForm>;
-  /**  React-hook-form control */
+  /** React-hook-form control */
   control: Control<OpenCallForm, any>;
-  /**  React-hook-form setValue function */
+  /** React-hook-form useForm getValues */
+  getValues?: UseFormGetValues<OpenCallForm>;
+  /** React-hook-form setValue function */
   setValue: UseFormSetValue<OpenCallForm>;
-  /**  React-hook-form resetField function */
+  /** React-hook-form resetField function */
   resetField?: UseFormResetField<OpenCallForm>;
 };
 
 export type OpenCallExpectedImpactProps = {
-  /**  React-hook-form register function */
+  /** React-hook-form register function */
   register: UseFormRegister<OpenCallForm>;
-  /**  React-hook-form state - errors */
+  /** React-hook-form state - errors */
   errors: FieldErrors<OpenCallForm>;
-  /**  React-hook-form clearErrors function */
+  /** React-hook-form clearErrors function */
   clearErrors: UseFormClearErrors<OpenCallForm>;
-  /**  React-hook-form setValue function */
+  /** React-hook-form setValue function */
   setValue: UseFormSetValue<OpenCallForm>;
+  /** React-hook-form useForm getValues */
+  getValues: UseFormGetValues<OpenCallForm>;
 };
 
 export type OpenCallFundingInformationProps = {
-  /**  React-hook-form register function */
+  /** React-hook-form register function */
   register: UseFormRegister<OpenCallForm>;
-  /**  React-hook-form state - errors */
+  /** React-hook-form state - errors */
   errors: FieldErrors<OpenCallForm>;
-  /**  React-hook-form clearErrors function */
+  /** React-hook-form clearErrors function */
   clearErrors: UseFormClearErrors<OpenCallForm>;
-  /**  React-hook-form setValue function */
+  /** React-hook-form setValue function */
   setValue: UseFormSetValue<OpenCallForm>;
   /** Instrument type enums */
   instrument_types: Enum[];
 };
 
 export type OpenCallClosingDateProps = {
-  /**  React-hook-form control */
+  /** React-hook-form control */
   control: Control<OpenCallForm, any>;
-  /**  React-hook-form state - errors */
+  /** React-hook-form state - errors */
   errors: FieldErrors<OpenCallForm>;
+  /** React-hook-form useForm getValues */
+  getValues: UseFormGetValues<OpenCallForm>;
 };

--- a/frontend/containers/project-form/types.ts
+++ b/frontend/containers/project-form/types.ts
@@ -27,7 +27,7 @@ export type ProjectFormProps = {
   leaveMessage: string;
   /** If is the create form. Default = false (update form) */
   isCreateForm?: boolean;
-  /** Values of the current project developer, in case it is the update form */
+  /** Values of the project when editing */
   initialValues?: Project;
   /** Whether the project data is still being loaded/fetched */
   isLoading?: boolean;
@@ -35,6 +35,7 @@ export type ProjectFormProps = {
   mutation: UseMutationResult<AxiosResponse<ResponseData<Project>>, AxiosError<ErrorResponse>>;
   /** Callback to execute when form has been submitted successfully */
   onComplete?: () => void;
+  /** Enums data */
   enums: GroupedEnums;
 };
 

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -1722,6 +1722,9 @@
   "aDn1WM": {
     "string": "Curated database"
   },
+  "aF/DIA": {
+    "string": "Leave project edition form"
+  },
   "aFyFm0": {
     "string": "Accepted"
   },
@@ -1865,6 +1868,9 @@
   },
   "e61Jf3": {
     "string": "Coming soon"
+  },
+  "eCiudu": {
+    "string": "Open call cover image"
   },
   "eE6uKi": {
     "string": "This data set, a collaboration between the Global Land Analysis & Discovery (GLAD) lab at the University of Maryland, Google, USGS, and NASA, measures areas of tree cover loss across all global land (except Antarctica and other Arctic islands) at approximately 30 × 30 meter resolution. The data were generated using multispectral satellite imagery from the Landsat 5 thematic mapper (TM), the Landsat 7 thematic mapper plus (ETM+), and the Landsat 8 Operational Land Imager (OLI) sensors. Over 1 million satellite images were processed and analyzed, including over 600,000 Landsat 7 images for the 2000-2012 interval, and more than 400,000 Landsat 5, 7, and 8 images for updates for the 2011-2021 interval. The clear land surface observations in the satellite images were assembled and a supervised learning algorithm was applied to identify per pixel tree cover loss."
@@ -2153,6 +2159,9 @@
   },
   "kEXoaQ": {
     "string": "About your work"
+  },
+  "kHpaMt": {
+    "string": "Edit Open Call"
   },
   "kN5g/0": {
     "string": "Indigenous Reserves"
@@ -2498,6 +2507,9 @@
   },
   "sV+3z0": {
     "string": "Currently looking for"
+  },
+  "sVpJRp": {
+    "string": "Leave open call edition form"
   },
   "sWdxgq": {
     "string": "Impact of projects that reduce carbon emissions from the land sector (deforestation/degradation), as wood and soil biomass as well as application of sustainable forest measures."

--- a/frontend/pages/open-call/[id]/edit.tsx
+++ b/frontend/pages/open-call/[id]/edit.tsx
@@ -1,0 +1,116 @@
+import { useIntl } from 'react-intl';
+
+import { useRouter } from 'next/router';
+
+import { withLocalizedRequests } from 'hoc/locale';
+
+import { groupBy } from 'lodash-es';
+
+import { loadI18nMessages } from 'helpers/i18n';
+import { useQueryReturnPath } from 'helpers/pages';
+
+import OpenCallForm from 'containers/open-call-form';
+
+import { Paths, UserRoles } from 'enums';
+import FormPageLayout, { FormPageLayoutProps } from 'layouts/form-page';
+import ProtectedPage from 'layouts/protected-page';
+import { PageComponent } from 'types';
+import { GroupedEnums } from 'types/enums';
+import { Investor } from 'types/investor';
+import { User } from 'types/user';
+
+import { getEnums } from 'services/enums/enumService';
+import { getOpenCall, useOpenCall, useUpdateOpenCall } from 'services/open-call/open-call-service';
+
+const OPEN_CALL_QUERY_PARAMS = {
+  includes: ['country', 'municipality', 'department', 'investor'],
+  // We set the `locale` as `null` so that we get the open call in the account's language instead of
+  // the UI language
+  locale: null,
+};
+
+export const getServerSideProps = withLocalizedRequests(async ({ params: { id }, locale }) => {
+  let openCall;
+  let enums;
+
+  try {
+    ({ data: openCall } = await getOpenCall(id as string, OPEN_CALL_QUERY_PARAMS));
+    enums = await getEnums();
+  } catch (e) {
+    // The user may be attempting to preview a drafted open call, which the endpoint won't return
+    // unless the ownership can be verified. We'll be loading it client side and redirect the user
+    // to the dashboard if the open call really doesn't exist or the user doesn't have permissions
+    openCall = null;
+  }
+
+  return {
+    props: {
+      intlMessages: await loadI18nMessages({ locale }),
+      openCall,
+      enums: groupBy(enums, 'type'),
+    },
+  };
+});
+
+type EditOpenCallProps = ReturnType<typeof getServerSideProps> extends Promise<{ props: infer T }>
+  ? T
+  : never;
+
+const EditOpenCall: PageComponent<EditOpenCallProps, FormPageLayoutProps> = ({
+  openCall: initialOpenCall,
+  enums,
+}) => {
+  const { formatMessage } = useIntl();
+  const router = useRouter();
+  const queryReturnPath = useQueryReturnPath();
+
+  const {
+    data: { data: openCall },
+    isFetching: isFetchingProject,
+  } = useOpenCall(router.query.id as string, OPEN_CALL_QUERY_PARAMS, initialOpenCall);
+
+  const updateOpenCall = useUpdateOpenCall({ locale: openCall?.language });
+
+  const getIsOwner = (_user: User, userAccount: Investor) => {
+    // The user must be a the creator of the open call to be allowed to edit it.
+    if (openCall?.investor?.id && userAccount?.id) {
+      return openCall.investor.id === userAccount.id;
+    }
+  };
+
+  const handleOnComplete = () => {
+    router.push(queryReturnPath || Paths.DashboardOpenCalls);
+  };
+
+  return (
+    <ProtectedPage
+      ownership={{
+        allowOwner: true,
+        getIsOwner,
+      }}
+      permissions={[UserRoles.Investor]}
+    >
+      <OpenCallForm
+        title={formatMessage({ defaultMessage: 'Edit Open Call', id: 'kHpaMt' })}
+        leaveMessage={formatMessage({
+          defaultMessage: 'Leave open call edition form',
+          id: 'sVpJRp',
+        })}
+        mutation={updateOpenCall}
+        onComplete={handleOnComplete}
+        initialValues={openCall}
+        isLoading={!openCall && isFetchingProject}
+        // The language of the content will be the same as the language of the account, which the
+        // API will automatically set
+        locale={null}
+        enums={enums as GroupedEnums}
+      />
+    </ProtectedPage>
+  );
+};
+
+EditOpenCall.layout = {
+  Component: FormPageLayout,
+};
+
+export default EditOpenCall;

--- a/frontend/pages/open-call/[id]/index.tsx
+++ b/frontend/pages/open-call/[id]/index.tsx
@@ -22,12 +22,16 @@ import { OpenCall } from 'types/open-calls';
 import { getEnums } from 'services/enums/enumService';
 import { getOpenCall, useOpenCall } from 'services/open-call/open-call-service';
 
+const OPEN_CALL_QUERY_PARAMS = {
+  includes: ['country', 'municipality', 'department', 'investor'],
+};
+
 export const getServerSideProps = withLocalizedRequests(async ({ params: { id }, locale }) => {
-  let openCall = null;
+  let openCall: OpenCall = null;
 
   // If getting the project fails, it's most likely because the record has not been found. Let's return a 404. Anything else will trigger a 500 by default.
   try {
-    openCall = await getOpenCall(id as string);
+    ({ data: openCall } = await getOpenCall(id as string, OPEN_CALL_QUERY_PARAMS));
   } catch (e) {
     return { notFound: true };
   }
@@ -52,7 +56,9 @@ const OpenCallPage: PageComponent<OpenCallPageProps, StaticPageLayoutProps> = ({
   openCall: openCallProp,
   enums,
 }) => {
-  const { openCall } = useOpenCall(openCallProp.id, openCallProp);
+  const {
+    data: { data: openCall },
+  } = useOpenCall(openCallProp.id, OPEN_CALL_QUERY_PARAMS, openCallProp);
 
   const { name, description, instrument_types } = openCall;
 

--- a/frontend/pages/open-calls/new.tsx
+++ b/frontend/pages/open-calls/new.tsx
@@ -48,7 +48,7 @@ const CreateOpenCallPage: PageComponent<InferGetServerSidePropsType<typeof getSe
     push(queryReturnPath || Paths.DashboardOpenCalls);
   };
 
-  const createOpenCall = useCreateOpenCall();
+  const createOpenCall = useCreateOpenCall({ locale: language });
 
   const getIsOwner = (_user: User, userAccount: Investor | ProjectDeveloper) => {
     setLanguage(userAccount?.language);
@@ -62,7 +62,7 @@ const CreateOpenCallPage: PageComponent<InferGetServerSidePropsType<typeof getSe
         title={formatMessage({ defaultMessage: 'Create Open Call', id: '7xC2j0' })}
         mutation={createOpenCall}
         enums={enums as GroupedEnums}
-        language={language}
+        locale={language}
         leaveMessage={formatMessage({
           defaultMessage: 'Leave open call creation form',
           id: '6FQ0Y8',

--- a/frontend/pages/project/[id]/edit.tsx
+++ b/frontend/pages/project/[id]/edit.tsx
@@ -33,7 +33,6 @@ const PROJECT_QUERY_PARAMS = {
     'department',
     'project_developer',
     'involved_project_developers',
-    'project_developer',
   ],
   // We set the `locale` as `null` so that we get the project in the account's language instead of the UI language
   locale: null,
@@ -104,8 +103,8 @@ const EditProject: PageComponent<EditProjectProps, FormPageLayoutProps> = ({
       <ProjectForm
         title={formatMessage({ defaultMessage: 'Edit project', id: 'qwCflo' })}
         leaveMessage={formatMessage({
-          defaultMessage: 'Leave project creation form',
-          id: 'vygPIS',
+          defaultMessage: 'Leave project edition form',
+          id: 'aF/DIA',
         })}
         mutation={updateProject}
         onComplete={handleOnComplete}

--- a/frontend/schemas/open-call.ts
+++ b/frontend/schemas/open-call.ts
@@ -51,7 +51,7 @@ export default (page: number) => {
 
   const openCallSchema: SchemaOf<Partial<OpenCallForm>> = object({
     name: string().required(messages.name),
-    picture: string(),
+    picture: string().nullable(),
     country_id: string().required(messages.country_id),
     department_id: string(),
     municipality_id: string(),

--- a/frontend/types/open-calls.ts
+++ b/frontend/types/open-calls.ts
@@ -52,7 +52,7 @@ export type OpenCallCreationPayload = Omit<OpenCallForm, 'closing_at'> & {
 };
 
 export type OpenCallUpdatePayload = Partial<OpenCallCreationPayload> & {
-  id: string;
+  id?: string;
 };
 
 export type OpenCallParams = {


### PR DESCRIPTION
This PR allows investor users to edit their open calls in the Dashboard.

In addition, this PR fixes an issue in the investor edition form where the previously selected SDGs wouldn't be highlighted.

## Testing instructions

- You can edit draft and published open calls
  - When creating/editing a draft open call, you don't see the screen about verification
- You can see the public page of published open calls (making sure nothing broke)
- You can create new open calls (making sure nothing broke)

## Tracking

[LET-885](https://vizzuality.atlassian.net/browse/LET-885)
