### PR TITLE
Tweak the styles of the open call public page

### DIFF
--- a/frontend/containers/open-call-page/header/component.tsx
+++ b/frontend/containers/open-call-page/header/component.tsx
@@ -110,7 +110,7 @@ export const OpenCallHeader: FC<OpenCallHeaderProps> = ({
             )}
             <p>{openCall.description}</p>
           </div>
-          <div className="flex flex-col justify-start lg:mr-4 p-6 bg-white drop-shadow-xl lg:mb-[-70%] h-full lg:translate-y-[-70%] lg:max-w-1/3 rounded-2xl mt-8 lg:mt-0">
+          <div className="mb-10 flex flex-col justify-start lg:mr-4 p-6 bg-white drop-shadow-xl lg:mb-[-70%] h-full lg:translate-y-[-70%] lg:max-w-1/3 rounded-2xl mt-8 lg:mt-0">
             <>
               <div className="flex flex-col gap-8 pl-2 sm:gap-11 sm:flex-row sm:justify-between">
                 <div className="flex flex-col items-center justify-end gap-2 sm:items-start">

--- a/frontend/containers/open-call-page/header/component.tsx
+++ b/frontend/containers/open-call-page/header/component.tsx
@@ -90,7 +90,7 @@ export const OpenCallHeader: FC<OpenCallHeaderProps> = ({
         >
           <LayoutContainer>
             <div className="mb-8 text-center lg:w-1/2 lg:text-left">
-              <h1 className="font-serif text-3xl text-white">{name}</h1>
+              <h1 className="font-serif text-2xl text-white lg:text-4xl">{name}</h1>
             </div>
           </LayoutContainer>
         </div>

--- a/frontend/containers/open-call-page/overview/component.tsx
+++ b/frontend/containers/open-call-page/overview/component.tsx
@@ -10,8 +10,8 @@ export const Overview: FC<OpenCallOverviewTypes> = ({ openCall }) => {
   const { country, municipality, department } = openCall;
 
   return (
-    <LayoutContainer id="overview" className="my-20 lg:mb-28">
-      <section className="p-4 font-serif lg:flex sm:p-6 rounded-2xl">
+    <LayoutContainer id="overview" className="mt-10 mb-20 lg:mb-28">
+      <LayoutContainer className="font-serif lg:flex">
         <div className="flex flex-col gap-10 lg:justify-between lg:flex-row">
           <div className="flex flex-col space-y-4 lg:mb-12 lg:w-1/2">
             <h2 className="text-2xl lg:text-3xl">
@@ -43,7 +43,7 @@ export const Overview: FC<OpenCallOverviewTypes> = ({ openCall }) => {
             </div>
           </div>
         </div>
-      </section>
+      </LayoutContainer>
     </LayoutContainer>
   );
 };

--- a/frontend/containers/project-page/header/component.tsx
+++ b/frontend/containers/project-page/header/component.tsx
@@ -123,7 +123,7 @@ export const Header: FC<HeaderProps> = ({ className, project }: HeaderProps) => 
           </div>
           <div className="text-center lg:mb-4 lg:text-left">
             <div className="lg:w-6/12">
-              <h1 className="font-serif text-3xl text-white">{project.name}</h1>
+              <h1 className="font-serif text-2xl text-white lg:text-4xl">{project.name}</h1>
             </div>
           </div>
         </LayoutContainer>

--- a/frontend/containers/project-page/header/component.tsx
+++ b/frontend/containers/project-page/header/component.tsx
@@ -144,7 +144,7 @@ export const Header: FC<HeaderProps> = ({ className, project }: HeaderProps) => 
           )}
           <p>{project.description}</p>
         </div>
-        <div className="lg:mr-4 p-6 bg-white drop-shadow-xl mb-16 pb-16 lg:pb-8 lg:mb-[-70%] h-full lg:translate-y-[-70%] lg:max-w-4/12 rounded-2xl mt-8 lg:mt-0 flex flex-col">
+        <div className="lg:mr-4 p-6 bg-white drop-shadow-xl mb-16 lg:pb-8 lg:mb-[-70%] h-full lg:translate-y-[-70%] lg:max-w-4/12 rounded-2xl mt-8 lg:mt-0 flex flex-col">
           {project.looking_for_funding ? (
             <div className="flex flex-col gap-8 md:flex-row">
               <div className="flex flex-col items-start justify-end w-full gap-2 text-center md:min-w-1/2">
@@ -215,7 +215,7 @@ export const Header: FC<HeaderProps> = ({ className, project }: HeaderProps) => 
               <FormattedMessage defaultMessage="Contact" id="zFegDD" />
             </Button>
           </div>
-          <div className="flex justify-center mt-4 lg:mt-0">
+          <div className="flex justify-center">
             <ShareIcons title={project.name} />
           </div>
         </div>

--- a/frontend/containers/project-page/overview/component.tsx
+++ b/frontend/containers/project-page/overview/component.tsx
@@ -33,7 +33,7 @@ export const Overview: React.FC<OverviewProps> = ({ project }: OverviewProps) =>
       <section className="p-4 mt-32 font-serif text-white sm:p-6 lg:mt-48 lg:p-16 bg-green-dark rounded-2xl">
         <div className="relative grid w-full grid-cols-1 gap-12 lg:grid-cols-2">
           <Map
-            className="absolute z-10 -mb-32 border-8 border-white drop-shadow-xl h-96 -top-44 lg:overflow-hidden rounded-xl"
+            className="absolute z-10 -mb-32 border-8 border-white drop-shadow-xl h-96 -top-28 lg:-top-44 lg:overflow-hidden rounded-xl"
             onMapViewportChange={handleViewportChange}
             bounds={bounds}
             viewport={viewport}

--- a/frontend/containers/share-icons/component.tsx
+++ b/frontend/containers/share-icons/component.tsx
@@ -3,8 +3,6 @@ import { FC, useState } from 'react';
 import { Facebook, Link, Mail, Twitter } from 'react-feather';
 import { FormattedMessage, useIntl } from 'react-intl';
 
-import classNames from 'classnames';
-
 import { useRouter } from 'next/router';
 
 import Button from 'components/button';
@@ -62,12 +60,7 @@ export const ShareIcons: FC<ShareIconsProps> = ({ title }) => {
   };
 
   return (
-    <div
-      className={classNames('self-center h-0', {
-        'translate-y-12': !isProjectPage,
-        'lg:translate-y-12': isProjectPage,
-      })}
-    >
+    <div className="absolute self-center translate-y-full -bottom-4">
       <div className="flex items-center gap-2">
         <span className="mr-2 text-sm leading-6 text-gray-600">
           <FormattedMessage defaultMessage="Share" id="OKhRC6" />
@@ -146,7 +139,7 @@ export const ShareIcons: FC<ShareIconsProps> = ({ title }) => {
         </Tooltip>
       </div>
       {copied && (
-        <div className="-translate-x-10 translate-y-4 absolute min-w-fit">
+        <div className="absolute -translate-x-10 translate-y-4 min-w-fit">
           <Toast
             id="copied-success"
             level="success"


### PR DESCRIPTION
This PR tweaks the spacing and font size of the top elements of the open call public page. The changes have been ported back to the project public page for consistency.

## Testing instructions

- The title of the page should be 56px
- The space between the description and the “Location” title should be around 40px

## Tracking

[LET-1005](https://vizzuality.atlassian.net/browse/LET-1005)
