### PR TITLE
fix: Adding missing FTS attributes required for OpenCall

### DIFF
--- a/backend/app/services/api/filterer.rb
+++ b/backend/app/services/api/filterer.rb
@@ -2,7 +2,7 @@ module API
   class Filterer
     attr_accessor :query, :original_query, :filters, :language
 
-    FULL_TEXT_FILTERS = %i[name description about mission problem solution expected_impact]
+    FULL_TEXT_FILTERS = %i[name description about mission problem solution expected_impact impact_description funding_priorities]
     FULL_TEXT_EXTRA_TABLES = {
       ProjectDeveloper => :account,
       Investor => :account

--- a/backend/spec/services/api/filterer_spec.rb
+++ b/backend/spec/services/api/filterer_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe API::Filterer do
         let!(:correct_open_call) { create :open_call, description_en: "TEST" }
         let!(:different_language_open_call) { create :open_call, description_es: "TEST" }
         let!(:different_text_open_call) { create :open_call, description_en: "DIFFERENT" }
-        let!(:ignored_column_open_call) { create :open_call, funding_priorities_en: "TEST" }
+        let!(:ignored_column_open_call) { create :open_call, funding_exclusions_en: "TEST" }
 
         it "returns only records with correct text at correct language" do
           expect(subject.call).to eq([correct_open_call])


### PR DESCRIPTION
I am adding `funding_priorities` and `impact_description` to FTS implementation which are required by OpenCalls.

## Testing instructions

I believe FE already supports this, so it can be tested on Stage after merge. It can also be verified at rswag doc --> update `funding_priorities` or `impact_description` to some special value and check that FTS via public endpoint works.

## Tracking

BugFix
