### PR TITLE
feat: Verify/Unverify/Delete open call at backoffice

### DIFF
--- a/backend/app/assets/stylesheets/application.tailwind.css
+++ b/backend/app/assets/stylesheets/application.tailwind.css
@@ -83,11 +83,11 @@
     @apply block px-4 py-2 text-base text-gray-900 placeholder-gray-400 placeholder-opacity-100 border border-solid border-beige hover:shadow-sm focus:shadow-sm focus:border-green-dark outline-none bg-white rounded-lg disabled:opacity-60 transition
   }
 
-  li[role="menuitem"] a {
-    @apply block px-8 py-2 hover:bg-gray-200;
+  li[role="menuitem"] a, li[role="menuitem"] button {
+    @apply block px-8 py-2 w-full hover:bg-gray-200;
   }
 
   li[role="menuitem"] .disabled-item {
-    @apply block px-8 py-2 opacity-60;
+    @apply block px-8 py-2 w-full opacity-60;
   }
 }

--- a/backend/app/controllers/backoffice/open_calls_controller.rb
+++ b/backend/app/controllers/backoffice/open_calls_controller.rb
@@ -1,8 +1,11 @@
 module Backoffice
   class OpenCallsController < BaseController
+    before_action :fetch_open_call, only: [:destroy, :verify, :unverify]
+
     def index
       @q = OpenCall.ransack params[:q]
       @open_calls = @q.result.includes(:country, :municipality, :department, investor: [:account])
+      @open_calls = @open_calls.order(:created_at)
 
       respond_to do |format|
         format.html do
@@ -14,6 +17,31 @@ module Backoffice
             type: "text/csv; charset=utf-8"
         end
       end
+    end
+
+    def destroy
+      @open_call.destroy!
+      InvestorMailer.open_call_destroyed(@open_call.investor, @open_call.name).deliver_later
+
+      redirect_to backoffice_open_calls_path, status: :see_other, notice: t("backoffice.messages.success_delete", model: t("backoffice.common.open_call"))
+    end
+
+    def verify
+      @open_call.update! trusted: true
+
+      redirect_back fallback_location: backoffice_open_calls_path
+    end
+
+    def unverify
+      @open_call.update! trusted: false
+
+      redirect_back fallback_location: backoffice_open_calls_path
+    end
+
+    private
+
+    def fetch_open_call
+      @open_call = OpenCall.find(params[:id])
     end
   end
 end

--- a/backend/app/views/backoffice/open_calls/index.html.erb
+++ b/backend/app/views/backoffice/open_calls/index.html.erb
@@ -21,18 +21,42 @@
     <th>
       <%= sort_link @q, :trusted, t("backoffice.common.status") %>
     </th>
+    <th class="opacity-25">
+      <%= svg "menu" %>
+    </th>
   </tr>
   </thead>
   <tbody>
-  <% @open_calls.each do |p| %>
+  <% @open_calls.each do |open_call| %>
     <tr>
-      <td><%= p.name %></td>
-      <td><%= p.investor.name %></td>
-      <td><%= [p.municipality&.name, p.department&.name, p.country&.name].compact.join(", ") %></td>
-      <td><%= p.open_call_applications_count %></td>
+      <td><%= open_call.name %></td>
+      <td><%= open_call.investor.name %></td>
+      <td><%= [open_call.municipality&.name, open_call.department&.name, open_call.country&.name].compact.join(", ") %></td>
+      <td><%= open_call.open_call_applications_count %></td>
       <td>
-        <%= status_tag :verified, t('backoffice.common.verified') if p.trusted?  %>
-        <%= status_tag :unverified, t('backoffice.common.unverified') unless p.trusted?  %>
+        <%= status_tag :verified, t('backoffice.common.verified') if open_call.trusted?  %>
+        <%= status_tag :unverified, t('backoffice.common.unverified') unless open_call.trusted?  %>
+      </td>
+      <td>
+        <%= render "menu" do %>
+          <% if open_call.trusted? %>
+            <%= render "backoffice/base/menu/item" do %>
+              <%= button_to t("backoffice.common.unverify"), unverify_backoffice_open_call_path(open_call.id), method: :post %>
+            <% end %>
+          <% end %>
+          <% unless open_call.trusted? %>
+            <%= render "backoffice/base/menu/item" do %>
+              <%= button_to t("backoffice.common.verify"), verify_backoffice_open_call_path(open_call.id), method: :post %>
+            <% end %>
+          <% end %>
+          <%= render "backoffice/base/menu/item" do %>
+            <%= link_to t("backoffice.common.delete"), backoffice_open_call_path(open_call.id),
+               data: {
+                 turbo_method: :delete,
+                 turbo_confirm: t("backoffice.messages.delete_confirmation", model: t("backoffice.common.open_call").downcase)
+               } %>
+          <% end %>
+        <% end %>
       </td>
     </tr>
   <% end %>

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -153,11 +153,14 @@ zu:
       project: Project
       admin: Administrator
       user: User
+      open_call: Open Call
       category: Category
       mosaic: Mosaic
       priority_landscapes: Priority landscapes
       verified: Verified
+      verify: Verify
       unverified: Unverified
+      unverify: Unverify
       edit: Edit
       save: Save
       cancel: Cancel

--- a/backend/config/routes/backoffice.rb
+++ b/backend/config/routes/backoffice.rb
@@ -19,7 +19,12 @@ namespace :backoffice do
   resources :investors, only: [:index, :edit, :update, :destroy]
   resources :project_developers, only: [:index, :edit, :update, :destroy]
   resources :projects, only: [:index, :edit, :update, :destroy]
-  resources :open_calls, only: [:index]
+  resources :open_calls, only: [:index, :destroy] do
+    member do
+      post :verify
+      post :unverify
+    end
+  end
   resources :admins
   resources :users, only: [:index, :edit, :update, :destroy]
 end

--- a/backend/spec/system/backoffice/open_calls_spec.rb
+++ b/backend/spec/system/backoffice/open_calls_spec.rb
@@ -62,5 +62,44 @@ RSpec.describe "Backoffice: Open Calls", type: :system do
         end
       end
     end
+
+    context "when deleting open call via menu" do
+      it "deletes open call" do
+        within_row(open_call.name) do
+          find("button.rounded-full").click
+          expect {
+            accept_confirm do
+              click_on t("backoffice.common.delete")
+            end
+          }.to have_enqueued_mail(InvestorMailer, :open_call_destroyed).with(open_call.investor, open_call.name)
+        end
+        expect(page).not_to have_text(open_call.name)
+      end
+    end
+
+    context "when unverifying open call via menu" do
+      it "unverifies open call" do
+        within_row(open_call.name) do
+          find("button.rounded-full").click
+          click_on t("backoffice.common.unverify")
+          expect(page).to have_text(I18n.t("backoffice.common.unverified"))
+        end
+      end
+    end
+
+    context "when verifying open call via menu" do
+      before do
+        open_call.update! trusted: false
+        visit "/backoffice/open_calls"
+      end
+
+      it "verifies open call" do
+        within_row(open_call.name) do
+          find("button.rounded-full").click
+          click_on t("backoffice.common.verify")
+          expect(page).to have_text(I18n.t("backoffice.common.verified"))
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR adds new actions to open call menu at backoffice. New actions are:
 - verify
 - unverify
 - delete

![Screenshot 2022-08-24 at 13 54 36](https://user-images.githubusercontent.com/20660167/186414438-8f858ce9-c687-402e-91f9-0e866cbbcf35.png)

## Testing instructions

At backoffice -- check that you can verify/unverify open call. It should be also possible to destroy open call via link at menu.

## Tracking

https://vizzuality.atlassian.net/browse/LET-908
https://vizzuality.atlassian.net/browse/LET-907
