### PR TITLE
Fix project page info card being displayed above the header

### DIFF
--- a/frontend/containers/project-page/header/component.tsx
+++ b/frontend/containers/project-page/header/component.tsx
@@ -144,7 +144,7 @@ export const Header: FC<HeaderProps> = ({ className, project }: HeaderProps) => 
           )}
           <p>{project.description}</p>
         </div>
-        <div className="lg:mr-4 p-6 bg-white drop-shadow-xl pb-16 lg:pb-8 lg:mb-[-70%] h-full lg:translate-y-[-70%] lg:max-w-4/12 rounded-2xl mt-8 lg:mt-0 flex flex-col">
+        <div className="lg:mr-4 p-6 bg-white drop-shadow-xl mb-16 pb-16 lg:pb-8 lg:mb-[-70%] h-full lg:translate-y-[-70%] lg:max-w-4/12 rounded-2xl mt-8 lg:mt-0 flex flex-col">
           {project.looking_for_funding ? (
             <div className="flex flex-col gap-8 md:flex-row">
               <div className="flex flex-col items-start justify-end w-full gap-2 text-center md:min-w-1/2">

--- a/frontend/containers/project-page/header/component.tsx
+++ b/frontend/containers/project-page/header/component.tsx
@@ -144,7 +144,7 @@ export const Header: FC<HeaderProps> = ({ className, project }: HeaderProps) => 
           )}
           <p>{project.description}</p>
         </div>
-        <div className="lg:mr-4 p-6 bg-white drop-shadow-xl pb-16 lg:pb-8 lg:mb-[-70%] h-full lg:translate-y-[-70%] lg:max-w-4/12 rounded-2xl mt-8 lg:mt-0 flex flex-col z-30">
+        <div className="lg:mr-4 p-6 bg-white drop-shadow-xl pb-16 lg:pb-8 lg:mb-[-70%] h-full lg:translate-y-[-70%] lg:max-w-4/12 rounded-2xl mt-8 lg:mt-0 flex flex-col">
           {project.looking_for_funding ? (
             <div className="flex flex-col gap-8 md:flex-row">
               <div className="flex flex-col items-start justify-end w-full gap-2 text-center md:min-w-1/2">


### PR DESCRIPTION
## Description

This PR fixes the info card on the project page header being displayed above the header when scrolling. 

## Testing instructions

Verify that, when scrolling on a project public page, the info card is not displayed above the header. 

## Tracking

[LET-995](https://vizzuality.atlassian.net/browse/LET-995)

## Screenshot  
<img width="818" alt="Screenshot 2022-08-24 at 14 07 30" src="https://user-images.githubusercontent.com/6273795/186426360-dffa9c7f-0ddb-4686-b391-dcfb7a22651c.png">

