### PR TITLE
Group the impacts by dimension in the project form

### DIFF
--- a/frontend/components/forms/field-info/component.stories.tsx
+++ b/frontend/components/forms/field-info/component.stories.tsx
@@ -13,10 +13,10 @@ export default {
 } as Meta;
 
 const Template: Story<FieldInfoProps> = (args: FieldInfoProps) => {
-  return <FieldInfo infoText={args.infoText} />;
+  return <FieldInfo content={args.content} />;
 };
 
 export const Default: Story<FieldInfoProps> = Template.bind({});
 Default.args = {
-  infoText: 'Info text',
+  content: 'Info text',
 };

--- a/frontend/components/forms/field-info/component.tsx
+++ b/frontend/components/forms/field-info/component.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 
 import { Info } from 'react-feather';
+import { FormattedMessage } from 'react-intl';
 
+import Button from 'components/button';
 import Tooltip from 'components/tooltip';
 
 import { FieldInfoProps } from './types';
 
-export const FieldInfo = ({ infoText }: FieldInfoProps) => {
+export const FieldInfo = ({ content }: FieldInfoProps) => {
   return (
     <Tooltip
       placement="auto"
@@ -14,14 +16,21 @@ export const FieldInfo = ({ infoText }: FieldInfoProps) => {
       arrowClassName="bg-black"
       content={
         <div className="max-w-xs p-2 font-sans text-sm font-normal text-white bg-black rounded-sm sm:max-w-md">
-          {infoText}
+          {content}
         </div>
       }
+      // This is needed in cases where, for example, we have a link inside the tooltip
+      interactive
     >
-      <Info
-        className="inline rounded cursor-pointer focus:border focus:border-green-dark focus:outline-none"
-        size={14.67}
-      />
+      <Button size="smallest" theme="naked" className="inline-flex align-middle">
+        <span className="sr-only">
+          <FormattedMessage defaultMessage="Info" id="we4Lby" />
+        </span>
+        <Info
+          className="inline rounded cursor-pointer focus:border focus:border-green-dark focus:outline-none"
+          size={14.67}
+        />
+      </Button>
     </Tooltip>
   );
 };

--- a/frontend/components/forms/field-info/types.ts
+++ b/frontend/components/forms/field-info/types.ts
@@ -1,4 +1,6 @@
+import React from 'react';
+
 export type FieldInfoProps = {
-  /** info text to display on Tooltip */
-  infoText: string | JSX.Element;
+  /** Content of the tooltip */
+  content: string | React.ReactNode;
 };

--- a/frontend/containers/forms/filters/component.tsx
+++ b/frontend/containers/forms/filters/component.tsx
@@ -125,7 +125,7 @@ export const Filters: FC<FiltersProps> = ({
                         {legends[index]}
                       </span>
                       <FieldInfo
-                        infoText={
+                        content={
                           <ul>
                             {item.map(({ name, id, description }) => (
                               <li key={id} className="mb-2">

--- a/frontend/containers/impact-chart/component.tsx
+++ b/frontend/containers/impact-chart/component.tsx
@@ -147,7 +147,7 @@ export const ImpactChart: FC<ImpactChartProps> = ({
               <span className="hidden mr-2 text-sm font-semibold text-gray-800 sm:flex">
                 {impactData[ImpactsEnum.Biodiversity].name}
               </span>
-              <FieldInfo infoText={impactData[ImpactsEnum.Biodiversity].description} />
+              <FieldInfo content={impactData[ImpactsEnum.Biodiversity].description} />
             </span>
           )}
           <span className="flex w-full">
@@ -156,7 +156,7 @@ export const ImpactChart: FC<ImpactChartProps> = ({
                 <span className="hidden mr-2 text-sm font-semibold text-gray-800 sm:flex">
                   {impactData[ImpactsEnum.Water].name}
                 </span>
-                <FieldInfo infoText={impactData[ImpactsEnum.Water].description} />
+                <FieldInfo content={impactData[ImpactsEnum.Water].description} />
               </span>
             )}
             <span className="relative flex items-center w-full overflow-x-hidden aspect-square">
@@ -169,7 +169,7 @@ export const ImpactChart: FC<ImpactChartProps> = ({
                 <span className="hidden mr-2 text-sm font-semibold text-gray-800 sm:flex">
                   {impactData[ImpactsEnum.Climate].name}
                 </span>
-                <FieldInfo infoText={impactData[ImpactsEnum.Climate].description} />
+                <FieldInfo content={impactData[ImpactsEnum.Climate].description} />
               </span>
             )}
           </span>
@@ -178,7 +178,7 @@ export const ImpactChart: FC<ImpactChartProps> = ({
               <span className="hidden mr-2 text-sm font-semibold text-gray-800 sm:flex">
                 {impactData[ImpactsEnum.Community].name}
               </span>
-              <FieldInfo infoText={impactData[ImpactsEnum.Community].description} />
+              <FieldInfo content={impactData[ImpactsEnum.Community].description} />
             </span>
           )}
         </div>

--- a/frontend/containers/investor-form/pages/impacts.tsx
+++ b/frontend/containers/investor-form/pages/impacts.tsx
@@ -82,7 +82,7 @@ export const Impact: FC<ImpactProps> = ({
                 />
               </span>
               <FieldInfo
-                infoText={
+                content={
                   <ul>
                     {impacts?.map(({ id, name, description }) => (
                       <li key={id}>

--- a/frontend/containers/investor-form/pages/investment.tsx
+++ b/frontend/containers/investor-form/pages/investment.tsx
@@ -45,7 +45,7 @@ const InvestmentInformation: FC<InvestmentInformationProps> = ({
                   />
                 </span>
                 <FieldInfo
-                  infoText={
+                  content={
                     <ul>
                       {categories?.map(({ id, name, description }) => (
                         <li key={id}>
@@ -140,7 +140,7 @@ const InvestmentInformation: FC<InvestmentInformationProps> = ({
                   />
                 </span>
                 <FieldInfo
-                  infoText={
+                  content={
                     <ul>
                       {instrument_types?.map(({ id, name, description }) => (
                         <li key={id}>

--- a/frontend/containers/investor-form/pages/profile.tsx
+++ b/frontend/containers/investor-form/pages/profile.tsx
@@ -52,7 +52,7 @@ export const Profile: FC<ProfileProps> = ({
             <FormattedMessage defaultMessage="Picture" id="wvoA3H" />
           </Label>
           <FieldInfo
-            infoText={formatMessage({
+            content={formatMessage({
               defaultMessage: 'Add your logo or a picture that identifies the account.',
               id: '2Cbk6h',
             })}
@@ -169,7 +169,7 @@ export const Profile: FC<ProfileProps> = ({
               <FormattedMessage defaultMessage="Email" id="sy+pv5" />
               <span className="ml-2.5">
                 <FieldInfo
-                  infoText={formatMessage({
+                  content={formatMessage({
                     defaultMessage: 'Insert the email to receive the contact messages.',
                     id: 'Qmlx+T',
                   })}
@@ -196,7 +196,7 @@ export const Profile: FC<ProfileProps> = ({
               <FormattedMessage defaultMessage="Phone number (optional)" id="JNTB42" />
               <span className="ml-2.5">
                 <FieldInfo
-                  infoText={formatMessage({
+                  content={formatMessage({
                     defaultMessage:
                       'Insert the phone number in case you would like to be contacted by phone.',
                     id: 'VkljLs',

--- a/frontend/containers/open-call-form/pages/expected-impact.tsx
+++ b/frontend/containers/open-call-form/pages/expected-impact.tsx
@@ -40,7 +40,7 @@ export const OpenCallExpectedImpact: FC<OpenCallExpectedImpactProps> = ({
               <FormattedMessage defaultMessage="Expected impact" id="XgaRPC" />
             </Label>
             <FieldInfo
-              infoText={formatMessage({
+              content={formatMessage({
                 defaultMessage:
                   'Describe briefly the impact that the project is expected to generate.',
                 id: 'jqCFCY',

--- a/frontend/containers/open-call-form/pages/funding-information.tsx
+++ b/frontend/containers/open-call-form/pages/funding-information.tsx
@@ -69,7 +69,7 @@ export const OpenCallFundingInformation: FC<OpenCallFundingInformationProps> = (
                 <FormattedMessage defaultMessage="Financial instruments available" id="EFVd2S" />
               </span>
               <FieldInfo
-                infoText={
+                content={
                   <ul>
                     {instrument_types?.map(({ id, name, description }) => (
                       <li key={id}>
@@ -122,7 +122,7 @@ export const OpenCallFundingInformation: FC<OpenCallFundingInformationProps> = (
               <FormattedMessage defaultMessage="Funding priorities" id="P1f6hp" />
             </Label>
             <FieldInfo
-              infoText={formatMessage({
+              content={formatMessage({
                 defaultMessage: 'What type of projects the funding is covering.',
                 id: 'b3Iz6I',
               })}
@@ -151,7 +151,7 @@ export const OpenCallFundingInformation: FC<OpenCallFundingInformationProps> = (
               <FormattedMessage defaultMessage="Funding exclusions" id="gQ16Mj" />
             </Label>
             <FieldInfo
-              infoText={formatMessage({
+              content={formatMessage({
                 defaultMessage: 'What type of projects the funding is not covering.',
                 id: 'ydCOwz',
               })}

--- a/frontend/containers/open-call-form/pages/information.tsx
+++ b/frontend/containers/open-call-form/pages/information.tsx
@@ -105,7 +105,7 @@ export const OpenCallInformation: FC<OpenCallInformationProps> = ({
               <FormattedMessage defaultMessage="Picture (optional)" id="8rdnTq" />
             </Label>
             <FieldInfo
-              infoText={formatMessage({
+              content={formatMessage({
                 defaultMessage: 'A picture can make your open call page more attractive.',
                 id: 'iFQwyC',
               })}

--- a/frontend/containers/project-developer-form/pages/about.tsx
+++ b/frontend/containers/project-developer-form/pages/about.tsx
@@ -68,7 +68,7 @@ export const About: FC<AboutProps> = ({
               <legend className="font-sans font-semibold text-sm text-gray-800 mb-4.5">
                 <span className="mr-2.5">{title}</span>
 
-                <FieldInfo infoText={infoText || getItemsInfoText(items)} />
+                <FieldInfo content={infoText || getItemsInfoText(items)} />
               </legend>
               {name === InterestNames.PriorityLandscapes && (
                 <Button

--- a/frontend/containers/project-developer-form/pages/profile.tsx
+++ b/frontend/containers/project-developer-form/pages/profile.tsx
@@ -52,7 +52,7 @@ export const Profile: FC<ProfileProps> = ({
             <FormattedMessage defaultMessage="Picture" id="wvoA3H" />
           </Label>
           <FieldInfo
-            infoText={formatMessage({
+            content={formatMessage({
               defaultMessage: 'Add your logo or a picture that indentifies the account.',
               id: 'bjubNC',
             })}
@@ -130,7 +130,7 @@ export const Profile: FC<ProfileProps> = ({
           />
           <span className="ml-2.5">
             <FieldInfo
-              infoText={formatMessage({
+              content={formatMessage({
                 defaultMessage:
                   'Add your legal registration number so we can verify your legal entity . This information will not be publicaly available.',
                 id: '11hyS6',
@@ -202,7 +202,7 @@ export const Profile: FC<ProfileProps> = ({
               <FormattedMessage defaultMessage="Email" id="sy+pv5" />
               <span className="ml-2.5">
                 <FieldInfo
-                  infoText={formatMessage({
+                  content={formatMessage({
                     defaultMessage: 'Insert the email to receive the contact messages.',
                     id: 'Qmlx+T',
                   })}
@@ -229,7 +229,7 @@ export const Profile: FC<ProfileProps> = ({
               <FormattedMessage defaultMessage="Phone number (optional)" id="JNTB42" />
               <span className="ml-2.5">
                 <FieldInfo
-                  infoText={formatMessage({
+                  content={formatMessage({
                     defaultMessage:
                       'Insert the phone number in case you would like to be contacted by phone.',
                     id: 'VkljLs',

--- a/frontend/containers/project-form/component.tsx
+++ b/frontend/containers/project-form/component.tsx
@@ -74,6 +74,7 @@ export const ProjectForm: FC<ProjectFormProps> = ({
     formState: { errors },
     control,
     getValues,
+    watch,
     setValue,
     clearErrors,
     resetField,
@@ -297,6 +298,7 @@ export const ProjectForm: FC<ProjectFormProps> = ({
             controlOptions={{ disabled: false }}
             errors={errors}
             getValues={getValues}
+            watch={watch}
             impacts={impact}
             impactAreas={impact_area}
             setValue={setValue}

--- a/frontend/containers/project-form/component.tsx
+++ b/frontend/containers/project-form/component.tsx
@@ -58,6 +58,7 @@ export const ProjectForm: FC<ProjectFormProps> = ({
     category,
     project_development_stage,
     project_target_group,
+    impact,
     impact_area,
     ticket_size,
     instrument_type,
@@ -296,7 +297,8 @@ export const ProjectForm: FC<ProjectFormProps> = ({
             controlOptions={{ disabled: false }}
             errors={errors}
             getValues={getValues}
-            impacts={impact_area}
+            impacts={impact}
+            impactAreas={impact_area}
             setValue={setValue}
             clearErrors={clearErrors}
           />

--- a/frontend/containers/project-form/pages/funding.tsx
+++ b/frontend/containers/project-form/pages/funding.tsx
@@ -74,7 +74,7 @@ const Funding = ({
                     />
                   </span>
                   <FieldInfo
-                    infoText={formatMessage({
+                    content={formatMessage({
                       defaultMessage:
                         'If you are not looking for funding and just want to publish your project, select No.',
                       id: 'OWnChd',
@@ -181,7 +181,7 @@ const Funding = ({
                     <FormattedMessage defaultMessage="Select the intrument type(s)" id="hWhIuU" />
                   </span>
                   <FieldInfo
-                    infoText={formatMessage({
+                    content={formatMessage({
                       defaultMessage:
                         'What type of financing are you looking for to implement your project or solution?',
                       id: 'ADBj6Y',
@@ -224,7 +224,7 @@ const Funding = ({
                   <FormattedMessage defaultMessage="How will the money be used?" id="1t1fGY" />
                 </span>
                 <FieldInfo
-                  infoText={formatMessage({
+                  content={formatMessage({
                     defaultMessage:
                       'Please briefly describe the main groups of activities or components for the implementation of the project. It is not necessary to be very detailed, just a logical sequence of the general lines of action. These groups of activities should be used to define the estimated budget below. No more than three groups of activities or components',
                     id: 'Ec0M9T',

--- a/frontend/containers/project-form/pages/general-information.tsx
+++ b/frontend/containers/project-form/pages/general-information.tsx
@@ -117,7 +117,7 @@ const GeneralInformation = ({
               <FormattedMessage defaultMessage="Project name" id="D5RCKi" />
             </span>
             <FieldInfo
-              infoText={formatMessage({
+              content={formatMessage({
                 defaultMessage: 'A great name is short, crisp, and easily understood.',
                 id: 'rPwaWt',
               })}
@@ -144,7 +144,7 @@ const GeneralInformation = ({
               <FormattedMessage defaultMessage="Project gallery (optional)" id="7aTDQM" />
             </span>
             <FieldInfo
-              infoText={formatMessage({
+              content={formatMessage({
                 defaultMessage:
                   'The project gallery will be the first thing other users will see on you page, it will help you to showcase you project.',
                 id: 'c1m3Q7',
@@ -215,7 +215,7 @@ const GeneralInformation = ({
               <FormattedMessage defaultMessage="Draw or upload your location" id="MHwpc4" />
             </span>
             <FieldInfo
-              infoText={
+              content={
                 <>
                   <p>
                     <FormattedMessage
@@ -261,7 +261,7 @@ const GeneralInformation = ({
                   />
                 </span>
                 <FieldInfo
-                  infoText={formatMessage({
+                  content={formatMessage({
                     defaultMessage: 'Do you have a partnership with someone else?',
                     id: 'nbqoY2',
                   })}

--- a/frontend/containers/project-form/pages/impact.tsx
+++ b/frontend/containers/project-form/pages/impact.tsx
@@ -73,10 +73,22 @@ export const Impact = ({
                 />
               </span>
               <FieldInfo
-                content={formatMessage({
-                  defaultMessage: 'This will help us measure the impact of your project',
-                  id: 'eTuDrh',
-                })}
+                content={formatMessage(
+                  {
+                    defaultMessage:
+                      'This will help us measure the impact of your project. Try to be as precise and realistic as possible, choosing only your main direct impacts. <a>Learn more</a>',
+                    id: 'c+PoWZ',
+                  },
+                  {
+                    a: (chunks: string) => (
+                      <Link href={FaqPaths['how-is-the-impact-calculated']}>
+                        <a className="underline" target="_blank">
+                          {chunks}
+                        </a>
+                      </Link>
+                    ),
+                  }
+                )}
               />
             </legend>
             {impacts.map((impact) => (

--- a/frontend/containers/project-form/pages/impact.tsx
+++ b/frontend/containers/project-form/pages/impact.tsx
@@ -1,5 +1,9 @@
+import { useMemo } from 'react';
+
 import { FieldError } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
+
+import { groupBy } from 'lodash-es';
 
 import Sdgs from 'containers/forms/sdgs';
 
@@ -14,11 +18,14 @@ export const Impact = ({
   register,
   errors,
   impacts,
+  impactAreas,
   setValue,
   clearErrors,
   getValues,
 }: ImpactProps) => {
   const { formatMessage } = useIntl();
+
+  const impactsByDimension = useMemo(() => groupBy(impactAreas, 'impact'), [impactAreas]);
 
   return (
     <div>
@@ -32,7 +39,7 @@ export const Impact = ({
         />
       </p>
       <form noValidate>
-        <div className="mb-6.5">
+        <div className="mb-10">
           <fieldset>
             <legend className="inline font-sans font-semibold text-sm text-gray-800 mb-4.5">
               <span className="mr-2.5">
@@ -48,25 +55,47 @@ export const Impact = ({
                 })}
               />
             </legend>
-            <TagGroup
-              name="impact_areas"
-              setValue={setValue}
-              errors={errors}
-              clearErrors={clearErrors}
-            >
-              {impacts?.map((item) => (
-                <Tag
-                  key={item.id}
-                  id={item.id}
-                  name="impact_areas"
-                  value={item.id}
-                  aria-describedby="impact-areas-error"
-                  register={register}
-                >
-                  {item.name}
-                </Tag>
-              ))}
-            </TagGroup>
+            {impacts.map((impact) => (
+              <div
+                key={impact.id}
+                className="mt-4 first-of-type:mt-0 px-4 py-4.5 bg-background-middle rounded-lg"
+              >
+                <fieldset>
+                  <legend className="text-sm text-gray-800 mb-4.5">
+                    <span className="font-semibold">{impact.name}</span> (
+                    <FormattedMessage
+                      defaultMessage="select <b>max. {areasCount}</b> areas"
+                      id="xDgU8W"
+                      values={{
+                        areasCount: (impactsByDimension[impact.id]?.length ?? 1) - 1,
+                        b: (chunks: string) => <span className="font-semibold">{chunks}</span>,
+                      }}
+                    />
+                    )
+                  </legend>
+                  <TagGroup
+                    name="impact_areas"
+                    setValue={setValue}
+                    errors={errors}
+                    clearErrors={clearErrors}
+                    thresholdToShowSelectAll={Infinity}
+                  >
+                    {impactsByDimension[impact.id]?.map((item) => (
+                      <Tag
+                        key={item.id}
+                        id={item.id}
+                        name="impact_areas"
+                        value={item.id}
+                        aria-describedby="impact-areas-error"
+                        register={register}
+                      >
+                        {item.name}
+                      </Tag>
+                    ))}
+                  </TagGroup>
+                </fieldset>
+              </div>
+            ))}
           </fieldset>
           <ErrorMessage
             id="impact-areas-error"

--- a/frontend/containers/project-form/pages/impact.tsx
+++ b/frontend/containers/project-form/pages/impact.tsx
@@ -73,7 +73,7 @@ export const Impact = ({
                 />
               </span>
               <FieldInfo
-                infoText={formatMessage({
+                content={formatMessage({
                   defaultMessage: 'This will help us measure the impact of your project',
                   id: 'eTuDrh',
                 })}

--- a/frontend/containers/project-form/pages/other-information.tsx
+++ b/frontend/containers/project-form/pages/other-information.tsx
@@ -30,7 +30,7 @@ const OtherInformation = ({ register, errors }: ProjectFormPagesProps<ProjectFor
               <FormattedMessage defaultMessage="Short description of the project" id="YWQkk+" />
             </span>
             <FieldInfo
-              infoText={formatMessage({
+              content={formatMessage({
                 defaultMessage:
                   "This description should succently explain your project. It should be a catching text since it's the first thing investors will read.",
                 id: '5mkG4O',
@@ -55,7 +55,7 @@ const OtherInformation = ({ register, errors }: ProjectFormPagesProps<ProjectFor
               <FormattedMessage defaultMessage="Relevant links (optional)" id="jKdvln" />
             </span>
             <FieldInfo
-              infoText={formatMessage({
+              content={formatMessage({
                 defaultMessage:
                   'Use this space to share links to documents, videos and websites that support your pitch.',
                 id: 'efZTBX',

--- a/frontend/containers/project-form/pages/project-description.tsx
+++ b/frontend/containers/project-form/pages/project-description.tsx
@@ -55,7 +55,7 @@ const ProjectDescription = ({
                   />
                 </span>
                 <FieldInfo
-                  infoText={formatMessage({
+                  content={formatMessage({
                     defaultMessage:
                       'Select the stage of development of the project or solution at the time of submitting this pitch',
                     id: '3hV8r4',
@@ -91,7 +91,7 @@ const ProjectDescription = ({
                   />
                 </span>
                 <FieldInfo
-                  infoText={formatMessage({
+                  content={formatMessage({
                     defaultMessage:
                       'Enter the estimated implementation duration for the project. MAX 36 months.',
                     id: '/Lbk/f',
@@ -126,7 +126,7 @@ const ProjectDescription = ({
                   />
                 </span>
                 <FieldInfo
-                  infoText={
+                  content={
                     <ul>
                       {category?.map(({ id, name, description }) => (
                         <li key={id}>
@@ -171,7 +171,7 @@ const ProjectDescription = ({
               <FormattedMessage defaultMessage="Problem you are solving" id="xBZz+E" />
             </span>
             <FieldInfo
-              infoText={formatMessage({
+              content={formatMessage({
                 defaultMessage:
                   'Describe the problem or market need that your project or solution seeks to address. It should be a very specific problem, not a macro global issue like "climate change" or "poverty". Make sure that your showing that the problem is addressing a specific demand (is real) and it affects the poor and vulnerable population and/or the environment. We recommend using numbers to give a dimension of the problem.',
                 id: '6xBvFx',
@@ -197,7 +197,7 @@ const ProjectDescription = ({
               <FormattedMessage defaultMessage="The solution or opportunity proposed" id="OSAxiC" />
             </span>
             <FieldInfo
-              infoText={formatMessage({
+              content={formatMessage({
                 defaultMessage:
                   'Describe the project or solution and describe clearly why you consider it is innovative, different from others and how it can generate an important change and impact towards the target groups. Highlight the characteristics that may attract partners, clients, or investors.',
                 id: 'eXDHt0',
@@ -224,7 +224,7 @@ const ProjectDescription = ({
                 <FormattedMessage defaultMessage="Target group" id="0L/mZC" />
               </span>
               <FieldInfo
-                infoText={formatMessage({
+                content={formatMessage({
                   defaultMessage:
                     'Identify the target group(s) of this solution. Try to be very specific and do not cover an unrealistic range of beneficiaries or clients.',
                   id: 'Zht65f',
@@ -266,7 +266,7 @@ const ProjectDescription = ({
               <FormattedMessage defaultMessage="Expected impact" id="XgaRPC" />
             </span>
             <FieldInfo
-              infoText={formatMessage({
+              content={formatMessage({
                 defaultMessage:
                   'Describe briefly the impact that the project is expected to generate to the identified users/beneficiaries. Try to explain how the solution or project will achieve this impact. Also try to give some estimates of the number of people impacted, at least to get an initial idea.',
                 id: '4JFhNG',

--- a/frontend/containers/project-form/pages/project-grow.tsx
+++ b/frontend/containers/project-form/pages/project-grow.tsx
@@ -29,7 +29,7 @@ export const ProjectGrow = ({ register, errors }: ProjectFormPagesProps<ProjectF
               <FormattedMessage defaultMessage="Replicability of the project" id="qoImFc" />
             </span>
             <FieldInfo
-              infoText={formatMessage({
+              content={formatMessage({
                 defaultMessage:
                   'Explain how the solution or project can be replicated in other contexts and geographies. Think practically about the existing opportunities, the partners and allies needed as well as the barriers that this replication effort may face such as climate issues, regulations and legal frameworks, land tenure, institutional capacity, etc.',
                 id: '6MoU6D',
@@ -55,7 +55,7 @@ export const ProjectGrow = ({ register, errors }: ProjectFormPagesProps<ProjectF
               <FormattedMessage defaultMessage="Sustainability of the project" id="8MAKwj" />
             </span>
             <FieldInfo
-              infoText={formatMessage({
+              content={formatMessage({
                 defaultMessage:
                   'Explain how the impact of the solution or project will be maintained after funding.  Try to be specific and not too vague. Is the solution or project will be financially viable? How? What are the key elements to ensure sustainability (business model, partners, partnerships with governments, etc.)?',
                 id: 'oN8abW',
@@ -81,7 +81,7 @@ export const ProjectGrow = ({ register, errors }: ProjectFormPagesProps<ProjectF
               <FormattedMessage defaultMessage="Progress and impact tracking" id="JJQfhh" />
             </span>
             <FieldInfo
-              infoText={formatMessage({
+              content={formatMessage({
                 defaultMessage:
                   'How do you plan to measure the progress and impact of the project or solution? What would be the key indicators to be used for these measurements?',
                 id: 'yb3Bot',

--- a/frontend/containers/project-form/types.ts
+++ b/frontend/containers/project-form/types.ts
@@ -10,6 +10,7 @@ import {
   UseFormSetValue,
   UseFormResetField,
   UseFormSetError,
+  UseFormWatch,
 } from 'react-hook-form';
 import { UseMutationResult } from 'react-query';
 
@@ -53,6 +54,8 @@ export type ProjectFormPagesProps<FormValues> = {
   };
   /** React-hook-form useForm getValues */
   getValues?: UseFormGetValues<FormValues>;
+  /** React-hook-form useForm watch */
+  watch?: UseFormWatch<FormValues>;
   /** React-hook-form useForm setValues */
   setValue?: UseFormSetValue<FormValues>;
   /** React-hook-form useForm clearErrors */

--- a/frontend/containers/project-form/types.ts
+++ b/frontend/containers/project-form/types.ts
@@ -71,6 +71,7 @@ export type ProjectDescriptionProps = ProjectFormPagesProps<ProjectForm> & {
 
 export type ImpactProps = ProjectFormPagesProps<ProjectForm> & {
   impacts: Enum[];
+  impactAreas: Enum[];
 };
 
 export type FundingProps = ProjectFormPagesProps<ProjectForm> & {

--- a/frontend/hooks/useFaq.tsx
+++ b/frontend/hooks/useFaq.tsx
@@ -31,6 +31,7 @@ export enum FaqQuestions {
   ForWhoIsTheProjectFor = 'for-who-is-the-project-for',
   HowCanIFundAProject = 'how-can-i-fund-a-project',
   WhatInfoToCreateProject = 'what-information-do-i-need-to-create-a-project',
+  HowIsTheImpactCalculated = 'how-is-the-impact-calculated',
   /** Open calls */
   WhatIsAnOpenCall = 'what-is-an-open-call',
   ForWhoIsTheOpenCallFor = 'for-who-is-the-open-call-for',
@@ -58,6 +59,7 @@ export const FaqPaths = {
   [FaqQuestions.ForWhoIsTheProjectFor]: `${Paths.FAQ}/${FaqSections.Projects}/${FaqQuestions.ForWhoIsTheProjectFor}`,
   [FaqQuestions.HowCanIFundAProject]: `${Paths.FAQ}/${FaqSections.Projects}/${FaqQuestions.HowCanIFundAProject}`,
   [FaqQuestions.WhatInfoToCreateProject]: `${Paths.FAQ}/${FaqSections.Projects}/${FaqQuestions.WhatInfoToCreateProject}`,
+  [FaqQuestions.HowIsTheImpactCalculated]: `${Paths.FAQ}/${FaqSections.Projects}/${FaqQuestions.HowIsTheImpactCalculated}`,
   /** Open calls */
   [FaqQuestions.WhatIsAnOpenCall]: `${Paths.FAQ}/${FaqSections.OpenCalls}/${FaqQuestions.WhatIsAnOpenCall}`,
   [FaqQuestions.ForWhoIsTheOpenCallFor]: `${Paths.FAQ}/${FaqSections.OpenCalls}/${FaqQuestions.ForWhoIsTheOpenCallFor}`,

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -2733,6 +2733,9 @@
   "xBZz+E": {
     "string": "Problem you are solving"
   },
+  "xDgU8W": {
+    "string": "select <b>max. {areasCount}</b> areas"
+  },
   "xG6n98": {
     "string": "Consolidation"
   },

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -1803,6 +1803,9 @@
   "btdgGc": {
     "string": "<a>Browse the open calls</a> posted by our investor community to identify new areas for project development."
   },
+  "c+PoWZ": {
+    "string": "This will help us measure the impact of your project. Try to be as precise and realistic as possible, choosing only your main direct impacts. <a>Learn more</a>"
+  },
   "c1m3Q7": {
     "string": "The project gallery will be the first thing other users will see on you page, it will help you to showcase you project."
   },
@@ -1910,9 +1913,6 @@
   },
   "eSLLyC": {
     "string": "To complete you registration and make full use of the platform, please select which account you would like to create."
-  },
-  "eTuDrh": {
-    "string": "This will help us measure the impact of your project"
   },
   "eXDHt0": {
     "string": "Describe the project or solution and describe clearly why you consider it is innovative, different from others and how it can generate an important change and impact towards the target groups. Highlight the characteristics that may attract partners, clients, or investors."

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -2652,6 +2652,9 @@
   "ui0dk9": {
     "string": "idea to be developed from scratch."
   },
+  "uuxwc2": {
+    "string": "If you select <b>all areas</b>, the impact will be 0. Consider choosing only your main direct ones. <a>Learn more</a>"
+  },
   "uyxTSu": {
     "string": "Select the impacts that you prioritize"
   },

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -2709,6 +2709,9 @@
   "wduJme": {
     "string": "Instrument"
   },
+  "we4Lby": {
+    "string": "Info"
+  },
   "whbx7G": {
     "string": "Geographic spaces of unique biodiversity conditions with sustainability and management plans developed by Herencia Colombia to ensure the provisioning of quality ecosystem services."
   },


### PR DESCRIPTION
This PR groups the impacts by dimension in the project form and warns the user against selecting all the impacts of one dimension to avoid getting a 0 score in that dimension.

## Testing instructions

Create and edit projects.

⚠️ I'm investigating a separate bugs where draft projects can't be edited.

## Tracking

[LET-979](https://vizzuality.atlassian.net/browse/LET-979)
