### PR TITLE
Project developers can apply to an open call

### DIFF
--- a/frontend/components/forms/combobox/component.tsx
+++ b/frontend/components/forms/combobox/component.tsx
@@ -25,6 +25,7 @@ export const Combobox = <FormValues extends FieldValues, T extends object>({
   direction = 'bottom',
   control,
   controlOptions,
+  height,
   ...rest
 }: ComboboxProps<FormValues, T>) => {
   const {
@@ -109,7 +110,7 @@ export const Combobox = <FormValues extends FieldValues, T extends object>({
           onClose={state.close}
           direction={direction}
         >
-          <Listbox {...listboxProps} listBoxRef={listboxRef} state={state} />
+          <Listbox {...listboxProps} height={height} listBoxRef={listboxRef} state={state} />
         </Popover>
       )}
     </div>

--- a/frontend/components/forms/combobox/types.ts
+++ b/frontend/components/forms/combobox/types.ts
@@ -1,13 +1,8 @@
-import {
-  Path,
-  Control,
-  RegisterOptions,
-  FieldPath,
-  UseControllerProps,
-  UseFormResetField,
-} from 'react-hook-form';
+import { Path, Control, RegisterOptions, FieldPath, UseControllerProps } from 'react-hook-form';
 
 import type { ComboBoxProps } from '@react-types/combobox';
+
+import { ListboxProps } from '../select/listbox';
 
 export type ComboboxProps<FormValues, T extends object> = {
   /** ID of the input */
@@ -27,13 +22,14 @@ export type ComboboxProps<FormValues, T extends object> = {
     /** Whether the input is disabled */
     disabled?: boolean;
   };
-} & Omit<
-  ComboBoxProps<T>,
-  | keyof RegisterOptions<FormValues, FieldPath<FormValues>>
-  | 'name'
-  | 'isDisabled'
-  | 'isRequired'
-  | 'inputValue'
-  | 'defaultInputValue'
-  | 'onInputChange'
->;
+} & Pick<ListboxProps, 'height'> &
+  Omit<
+    ComboBoxProps<T>,
+    | keyof RegisterOptions<FormValues, FieldPath<FormValues>>
+    | 'name'
+    | 'isDisabled'
+    | 'isRequired'
+    | 'inputValue'
+    | 'defaultInputValue'
+    | 'onInputChange'
+  >;

--- a/frontend/components/forms/select/listbox/component.tsx
+++ b/frontend/components/forms/select/listbox/component.tsx
@@ -2,17 +2,27 @@ import React, { useRef } from 'react';
 
 import { useListBox } from 'react-aria';
 
+import cx from 'classnames';
+
 import Option from '../option';
 
 import { ListboxProps } from './types';
 
 export function Listbox(props: ListboxProps) {
   const ref = useRef<HTMLUListElement>(null);
-  const { listBoxRef = ref, state } = props;
+  const { listBoxRef = ref, state, height = 'default' } = props;
   const { listBoxProps } = useListBox(props, state, listBoxRef);
 
   return (
-    <ul {...listBoxProps} ref={listBoxRef} className="overflow-y-auto outline-none max-h-72">
+    <ul
+      {...listBoxProps}
+      ref={listBoxRef}
+      className={cx({
+        'overflow-y-auto outline-none': true,
+        'max-h-72': height === 'default',
+        'max-h-48': height === 'small',
+      })}
+    >
       {Array.from(state.collection).map((item) => (
         <Option key={item.key} item={item} state={state} />
       ))}

--- a/frontend/components/forms/select/listbox/types.ts
+++ b/frontend/components/forms/select/listbox/types.ts
@@ -5,4 +5,6 @@ import type { AriaListBoxOptions } from '@react-aria/listbox';
 export interface ListboxProps extends AriaListBoxOptions<unknown> {
   listBoxRef?: React.RefObject<HTMLUListElement>;
   state: ListState<unknown>;
+  /** Height of the listbox, dictating its max height. Defaults to 'default' */
+  height?: 'default' | 'small';
 }

--- a/frontend/containers/open-call-application-modal/component.tsx
+++ b/frontend/containers/open-call-application-modal/component.tsx
@@ -169,6 +169,7 @@ export const OpenCallApplicationModal: FC<OpenCallApplicationModalProps> = ({
             <Textarea
               id="message"
               name="message"
+              className="mt-2.5"
               register={register}
               aria-describedby="message-error"
             />

--- a/frontend/containers/open-call-application-modal/component.tsx
+++ b/frontend/containers/open-call-application-modal/component.tsx
@@ -127,15 +127,15 @@ export const OpenCallApplicationModal: FC<OpenCallApplicationModalProps> = ({
                 defaultMessage: 'select project',
                 id: 'kRnyPA',
               })}
-              aria-describedby="project-id-error"
+              aria-describedby="project-id-error project-id-note"
             >
               {sortedProjects.map(({ id, name }) => (
                 <Option key={id}>{name}</Option>
               ))}
             </Combobox>
-            <ErrorMessage id="message-error" errorText={errors?.project_id?.message} />
+            <ErrorMessage id="project-id-error" errorText={errors?.project_id?.message} />
 
-            <span className="mt-2">
+            <span id="project-id-note" className="mt-2">
               <Link href={Paths.ProjectCreation} passHref>
                 <a className="inline text-sm text-gray-600 underline rounded-full focus-visible:outline focus-visible:outline-green-dark focus-visible:outline-2 focus-visible:outline-offset-2">
                   <FormattedMessage
@@ -184,6 +184,7 @@ export const OpenCallApplicationModal: FC<OpenCallApplicationModalProps> = ({
             <FormattedMessage defaultMessage="Cancel" id="47FYwb" />
           </Button>
           <Button
+            type="submit"
             className="flex-shrink-0 mr-5"
             theme="primary-green"
             size="small"

--- a/frontend/containers/open-call-application-modal/component.tsx
+++ b/frontend/containers/open-call-application-modal/component.tsx
@@ -45,6 +45,11 @@ export const OpenCallApplicationModal: FC<OpenCallApplicationModalProps> = ({
     [projects]
   );
 
+  const defaultValues = {
+    project_id: null,
+    message: '',
+  };
+
   const {
     control,
     formState: { errors },
@@ -57,12 +62,12 @@ export const OpenCallApplicationModal: FC<OpenCallApplicationModalProps> = ({
     shouldFocusError: true,
     shouldUseNativeValidation: true,
     reValidateMode: 'onChange',
-    defaultValues: {},
+    defaultValues,
   });
 
   const closeModal = () => {
     applyToOpenCall.reset();
-    reset();
+    reset(defaultValues);
     clearErrors();
     onClose();
   };

--- a/frontend/containers/open-call-application-modal/component.tsx
+++ b/frontend/containers/open-call-application-modal/component.tsx
@@ -1,0 +1,204 @@
+import { FC, useMemo, useState } from 'react';
+
+import { useForm } from 'react-hook-form';
+import { FormattedMessage, useIntl } from 'react-intl';
+
+import Link from 'next/link';
+
+import { useGetAlert } from 'helpers/pages';
+
+import Alert from 'components/alert';
+import Button from 'components/button';
+import Combobox, { Option } from 'components/forms/combobox';
+import ErrorMessage from 'components/forms/error-message';
+import FieldInfo from 'components/forms/field-info';
+import Label from 'components/forms/label';
+import Textarea from 'components/forms/textarea';
+import Loading from 'components/loading';
+import Modal from 'components/modal';
+import { Paths } from 'enums';
+import { OpenCallApplicationForm } from 'types/open-calls';
+import { useApplyToOpenCallResolver } from 'validations/open-call-application';
+
+import { useAccountProjectsList } from 'services/account';
+import { useApplyToOpenCall } from 'services/open-call/open-call-service';
+
+import type { OpenCallApplicationModalProps } from './types';
+
+export const OpenCallApplicationModal: FC<OpenCallApplicationModalProps> = ({
+  openCallId,
+  isOpen,
+  onClose,
+}: OpenCallApplicationModalProps) => {
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+
+  const { formatMessage } = useIntl();
+  const applyToOpenCall = useApplyToOpenCall();
+  const alert = useGetAlert(applyToOpenCall.error);
+  const resolver = useApplyToOpenCallResolver();
+
+  const { data: { data: projects } = { data: [] }, isLoading: isLoadingProjects } =
+    useAccountProjectsList();
+
+  const sortedProjects = useMemo(
+    () => projects.sort((a, b) => a.name.localeCompare(b.name)),
+    [projects]
+  );
+
+  const {
+    control,
+    formState: { errors },
+    clearErrors,
+    handleSubmit,
+    register,
+    reset,
+  } = useForm<OpenCallApplicationForm>({
+    resolver,
+    shouldFocusError: true,
+    shouldUseNativeValidation: true,
+    reValidateMode: 'onChange',
+    defaultValues: {},
+  });
+
+  const closeModal = () => {
+    applyToOpenCall.reset();
+    reset();
+    clearErrors();
+    onClose();
+  };
+
+  const onSubmit = (values: OpenCallApplicationForm) => {
+    const { project_id, message } = values;
+
+    setIsSubmitting(true);
+
+    applyToOpenCall.mutate(
+      { open_call_id: openCallId, project_id, message },
+      {
+        onSuccess: closeModal,
+        onSettled: () => {
+          setIsSubmitting(false);
+        },
+      }
+    );
+  };
+
+  return (
+    <Modal
+      onDismiss={closeModal}
+      title={formatMessage({ defaultMessage: 'Apply to Open Call', id: 'vC2u0N' })}
+      open={isOpen}
+      size="narrow"
+      scrollable={false}
+    >
+      <form className="flex flex-col" noValidate autoComplete="off">
+        <p className="mb-2 font-serif text-3xl text-green-dark">
+          <FormattedMessage defaultMessage="Apply" id="EWw/tK" />
+        </p>
+
+        <p className="mb-4">
+          <FormattedMessage
+            defaultMessage="Select one of your projects and tell the investor why your project should receive the funding to apply."
+            id="iosznt"
+          />
+        </p>
+        {isLoadingProjects ? (
+          <div className="relative flex items-center justify-center h-20">
+            <Loading visible={true} iconClassName="w-8 h-8" />
+          </div>
+        ) : (
+          <>
+            <div>
+              <Label className="mr-2" htmlFor="project-id">
+                <FormattedMessage defaultMessage="Select project to apply" id="3BlzQw" />
+              </Label>
+              <FieldInfo
+                infoText={formatMessage({
+                  defaultMessage: 'Choose one of your projects to apply to the open call.',
+                  id: 'b6bipu',
+                })}
+              />
+            </div>
+            <Combobox
+              control={control}
+              controlOptions={{ disabled: false }}
+              aria-required
+              name="project_id"
+              id="project-id"
+              className="mt-2.5 w-full h-10 border border-beige rounded-lg px-4"
+              placeholder={formatMessage({
+                defaultMessage: 'select project',
+                id: 'kRnyPA',
+              })}
+              aria-describedby="project-id-error"
+            >
+              {sortedProjects.map(({ id, name }) => (
+                <Option key={id}>{name}</Option>
+              ))}
+            </Combobox>
+            <ErrorMessage id="message-error" errorText={errors?.project_id?.message} />
+
+            <span className="mt-2">
+              <Link href={Paths.ProjectCreation} passHref>
+                <a className="inline text-sm text-gray-600 underline rounded-full focus-visible:outline focus-visible:outline-green-dark focus-visible:outline-2 focus-visible:outline-offset-2">
+                  <FormattedMessage
+                    defaultMessage="Don’t have a project yet? Create a project now"
+                    id="SFCYg4"
+                  />
+                </a>
+              </Link>
+            </span>
+
+            <div className="mt-4">
+              <Label className="mr-2" htmlFor="message">
+                <FormattedMessage defaultMessage="Type your message" id="HtMY9H" />
+              </Label>
+              <FieldInfo
+                infoText={formatMessage({
+                  defaultMessage: 'Tell the investor why your project should receive the funding.',
+                  id: '3WLO/M',
+                })}
+              />
+            </div>
+            <Textarea
+              id="message"
+              name="message"
+              register={register}
+              aria-describedby="message-error"
+            />
+            <ErrorMessage id="message-error" errorText={errors?.message?.message} />
+          </>
+        )}
+        {alert && (
+          <Alert type="warning" className="my-4 -mb-4 rounded">
+            {/* useGetAlert returns an array, but the endpoint only sends one error message at a time. */}
+            {alert[0]}
+          </Alert>
+        )}
+
+        <div className="flex justify-end mt-8">
+          <Button
+            theme="secondary-green"
+            size="small"
+            className="flex-shrink-0 mr-5"
+            onClick={closeModal}
+          >
+            <FormattedMessage defaultMessage="Cancel" id="47FYwb" />
+          </Button>
+          <Button
+            className="flex-shrink-0 mr-5"
+            theme="primary-green"
+            size="small"
+            disabled={isSubmitting || isLoadingProjects}
+            onClick={handleSubmit(onSubmit)}
+          >
+            <FormattedMessage defaultMessage="Send application" id="qY71uO" />
+            <Loading className="ml-2" visible={isSubmitting} />
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
+export default OpenCallApplicationModal;

--- a/frontend/containers/open-call-application-modal/component.tsx
+++ b/frontend/containers/open-call-application-modal/component.tsx
@@ -126,6 +126,7 @@ export const OpenCallApplicationModal: FC<OpenCallApplicationModalProps> = ({
               name="project_id"
               id="project-id"
               className="mt-2.5 w-full h-10 border border-beige rounded-lg px-4"
+              height="small"
               placeholder={formatMessage({
                 defaultMessage: 'select project',
                 id: 'kRnyPA',

--- a/frontend/containers/open-call-application-modal/component.tsx
+++ b/frontend/containers/open-call-application-modal/component.tsx
@@ -118,7 +118,7 @@ export const OpenCallApplicationModal: FC<OpenCallApplicationModalProps> = ({
                 <FormattedMessage defaultMessage="Select project to apply" id="3BlzQw" />
               </Label>
               <FieldInfo
-                infoText={formatMessage({
+                content={formatMessage({
                   defaultMessage: 'Choose one of your projects to apply to the open call.',
                   id: 'b6bipu',
                 })}
@@ -160,7 +160,7 @@ export const OpenCallApplicationModal: FC<OpenCallApplicationModalProps> = ({
                 <FormattedMessage defaultMessage="Type your message" id="HtMY9H" />
               </Label>
               <FieldInfo
-                infoText={formatMessage({
+                content={formatMessage({
                   defaultMessage: 'Tell the investor why your project should receive the funding.',
                   id: '3WLO/M',
                 })}

--- a/frontend/containers/open-call-application-modal/component.tsx
+++ b/frontend/containers/open-call-application-modal/component.tsx
@@ -193,8 +193,8 @@ export const OpenCallApplicationModal: FC<OpenCallApplicationModalProps> = ({
             disabled={isSubmitting || isLoadingProjects}
             onClick={handleSubmit(onSubmit)}
           >
+            <Loading className="mr-2" visible={isSubmitting} />
             <FormattedMessage defaultMessage="Send application" id="qY71uO" />
-            <Loading className="ml-2" visible={isSubmitting} />
           </Button>
         </div>
       </form>

--- a/frontend/containers/open-call-application-modal/component.tsx
+++ b/frontend/containers/open-call-application-modal/component.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo, useState } from 'react';
+import { FC, useMemo } from 'react';
 
 import { useForm } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
@@ -30,8 +30,6 @@ export const OpenCallApplicationModal: FC<OpenCallApplicationModalProps> = ({
   isOpen,
   onClose,
 }: OpenCallApplicationModalProps) => {
-  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
-
   const { formatMessage } = useIntl();
   const applyToOpenCall = useApplyToOpenCall();
   const alert = useGetAlert(applyToOpenCall.error);
@@ -75,16 +73,9 @@ export const OpenCallApplicationModal: FC<OpenCallApplicationModalProps> = ({
   const onSubmit = (values: OpenCallApplicationForm) => {
     const { project_id, message } = values;
 
-    setIsSubmitting(true);
-
     applyToOpenCall.mutate(
       { open_call_id: openCallId, project_id, message },
-      {
-        onSuccess: closeModal,
-        onSettled: () => {
-          setIsSubmitting(false);
-        },
-      }
+      { onSuccess: closeModal }
     );
   };
 
@@ -196,10 +187,10 @@ export const OpenCallApplicationModal: FC<OpenCallApplicationModalProps> = ({
             className="flex-shrink-0 mr-5"
             theme="primary-green"
             size="small"
-            disabled={isSubmitting || isLoadingProjects}
+            disabled={applyToOpenCall.isLoading || isLoadingProjects}
             onClick={handleSubmit(onSubmit)}
           >
-            <Loading className="mr-2" visible={isSubmitting} />
+            <Loading className="mr-2" visible={applyToOpenCall.isLoading} />
             <FormattedMessage defaultMessage="Send application" id="qY71uO" />
           </Button>
         </div>

--- a/frontend/containers/open-call-application-modal/index.ts
+++ b/frontend/containers/open-call-application-modal/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { OpenCallApplicationModalProps } from './types';

--- a/frontend/containers/open-call-application-modal/types.ts
+++ b/frontend/containers/open-call-application-modal/types.ts
@@ -1,0 +1,8 @@
+export type OpenCallApplicationModalProps = {
+  /** ID of the open call to apply to */
+  openCallId: string;
+  /** Whether the modal is open */
+  isOpen: boolean;
+  /** Callback executed when the user closes the modal */
+  onClose: () => void;
+};

--- a/frontend/containers/open-call-page/header/component.tsx
+++ b/frontend/containers/open-call-page/header/component.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo } from 'react';
+import { FC, useMemo, useState } from 'react';
 
 import { Heart } from 'react-feather';
 import { FormattedMessage, useIntl } from 'react-intl';
@@ -14,6 +14,7 @@ import useMe from 'hooks/me';
 import { translatedLanguageNameForLocale } from 'helpers/intl';
 
 import Breadcrumbs from 'containers/breadcrumbs';
+import OpenCallApplicationModal from 'containers/open-call-application-modal';
 import ShareIcons from 'containers/share-icons';
 
 import Button from 'components/button';
@@ -28,15 +29,13 @@ import OpenCallChart from '../chart';
 
 import { OpenCallHeaderProps } from '.';
 
-export const OpenCallHeader: FC<OpenCallHeaderProps> = ({
-  openCall,
-  instrumentTypes,
-  handleApply,
-}) => {
+export const OpenCallHeader: FC<OpenCallHeaderProps> = ({ openCall, instrumentTypes }) => {
   const intl = useIntl();
   const { locale } = useRouter();
   const favoriteOpenCall = useFavoriteOpenCall();
   const { user } = useMe();
+
+  const [showApplicationModal, setShowApplicationModal] = useState<boolean>(false);
 
   const {
     id,
@@ -74,133 +73,139 @@ export const OpenCallHeader: FC<OpenCallHeaderProps> = ({
   };
 
   return (
-    <LayoutContainer className="-mt-10 md:mt-0 lg:-mt-16">
-      <Breadcrumbs
-        className="sm:px-6 lg:px-8"
-        substitutions={{
-          id: { name },
-        }}
-      />
-      <div className="mt-4">
-        <div
-          className="flex items-end sm:mx-4 bg-center bg-cover lg:mx-0 rounded-2xl bg-radial-green-dark bg-green-dark min-h-[250px] lg:min-h-[372px]"
-          style={{
-            ...(coverImage && { backgroundImage: `url(${coverImage})` }),
+    <>
+      <LayoutContainer className="-mt-10 md:mt-0 lg:-mt-16">
+        <Breadcrumbs
+          className="sm:px-6 lg:px-8"
+          substitutions={{
+            id: { name },
           }}
-        >
-          <LayoutContainer>
-            <div className="mb-8 text-center lg:w-1/2 lg:text-left">
-              <h1 className="font-serif text-2xl text-white lg:text-4xl">{name}</h1>
+        />
+        <div className="mt-4">
+          <div
+            className="flex items-end sm:mx-4 bg-center bg-cover lg:mx-0 rounded-2xl bg-radial-green-dark bg-green-dark min-h-[250px] lg:min-h-[372px]"
+            style={{
+              ...(coverImage && { backgroundImage: `url(${coverImage})` }),
+            }}
+          >
+            <LayoutContainer>
+              <div className="mb-8 text-center lg:w-1/2 lg:text-left">
+                <h1 className="font-serif text-2xl text-white lg:text-4xl">{name}</h1>
+              </div>
+            </LayoutContainer>
+          </div>
+          <LayoutContainer className="flex flex-col justify-between mt-8 lg:flex-row">
+            <div className="w-full lg:w-6/12">
+              {originalLanguage && (
+                <span className="block mb-4 text-sm text-gray-400">
+                  <FormattedMessage
+                    defaultMessage="Note: The content of this page was originally written in <span>{language}</span>."
+                    id="zXxFL9"
+                    values={{
+                      language: translatedLanguageNameForLocale(intl, originalLanguage),
+                      span: (chunks: string) => <span className="underline">{chunks}</span>,
+                    }}
+                  />
+                </span>
+              )}
+              <p>{openCall.description}</p>
+            </div>
+            <div className="mb-10 flex flex-col justify-start lg:mr-4 p-6 bg-white drop-shadow-xl lg:mb-[-70%] h-full lg:translate-y-[-70%] lg:max-w-1/3 rounded-2xl mt-8 lg:mt-0">
+              <>
+                <div className="flex flex-col gap-8 pl-2 sm:gap-11 sm:flex-row sm:justify-between">
+                  <div className="flex flex-col items-center justify-end gap-2 sm:items-start">
+                    <span aria-labelledby="open-call-value" className="text-2xl font-semibold">
+                      ${maximum_funding_per_project.toLocaleString(locale)}
+                    </span>
+                    <span id="open-call-value" className="text-gray-400">
+                      <FormattedMessage defaultMessage="Value" id="GufXy5" />
+                    </span>
+                  </div>
+                  <div className="flex flex-col items-center justify-end gap-2 sm:items-start">
+                    <div className="max-w-full text-center sm:text-left">
+                      {instrumentTypes?.map((type) => {
+                        return (
+                          <p
+                            aria-labelledby="block open-call-instrument-types"
+                            key={type}
+                            className={cx('font-semibold whitespace-nowrap', {
+                              'text-2xl': instrument_types.length === 1,
+                              'text-xl': instrument_types.length > 1,
+                            })}
+                          >
+                            {type}
+                          </p>
+                        );
+                      })}
+                    </div>
+                    <span id="open-call-instrument-types" className="text-gray-400">
+                      <FormattedMessage
+                        defaultMessage="{numInstrumentTypes, plural, one {Instrument type} other {Instrument types}}"
+                        id="eFJIPT"
+                        values={{
+                          numInstrumentTypes: instrument_types?.length || 0,
+                        }}
+                      />
+                    </span>
+                  </div>
+                </div>
+                <hr className="mt-6 mb-8" />
+                <div className="flex flex-col justify-between gap-8 pl-2 sm:flex-row sm:gap-11">
+                  <div className="flex flex-col items-center justify-end gap-2 sm:items-start">
+                    <span id="total-of-projects" className="text-2xl font-semibold text-gray-700">
+                      {openCallRange.deadline}
+                    </span>
+                    <span aria-labelledby="total-of-projects" className="text-gray-400">
+                      <FormattedMessage defaultMessage="Deadline" id="8/Da7A" />
+                    </span>
+                  </div>
+                  {openCallRange.remaining <= 8 && (
+                    <div className="flex flex-col items-center justify-end gap-2 text-center">
+                      <div className="w-[82px] h-[82px] rounded-full flex justify-center items-center">
+                        <OpenCallChart openCallRange={openCallRange} />
+                        <p className="absolute max-w-[62px] text-xs font-semibold text-green-dark">
+                          {status !== OpenCallStatus.Closed ? (
+                            <FormattedMessage defaultMessage="Ending soon" id="8mCCtS" />
+                          ) : (
+                            <FormattedMessage defaultMessage="Closed" id="Fv1ZSz" />
+                          )}
+                        </p>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </>
+
+              <div className="flex flex-col justify-between gap-4 lg:flex-row mt-7">
+                <Button
+                  className="justify-center"
+                  theme="secondary-green"
+                  onClick={handleFavoriteClick}
+                  disabled={!user}
+                  aria-pressed={favourite}
+                >
+                  <Icon icon={Heart} className={cx('w-4 mr-3', { 'fill-green-dark': favourite })} />
+                  <FormattedMessage defaultMessage="Favorite" id="5Hzwqs" />
+                </Button>
+                <Button
+                  className="w-full lg:max-w-[200px] justify-center"
+                  theme="primary-green"
+                  onClick={() => setShowApplicationModal(true)}
+                >
+                  <FormattedMessage defaultMessage="Apply now" id="VR4TEV" />
+                </Button>
+              </div>
+              <ShareIcons title={name} />
             </div>
           </LayoutContainer>
         </div>
-        <LayoutContainer className="flex flex-col justify-between mt-8 lg:flex-row">
-          <div className="w-full lg:w-6/12">
-            {originalLanguage && (
-              <span className="block mb-4 text-sm text-gray-400">
-                <FormattedMessage
-                  defaultMessage="Note: The content of this page was originally written in <span>{language}</span>."
-                  id="zXxFL9"
-                  values={{
-                    language: translatedLanguageNameForLocale(intl, originalLanguage),
-                    span: (chunks: string) => <span className="underline">{chunks}</span>,
-                  }}
-                />
-              </span>
-            )}
-            <p>{openCall.description}</p>
-          </div>
-          <div className="mb-10 flex flex-col justify-start lg:mr-4 p-6 bg-white drop-shadow-xl lg:mb-[-70%] h-full lg:translate-y-[-70%] lg:max-w-1/3 rounded-2xl mt-8 lg:mt-0">
-            <>
-              <div className="flex flex-col gap-8 pl-2 sm:gap-11 sm:flex-row sm:justify-between">
-                <div className="flex flex-col items-center justify-end gap-2 sm:items-start">
-                  <span aria-labelledby="open-call-value" className="text-2xl font-semibold">
-                    ${maximum_funding_per_project.toLocaleString(locale)}
-                  </span>
-                  <span id="open-call-value" className="text-gray-400">
-                    <FormattedMessage defaultMessage="Value" id="GufXy5" />
-                  </span>
-                </div>
-                <div className="flex flex-col items-center justify-end gap-2 sm:items-start">
-                  <div className="max-w-full text-center sm:text-left">
-                    {instrumentTypes?.map((type) => {
-                      return (
-                        <p
-                          aria-labelledby="block open-call-instrument-types"
-                          key={type}
-                          className={cx('font-semibold whitespace-nowrap', {
-                            'text-2xl': instrument_types.length === 1,
-                            'text-xl': instrument_types.length > 1,
-                          })}
-                        >
-                          {type}
-                        </p>
-                      );
-                    })}
-                  </div>
-                  <span id="open-call-instrument-types" className="text-gray-400">
-                    <FormattedMessage
-                      defaultMessage="{numInstrumentTypes, plural, one {Instrument type} other {Instrument types}}"
-                      id="eFJIPT"
-                      values={{
-                        numInstrumentTypes: instrument_types?.length || 0,
-                      }}
-                    />
-                  </span>
-                </div>
-              </div>
-              <hr className="mt-6 mb-8" />
-              <div className="flex flex-col justify-between gap-8 pl-2 sm:flex-row sm:gap-11">
-                <div className="flex flex-col items-center justify-end gap-2 sm:items-start">
-                  <span id="total-of-projects" className="text-2xl font-semibold text-gray-700">
-                    {openCallRange.deadline}
-                  </span>
-                  <span aria-labelledby="total-of-projects" className="text-gray-400">
-                    <FormattedMessage defaultMessage="Deadline" id="8/Da7A" />
-                  </span>
-                </div>
-                {openCallRange.remaining <= 8 && (
-                  <div className="flex flex-col items-center justify-end gap-2 text-center">
-                    <div className="w-[82px] h-[82px] rounded-full flex justify-center items-center">
-                      <OpenCallChart openCallRange={openCallRange} />
-                      <p className="absolute max-w-[62px] text-xs font-semibold text-green-dark">
-                        {status !== OpenCallStatus.Closed ? (
-                          <FormattedMessage defaultMessage="Ending soon" id="8mCCtS" />
-                        ) : (
-                          <FormattedMessage defaultMessage="Closed" id="Fv1ZSz" />
-                        )}
-                      </p>
-                    </div>
-                  </div>
-                )}
-              </div>
-            </>
-
-            <div className="flex flex-col justify-between gap-4 lg:flex-row mt-7">
-              <Button
-                className="justify-center"
-                theme="secondary-green"
-                onClick={handleFavoriteClick}
-                disabled={!user}
-                aria-pressed={favourite}
-              >
-                <Icon icon={Heart} className={cx('w-4 mr-3', { 'fill-green-dark': favourite })} />
-                <FormattedMessage defaultMessage="Favorite" id="5Hzwqs" />
-              </Button>
-              <Button
-                className="w-full lg:max-w-[200px] justify-center"
-                theme="primary-green"
-                onClick={handleApply}
-                disabled
-              >
-                <FormattedMessage defaultMessage="Apply now" id="VR4TEV" />
-              </Button>
-            </div>
-            <ShareIcons title={name} />
-          </div>
-        </LayoutContainer>
-      </div>
-    </LayoutContainer>
+      </LayoutContainer>
+      <OpenCallApplicationModal
+        openCallId={id}
+        isOpen={showApplicationModal}
+        onClose={() => setShowApplicationModal(false)}
+      />
+    </>
   );
 };
 

--- a/frontend/containers/open-call-page/header/component.tsx
+++ b/frontend/containers/open-call-page/header/component.tsx
@@ -9,8 +9,6 @@ import { useRouter } from 'next/router';
 
 import dayjs from 'dayjs';
 
-import useMe from 'hooks/me';
-
 import { translatedLanguageNameForLocale } from 'helpers/intl';
 
 import Breadcrumbs from 'containers/breadcrumbs';
@@ -20,9 +18,10 @@ import ShareIcons from 'containers/share-icons';
 import Button from 'components/button';
 import Icon from 'components/icon';
 import LayoutContainer from 'components/layout-container';
-import { Languages, OpenCallStatus } from 'enums';
+import { Languages, OpenCallStatus, UserRoles } from 'enums';
 import languages from 'locales.config.json';
 
+import { useAccount } from 'services/account';
 import { useFavoriteOpenCall } from 'services/open-call/open-call-service';
 
 import OpenCallChart from '../chart';
@@ -33,7 +32,7 @@ export const OpenCallHeader: FC<OpenCallHeaderProps> = ({ openCall, instrumentTy
   const intl = useIntl();
   const { locale } = useRouter();
   const favoriteOpenCall = useFavoriteOpenCall();
-  const { user } = useMe();
+  const { userAccount } = useAccount();
 
   const [showApplicationModal, setShowApplicationModal] = useState<boolean>(false);
 
@@ -181,7 +180,7 @@ export const OpenCallHeader: FC<OpenCallHeaderProps> = ({ openCall, instrumentTy
                   className="justify-center"
                   theme="secondary-green"
                   onClick={handleFavoriteClick}
-                  disabled={!user}
+                  disabled={!userAccount}
                   aria-pressed={favourite}
                 >
                   <Icon icon={Heart} className={cx('w-4 mr-3', { 'fill-green-dark': favourite })} />
@@ -189,6 +188,11 @@ export const OpenCallHeader: FC<OpenCallHeaderProps> = ({ openCall, instrumentTy
                 </Button>
                 <Button
                   className="w-full lg:max-w-[200px] justify-center"
+                  disabled={
+                    !userAccount ||
+                    userAccount.type !== UserRoles.ProjectDeveloper ||
+                    status !== OpenCallStatus.Launched
+                  }
                   theme="primary-green"
                   onClick={() => setShowApplicationModal(true)}
                 >

--- a/frontend/containers/open-call-page/header/types.ts
+++ b/frontend/containers/open-call-page/header/types.ts
@@ -5,6 +5,4 @@ export type OpenCallHeaderProps = {
   openCall: OpenCall;
   /** List of instrument type names */
   instrumentTypes: string[];
-  /** function to apply to a open call */
-  handleApply: () => void;
 };

--- a/frontend/containers/open-call-page/investor/component.tsx
+++ b/frontend/containers/open-call-page/investor/component.tsx
@@ -70,7 +70,7 @@ export const OpenCallInvestorAndFooter: FC<OpenCallInvestorProps> = ({ openCall 
                 disabled={
                   !userAccount ||
                   userAccount.type !== UserRoles.ProjectDeveloper ||
-                  status !== OpenCallStatus.Launched
+                  openCall.status !== OpenCallStatus.Launched
                 }
                 onClick={() => setShowApplicationModal(true)}
               >

--- a/frontend/containers/open-call-page/investor/component.tsx
+++ b/frontend/containers/open-call-page/investor/component.tsx
@@ -5,22 +5,21 @@ import { FormattedMessage } from 'react-intl';
 
 import cx from 'classnames';
 
-import useMe from 'hooks/me';
-
 import OpenCallApplicationModal from 'containers/open-call-application-modal';
 import ProfileCard from 'containers/profile-card';
 
 import Button from 'components/button';
 import Icon from 'components/icon';
 import LayoutContainer from 'components/layout-container';
-import { Paths } from 'enums';
+import { OpenCallStatus, Paths, UserRoles } from 'enums';
 
+import { useAccount } from 'services/account';
 import { useFavoriteOpenCall } from 'services/open-call/open-call-service';
 
 import { OpenCallInvestorProps } from '.';
 
 export const OpenCallInvestorAndFooter: FC<OpenCallInvestorProps> = ({ openCall }) => {
-  const { user } = useMe();
+  const { userAccount } = useAccount();
   const favoriteOpenCall = useFavoriteOpenCall();
   const [showApplicationModal, setShowApplicationModal] = useState<boolean>(false);
 
@@ -66,7 +65,15 @@ export const OpenCallInvestorAndFooter: FC<OpenCallInvestorProps> = ({ openCall 
               />
             </h2>
             <div className="flex flex-col items-center justify-center gap-4 mt-8 sm:flex-row sm:mt-14">
-              <Button theme="primary-white" onClick={() => setShowApplicationModal(true)}>
+              <Button
+                theme="primary-white"
+                disabled={
+                  !userAccount ||
+                  userAccount.type !== UserRoles.ProjectDeveloper ||
+                  status !== OpenCallStatus.Launched
+                }
+                onClick={() => setShowApplicationModal(true)}
+              >
                 <span className="text-lg">
                   <FormattedMessage defaultMessage="Apply now" id="VR4TEV" />
                 </span>
@@ -74,7 +81,7 @@ export const OpenCallInvestorAndFooter: FC<OpenCallInvestorProps> = ({ openCall 
               <span className="text-xl text-white">
                 <FormattedMessage defaultMessage="or" id="Ntjkqd" />
               </span>
-              <Button disabled={!user} theme="secondary-white" onClick={handleFavoriteClick}>
+              <Button disabled={!userAccount} theme="secondary-white" onClick={handleFavoriteClick}>
                 <Icon
                   icon={Heart}
                   className={cx('w-4 mr-3', {

--- a/frontend/containers/open-call-page/investor/component.tsx
+++ b/frontend/containers/open-call-page/investor/component.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useState } from 'react';
 
 import { Heart } from 'react-feather';
 import { FormattedMessage } from 'react-intl';
@@ -7,6 +7,7 @@ import cx from 'classnames';
 
 import useMe from 'hooks/me';
 
+import OpenCallApplicationModal from 'containers/open-call-application-modal';
 import ProfileCard from 'containers/profile-card';
 
 import Button from 'components/button';
@@ -18,9 +19,10 @@ import { useFavoriteOpenCall } from 'services/open-call/open-call-service';
 
 import { OpenCallInvestorProps } from '.';
 
-export const OpenCallInvestorAndFooter: FC<OpenCallInvestorProps> = ({ openCall, handleApply }) => {
+export const OpenCallInvestorAndFooter: FC<OpenCallInvestorProps> = ({ openCall }) => {
   const { user } = useMe();
   const favoriteOpenCall = useFavoriteOpenCall();
+  const [showApplicationModal, setShowApplicationModal] = useState<boolean>(false);
 
   const { investor } = openCall;
 
@@ -30,60 +32,70 @@ export const OpenCallInvestorAndFooter: FC<OpenCallInvestorProps> = ({ openCall,
   };
 
   return (
-    <div className="w-full pt-20 bg-background-middle">
-      <LayoutContainer>
-        <LayoutContainer className="flex flex-col justify-between pb-20 gap-y-12 md:flex-row">
-          <div className="w-full">
-            <h2 className="mb-4 font-serif text-4xl font-bold">
-              <FormattedMessage defaultMessage="Investor" id="nEvNJb" />
-            </h2>
-            <p className="text-gray-700">
-              <FormattedMessage defaultMessage="Who is financing this open call" id="Knhvmr" />
-            </p>
-          </div>
-          <div className="w-full">
-            <ProfileCard
-              className="min-w-full"
-              description={investor?.about}
-              link={`${Paths.Investor}/${investor?.slug}`}
-              name={investor?.name}
-              picture={investor?.picture?.small}
-              profileType="investor"
-              type={investor?.type}
-            />
-          </div>
-        </LayoutContainer>
-      </LayoutContainer>
-      <div className="py-8 text-center sm:py-20 bg-green-dark">
+    <>
+      <div className="w-full pt-20 bg-background-middle">
         <LayoutContainer>
-          <h2 className="max-w-2xl mx-auto font-serif text-3xl font-semibold text-white lg:text-4xl">
-            <FormattedMessage defaultMessage="Would you like to apply for this fund?" id="8KmEyC" />
-          </h2>
-          <div className="flex flex-col items-center justify-center gap-4 mt-8 sm:flex-row sm:mt-14">
-            <Button disabled theme="primary-white" onClick={handleApply}>
-              <span className="text-lg">
-                <FormattedMessage defaultMessage="Apply now" id="VR4TEV" />
-              </span>
-            </Button>
-            <span className="text-xl text-white">
-              <FormattedMessage defaultMessage="or" id="Ntjkqd" />
-            </span>
-            <Button disabled={!user} theme="secondary-white" onClick={handleFavoriteClick}>
-              <Icon
-                icon={Heart}
-                className={cx('w-4 mr-3', {
-                  'fill-green-dark': !openCall.favourite,
-                  'fill-white': openCall.favourite,
-                })}
+          <LayoutContainer className="flex flex-col justify-between pb-20 gap-y-12 md:flex-row">
+            <div className="w-full">
+              <h2 className="mb-4 font-serif text-4xl font-bold">
+                <FormattedMessage defaultMessage="Investor" id="nEvNJb" />
+              </h2>
+              <p className="text-gray-700">
+                <FormattedMessage defaultMessage="Who is financing this open call" id="Knhvmr" />
+              </p>
+            </div>
+            <div className="w-full">
+              <ProfileCard
+                className="min-w-full"
+                description={investor?.about}
+                link={`${Paths.Investor}/${investor?.slug}`}
+                name={investor?.name}
+                picture={investor?.picture?.small}
+                profileType="investor"
+                type={investor?.type}
               />
-              <span className="text-lg">
-                <FormattedMessage defaultMessage="Favorite" id="5Hzwqs" />
-              </span>
-            </Button>
-          </div>
+            </div>
+          </LayoutContainer>
         </LayoutContainer>
+        <div className="py-8 text-center sm:py-20 bg-green-dark">
+          <LayoutContainer>
+            <h2 className="max-w-2xl mx-auto font-serif text-3xl font-semibold text-white lg:text-4xl">
+              <FormattedMessage
+                defaultMessage="Would you like to apply for this fund?"
+                id="8KmEyC"
+              />
+            </h2>
+            <div className="flex flex-col items-center justify-center gap-4 mt-8 sm:flex-row sm:mt-14">
+              <Button theme="primary-white" onClick={() => setShowApplicationModal(true)}>
+                <span className="text-lg">
+                  <FormattedMessage defaultMessage="Apply now" id="VR4TEV" />
+                </span>
+              </Button>
+              <span className="text-xl text-white">
+                <FormattedMessage defaultMessage="or" id="Ntjkqd" />
+              </span>
+              <Button disabled={!user} theme="secondary-white" onClick={handleFavoriteClick}>
+                <Icon
+                  icon={Heart}
+                  className={cx('w-4 mr-3', {
+                    'fill-green-dark': !openCall.favourite,
+                    'fill-white': openCall.favourite,
+                  })}
+                />
+                <span className="text-lg">
+                  <FormattedMessage defaultMessage="Favorite" id="5Hzwqs" />
+                </span>
+              </Button>
+            </div>
+          </LayoutContainer>
+        </div>
       </div>
-    </div>
+      <OpenCallApplicationModal
+        openCallId={openCall.id}
+        isOpen={showApplicationModal}
+        onClose={() => setShowApplicationModal(false)}
+      />
+    </>
   );
 };
 

--- a/frontend/containers/open-call-page/investor/types.ts
+++ b/frontend/containers/open-call-page/investor/types.ts
@@ -3,6 +3,4 @@ import { OpenCall } from 'types/open-calls';
 export type OpenCallInvestorProps = {
   /** The open call object we are displaying the banner for */
   openCall: OpenCall;
-  /** Function to apply to a open call */
-  handleApply: () => void;
 };

--- a/frontend/enums/index.ts
+++ b/frontend/enums/index.ts
@@ -74,8 +74,10 @@ export enum Queries {
   FavoriteProjectsList = 'favorite_projects',
   /** Single project */
   Project = 'project',
-  /** List of projects */
+  /** List of open calls */
   OpenCallList = 'open_calls',
+  /** List of open call applications */
+  OpenCallApplicationList = 'open_calls_applications',
   /** List of favorited projects */
   FavoriteOpenCallsList = 'favorite_open_calls',
   /** Single open call */

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -236,8 +236,14 @@
   "3BcZ1K": {
     "string": "Conservation"
   },
+  "3BlzQw": {
+    "string": "Select project to apply"
+  },
   "3T3umg": {
     "string": "If you are the owner of the account, please transfer the ownership before continuing."
+  },
+  "3WLO/M": {
+    "string": "Tell the investor why your project should receive the funding."
   },
   "3ciGOS": {
     "string": "Grant"
@@ -770,6 +776,9 @@
   "EVKdUn": {
     "string": "Priority Landscape"
   },
+  "EWw/tK": {
+    "string": "Apply"
+  },
   "Ec0M9T": {
     "string": "Please briefly describe the main groups of activities or components for the implementation of the project. It is not necessary to be very detailed, just a logical sequence of the general lines of action. These groups of activities should be used to define the estimated budget below. No more than three groups of activities or components"
   },
@@ -913,6 +922,9 @@
   },
   "HnG9/3": {
     "string": "Insert password"
+  },
+  "HtMY9H": {
+    "string": "Type your message"
   },
   "HvSsTa": {
     "string": "HeCo Invest is currently on Beta version. We are still testing and making improvements and for that reason some features may not be fully functional."
@@ -1386,6 +1398,9 @@
   "S27Bu1": {
     "string": "<span>Note:</span>The content of this project should be written in {language}"
   },
+  "SFCYg4": {
+    "string": "Don’t have a project yet? Create a project now"
+  },
   "SFGITa": {
     "string": "Amazon Heart"
   },
@@ -1782,6 +1797,9 @@
   "b3Iz6I": {
     "string": "What type of projects the funding is covering."
   },
+  "b6bipu": {
+    "string": "Choose one of your projects to apply to the open call."
+  },
   "bNpbHr": {
     "string": "Find other people with similar interests. Join forces, secure more investment and create a greater impact."
   },
@@ -2115,6 +2133,9 @@
   "inQ2Q1": {
     "string": "Topics/sector categories"
   },
+  "iosznt": {
+    "string": "Select one of your projects and tell the investor why your project should receive the funding to apply."
+  },
   "ipYSrV": {
     "string": "The email where you want to receive contacts from Investors or other Project Developers"
   },
@@ -2198,6 +2219,9 @@
   },
   "kPq9Kx": {
     "string": "HeCo priority landscape"
+  },
+  "kRnyPA": {
+    "string": "select project"
   },
   "kTXMXN": {
     "string": "Displays the protected areas signed into the RUNAP (Unique Registry of Protected Areas) of Colombia"
@@ -2442,6 +2466,9 @@
   "qPKAOa": {
     "string": "Paulson Institute: The Paulson Institute (PI) is a non-partisan, independent “think and do tank” delivering solutions that contribute to a more resilient and sustainable world. PI operates at the intersection of economics, financial markets, and environmental protection by promoting market-based solutions to ensure green economic growth. Under their Financing Nature initiative, they are working to identify and implement innovative mechanisms that can rapidly mobilize substantial amounts of funding for nature conservation."
   },
+  "qY71uO": {
+    "string": "Send application"
+  },
   "qZPjW2": {
     "string": "What is a verification badge?"
   },
@@ -2660,6 +2687,9 @@
   },
   "v9GdgG": {
     "string": "File {fileName} is larger than {fileSize}MB"
+  },
+  "vC2u0N": {
+    "string": "Apply to Open Call"
   },
   "vIKTZ9": {
     "string": "If you have interest in this project contact the project developer to know how you can work together."

--- a/frontend/pages/open-call/[id]/index.tsx
+++ b/frontend/pages/open-call/[id]/index.tsx
@@ -91,24 +91,17 @@ const OpenCallPage: PageComponent<OpenCallPageProps, StaticPageLayoutProps> = ({
     (instrumentType) => allInstrumentTypes.find((type) => type.id === instrumentType).name
   );
 
-  // To implement
-  const handleApply = () => {};
-
   return (
     <div>
       <Head title={openCall.name} description={openCall.description} />
-      <OpenCallHeader
-        openCall={openCall}
-        instrumentTypes={instrumentTypeNames}
-        handleApply={handleApply}
-      />
+      <OpenCallHeader openCall={openCall} instrumentTypes={instrumentTypeNames} />
       <OpenCallOverview openCall={openCall} />
       <OpenCallFundingInformation
         instrumentTypes={instrumentTypeNames}
         openCall={openCall}
         allSdgs={allSdgs}
       />
-      <OpenCallInvestorAndFooter openCall={openCall} handleApply={handleApply} />
+      <OpenCallInvestorAndFooter openCall={openCall} />
     </div>
   );
 };

--- a/frontend/services/open-call/open-call-service.ts
+++ b/frontend/services/open-call/open-call-service.ts
@@ -20,6 +20,7 @@ import {
   OpenCallCreationPayload,
   OpenCallParams,
   OpenCallUpdatePayload,
+  OpenCallApplicationPayload,
 } from 'types/open-calls';
 
 import API from 'services/api';
@@ -251,6 +252,41 @@ export const useFavoriteOpenCall = () => {
         queryClient.invalidateQueries(Queries.OpenCallList);
         queryClient.invalidateQueries(Queries.FavoriteOpenCallsList);
         queryClient.setQueryData([Queries.OpenCall, data.id], data);
+      },
+    }
+  );
+};
+
+/**
+ * Hook to apply to an open call
+ **/
+export const useApplyToOpenCall = (): UseMutationResult<
+  AxiosResponse<ResponseData<OpenCall>>,
+  AxiosError<ErrorResponse>,
+  OpenCallApplicationPayload
+> => {
+  const queryClient = useQueryClient();
+
+  const applyToOpenCall = (
+    projectId: string,
+    openCallId: string,
+    message: string
+  ): Promise<AxiosResponse<ResponseData<OpenCall>>> => {
+    const config: AxiosRequestConfig = {
+      method: 'POST',
+      url: `/api/v1/account/open_call_applications`,
+      data: { project_id: projectId, open_call_id: openCallId, message },
+    };
+
+    return API(config);
+  };
+
+  return useMutation(
+    ({ project_id, open_call_id, message }: OpenCallApplicationPayload) =>
+      applyToOpenCall(project_id, open_call_id, message),
+    {
+      onSuccess() {
+        queryClient.invalidateQueries(Queries.OpenCallApplicationList);
       },
     }
   );

--- a/frontend/types/open-calls.ts
+++ b/frontend/types/open-calls.ts
@@ -60,3 +60,12 @@ export type OpenCallParams = {
   includes?: string[];
   filter?: string;
 };
+
+export type OpenCallApplicationForm = {
+  project_id: string;
+  message: string;
+};
+
+export type OpenCallApplicationPayload = OpenCallApplicationForm & {
+  open_call_id: string;
+};

--- a/frontend/validations/open-call-application.ts
+++ b/frontend/validations/open-call-application.ts
@@ -1,0 +1,29 @@
+import { useIntl } from 'react-intl';
+
+import { yupResolver } from '@hookform/resolvers/yup';
+import { SchemaOf, object, string } from 'yup';
+
+import { OpenCallApplicationForm } from 'types/open-calls';
+
+export const useApplyToOpenCallResolver = () => {
+  const { formatMessage } = useIntl();
+
+  const schema: SchemaOf<Omit<OpenCallApplicationForm, 'open_call_id'>> = object().shape({
+    project_id: string()
+      .nullable()
+      .required(
+        formatMessage({
+          defaultMessage: 'You need to select a project.',
+          id: 'L/i942',
+        })
+      ),
+    message: string().required(
+      formatMessage({
+        defaultMessage: 'You need to enter a message.',
+        id: 'i8NU3I',
+      })
+    ),
+  });
+
+  return yupResolver(schema);
+};

--- a/frontend/validations/open-call-application.ts
+++ b/frontend/validations/open-call-application.ts
@@ -17,12 +17,20 @@ export const useApplyToOpenCallResolver = () => {
           id: 'L/i942',
         })
       ),
-    message: string().required(
-      formatMessage({
-        defaultMessage: 'You need to enter a message.',
-        id: 'i8NU3I',
-      })
-    ),
+    message: string()
+      .max(
+        600,
+        formatMessage({
+          defaultMessage: 'The message can have a maximum of 600 characters',
+          id: '0ZgDo2',
+        })
+      )
+      .required(
+        formatMessage({
+          defaultMessage: 'You need to enter a message.',
+          id: 'i8NU3I',
+        })
+      ),
   });
 
   return yupResolver(schema);


### PR DESCRIPTION
## Description

**In this PR:**  
- Added a new `useApplyToOpenCall` service/hook to `open-call-service`  
  _used to submit a new open call application_  
- Added `OpenCallApplication` types and form validation schema  
- Added a new `OpenCallApplicationModal` component  
  _modal with the form where the PD can choose a project & message to apply to an open call_   
- OpenCall page changes
  - A PD can apply to an OpenCall from both the header and the CTA at the footer  
    _Using the new `OpenCallApplicationModal`_
  - The open call application buttons are disabled for:
    - Investors  
    - Non-signed in users  
    - Open calls with a status other than `Launched`

**Others:**  
- I've added a new prop to the `Combobox` component so we can have a smaller listbox  
  _This was needed because the default size would not fit the `OpenCallApplication` modal_

## Testing instructions

Verify that:  
- Using a PD account:  
  - Navigate to a closed OpenCall page
    - Verify that the user cannot apply to the open call  
  - Navigate to an open OpelCall page  
    - Verify that the user can open the open call application modal  
    - The form validation works  
      _we don't have a way to view open call applications yet, so the easiest way to confirm it is submitted successfully is to check if the request goes through via devtools/network. We can also grab the `id` and verify that it can be deleted via swagger_  
    - Attempting to re-apply to the open call results in an "open call already taken" error  
      _To test that the modal/form can display errors coming from the endpoint_  
- Using an Investor account  
  - Verify that the user cannot apply to an open call
    _the buttons in the open call page are disabled_
- Without being signed in  
  - Verify that the user cannot apply to an open call
    _the buttons in the open call page are disabled_

## Tracking

[LET-898](https://vizzuality.atlassian.net/browse/LET-898)
[LET-983](https://vizzuality.atlassian.net/browse/LET-983)

## Screenshots

**Modal/form**  
<img width="591" alt="Screenshot 2022-08-29 at 12 57 29" src="https://user-images.githubusercontent.com/6273795/187195940-c6bd342b-c589-4a63-9242-00f058a19692.png">



**FE validation errors**  

<img width="591" alt="Screenshot 2022-08-29 at 12 57 56" src="https://user-images.githubusercontent.com/6273795/187196024-4eb65de7-9c32-4168-aedd-3ebc087a6868.png">

**BE alerts**  

<img width="588" alt="Screenshot 2022-08-29 at 12 58 36" src="https://user-images.githubusercontent.com/6273795/187196168-54f858e3-3629-4c6e-9783-1fec716291ff.png">
