### PR TITLE
feat: Impact Area enum contains Impact flag

### DIFF
--- a/backend/app/models/impact.rb
+++ b/backend/app/models/impact.rb
@@ -1,12 +1,7 @@
 class Impact
   include EnumModel
 
-  TYPES = %w[
-    biodiversity
-    climate
-    water
-    community
-  ].freeze
+  TYPES = ImpactArea::TYPES_WITH_GROUPS.keys
 
   def description
     read_attribute("description")

--- a/backend/app/models/impact_area.rb
+++ b/backend/app/models/impact_area.rb
@@ -1,19 +1,15 @@
 class ImpactArea
   include EnumModel
 
-  TYPES = %w[
-    conservation
-    restoration
-    pollutants-reduction
-    carbon-emission-reduction
-    energy-efficiency
-    renewable-energy
-    carbon-storage-or-sequestration
-    water-capacity-or-efficiency
-    hydrometerological-risk-reduction
-    sustainable-food
-    gender-equality-jobs
-    indigenous-or-ethic-jobs
-    community-empowerment
-  ].freeze
+  TYPES_WITH_GROUPS = {
+    "biodiversity" => %w[conservation restoration pollutants-reduction],
+    "climate" => %w[carbon-emission-reduction energy-efficiency renewable-energy carbon-storage-or-sequestration],
+    "water" => %w[water-capacity-or-efficiency hydrometerological-risk-reduction sustainable-food],
+    "community" => %w[gender-equality-jobs indigenous-or-ethic-jobs community-empowerment]
+  }.freeze
+  TYPES = TYPES_WITH_GROUPS.values.flatten
+
+  def impact
+    TYPES_WITH_GROUPS.invert.detect { |k, _| k.include? id }.last
+  end
 end

--- a/backend/app/serializers/api/v1/enums/impact_area_serializer.rb
+++ b/backend/app/serializers/api/v1/enums/impact_area_serializer.rb
@@ -3,6 +3,8 @@ module API
     module Enums
       class ImpactAreaSerializer
         include EnumSerializer
+
+        attribute :impact
       end
     end
   end

--- a/backend/app/views/backoffice/projects/_form.html.erb
+++ b/backend/app/views/backoffice/projects/_form.html.erb
@@ -51,7 +51,12 @@
   <h2 class="mb-4 mt-6 text-gray-600 font-semibold text-xl">
     <%= t(".impact") %>
   </h2>
-  <%= f.input :impact_areas, collection: ImpactArea.all, label: t("simple_form.labels.project.impact_areas"), as: :check_boxes %>
+  <%= f.label :impact_areas %>
+  <div class="ml-2">
+    <% ImpactArea::TYPES_WITH_GROUPS.each do |impact, impact_areas| %>
+      <%= f.input :impact_areas, collection: impact_areas, label: Impact.find(impact).to_s, required: false, as: :check_boxes %>
+    <% end %>
+  </div>
   <%= f.input :sdgs, collection: Sdg.all, label: t("simple_form.labels.project.sdgs"), as: :check_boxes %>
 
   <h2 class="mb-4 mt-6 text-gray-600 font-semibold text-xl">

--- a/backend/app/views/backoffice/projects/_form.html.erb
+++ b/backend/app/views/backoffice/projects/_form.html.erb
@@ -54,7 +54,7 @@
   <%= f.label :impact_areas %>
   <div class="ml-2">
     <% ImpactArea::TYPES_WITH_GROUPS.each do |impact, impact_areas| %>
-      <%= f.input :impact_areas, collection: impact_areas, label: Impact.find(impact).to_s, required: false, as: :check_boxes %>
+      <%= f.input :impact_areas, collection: ImpactArea.find_many(impact_areas), label: Impact.find(impact).to_s, required: false, as: :check_boxes %>
     <% end %>
   </div>
   <%= f.input :sdgs, collection: Sdg.all, label: t("simple_form.labels.project.sdgs"), as: :check_boxes %>

--- a/backend/spec/fixtures/snapshots/api/v1/enums.json
+++ b/backend/spec/fixtures/snapshots/api/v1/enums.json
@@ -81,91 +81,104 @@
       "id": "conservation",
       "type": "impact_area",
       "attributes": {
-        "name": "Conservation"
+        "name": "Conservation",
+        "impact": "biodiversity"
       }
     },
     {
       "id": "restoration",
       "type": "impact_area",
       "attributes": {
-        "name": "Restoration"
+        "name": "Restoration",
+        "impact": "biodiversity"
       }
     },
     {
       "id": "pollutants-reduction",
       "type": "impact_area",
       "attributes": {
-        "name": "Pollutants reduction"
+        "name": "Pollutants reduction",
+        "impact": "biodiversity"
       }
     },
     {
       "id": "carbon-emission-reduction",
       "type": "impact_area",
       "attributes": {
-        "name": "Carbon emission reduction"
+        "name": "Carbon emission reduction",
+        "impact": "climate"
       }
     },
     {
       "id": "energy-efficiency",
       "type": "impact_area",
       "attributes": {
-        "name": "Energy efficiency"
+        "name": "Energy efficiency",
+        "impact": "climate"
       }
     },
     {
       "id": "renewable-energy",
       "type": "impact_area",
       "attributes": {
-        "name": "Renewable energy"
+        "name": "Renewable energy",
+        "impact": "climate"
       }
     },
     {
       "id": "carbon-storage-or-sequestration",
       "type": "impact_area",
       "attributes": {
-        "name": "Carbon storage or sequestration"
+        "name": "Carbon storage or sequestration",
+        "impact": "climate"
       }
     },
     {
       "id": "water-capacity-or-efficiency",
       "type": "impact_area",
       "attributes": {
-        "name": "Water capacity or efficiency"
+        "name": "Water capacity or efficiency",
+        "impact": "water"
       }
     },
     {
       "id": "hydrometerological-risk-reduction",
       "type": "impact_area",
       "attributes": {
-        "name": "Hydrometerological risk reduction"
+        "name": "Hydrometerological risk reduction",
+        "impact": "water"
       }
     },
     {
       "id": "sustainable-food",
       "type": "impact_area",
       "attributes": {
-        "name": "Sustainable food"
+        "name": "Sustainable food",
+        "impact": "water"
       }
     },
     {
       "id": "gender-equality-jobs",
       "type": "impact_area",
       "attributes": {
-        "name": "Gender equality jobs"
+        "name": "Gender equality jobs",
+        "impact": "community"
       }
     },
     {
       "id": "indigenous-or-ethic-jobs",
       "type": "impact_area",
       "attributes": {
-        "name": "Indigenous or ethic jobs"
+        "name": "Indigenous or ethic jobs",
+        "impact": "community"
       }
     },
     {
       "id": "community-empowerment",
       "type": "impact_area",
       "attributes": {
-        "name": "Community empowerment"
+        "name": "Community empowerment",
+        "impact": "community"
       }
     },
     {


### PR DESCRIPTION
This PR adds `impact` flag to `ImpactArea` enum. Value of this flag corresponds always to values from `Impact` enum (`biodiversity`, `climate`, etc.).

![Screenshot 2022-08-26 at 12 43 07](https://user-images.githubusercontent.com/20660167/186887190-f6191e95-8832-4231-8865-bfe3e22c2f27.png)

## Testing instructions

Via Rswag doc: enum for impact areas should contain impact group. Via backoffice: Impact areas at Project form should be grouped.

## Tracking

https://vizzuality.atlassian.net/browse/LET-968
