### PR TITLE
refactoring: Slug can be used for project and open call filter

### DIFF
--- a/backend/app/controllers/api/v1/accounts/open_call_applications_controller.rb
+++ b/backend/app/controllers/api/v1/accounts/open_call_applications_controller.rb
@@ -86,7 +86,7 @@ module API
 
         def slug_or_id_filter_for(query, value, association)
           return query if value.blank?
-          return query.where "#{association}_id" => value if fetching_by_uuid? value
+          return query.where "#{association}_id".to_sym => value if fetching_by_uuid? value
 
           query.joins(association).where association.to_s.pluralize => {slug: value}
         end

--- a/backend/app/controllers/api/v1/base_controller.rb
+++ b/backend/app/controllers/api/v1/base_controller.rb
@@ -29,8 +29,8 @@ module API
         raise API::Error, "application/json content type is required by the requested endpoint"
       end
 
-      def fetching_by_uuid?
-        /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/.match?(params[:id])
+      def fetching_by_uuid?(value = params[:id])
+        /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/.match?(value)
       end
     end
   end

--- a/backend/spec/requests/api/v1/accounts/open_call_applications_spec.rb
+++ b/backend/spec/requests/api/v1/accounts/open_call_applications_spec.rb
@@ -77,8 +77,24 @@ RSpec.describe "API V1 Account Open Call Applications", type: :request do
             end
           end
 
+          context "when filtered by project slug" do
+            let("filter[project_id]") { project_developer_searched_application.project.slug }
+
+            it "contains only correct records" do
+              expect(response_json["data"].pluck("id")).to eq([project_developer_searched_application.id])
+            end
+          end
+
           context "when filtered by open call" do
             let("filter[open_call_id]") { project_developer_searched_application.open_call_id }
+
+            it "contains only correct records" do
+              expect(response_json["data"].pluck("id")).to eq([project_developer_searched_application.id])
+            end
+          end
+
+          context "when filtered by open call slug" do
+            let("filter[open_call_id]") { project_developer_searched_application.open_call.slug }
 
             it "contains only correct records" do
               expect(response_json["data"].pluck("id")).to eq([project_developer_searched_application.id])


### PR DESCRIPTION
Project and OpenCall filters at OpenCallApplication `index` API endpoint supports `ID` and `slug` now.

## Testing instructions

Please use again rswag documentation

## Tracking

https://vizzuality.atlassian.net/browse/LET-931 - slight enhancement of API
