### PR TITLE
Allow users to favorite open calls

### DIFF
--- a/frontend/containers/open-call-page/header/component.tsx
+++ b/frontend/containers/open-call-page/header/component.tsx
@@ -70,14 +70,7 @@ export const OpenCallHeader: FC<OpenCallHeaderProps> = ({
 
   const handleFavoriteClick = () => {
     // This mutation uses a 'DELETE' request when the isFavorite is true, and a 'POST' request when is false.
-    favoriteOpenCall.mutate(
-      { id, isFavourite: favourite },
-      {
-        onSuccess: (data) => {
-          openCall.favourite = data.favourite;
-        },
-      }
-    );
+    favoriteOpenCall.mutate({ id, isFavourite: favourite });
   };
 
   return (

--- a/frontend/containers/open-call-page/header/component.tsx
+++ b/frontend/containers/open-call-page/header/component.tsx
@@ -9,6 +9,8 @@ import { useRouter } from 'next/router';
 
 import dayjs from 'dayjs';
 
+import useMe from 'hooks/me';
+
 import { translatedLanguageNameForLocale } from 'helpers/intl';
 
 import Breadcrumbs from 'containers/breadcrumbs';
@@ -20,6 +22,8 @@ import LayoutContainer from 'components/layout-container';
 import { Languages, OpenCallStatus } from 'enums';
 import languages from 'locales.config.json';
 
+import { useFavoriteOpenCall } from 'services/open-call/open-call-service';
+
 import OpenCallChart from '../chart';
 
 import { OpenCallHeaderProps } from '.';
@@ -27,12 +31,15 @@ import { OpenCallHeaderProps } from '.';
 export const OpenCallHeader: FC<OpenCallHeaderProps> = ({
   openCall,
   instrumentTypes,
-  handleFavorite,
   handleApply,
 }) => {
   const intl = useIntl();
   const { locale } = useRouter();
+  const favoriteOpenCall = useFavoriteOpenCall();
+  const { user } = useMe();
+
   const {
+    id,
     name,
     instrument_types,
     maximum_funding_per_project,
@@ -43,6 +50,7 @@ export const OpenCallHeader: FC<OpenCallHeaderProps> = ({
     status,
     favourite,
   } = openCall;
+
   const coverImage = picture?.medium;
   const originalLanguage =
     language || (languages.locales.find((locale) => locale.default)?.locale as Languages);
@@ -59,6 +67,18 @@ export const OpenCallHeader: FC<OpenCallHeaderProps> = ({
     const consumed = duration - remaining;
     return { consumed, remaining, deadline };
   }, [closing_at, created_at]);
+
+  const handleFavoriteClick = () => {
+    // This mutation uses a 'DELETE' request when the isFavorite is true, and a 'POST' request when is false.
+    favoriteOpenCall.mutate(
+      { id, isFavourite: favourite },
+      {
+        onSuccess: (data) => {
+          openCall.favourite = data.favourite;
+        },
+      }
+    );
+  };
 
   return (
     <LayoutContainer className="-mt-10 md:mt-0 lg:-mt-16">
@@ -167,8 +187,8 @@ export const OpenCallHeader: FC<OpenCallHeaderProps> = ({
               <Button
                 className="justify-center"
                 theme="secondary-green"
-                onClick={handleFavorite}
-                disabled
+                onClick={handleFavoriteClick}
+                disabled={!user}
                 aria-pressed={favourite}
               >
                 <Icon icon={Heart} className={cx('w-4 mr-3', { 'fill-green-dark': favourite })} />

--- a/frontend/containers/open-call-page/header/types.ts
+++ b/frontend/containers/open-call-page/header/types.ts
@@ -5,8 +5,6 @@ export type OpenCallHeaderProps = {
   openCall: OpenCall;
   /** List of instrument type names */
   instrumentTypes: string[];
-  /** function to favorite/unfavorite open call */
-  handleFavorite: () => void;
   /** function to apply to a open call */
   handleApply: () => void;
 };

--- a/frontend/containers/open-call-page/investor/component.tsx
+++ b/frontend/containers/open-call-page/investor/component.tsx
@@ -5,6 +5,8 @@ import { FormattedMessage } from 'react-intl';
 
 import cx from 'classnames';
 
+import useMe from 'hooks/me';
+
 import ProfileCard from 'containers/profile-card';
 
 import Button from 'components/button';
@@ -12,14 +14,28 @@ import Icon from 'components/icon';
 import LayoutContainer from 'components/layout-container';
 import { Paths } from 'enums';
 
+import { useFavoriteOpenCall } from 'services/open-call/open-call-service';
+
 import { OpenCallInvestorProps } from '.';
 
-export const OpenCallInvestorAndFooter: FC<OpenCallInvestorProps> = ({
-  investor,
-  handleApply,
-  handleFavorite,
-  // favourite,
-}) => {
+export const OpenCallInvestorAndFooter: FC<OpenCallInvestorProps> = ({ openCall, handleApply }) => {
+  const { user } = useMe();
+  const favoriteOpenCall = useFavoriteOpenCall();
+
+  const { investor } = openCall;
+
+  const handleFavoriteClick = () => {
+    // This mutation uses a 'DELETE' request when the isFavorite is true, and a 'POST' request when is false.
+    favoriteOpenCall.mutate(
+      { id: openCall.id, isFavourite: openCall.favourite },
+      {
+        onSuccess: (data) => {
+          openCall.favourite = data.favourite;
+        },
+      }
+    );
+  };
+
   return (
     <div className="w-full pt-20 bg-background-middle">
       <LayoutContainer>
@@ -59,11 +75,13 @@ export const OpenCallInvestorAndFooter: FC<OpenCallInvestorProps> = ({
             <span className="text-xl text-white">
               <FormattedMessage defaultMessage="or" id="Ntjkqd" />
             </span>
-            <Button disabled theme="secondary-white" onClick={handleFavorite}>
+            <Button disabled={!user} theme="secondary-white" onClick={handleFavoriteClick}>
               <Icon
                 icon={Heart}
-                // className={cx('w-4 mr-3', { 'fill-green-dark': favourite })}
-                className={cx('w-4 mr-3')}
+                className={cx('w-4 mr-3', {
+                  'fill-green-dark': !openCall.favourite,
+                  'fill-white': openCall.favourite,
+                })}
               />
               <span className="text-lg">
                 <FormattedMessage defaultMessage="Favorite" id="5Hzwqs" />

--- a/frontend/containers/open-call-page/investor/component.tsx
+++ b/frontend/containers/open-call-page/investor/component.tsx
@@ -26,14 +26,7 @@ export const OpenCallInvestorAndFooter: FC<OpenCallInvestorProps> = ({ openCall,
 
   const handleFavoriteClick = () => {
     // This mutation uses a 'DELETE' request when the isFavorite is true, and a 'POST' request when is false.
-    favoriteOpenCall.mutate(
-      { id: openCall.id, isFavourite: openCall.favourite },
-      {
-        onSuccess: (data) => {
-          openCall.favourite = data.favourite;
-        },
-      }
-    );
+    favoriteOpenCall.mutate({ id: openCall.id, isFavourite: openCall.favourite });
   };
 
   return (

--- a/frontend/containers/open-call-page/investor/types.ts
+++ b/frontend/containers/open-call-page/investor/types.ts
@@ -1,14 +1,8 @@
-import { MutableRefObject } from 'react';
-
-import { Investor } from 'types/investor';
+import { OpenCall } from 'types/open-calls';
 
 export type OpenCallInvestorProps = {
-  /** The open call investor */
-  investor: Investor;
-  /** Function to favorite/unfavorite open call */
-  handleFavorite: () => void;
+  /** The open call object we are displaying the banner for */
+  openCall: OpenCall;
   /** Function to apply to a open call */
   handleApply: () => void;
-  // /** Whether the open call is favourite */
-  // favourite: boolean;
 };

--- a/frontend/pages/open-call/[id]/index.tsx
+++ b/frontend/pages/open-call/[id]/index.tsx
@@ -67,9 +67,6 @@ const OpenCallPage: PageComponent<OpenCallPageProps, StaticPageLayoutProps> = ({
   );
 
   // To implement
-  const handleFavorite = () => {};
-
-  // To implement
   const handleApply = () => {};
 
   return (
@@ -86,11 +83,7 @@ const OpenCallPage: PageComponent<OpenCallPageProps, StaticPageLayoutProps> = ({
         openCall={openCall}
         allSdgs={allSdgs}
       />
-      <OpenCallInvestorAndFooter
-        investor={openCall?.investor}
-        handleFavorite={handleFavorite}
-        handleApply={handleApply}
-      />
+      <OpenCallInvestorAndFooter openCall={openCall} handleApply={handleApply} />
     </div>
   );
 };

--- a/frontend/pages/open-call/[id]/index.tsx
+++ b/frontend/pages/open-call/[id]/index.tsx
@@ -1,5 +1,3 @@
-import { useRef } from 'react';
-
 import { withLocalizedRequests } from 'hoc/locale';
 
 import { groupBy } from 'lodash-es';
@@ -80,7 +78,6 @@ const OpenCallPage: PageComponent<OpenCallPageProps, StaticPageLayoutProps> = ({
       <OpenCallHeader
         openCall={openCall}
         instrumentTypes={instrumentTypeNames}
-        handleFavorite={handleFavorite}
         handleApply={handleApply}
       />
       <OpenCallOverview openCall={openCall} />


### PR DESCRIPTION
## Description

This PR adds the frontend functionality to allow a user to favourite/unfavourite open calls from both the header and CTA at the bottom of the open calls public page. 

**In this PR:**
- Added `useFavoriteOpenCall` to `open-call-service`  
- Implementation to make the _"Favorite"_ button (header) in the open call public page work  
- Implementation to make the _"Favorite"_ button (CTA, above the footer) in the open call public page work   

**Notes:**  
The endpoint hasn't been yet implemented and is tracked by [LET-989](https://vizzuality.atlassian.net/browse/LET-989), so the implementation will not work as of now. However, the logic is a copy-paste of the one used for projects, PDs, investors, and the endpoint was inferred from those as well. 

## Testing instructions

Verify that:  
- When a user is not signed in, the "favorite" buttons are disabled  
- When a user is signed in, clicking the "favorite" buttons sends a POST request to the (inferred, not yet implemented) API endpoint 

One could also pass `openCall={{...openCall, { favourite: true }}` to both `OpenCallHeader` and `OpenCallInvestorAndFooter` in `/pages/open-call/[id]/index.tsx`, to verify that the button icons get filled with a solid color when `favourite` is set to `true`

## Tracking

[LET-962](https://vizzuality.atlassian.net/browse/LET-962)
