### PR TITLE
Fix a bug preventing the edition of projects, especially drafts

### DIFF
--- a/frontend/containers/project-form/component.tsx
+++ b/frontend/containers/project-form/component.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useState } from 'react';
+import { FC, useCallback, useState, useEffect } from 'react';
 
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
@@ -221,6 +221,17 @@ export const ProjectForm: FC<ProjectFormProps> = ({
   const contentLocale = defaultValues?.language || userAccount?.language;
   const isOutroPage = currentPage === totalPages;
 
+  // This component may be mounted when `project` has not resolved yet (`isLoading` will be `true`).
+  // In that case, we want to make sure the form is populated with the default values.
+  // `useForm`'s `defaultValues` attribute is only read on mount.
+  useEffect(() => {
+    if (!isLoading && defaultValues) {
+      Object.entries(defaultValues).map(([key, value]) => {
+        setValue(key as keyof ProjectFormType, value);
+      });
+    }
+  }, [isLoading, defaultValues, setValue]);
+
   return (
     <>
       <Head title={title} />
@@ -272,6 +283,7 @@ export const ProjectForm: FC<ProjectFormProps> = ({
             controlOptions={{ disabled: false }}
             errors={errors}
             getValues={getValues}
+            watch={watch}
             resetField={resetField}
             setValue={setValue}
             clearErrors={clearErrors}

--- a/frontend/containers/project-form/pages/general-information.tsx
+++ b/frontend/containers/project-form/pages/general-information.tsx
@@ -30,6 +30,7 @@ const GeneralInformation = ({
   errors,
   control,
   getValues,
+  watch,
   resetField,
   setValue,
   clearErrors,
@@ -46,22 +47,28 @@ const GeneralInformation = ({
     fields: ['name'],
   });
 
+  const watchedProjectImagesAttributes = watch('project_images_attributes');
+  const watchedProjectImagesAttributesCover = watch('project_images_attributes_cover');
+  const watchedInvolvedProjectDeveloper = watch('involved_project_developer');
+
   useEffect(() => {
-    const defaultImages = getValues('project_images_attributes');
-    setImages(defaultImages || []);
+    setImages(watchedProjectImagesAttributes || []);
 
     setCoverImage(
-      getValues('project_images_attributes_cover') || defaultImages?.length
-        ? defaultImages[0]?.file
+      watchedProjectImagesAttributesCover || watchedProjectImagesAttributes?.length
+        ? watchedProjectImagesAttributes[0]?.file
         : undefined
     );
 
-    const involvedProjectDeveloper = getValues('involved_project_developer');
     // If there is a value for involved_project_developer, it checks the corresponding radio button
-    if (typeof involvedProjectDeveloper === 'number') {
-      setDefaultInvolvedProjectDeveloper(!!Number(involvedProjectDeveloper));
+    if (typeof watchedInvolvedProjectDeveloper === 'number') {
+      setDefaultInvolvedProjectDeveloper(!!Number(watchedInvolvedProjectDeveloper));
     }
-  }, [getValues]);
+  }, [
+    watchedProjectImagesAttributes,
+    watchedProjectImagesAttributesCover,
+    watchedInvolvedProjectDeveloper,
+  ]);
 
   const handleChangeInvolvedProjectDeveloper = (e: ChangeEvent<HTMLInputElement>) => {
     setDefaultInvolvedProjectDeveloper(!!Number(e.target.value));

--- a/frontend/pages/project/[id]/edit.tsx
+++ b/frontend/pages/project/[id]/edit.tsx
@@ -43,8 +43,13 @@ export const getServerSideProps = withLocalizedRequests(async ({ params: { id },
   let enums;
 
   try {
-    ({ data: project } = await getProject(id as string, PROJECT_QUERY_PARAMS));
+    // The enums and any data mandatory for the page should be placed before the request for the
+    // project's data. The reason is that if the project is a draft, the request will fail and
+    // execute again on the client. Any request after the project's won't be initiated.
+    // We can either put the other requests before the project's or re-execute them on the client.
     enums = await getEnums();
+
+    ({ data: project } = await getProject(id as string, PROJECT_QUERY_PARAMS));
   } catch (e) {
     // The user may be attempting to preview a drafted project, which the endpoint won't return
     // unless the ownership can be verified. We'll be loading it client side and redirect the user


### PR DESCRIPTION
This PR fixes issues that prevented the edition of projects, especially drafts:
- The fields wouldn't be filled in with the project's data (drafts only)
- The fields based on enums wouldn't be rendered or crash (drafts only)
- The “involved PD” field wouldn't always be restored correctly

## Testing instructions

1. Go to the list of projects
2. Edit a draft project

Make sure all the fields are restored (enums or not), including the “involved PD” field.

3. Go back to the list of projects
4. Reload the page
5. Edit a draft project

Make sure the “involved PD” field is restored.

6. Try creating a new project

## Tracking

[LET-1016](https://vizzuality.atlassian.net/browse/LET-1016)
