### PR TITLE
feat: Notify investor owner when open call is destroyed via API

### DIFF
--- a/backend/app/controllers/api/v1/accounts/open_calls_controller.rb
+++ b/backend/app/controllers/api/v1/accounts/open_calls_controller.rb
@@ -40,6 +40,7 @@ module API
 
         def destroy
           @open_call.destroy!
+          InvestorMailer.open_call_destroyed(@open_call.investor, @open_call.name).deliver_later
           head :ok
         end
 

--- a/backend/app/mailers/investor_mailer.rb
+++ b/backend/app/mailers/investor_mailer.rb
@@ -1,0 +1,10 @@
+class InvestorMailer < ApplicationMailer
+  def open_call_destroyed(investor, open_call_name)
+    @user = investor.owner
+    @open_call_name = open_call_name
+
+    I18n.with_locale investor.account_language do
+      mail to: @user.email
+    end
+  end
+end

--- a/backend/app/views/investor_mailer/open_call_destroyed.html.erb
+++ b/backend/app/views/investor_mailer/open_call_destroyed.html.erb
@@ -1,0 +1,3 @@
+<h3><%= t "investor_mailer.greetings", full_name: @user.full_name %></h3>
+<p><%= t "investor_mailer.open_call_destroyed.content", open_call_name: @open_call_name %></p>
+<p><%= t "investor_mailer.farewell_html" %></p>

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -323,6 +323,12 @@ zu:
     project_destroyed:
       subject: Project has been removed.
       content: Project %{project_name} which you have been collaborator of have been removed.
+  investor_mailer:
+    greetings: Dear %{full_name},
+    farewell_html: Best Regards,<br />Your HeCo Team
+    open_call_destroyed:
+      subject: Open Call has been removed.
+      content: Open Call with name %{open_call_name} have been removed.
   enums:
     review_status:
       approved:

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -328,7 +328,7 @@ zu:
     farewell_html: Best Regards,<br />Your HeCo Team
     open_call_destroyed:
       subject: Open Call has been removed.
-      content: Open Call with name %{open_call_name} have been removed.
+      content: Open Call with name %{open_call_name} has been removed.
   enums:
     review_status:
       approved:

--- a/backend/spec/mailers/investor_mailer_spec.rb
+++ b/backend/spec/mailers/investor_mailer_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe InvestorMailer, type: :mailer do
+  let(:investor) { create :investor }
+  let(:open_call) { create :open_call, investor: investor }
+
+  describe ".open_call_destroyed" do
+    let(:mail) { InvestorMailer.open_call_destroyed investor, open_call.name }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq(I18n.t("investor_mailer.open_call_destroyed.subject"))
+      expect(mail.to).to eq([investor.owner.email])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match(I18n.t("investor_mailer.greetings", full_name: investor.owner.full_name))
+      expect(mail.body.encoded).to match(I18n.t("investor_mailer.open_call_destroyed.content", open_call_name: open_call.name))
+      expect(mail.body.encoded).to match(I18n.t("investor_mailer.farewell_html"))
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/accounts/open_calls_spec.rb
+++ b/backend/spec/requests/api/v1/accounts/open_calls_spec.rb
@@ -347,6 +347,12 @@ RSpec.describe "API V1 Account Open Calls", type: :request do
           }.to change(OpenCall, :count).by(-1)
         end
 
+        it "sends email that open call was destroyed to investor owner" do |example|
+          expect {
+            submit_request example.metadata
+          }.to have_enqueued_mail(InvestorMailer, :open_call_destroyed).with(open_call.investor, open_call.name)
+        end
+
         context "when slug is used" do
           let(:id) { open_call.slug }
 


### PR DESCRIPTION
Send notification to investor owner when his/her open call gets destroyed via API.

## Testing instructions

Via rswag -- check that you get e-mail when your open call is destroyed

## Tracking

https://vizzuality.atlassian.net/browse/LET-959