### PR TITLE
Fix LocationSelectors not using initial values to filter locations

### DIFF
--- a/frontend/containers/forms/location-selectors/component.stories.tsx
+++ b/frontend/containers/forms/location-selectors/component.stories.tsx
@@ -24,6 +24,7 @@ const Template: Story<LocationSelectorsTypes<FormValues>> = ({ fields }) => {
     control,
     formState: { errors },
     resetField,
+    getValues,
     handleSubmit,
   } = useForm<FormValues>();
 
@@ -40,6 +41,7 @@ const Template: Story<LocationSelectorsTypes<FormValues>> = ({ fields }) => {
         errors={errors}
         fields={fields}
         resetField={resetField}
+        getValues={getValues}
       />
       <Button className="my-4" type="submit">
         Submit

--- a/frontend/containers/forms/location-selectors/component.tsx
+++ b/frontend/containers/forms/location-selectors/component.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { FieldValues } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
@@ -22,12 +22,23 @@ export const LocationSelectors = <FormValues extends FieldValues>({
   fields,
 }: LocationSelectorsTypes<FormValues>) => {
   const { country, state, municipality } = fields;
+  const [countryFormValue, departmentFormValue] = getValues([country.fieldName, state.fieldName]);
+
   const { formatMessage } = useIntl();
   const { locations } = useGroupedLocations({ includes: 'parent' });
   const [locationsFilter, setLocationsFilter] = useState<{ country: string; department: string }>({
-    country: getValues(country.fieldName),
-    department: getValues(state.fieldName),
+    country: countryFormValue,
+    department: departmentFormValue,
   });
+
+  // This component may be mounted before all the data has been resolved. As such, we want to make
+  // sure `locationsFilter`is updated when/if the country and department form values change.
+  useEffect(() => {
+    setLocationsFilter({
+      country: countryFormValue,
+      department: departmentFormValue,
+    });
+  }, [countryFormValue, departmentFormValue]);
 
   const getOptions = useMemo(
     () => (locationType: LocationsTypes, filter: 'department' | 'country') => {

--- a/frontend/containers/forms/location-selectors/component.tsx
+++ b/frontend/containers/forms/location-selectors/component.tsx
@@ -18,14 +18,15 @@ export const LocationSelectors = <FormValues extends FieldValues>({
   control,
   errors,
   resetField,
+  getValues,
   fields,
 }: LocationSelectorsTypes<FormValues>) => {
   const { country, state, municipality } = fields;
   const { formatMessage } = useIntl();
   const { locations } = useGroupedLocations({ includes: 'parent' });
   const [locationsFilter, setLocationsFilter] = useState<{ country: string; department: string }>({
-    country: undefined,
-    department: undefined,
+    country: getValues(country.fieldName),
+    department: getValues(state.fieldName),
   });
 
   const getOptions = useMemo(

--- a/frontend/containers/forms/location-selectors/types.ts
+++ b/frontend/containers/forms/location-selectors/types.ts
@@ -4,6 +4,7 @@ import {
   FieldPath,
   Path,
   UseControllerProps,
+  UseFormGetValues,
   UseFormResetField,
 } from 'react-hook-form';
 
@@ -14,6 +15,8 @@ export type LocationSelectorsTypes<FormValues> = {
   control: Control<FormValues, FieldPath<FormValues>>;
   /** React-hook-form useForm resetField */
   resetField?: UseFormResetField<FormValues>;
+  /** React-hook-form useForm getValues */
+  getValues: UseFormGetValues<FormValues>;
   /** Fields displayed */
   fields: {
     country: {

--- a/frontend/containers/open-call-form/pages/information.tsx
+++ b/frontend/containers/open-call-form/pages/information.tsx
@@ -143,6 +143,7 @@ export const OpenCallInformation: FC<OpenCallInformationProps> = ({
           <LocationSelectors
             control={control}
             resetField={resetField}
+            getValues={getValues}
             errors={errors}
             fields={{
               country: { fieldName: 'country_id', required: true },

--- a/frontend/containers/project-form/pages/general-information.tsx
+++ b/frontend/containers/project-form/pages/general-information.tsx
@@ -200,6 +200,7 @@ const GeneralInformation = ({
           <LocationSelectors
             control={control}
             resetField={resetField}
+            getValues={getValues}
             errors={errors}
             fields={{
               country: { fieldName: 'country_id', required: true },


### PR DESCRIPTION
## Description

This PR is a quick fix for the bug described on JIRA [here](https://vizzuality.atlassian.net/browse/LET-266?focusedCommentId=18710). 

When editing a form with `LocationSelectors`, the component was not setting `locationsFilter`'s `country` and `department`, causing the locations in the dropdown to not be filtered initially. 

## Testing instructions

1. Create an open call  
2. Go back to the dashboard, and edit the already created open call  

Verify that `municipality` is filtered correctly. 

## Tracking

N/A
