### PR TITLE
feat: notify investor when PD withdraws its application

### DIFF
--- a/backend/app/controllers/api/v1/accounts/open_call_applications_controller.rb
+++ b/backend/app/controllers/api/v1/accounts/open_call_applications_controller.rb
@@ -48,6 +48,7 @@ module API
 
         def destroy
           @open_call_application.destroy!
+          InvestorMailer.open_call_application_destroyed(@open_call_application.investor, @open_call_application.project).deliver_later
           head :ok
         end
 

--- a/backend/app/mailers/investor_mailer.rb
+++ b/backend/app/mailers/investor_mailer.rb
@@ -7,4 +7,13 @@ class InvestorMailer < ApplicationMailer
       mail to: @user.email
     end
   end
+
+  def open_call_application_destroyed(investor, project)
+    @user = investor.owner
+    @project = project
+
+    I18n.with_locale investor.account_language do
+      mail to: @user.email
+    end
+  end
 end

--- a/backend/app/views/investor_mailer/open_call_application_destroyed.html.erb
+++ b/backend/app/views/investor_mailer/open_call_application_destroyed.html.erb
@@ -1,0 +1,3 @@
+<h3><%= t "investor_mailer.greetings", full_name: @user.full_name %></h3>
+<p><%= t "investor_mailer.open_call_application_destroyed.content", project_name: @project.name %></p>
+<p><%= t "investor_mailer.farewell_html" %></p>

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -333,6 +333,9 @@ zu:
     open_call_destroyed:
       subject: Open Call has been removed.
       content: Open Call with name %{open_call_name} has been removed.
+    open_call_application_destroyed:
+      subject: Project developer withdrew its application
+      content: Application of project with name %{project_name} has been withdrawn.
   enums:
     review_status:
       approved:

--- a/backend/spec/mailers/investor_mailer_spec.rb
+++ b/backend/spec/mailers/investor_mailer_spec.rb
@@ -18,4 +18,20 @@ RSpec.describe InvestorMailer, type: :mailer do
       expect(mail.body.encoded).to match(I18n.t("investor_mailer.farewell_html"))
     end
   end
+
+  describe ".open_call_application_destroyed" do
+    let(:project) { create :project }
+    let(:mail) { InvestorMailer.open_call_application_destroyed investor, project }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq(I18n.t("investor_mailer.open_call_application_destroyed.subject"))
+      expect(mail.to).to eq([investor.owner.email])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match(I18n.t("investor_mailer.greetings", full_name: investor.owner.full_name))
+      expect(mail.body.encoded).to match(I18n.t("investor_mailer.open_call_application_destroyed.content", project_name: project.name))
+      expect(mail.body.encoded).to match(I18n.t("investor_mailer.farewell_html"))
+    end
+  end
 end

--- a/backend/spec/requests/api/v1/accounts/open_call_applications_spec.rb
+++ b/backend/spec/requests/api/v1/accounts/open_call_applications_spec.rb
@@ -399,6 +399,12 @@ RSpec.describe "API V1 Account Open Call Applications", type: :request do
             assert_response_matches_metadata example.metadata
           }.to change(OpenCallApplication, :count).by(-1)
         end
+
+        it "sends email to investor" do |example|
+          expect {
+            submit_request example.metadata
+          }.to have_enqueued_mail(InvestorMailer, :open_call_application_destroyed).with(open_call_application.investor, open_call_application.project)
+        end
       end
     end
   end


### PR DESCRIPTION
Send email to Investor owner when PD withdraws its open call application.

## Testing instructions

Destroy open call application via rswag doc and check that you receive email notification (you need to be owner of investor account).

## Tracking

https://vizzuality.atlassian.net/browse/LET-970
