### PR TITLE
Investor users can see the details of a project that has applied to an open call in Dashboard

### DIFF
--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -881,6 +881,9 @@
   "Fv1ZSz": {
     "string": "Closed"
   },
+  "FvveL5": {
+    "string": "Open call"
+  },
   "Fxekek": {
     "string": "Invite again"
   },
@@ -1847,6 +1850,9 @@
   },
   "aT5Ajq": {
     "string": "Start drawing"
+  },
+  "aa5EE8": {
+    "string": "applications"
   },
   "adPUXO": {
     "string": "Until approval you can continue exploring our database."

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -1281,6 +1281,9 @@
   "O3WloJ": {
     "string": "No open calls"
   },
+  "O95R3Z": {
+    "string": "Phone"
+  },
   "OBhULP": {
     "string": "Open calls"
   },
@@ -2352,6 +2355,9 @@
   "l2HvdU": {
     "string": "Estimated duration for project in months"
   },
+  "lJfJXg": {
+    "string": "About the project developer"
+  },
   "lYS3vO": {
     "string": "Project developers provide the impact information during the project registration phase by selecting one or more indicators from each dimension."
   },
@@ -2684,6 +2690,9 @@
   },
   "sV+3z0": {
     "string": "Currently looking for"
+  },
+  "sVbuuM": {
+    "string": "{projectName} application"
   },
   "sVpJRp": {
     "string": "Leave open call edition form"

--- a/frontend/pages/dashboard/open-call/[openCallId]/application/[applicationId].tsx
+++ b/frontend/pages/dashboard/open-call/[openCallId]/application/[applicationId].tsx
@@ -111,12 +111,13 @@ export const OpenCallDetailsPage: PageComponent<OpenCallDetailsPageProps, Dashbo
   return (
     <ProtectedPage permissions={[UserRoles.Investor]}>
       <Head
-        title={`${
-          project?.name || intl.formatMessage({ defaultMessage: 'Project', id: 'k36uSw' })
-        } ${intl.formatMessage({
-          defaultMessage: 'application',
-          id: 'HFalmD',
-        })}`}
+        title={intl.formatMessage(
+          { defaultMessage: '{projectName} application', id: 'sVbuuM' },
+          {
+            projectName:
+              project?.name || intl.formatMessage({ defaultMessage: 'Project', id: 'k36uSw' }),
+          }
+        )}
       />
       <DashboardLayout
         header="breadcrumbs"

--- a/frontend/pages/dashboard/open-call/[openCallId]/application/[applicationId].tsx
+++ b/frontend/pages/dashboard/open-call/[openCallId]/application/[applicationId].tsx
@@ -1,0 +1,235 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { ExternalLink as ExternalLinkIcon, X as XIcon } from 'react-feather';
+import { FormattedMessage, useIntl } from 'react-intl';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+import { withLocalizedRequests } from 'hoc/locale';
+
+import dayjs from 'dayjs';
+import { groupBy } from 'lodash-es';
+
+import { loadI18nMessages } from 'helpers/i18n';
+
+import WithdrawApplicationModal from 'containers/dashboard/open-call-applications/withdraw-application-modal';
+
+import Head from 'components/head';
+import LayoutContainer from 'components/layout-container';
+import { EnumTypes, Paths, UserRoles } from 'enums';
+import DashboardLayout, { DashboardLayoutProps } from 'layouts/dashboard';
+import NakedLayout from 'layouts/naked';
+import ProtectedPage from 'layouts/protected-page';
+import { PageComponent } from 'types';
+import { GroupedEnums as GroupedEnumsType } from 'types/enums';
+
+import { getEnums } from 'services/enums/enumService';
+import { useOpenCallApplication } from 'services/open-call/application-service';
+
+const SECTION_CLASSNAMES = 'break-all';
+const GRID_CLASSNAMES = 'grid grid-cols-1 lg:grid-cols-[240px_1fr] gap-y-4';
+const LABEL_CLASSNAMES = 'flex items-center text-sm font-semibold text-gray-800';
+const LINK_CLASSNAMES =
+  'inline-flex gap-2 px-2 -mx-2 underline rounded-full text-green-dark focus-visible:outline focus-visible:outline-green-dark focus-visible:outline-2 focus-visible:outline-offset-2';
+
+export const getServerSideProps = withLocalizedRequests(async ({ locale }) => {
+  const enums = await getEnums();
+
+  return {
+    props: {
+      intlMessages: await loadI18nMessages({ locale }),
+      enums: groupBy(enums, 'type'),
+    },
+  };
+});
+
+type OpenCallDetailsPageProps = {
+  enums: GroupedEnumsType;
+};
+
+export const OpenCallDetailsPage: PageComponent<OpenCallDetailsPageProps, DashboardLayoutProps> = ({
+  enums,
+}) => {
+  const placeholderPicture = '/images/placeholders/profile-logo.png';
+
+  const [projectDeveloperPhoto, setProjectDeveloperPhoto] = useState<string>(placeholderPicture);
+
+  const intl = useIntl();
+  const router = useRouter();
+
+  const {
+    data: openCallApplication,
+    isLoading,
+    isLoadingError,
+  } = useOpenCallApplication(router.query.applicationId as string, {
+    includes: ['open_call', 'project', 'project_developer'],
+  });
+
+  const {
+    open_call: openCall,
+    project_developer: projectDeveloper,
+    project,
+  } = openCallApplication || {};
+
+  useEffect(() => {
+    if (!projectDeveloper?.picture?.small) return;
+    setProjectDeveloperPhoto(projectDeveloper?.picture?.small);
+  }, [projectDeveloper]);
+
+  const breadcrumbsProps = {
+    substitutions: {
+      'open-call': {
+        name: intl.formatMessage({
+          defaultMessage: 'Open calls',
+          id: 'OBhULP',
+        }),
+        link: Paths.DashboardOpenCalls,
+      },
+      openCallId: { name: openCall?.name },
+      applicationId: { name: project?.name },
+    },
+    hidden: ['dashboard', 'application'],
+  };
+
+  const projectDeveloperTypeName = useMemo(
+    () =>
+      enums[EnumTypes.ProjectDeveloperType].find(
+        ({ id }) => id === projectDeveloper?.project_developer_type
+      )?.name,
+    [enums, projectDeveloper]
+  );
+
+  // If we can't load the open call, it may have been removed or the user not have access to it. Let's
+  // redirect the user to the Dashboard open calls list.
+  if (isLoadingError) {
+    router.push(Paths.DashboardOpenCalls);
+    return null;
+  }
+
+  return (
+    <ProtectedPage permissions={[UserRoles.Investor]}>
+      <Head
+        title={`${
+          project?.name || intl.formatMessage({ defaultMessage: 'Project', id: 'k36uSw' })
+        } ${intl.formatMessage({
+          defaultMessage: 'application',
+          id: 'HFalmD',
+        })}`}
+      />
+      <DashboardLayout
+        header="breadcrumbs"
+        isLoading={isLoading}
+        breadcrumbsProps={breadcrumbsProps}
+      >
+        <LayoutContainer layout="narrow">
+          <div className="flex flex-col gap-4 p-6 break-all bg-white border rounded-lg lg:mt-4 lg:mb-14">
+            <div className="flex flex-col items-center justify-between lg:flex-row">
+              <span>
+                <h1 className="text-xl font-semibold">{project?.name}</h1>
+              </span>
+              <span className="flex flex-col-reverse items-center gap-4 mt-2 lg:gap-2 lg:mt-0 lg:flex-row">
+                <Link href={`${Paths.Project}/${project?.slug}`}>
+                  <a
+                    className="flex gap-2 px-2 text-sm rounded-full text-green-dark focus-visible:outline focus-visible:outline-green-dark focus-visible:outline-2 focus-visible:outline-offset-2"
+                    target="_blank"
+                  >
+                    <ExternalLinkIcon className="w-4 h-4 translate-y-px" />
+                    <FormattedMessage defaultMessage="View public page" id="03HUos" />
+                  </a>
+                </Link>
+              </span>
+            </div>
+
+            <div className={SECTION_CLASSNAMES}>
+              <div className={GRID_CLASSNAMES}>
+                <span className={LABEL_CLASSNAMES}>
+                  <FormattedMessage defaultMessage="Application date" id="kUEzKa" />
+                </span>
+                <span>{dayjs(openCallApplication?.created_at).format('DD MMM YYYY')}</span>
+                {projectDeveloper?.contact_email && (
+                  <>
+                    <span className={LABEL_CLASSNAMES}>
+                      <FormattedMessage defaultMessage="Email" id="sy+pv5" />
+                    </span>
+                    <span className="break">
+                      <Link href={`mailto:${projectDeveloper?.contact_email}`}>
+                        <a className={LINK_CLASSNAMES} target="_blank">
+                          {projectDeveloper?.contact_email}
+                        </a>
+                      </Link>
+                    </span>
+                  </>
+                )}
+                {projectDeveloper?.contact_phone && (
+                  <>
+                    <span className={LABEL_CLASSNAMES}>
+                      <FormattedMessage defaultMessage="Phone" id="O95R3Z" />
+                    </span>
+                    <span>
+                      <Link href={`tel:${projectDeveloper?.contact_phone}`}>
+                        <a className={LINK_CLASSNAMES} target="_blank">
+                          {projectDeveloper?.contact_phone}
+                        </a>
+                      </Link>
+                    </span>
+                  </>
+                )}
+                <span className={LABEL_CLASSNAMES}>
+                  <FormattedMessage defaultMessage="Project developer" id="yF82he" />
+                </span>
+                <span>
+                  <Link href={`${Paths.ProjectDeveloper}/${projectDeveloper?.slug}`}>
+                    <a className={LINK_CLASSNAMES} target="_blank">
+                      {projectDeveloper?.name}
+                    </a>
+                  </Link>
+                </span>
+              </div>
+              <div className="mt-4">
+                <span className={LABEL_CLASSNAMES}>
+                  <FormattedMessage defaultMessage="Message" id="T7Ry38" />
+                </span>
+                <span className="block mt-2">{openCallApplication?.message}</span>
+              </div>
+              <div className="mt-12">
+                <span className={LABEL_CLASSNAMES}>
+                  <FormattedMessage defaultMessage="About the project developer" id="lJfJXg" />
+                </span>
+                <div className="flex flex-col gap-3 mt-3 md:gap-10 md:flex-row">
+                  <div>
+                    <span className="relative flex-shrink-0 block overflow-hidden rounded-full w-18 aspect-square">
+                      <Image
+                        className="w-18"
+                        src={projectDeveloperPhoto}
+                        alt={intl.formatMessage(
+                          { defaultMessage: '{name} picture', id: 'rLzWx9' },
+                          { name: projectDeveloper?.name }
+                        )}
+                        layout="fill"
+                        objectFit="cover"
+                        onError={() => setProjectDeveloperPhoto(placeholderPicture)}
+                      />
+                    </span>
+                  </div>
+                  <div className="flex flex-col gap-1.5">
+                    <span className="text-xl font-semibold">{projectDeveloper?.name}</span>
+                    <span className="text-gray-800">{projectDeveloperTypeName}</span>
+                    <span className="mt-1">{projectDeveloper?.about}</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </LayoutContainer>
+      </DashboardLayout>
+    </ProtectedPage>
+  );
+};
+
+OpenCallDetailsPage.layout = {
+  Component: NakedLayout,
+};
+
+export default OpenCallDetailsPage;

--- a/frontend/pages/dashboard/open-call/[openCallId]/index.tsx
+++ b/frontend/pages/dashboard/open-call/[openCallId]/index.tsx
@@ -1,0 +1,89 @@
+import { useIntl } from 'react-intl';
+
+import { useRouter } from 'next/router';
+
+import { withLocalizedRequests } from 'hoc/locale';
+
+import { groupBy } from 'lodash-es';
+
+import { loadI18nMessages } from 'helpers/i18n';
+
+import Head from 'components/head';
+import { Paths, UserRoles } from 'enums';
+import DashboardLayout, { DashboardLayoutProps } from 'layouts/dashboard';
+import NakedLayout from 'layouts/naked';
+import ProtectedPage from 'layouts/protected-page';
+import { PageComponent } from 'types';
+
+import { useOpenCall } from 'services/open-call/open-call-service';
+
+export const getServerSideProps = withLocalizedRequests(async ({ locale }) => {
+  return {
+    props: {
+      intlMessages: await loadI18nMessages({ locale }),
+    },
+  };
+});
+
+type OpenCallApplicationsPageProps = {};
+
+export const OpenCallApplicationsPage: PageComponent<
+  OpenCallApplicationsPageProps,
+  DashboardLayoutProps
+> = () => {
+  const intl = useIntl();
+  const router = useRouter();
+
+  const {
+    data: openCall,
+    isLoading,
+    isLoadingError,
+  } = useOpenCall(router.query.openCallId as string);
+
+  const breadcrumbsProps = {
+    substitutions: {
+      'open-call': {
+        name: intl.formatMessage({
+          defaultMessage: 'Open calls',
+          id: 'OBhULP',
+        }),
+        link: Paths.DashboardOpenCalls,
+      },
+      openCallId: { name: openCall?.name },
+    },
+    hidden: ['dashboard'],
+  };
+
+  // If we can't load the open call, it may have been removed or the user not have access to it. Let's
+  // redirect the user to the Dashboard open call applications list.
+  if (isLoadingError) {
+    router.push(Paths.DashboardOpenCalls);
+    return null;
+  }
+
+  return (
+    <ProtectedPage permissions={[UserRoles.Investor]}>
+      <Head
+        title={`${
+          openCall?.name || intl.formatMessage({ defaultMessage: 'Open call', id: 'FvveL5' })
+        } ${intl.formatMessage({
+          defaultMessage: 'applications',
+          id: 'aa5EE8',
+        })}`}
+      />
+      <DashboardLayout
+        isLoading={isLoading}
+        header="breadcrumbs"
+        breadcrumbsProps={breadcrumbsProps}
+      >
+        Open call applications table
+      </DashboardLayout>
+    </ProtectedPage>
+  );
+};
+
+OpenCallApplicationsPage.layout = {
+  Component: NakedLayout,
+};
+
+export default OpenCallApplicationsPage;

--- a/frontend/pages/open-call/[id]/edit.tsx
+++ b/frontend/pages/open-call/[id]/edit.tsx
@@ -34,7 +34,7 @@ export const getServerSideProps = withLocalizedRequests(async ({ params: { id },
   let enums;
 
   try {
-    ({ data: openCall } = await getOpenCall(id as string, OPEN_CALL_QUERY_PARAMS));
+    openCall = await getOpenCall(id as string, OPEN_CALL_QUERY_PARAMS);
     enums = await getEnums();
   } catch (e) {
     // The user may be attempting to preview a drafted open call, which the endpoint won't return
@@ -64,10 +64,11 @@ const EditOpenCall: PageComponent<EditOpenCallProps, FormPageLayoutProps> = ({
   const router = useRouter();
   const queryReturnPath = useQueryReturnPath();
 
-  const {
-    data: { data: openCall },
-    isFetching: isFetchingProject,
-  } = useOpenCall(router.query.id as string, OPEN_CALL_QUERY_PARAMS, initialOpenCall);
+  const { data: openCall, isFetching: isFetchingProject } = useOpenCall(
+    router.query.id as string,
+    OPEN_CALL_QUERY_PARAMS,
+    initialOpenCall
+  );
 
   const updateOpenCall = useUpdateOpenCall({ locale: openCall?.language });
 

--- a/frontend/pages/open-call/[id]/index.tsx
+++ b/frontend/pages/open-call/[id]/index.tsx
@@ -37,7 +37,7 @@ export const getServerSideProps = withLocalizedRequests<GetServerSideProps>(
     // If getting the project fails, it's most likely because the record has not been found. Let's return a 404. Anything else will trigger a 500 by default.
     try {
       enums = await getEnums();
-      ({ data: openCall } = await getOpenCall(id as string, OPEN_CALL_QUERY_PARAMS));
+      openCall = await getOpenCall(id as string, OPEN_CALL_QUERY_PARAMS);
     } catch (e) {
       // If getting the open call fails, it's most likely because the record has not been found.
       if (query?.preview) {
@@ -71,10 +71,11 @@ const OpenCallPage: PageComponent<OpenCallPageProps, StaticPageLayoutProps> = ({
 }) => {
   const router = useRouter();
 
-  const {
-    data: { data: openCall },
-    isFetching: isFetchingOpenCall,
-  } = useOpenCall(router.query.id as string, OPEN_CALL_QUERY_PARAMS, openCallProp);
+  const { data: openCall, isFetching: isFetchingOpenCall } = useOpenCall(
+    router.query.id as string,
+    OPEN_CALL_QUERY_PARAMS,
+    openCallProp
+  );
 
   if (!openCall) {
     if (!isFetchingOpenCall) router.push(Paths.Dashboard);

--- a/frontend/services/open-call/open-call-service.ts
+++ b/frontend/services/open-call/open-call-service.ts
@@ -74,10 +74,7 @@ export const getOpenCall = async (
     includes?: string[];
     locale?: string;
   }
-): Promise<{
-  data: OpenCall;
-  included: any[]; // TODO
-}> => {
+): Promise<OpenCall> => {
   const { includes, ...rest } = params || {};
 
   const config: AxiosRequestConfig = {
@@ -88,7 +85,7 @@ export const getOpenCall = async (
       ...rest,
     },
   };
-  return await API.request(config).then((response) => response.data);
+  return await API.request(config).then((response) => response.data.data);
 };
 
 /** Use query for a single OpenCall */
@@ -99,7 +96,7 @@ export function useOpenCall(
 ) {
   const query = useLocalizedQuery([Queries.OpenCall, id], () => getOpenCall(id, params), {
     refetchOnWindowFocus: false,
-    initialData: { data: initialData, included: [] },
+    initialData,
   });
 
   return useMemo(


### PR DESCRIPTION
## Description

This PR adds a page where an Investor can see the details of a project/PD that has applied to an open call. 

**In this PR:**  
- Minor simplification of how open calls are fetched  
- Added a placeholder page for the list of applications to an open call (Investor dashboard)  
  _This was used mostly to set-up/test breadcrumbs_  
- Added the open-call-application/project page to the Investor dashboard  

**Notes:**  
- The funding toggle is tracked by a [different task](https://vizzuality.atlassian.net/browse/LET-986)

## Testing instructions

- Using a PD account:  
  - Create an Open call application
  - Visit dashboard/open-call-applications, open the details page of the application, copy its `id` from the url  
- Using an Investor account:  
  - Visit the open call public page and copy its `slug` from the URL  
  - Access the open call application details page via url in the following format: 
    `http://localhost:3000/en/dashboard/open-call/${openCallSlug}/application/${applicationId}`

Verify that:  
  - Breadcrumbs match the designs  
  - Project name is correct  
  - The project developer information is correct  
  - The open call application message is correct  
  - Links work correctly 

## Tracking

[LET-912](https://vizzuality.atlassian.net/browse/LET-912)

## Screenshot

<img width="1680" alt="Screenshot 2022-09-01 at 11 30 02" src="https://user-images.githubusercontent.com/6273795/187893466-6710e583-152f-43a9-bb75-fef70730e3d4.png">

