### PR TITLE
Allow visitors to filter projects and PDs by priority landscape

### DIFF
--- a/frontend/containers/forms/filters/component.tsx
+++ b/frontend/containers/forms/filters/component.tsx
@@ -13,9 +13,10 @@ import Tag from 'components/forms/tag';
 import TagGroup from 'components/forms/tag-group';
 import Icon from 'components/icon';
 import Loading from 'components/loading';
-import { EnumTypes } from 'enums';
+import { EnumTypes, LocationsTypes } from 'enums';
 
 import { useEnums } from 'services/enums/enumService';
+import { usePriorityLandscapes } from 'services/locations/locations';
 
 import { FiltersProps, FilterForm } from './types';
 
@@ -43,13 +44,35 @@ export const Filters: FC<FiltersProps> = ({
     isLoading,
   } = useEnums();
 
-  const filters = [category, impact, ticket_size, instrument_type];
+  const { priorityLandscapes } = usePriorityLandscapes();
 
-  const legends = [
-    formatMessage({ defaultMessage: 'Category', id: 'ccXLVi' }),
-    formatMessage({ defaultMessage: 'Impact', id: 'W2JBdp' }),
-    formatMessage({ defaultMessage: 'Ticket size', id: 'lfx6Nc' }),
-    formatMessage({ defaultMessage: 'Instrument', id: 'wduJme' }),
+  const filters = [
+    { title: formatMessage({ defaultMessage: 'Category', id: 'ccXLVi' }), values: category },
+    { title: formatMessage({ defaultMessage: 'Impact', id: 'W2JBdp' }), values: impact },
+    { title: formatMessage({ defaultMessage: 'Ticket size', id: 'lfx6Nc' }), values: ticket_size },
+    {
+      title: formatMessage({ defaultMessage: 'Instrument', id: 'wduJme' }),
+      values: instrument_type,
+    },
+    {
+      title: formatMessage({ defaultMessage: 'Priority landscape', id: 'dwB95+' }),
+      description: formatMessage(
+        {
+          defaultMessage:
+            'Priority landscapes are <b>unique regions</b> due to their biodiversity, cultural heritages, and regulation of water systems. As such, the projects located in these landscapes will have the greatest impact on people and nature.',
+          id: 'zyG32m',
+        },
+        {
+          b: (chunks: string) => <span className="font-semibold">{chunks}</span>,
+        }
+      ),
+      values:
+        priorityLandscapes?.map(({ id, name }) => ({
+          id,
+          type: LocationsTypes.PriorityLandscapes,
+          name,
+        })) ?? [],
+    },
   ];
 
   const handleClear = () => {
@@ -108,68 +131,66 @@ export const Filters: FC<FiltersProps> = ({
             </Button>
           </div>
 
-          <div className="flex flex-col flex-wrap sm:flex-row gap-y-4">
-            {filters?.map((item, index) => {
-              const fieldName = item[0].type;
+          <div className="flex flex-col flex-wrap gap-y-4">
+            {filters?.map((filter) => {
               return (
-                <div
-                  key={fieldName}
-                  className={cx({
-                    'sm:w-2/3 sm:pr-10': index % 2 === 0,
-                    'sm:w-1/3': index % 2 !== 0,
-                  })}
-                >
+                <div key={filter.title}>
                   <fieldset>
                     <legend className="inline mb-3 font-sans text-base font-medium text-black">
                       <span className="mr-2 font-sans text-sm font-semibold text-gray-800">
-                        {legends[index]}
+                        {filter.title}
                       </span>
                       <FieldInfo
                         content={
-                          <ul>
-                            {item.map(({ name, id, description }) => (
-                              <li key={id} className="mb-2">
-                                <p className="font-bold ">{name}</p>
-                                <p>{description}</p>
-                              </li>
-                            ))}
-                          </ul>
+                          filter.description ? (
+                            filter.description
+                          ) : (
+                            <ul>
+                              {filter.values.map((value) => (
+                                <li key={value.id} className="mb-2">
+                                  <p className="font-bold ">{value.name}</p>
+                                  {!!value.description && <p>{value.description}</p>}
+                                </li>
+                              ))}
+                            </ul>
+                          )
                         }
                       />
                     </legend>
 
-                    <TagGroup
-                      key={fieldName}
-                      name={fieldName}
-                      type="radio"
-                      clearErrors={clearErrors}
-                      setValue={setValue}
-                      errors={errors}
-                      thresholdToShowSelectAll={Infinity}
-                      className="flex flex-wrap gap-2"
-                      isFilterTag
-                    >
-                      {item.map(({ name, id, type, description }) => (
-                        <Tag
-                          key={id}
-                          id={`${id}-tag`}
-                          name={type}
-                          value={id}
-                          register={register}
-                          registerOptions={{
-                            disabled: false,
-                            onChange,
-                          }}
-                          type="radio"
-                          isfilterTag
-                          onClick={onChange}
-                        >
-                          <span className="block">
-                            {type === EnumTypes.TicketSize ? description : name}
-                          </span>
-                        </Tag>
-                      ))}
-                    </TagGroup>
+                    {!!filter.values.length && (
+                      <TagGroup
+                        name={filter.values?.[0].type}
+                        type="radio"
+                        clearErrors={clearErrors}
+                        setValue={setValue}
+                        errors={errors}
+                        thresholdToShowSelectAll={Infinity}
+                        className="flex flex-wrap gap-2"
+                        isFilterTag
+                      >
+                        {filter.values.map(({ name, id, type, description }) => (
+                          <Tag
+                            key={id}
+                            id={`${id}-tag`}
+                            name={type}
+                            value={id}
+                            register={register}
+                            registerOptions={{
+                              disabled: false,
+                              onChange,
+                            }}
+                            type="radio"
+                            isfilterTag
+                            onClick={onChange}
+                          >
+                            <span className="block">
+                              {type === EnumTypes.TicketSize ? description : name}
+                            </span>
+                          </Tag>
+                        ))}
+                      </TagGroup>
+                    )}
                   </fieldset>
                 </div>
               );

--- a/frontend/containers/forms/filters/component.tsx
+++ b/frontend/containers/forms/filters/component.tsx
@@ -111,176 +111,184 @@ export const Filters: FC<FiltersProps> = ({
   return isLoading ? (
     <Loading />
   ) : (
-    <div className="p-6">
-      <form onSubmit={handleSubmit(onSubmitFilters)}>
-        <div>
-          <div className="flex justify-between">
-            <div className="flex items-center mb-4">
-              <Checkbox
-                id="verified"
-                name="only_verified"
-                register={register}
-                registerOptions={{ onChange: onCheckboxChange }}
-              />
-              <label htmlFor="verified" className="mt-1 text-sm font-normal text-gray-800">
-                <FormattedMessage defaultMessage="Show verified content only" id="i9eK6b" />
-              </label>
-            </div>
-            <Button theme="naked" className="px-0 py-0" onClick={closeFilters}>
-              <CloseIcon className="w-4 h-4 transition-transform rotate-0 hover:rotate-180" />
-            </Button>
-          </div>
-
-          <div className="flex flex-col flex-wrap gap-y-4">
-            {filters?.map((filter) => {
-              return (
-                <div key={filter.title}>
-                  <fieldset>
-                    <legend className="inline mb-3 font-sans text-base font-medium text-black">
-                      <span className="mr-2 font-sans text-sm font-semibold text-gray-800">
-                        {filter.title}
-                      </span>
-                      <FieldInfo
-                        content={
-                          filter.description ? (
-                            filter.description
-                          ) : (
-                            <ul>
-                              {filter.values.map((value) => (
-                                <li key={value.id} className="mb-2">
-                                  <p className="font-bold ">{value.name}</p>
-                                  {!!value.description && <p>{value.description}</p>}
-                                </li>
-                              ))}
-                            </ul>
-                          )
-                        }
-                      />
-                    </legend>
-
-                    {!!filter.values.length && (
-                      <TagGroup
-                        name={filter.values?.[0].type}
-                        type="radio"
-                        clearErrors={clearErrors}
-                        setValue={setValue}
-                        errors={errors}
-                        thresholdToShowSelectAll={Infinity}
-                        className="flex flex-wrap gap-2"
-                        isFilterTag
-                      >
-                        {filter.values.map(({ name, id, type, description }) => (
-                          <Tag
-                            key={id}
-                            id={`${id}-tag`}
-                            name={type}
-                            value={id}
-                            register={register}
-                            registerOptions={{
-                              disabled: false,
-                              onChange,
-                            }}
-                            type="radio"
-                            isfilterTag
-                            onClick={onChange}
-                          >
-                            <span className="block">
-                              {type === EnumTypes.TicketSize ? description : name}
-                            </span>
-                          </Tag>
-                        ))}
-                      </TagGroup>
-                    )}
-                  </fieldset>
-                </div>
-              );
-            })}
-          </div>
-
-          <div className="flex my-4">
-            {/* More filters accordion header https://www.w3.org/WAI/ARIA/apg/example-index/accordion/accordion.html */}
-            <h3>
-              <Button
-                onClick={() => setShowMoreFilters(!showMoreFilters)}
-                theme="naked"
-                className="px-0 py-0 font-sans text-base font-medium text-black"
-                id="more-filters-button"
-                aria-expanded={showMoreFilters}
-                aria-controls="more-filters"
-              >
-                <FormattedMessage defaultMessage="More filters" id="vdJRZj" />
-                <Icon className="w-5 h-5 ml-1" icon={showMoreFilters ? ChevronUp : ChevronDown} />
-              </Button>
-            </h3>
-          </div>
-
-          {/* More filters accordion pannel */}
-          {showMoreFilters && (
-            <div
-              id="more-filters"
-              role="region"
-              aria-labelledby="more-filters-button"
-              className="mb-6"
-            >
-              <fieldset>
-                <legend className="inline mb-3 font-sans text-base font-medium text-black">
-                  <FormattedMessage defaultMessage="SDG's" id="d3TPmn" />
-                </legend>
-
-                <div className="flex flex-wrap gap-4">
-                  <TagGroup
-                    name="sdg"
-                    type="radio"
-                    clearErrors={clearErrors}
-                    setValue={setValue}
-                    errors={errors}
-                    thresholdToShowSelectAll={Infinity}
-                    isFilterTag
-                  >
-                    {sdg.map(({ name, type, id }) => (
-                      <Tag
-                        key={id}
-                        id={`${id}-tag`}
-                        name={type}
-                        value={id}
-                        register={register}
-                        registerOptions={{
-                          disabled: false,
-                          onChange,
-                        }}
-                        type="radio"
-                        isfilterTag
-                        onClick={onChange}
-                      >
-                        <span className="block">{name}</span>
-                      </Tag>
-                    ))}
-                  </TagGroup>
-                </div>
-              </fieldset>
-            </div>
-          )}
-          <div className="items-center justify-between text-sm text-gray-600 sm:flex">
-            <div className="mb-4 sm:mb-0">
-              <p>
-                <FormattedMessage
-                  defaultMessage="Note: Some filters not apply to all tabs"
-                  id="j4lBL7"
-                />
-              </p>
-            </div>
-            <div className="flex justify-end gap-4">
-              <Button theme="secondary-green" onClick={handleClear}>
-                <FormattedMessage defaultMessage="Clear filters" id="F4gyn3" />
-              </Button>
-              <Button theme="primary-green" type="submit">
-                <FormattedMessage defaultMessage="Search" id="xmcVZ0" />
-              </Button>
-            </div>
+    <form
+      className="relative p-6 max-h-[75vh] flex flex-col"
+      onSubmit={handleSubmit(onSubmitFilters)}
+    >
+      <Button
+        theme="naked"
+        size="smallest"
+        className="absolute top-6 right-6"
+        onClick={closeFilters}
+      >
+        <span className="sr-only">
+          <FormattedMessage defaultMessage="Close filters" id="78vrMq" />
+        </span>
+        <CloseIcon className="w-4 h-4 transition-transform rotate-0 hover:rotate-180" />
+      </Button>
+      <div className="overflow-y-auto">
+        <div className="flex justify-between">
+          <div className="flex items-center mb-4">
+            <Checkbox
+              id="verified"
+              name="only_verified"
+              register={register}
+              registerOptions={{ onChange: onCheckboxChange }}
+            />
+            <label htmlFor="verified" className="mt-1 text-sm font-normal text-gray-800">
+              <FormattedMessage defaultMessage="Show verified content only" id="i9eK6b" />
+            </label>
           </div>
         </div>
-      </form>
-    </div>
+
+        <div className="flex flex-col flex-wrap gap-y-4">
+          {filters?.map((filter) => {
+            return (
+              <div key={filter.title}>
+                <fieldset>
+                  <legend className="inline mb-3 font-sans text-base font-medium text-black">
+                    <span className="mr-2 font-sans text-sm font-semibold text-gray-800">
+                      {filter.title}
+                    </span>
+                    <FieldInfo
+                      content={
+                        filter.description ? (
+                          filter.description
+                        ) : (
+                          <ul>
+                            {filter.values.map((value) => (
+                              <li key={value.id} className="mb-2">
+                                <p className="font-bold ">{value.name}</p>
+                                {!!value.description && <p>{value.description}</p>}
+                              </li>
+                            ))}
+                          </ul>
+                        )
+                      }
+                    />
+                  </legend>
+
+                  {!!filter.values.length && (
+                    <TagGroup
+                      name={filter.values?.[0].type}
+                      type="radio"
+                      clearErrors={clearErrors}
+                      setValue={setValue}
+                      errors={errors}
+                      thresholdToShowSelectAll={Infinity}
+                      className="flex flex-wrap gap-2"
+                      isFilterTag
+                    >
+                      {filter.values.map(({ name, id, type, description }) => (
+                        <Tag
+                          key={id}
+                          id={`${id}-tag`}
+                          name={type}
+                          value={id}
+                          register={register}
+                          registerOptions={{
+                            disabled: false,
+                            onChange,
+                          }}
+                          type="radio"
+                          isfilterTag
+                          onClick={onChange}
+                        >
+                          <span className="block">
+                            {type === EnumTypes.TicketSize ? description : name}
+                          </span>
+                        </Tag>
+                      ))}
+                    </TagGroup>
+                  )}
+                </fieldset>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="flex my-4">
+          {/* More filters accordion header https://www.w3.org/WAI/ARIA/apg/example-index/accordion/accordion.html */}
+          <h3>
+            <Button
+              onClick={() => setShowMoreFilters(!showMoreFilters)}
+              theme="naked"
+              className="px-0 py-0 font-sans text-base font-medium text-black"
+              id="more-filters-button"
+              aria-expanded={showMoreFilters}
+              aria-controls="more-filters"
+            >
+              <FormattedMessage defaultMessage="More filters" id="vdJRZj" />
+              <Icon className="w-5 h-5 ml-1" icon={showMoreFilters ? ChevronUp : ChevronDown} />
+            </Button>
+          </h3>
+        </div>
+
+        {/* More filters accordion pannel */}
+        {showMoreFilters && (
+          <div
+            className="mb-4"
+            id="more-filters"
+            role="region"
+            aria-labelledby="more-filters-button"
+          >
+            <fieldset>
+              <legend className="inline mb-3 font-sans text-base font-medium text-black sm:mb-2">
+                <FormattedMessage defaultMessage="SDG's" id="d3TPmn" />
+              </legend>
+
+              <div className="flex flex-wrap gap-4">
+                <TagGroup
+                  name="sdg"
+                  type="radio"
+                  clearErrors={clearErrors}
+                  setValue={setValue}
+                  errors={errors}
+                  thresholdToShowSelectAll={Infinity}
+                  isFilterTag
+                >
+                  {sdg.map(({ name, type, id }) => (
+                    <Tag
+                      key={id}
+                      id={`${id}-tag`}
+                      name={type}
+                      value={id}
+                      register={register}
+                      registerOptions={{
+                        disabled: false,
+                        onChange,
+                      }}
+                      type="radio"
+                      isfilterTag
+                      onClick={onChange}
+                    >
+                      <span className="block">{name}</span>
+                    </Tag>
+                  ))}
+                </TagGroup>
+              </div>
+            </fieldset>
+          </div>
+        )}
+      </div>
+      <div className="items-center justify-between flex-shrink-0 gap-4 pt-2 sm:pt-4 sm:flex">
+        <p className="mb-4 text-sm text-gray-600 sm:mb-0">
+          <FormattedMessage defaultMessage="Note: Some filters not apply to all tabs" id="j4lBL7" />
+        </p>
+        <div className="flex flex-col gap-2 sm:gap-4 sm:flex-row">
+          <Button
+            theme="secondary-green"
+            className="justify-center sm:justify-between"
+            onClick={handleClear}
+          >
+            <FormattedMessage defaultMessage="Clear filters" id="F4gyn3" />
+          </Button>
+          <Button theme="primary-green" className="justify-center sm:justify-between" type="submit">
+            <FormattedMessage defaultMessage="Search" id="xmcVZ0" />
+          </Button>
+        </div>
+      </div>
+    </form>
   );
 };
 

--- a/frontend/containers/search-auto-suggestion/component.tsx
+++ b/frontend/containers/search-auto-suggestion/component.tsx
@@ -7,9 +7,11 @@ import cx from 'classnames';
 import { useFilterNames } from 'helpers/pages';
 
 import Button from 'components/button';
+import { EnumTypes, LocationsTypes } from 'enums';
 import { Enum } from 'types/enums';
 
 import { useEnums } from 'services/enums/enumService';
+import { usePriorityLandscapes } from 'services/locations/locations';
 
 import { SeachAutoSuggestionProps } from './types';
 
@@ -24,13 +26,27 @@ export const SearchAutoSugegstion: FC<SeachAutoSuggestionProps> = ({
   const { data, isLoading } = useEnums();
 
   const filterNames = useFilterNames();
+  const { priorityLandscapes } = usePriorityLandscapes();
 
   const filters: Enum[] = useMemo(() => {
     if (!isLoading) {
       const { category, ticket_size, instrument_type, impact, sdg } = data;
-      return [category, ticket_size, instrument_type, impact, sdg].flat();
+      return [
+        category,
+        ticket_size,
+        instrument_type,
+        impact,
+        sdg,
+        priorityLandscapes?.map(({ id, name }) => ({
+          id,
+          // A bit hacky but the priority landscapes are not enums. It was assumed that filters
+          // would only be based on enums.
+          type: LocationsTypes.PriorityLandscapes as unknown as EnumTypes,
+          name,
+        })) ?? [],
+      ].flat();
     }
-  }, [isLoading]);
+  }, [data, isLoading, priorityLandscapes]);
 
   const handleCloseSuggestions = useCallback(() => {
     closeSuggestions();
@@ -54,7 +70,7 @@ export const SearchAutoSugegstion: FC<SeachAutoSuggestionProps> = ({
       }
     }
     handleCloseSuggestions();
-  }, [closeSuggestions, filters, searchText]);
+  }, [closeSuggestions, filters, handleCloseSuggestions, searchText]);
 
   return (
     <div

--- a/frontend/helpers/pages.ts
+++ b/frontend/helpers/pages.ts
@@ -10,7 +10,7 @@ import { useRouter } from 'next/router';
 
 import { AxiosError } from 'axios';
 
-import { EnumTypes, Languages, Paths } from 'enums';
+import { EnumTypes, Languages, LocationsTypes, Paths } from 'enums';
 import languages from 'locales.config.json';
 import { Enum } from 'types/enums';
 import { Locations } from 'types/locations';
@@ -150,6 +150,10 @@ export const useFilterNames = () => {
     [EnumTypes.TicketSize]: formatMessage({ defaultMessage: 'Ticket size', id: 'lfx6Nc' }),
     [EnumTypes.InstrumentType]: formatMessage({ defaultMessage: 'Instrument', id: 'wduJme' }),
     [EnumTypes.Sdg]: formatMessage({ defaultMessage: 'SDGs', id: 'JQjEP9' }),
+    [LocationsTypes.PriorityLandscapes]: formatMessage({
+      defaultMessage: 'Priority landscape',
+      id: 'dwB95+',
+    }),
   };
 };
 

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -1890,6 +1890,9 @@
   "dkNQOz": {
     "string": "Projects of all sizes"
   },
+  "dwB95+": {
+    "string": "Priority landscape"
+  },
   "e0c9xF": {
     "string": "insert the name of the investor/funder"
   },
@@ -2864,6 +2867,9 @@
   },
   "zxHx8B": {
     "string": "You have been invited to join the {accountName} account"
+  },
+  "zyG32m": {
+    "string": "Priority landscapes are <b>unique regions</b> due to their biodiversity, cultural heritages, and regulation of water systems. As such, the projects located in these landscapes will have the greatest impact on people and nature."
   },
   "zyydTD": {
     "string": "Your account has been <b>approved</b>, your profile is now publicly visible."

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -407,6 +407,9 @@
   "770IIS": {
     "string": "Investment information"
   },
+  "78vrMq": {
+    "string": "Close filters"
+  },
   "7A5ik/": {
     "string": "The phone number for Investors or other Project Developers to reach you/your team"
   },


### PR DESCRIPTION
This PR allows the visitors to filter projects and PDs on the Discover page by priority landscape.

## Testing instructions

- You can search by priority landscape
- The list of projects and PDs are correctly filtered
- If you apply a priority landscape filter and reload the page, it's still applied (i.e. we correctly read from the URL)
- Priority landscapes are suggested when typing their name in the search box

## Tracking

[LET-994](https://vizzuality.atlassian.net/browse/LET-994)
