### PR TITLE
Display 0-10 total impact scores

### DIFF
--- a/frontend/containers/impact-text/component.tsx
+++ b/frontend/containers/impact-text/component.tsx
@@ -49,10 +49,7 @@ export const ImpactText: FC<ImpactTextProps> = ({ className, area, impact }) => 
     [allImpacts, highestImpactId]
   );
 
-  const impactScore = useMemo(
-    () => (impact?.total ? Math.round(impact?.total * 10) : null),
-    [impact]
-  );
+  const impactScore = useMemo(() => impact?.total?.toFixed(1) ?? null, [impact]);
 
   if (isLoadingAllImpacts) return null;
 

--- a/frontend/containers/modals/impact/component.tsx
+++ b/frontend/containers/modals/impact/component.tsx
@@ -78,7 +78,7 @@ export const ImpactModal: React.FC<ImpactModalProps> = ({
         </div>
         <div className="max-w-md mx-auto">
           <Image
-            src="/images/about-impact-chart.svg"
+            src="/images/about/about-impact-chart.svg"
             width={308}
             height={252}
             layout="intrinsic"

--- a/frontend/containers/project-page/impact/component.tsx
+++ b/frontend/containers/project-page/impact/component.tsx
@@ -27,10 +27,7 @@ export const Impact: React.FC<ImpactProps> = ({ project, enums }: ImpactProps) =
   const intl = useIntl();
 
   const impact = useMemo(() => projectImpact(project)[impactLocation], [impactLocation, project]);
-  const impactScore = useMemo(
-    () => (impact?.total ? Math.round(impact?.total * 10) : null),
-    [impact]
-  );
+  const impactScore = useMemo(() => impact?.total?.toFixed(1) ?? null, [impact]);
   const targetGroups = enums?.project_target_group?.filter((targetGroup) =>
     project.target_groups?.includes(targetGroup.id)
   );
@@ -156,7 +153,7 @@ export const Impact: React.FC<ImpactProps> = ({ project, enums }: ImpactProps) =
               {impactScore && (
                 <div className="flex-col items-center hidden p-6 font-semibold bg-white lg:flex w-52 rounded-xl">
                   <p className=" text-green-dark">
-                    <span className="text-2xl">{impactScore}</span>/ 100
+                    <span className="text-2xl">{impactScore}</span>/ 10
                   </p>
                   <div className="flex items-center space-x-2">
                     <p className="text-base text-gray-800">
@@ -170,8 +167,8 @@ export const Impact: React.FC<ImpactProps> = ({ project, enums }: ImpactProps) =
                       content={
                         <div className="max-w-md p-2 font-sans text-sm font-normal text-white bg-black rounded-sm w-72">
                           <FormattedMessage
-                            defaultMessage="Integration of project impact in each dimension (climate, biodiversity, water community) into a single score, ranging from 0 to 100."
-                            id="sFn7MX"
+                            defaultMessage="Integration of project impact in each dimension (climate, biodiversity, water community) into a single score, ranging from 0 to 10."
+                            id="Kg0xQM"
                           />
                         </div>
                       }
@@ -194,7 +191,7 @@ export const Impact: React.FC<ImpactProps> = ({ project, enums }: ImpactProps) =
             {impactScore && (
               <div className="flex flex-col items-center p-6 font-semibold bg-white lg:hidden w-52 rounded-xl">
                 <p className="text-green-dark">
-                  <span className="text-2xl">{impactScore}</span>/ 100
+                  <span className="text-2xl">{impactScore}</span>/ 10
                 </p>
                 <div className="flex items-center space-x-2">
                   <p className="text-base text-gray-800">
@@ -208,8 +205,8 @@ export const Impact: React.FC<ImpactProps> = ({ project, enums }: ImpactProps) =
                     content={
                       <div className="max-w-md p-2 font-sans text-sm font-normal text-white bg-black rounded-sm w-72">
                         <FormattedMessage
-                          defaultMessage="Integration of project impact in each dimension (climate, biodiversity, water community) into a single score, ranging from 0 to 100."
-                          id="sFn7MX"
+                          defaultMessage="Integration of project impact in each dimension (climate, biodiversity, water community) into a single score, ranging from 0 to 10."
+                          id="Kg0xQM"
                         />
                       </div>
                     }

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -1032,6 +1032,9 @@
   "KcJ5IK": {
     "string": "Select the deadline for this open call."
   },
+  "Kg0xQM": {
+    "string": "Integration of project impact in each dimension (climate, biodiversity, water community) into a single score, ranging from 0 to 10."
+  },
   "KkT/Fh": {
     "string": "Update password"
   },
@@ -2498,9 +2501,6 @@
   },
   "s63oNj": {
     "string": "Are you sure you want to delete your user? You can't undo this action and you will lose your access to the platform."
-  },
-  "sFn7MX": {
-    "string": "Integration of project impact in each dimension (climate, biodiversity, water community) into a single score, ranging from 0 to 100."
   },
   "sH3zMa": {
     "string": "Launched"

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -70,6 +70,7 @@ module.exports = {
       decimal: 'decimal',
       'lower-latin': 'lower-latin',
       'lower-roman': 'lower-roman',
+      disc: 'disc',
     },
     extend: {
       spacing: {


### PR DESCRIPTION
This PR displays all the total impact scores in a 0-10 scale, with a precision of one decimal. It also fixes the display of the “How is the impact calculated?” modal on the project public page.

## Testing instructions

- On Discover, inside the project details card, the total impact score is between 0 and 10, with one decimal
- On the public page of projects, below the “Estimated impact” section, the total impact score is between 0 and 10, with one decimal
- On the public page of projects, the tooltip next to “Impact score” explains that the score is between 0 and 10
- On the public page of projects, inside the “How is the impact calculated?” modal, the image and bullet points are displayed

## Tracking

[LET-981](https://vizzuality.atlassian.net/browse/LET-981)