### PR TITLE
Fix incorrect opencall api url (favoriting)

### DIFF
--- a/frontend/services/open-call/open-call-service.ts
+++ b/frontend/services/open-call/open-call-service.ts
@@ -188,7 +188,7 @@ export const useFavoriteOpenCall = () => {
   ): Promise<OpenCall> => {
     const config: AxiosRequestConfig = {
       method: isFavourite ? 'DELETE' : 'POST',
-      url: `/api/v1/open-calls/${openCallId}/favourite_open_call`,
+      url: `/api/v1/open_calls/${openCallId}/favourite_open_call`,
       data: { open_call_id: openCallId },
     };
 


### PR DESCRIPTION
## Description

The endpoint url used by the frontend to favourite/unfavourite open calls has a mistake, this is a quick fix. 

## Testing instructions

Verify that favouriting/unfavouriting open calls works correctly. 

## Tracking

[LET-1000](https://vizzuality.atlassian.net/browse/LET-1000)
