### PR TITLE
Fixes inconsistencies in displayed languages for first time users (mostly)

### DIFF
--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import { IntlProvider } from 'react-intl';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider as ReduxProvider } from 'react-redux';
@@ -9,6 +11,8 @@ import { I18nProvider } from '@react-aria/i18n';
 import { OverlayProvider } from '@react-aria/overlays';
 import { SSRProvider } from '@react-aria/ssr';
 import { Hydrate } from 'react-query/hydration';
+
+import { getCookie, setCookie } from 'helpers/cookies';
 
 import StaticPageLayout from 'layouts/static-page';
 import store from 'store';
@@ -44,6 +48,32 @@ const HeCoApp: React.FC<AppProps> = ({ Component, pageProps }: Props) => {
       layoutProps = Component.layout.props;
     }
   }
+
+  // WARN: do not modify without knowing exactly what are the consequences
+  // When the user visits any page, Next.js determines the supported locale the user is using:
+  // https://nextjs.org/docs/advanced-features/i18n-routing#automatic-locale-detection
+  // This locale is the one that can be retrieved through the `useRouter` hook as well as the one
+  // used by the server-side requests made through the `withLocalizedRequests` HOC.
+  // The client requests are also localized by default when using the axios instances in
+  // `services/api.ts`, nevertheless, they don't rely on Next.js `locale` attribute but rather on
+  // the `NEXT_LOCALE` cookie since we can't have access to the Next.js hook there. If no cookie is
+  // set, then the requests fallbacks to the default locale set in `locales.config.json`.
+  // Look at this example:
+  // - The user's browser is set in English
+  // - The application's default locale is Spanish
+  // - This is the user's first visit
+  // - If the user goes on a fully static page (such as the homepage) all of its content will be
+  //   displayed in English (Next.js determines the locale based on the `Accept-Language` header)
+  // - If the user goes to a non-static page (such as Discover), all the content rendered on the
+  //   server will be in English, but all the requests made on the client will fetch content in
+  //   Spanish since no `NEXT_LOCALE` cookie exists
+  // For this reason, we want to always set the cookie on the first given opportunity.
+  useEffect(() => {
+    if (!getCookie('NEXT_LOCALE')) {
+      // Set a cookie for 1 year
+      setCookie('NEXT_LOCALE', `${locale}; path=/; max-age=31536000; secure`);
+    }
+  }, [locale]);
 
   return (
     <IntlProvider


### PR DESCRIPTION
This PR fixes an issue where requests made on the client could use the application's default locale instead of the locale detected by Next.js. This would result in pages with a mix of two languages:
- The server-side content would render in the locale detected by Next.js
- The content coming from client-side requests would be in the application's default locale

## Testing instructions

This steps can be replicated with either Chrome or Firefox.

1. Set your browser to English
2. If you have any private windows opened, close them
3. Open a new private window
4. Open the homepage

The whole content will be in English.

5. Navigate to the Discover page

The whole content should be in English. Particularly, have a look at the projects cards, since this is what was displayed in Spanish (the app's default language).

## Tracking

- [LET-958](https://vizzuality.atlassian.net/browse/LET-958)
- [LET-948](https://vizzuality.atlassian.net/browse/LET-948) (likely to be the same issue; to test it follow the same steps but sign up as a PD and check if the dropdown options are in English)
