### PR TITLE
Investor users can see the list of projects which have applied to an open call in Dashboard

### DIFF
--- a/frontend/containers/dashboard/open-call-applications/table/component.tsx
+++ b/frontend/containers/dashboard/open-call-applications/table/component.tsx
@@ -32,7 +32,7 @@ export const OpenCallApplicationsTable: FC<OpenCallApplicationsTableProps> = () 
     isFetching: isFetchingOpenCallApplications,
   } = useAccountOpenCallApplicationsList({
     includes: ['investor', 'project', 'open_call'],
-    filter: search,
+    filters: { search },
   });
 
   const isSearching = !!search;

--- a/frontend/containers/dashboard/open-call-details/table/cells/actions/component.tsx
+++ b/frontend/containers/dashboard/open-call-details/table/cells/actions/component.tsx
@@ -1,0 +1,29 @@
+import { FC } from 'react';
+
+import { FormattedMessage } from 'react-intl';
+
+import Link from 'next/link';
+
+import { Paths } from 'enums';
+
+import { CellActionsProps } from './types';
+
+export const CellActions: FC<CellActionsProps> = ({
+  row: {
+    original: { openCall, openCallApplication },
+  },
+}: CellActionsProps) => {
+  return (
+    <div className="flex items-center justify-center gap-3">
+      <Link
+        href={`${Paths.DashboardOpenCallDetails}/${openCall?.slug}/application/${openCallApplication?.id}`}
+      >
+        <a className="px-2 py-1 text-sm transition-all text-green-dark focus-visible:outline-green-dark rounded-2xl">
+          <FormattedMessage defaultMessage="Details" id="Lv0zJu" />
+        </a>
+      </Link>
+    </div>
+  );
+};
+
+export default CellActions;

--- a/frontend/containers/dashboard/open-call-details/table/cells/actions/index.ts
+++ b/frontend/containers/dashboard/open-call-details/table/cells/actions/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { CellActionsProps } from './types';

--- a/frontend/containers/dashboard/open-call-details/table/cells/actions/types.ts
+++ b/frontend/containers/dashboard/open-call-details/table/cells/actions/types.ts
@@ -1,0 +1,11 @@
+import { OpenCallApplication } from 'types/open-call-applications';
+import { OpenCall } from 'types/open-calls';
+
+export type CellActionsProps = {
+  row: {
+    original: {
+      openCallApplication: OpenCallApplication;
+      openCall: OpenCall;
+    };
+  };
+};

--- a/frontend/containers/dashboard/open-call-details/table/cells/project-developer/component.tsx
+++ b/frontend/containers/dashboard/open-call-details/table/cells/project-developer/component.tsx
@@ -1,0 +1,34 @@
+import { FC } from 'react';
+
+import Link from 'next/link';
+
+import { CellProjectDeveloperProps } from './types';
+
+export const CellProjectDeveloper: FC<CellProjectDeveloperProps> = ({
+  row,
+  cell,
+}: CellProjectDeveloperProps) => {
+  const {
+    original: { projectDeveloper },
+  } = row;
+
+  const { value } = cell;
+
+  return (
+    <div className="flex flex-col">
+      <span className="text-gray-600">{value}</span>
+      <span>
+        <Link href={`mailto:${projectDeveloper?.contact_email}`}>
+          <a
+            className="px-2 py-1 -mx-2 underline transition-all text-green-dark focus-visible:outline-green-dark rounded-2xl"
+            target="_blank"
+          >
+            {projectDeveloper?.contact_email}
+          </a>
+        </Link>
+      </span>
+    </div>
+  );
+};
+
+export default CellProjectDeveloper;

--- a/frontend/containers/dashboard/open-call-details/table/cells/project-developer/index.ts
+++ b/frontend/containers/dashboard/open-call-details/table/cells/project-developer/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { CellProjectDeveloperProps } from './types';

--- a/frontend/containers/dashboard/open-call-details/table/cells/project-developer/types.ts
+++ b/frontend/containers/dashboard/open-call-details/table/cells/project-developer/types.ts
@@ -1,0 +1,12 @@
+import { ProjectDeveloper } from 'types/projectDeveloper';
+
+export type CellProjectDeveloperProps = {
+  cell: {
+    value: string;
+  };
+  row: {
+    original: {
+      projectDeveloper: ProjectDeveloper;
+    };
+  };
+};

--- a/frontend/containers/dashboard/open-call-details/table/cells/status/component.tsx
+++ b/frontend/containers/dashboard/open-call-details/table/cells/status/component.tsx
@@ -1,0 +1,27 @@
+import { FC } from 'react';
+
+import cx from 'classnames';
+
+import { CellStatusProps } from './types';
+
+export const CellStatus: FC<CellStatusProps> = ({ row, cell }: CellStatusProps) => {
+  const {
+    original: { openCallApplication },
+  } = row;
+
+  const { value } = cell;
+
+  return (
+    <span
+      className={cx({
+        'bg-opacity-20 text-sm px-2.5 py-0.5 rounded-2xl': true,
+        'bg-gray-800 text-gray-800': !openCallApplication.funded,
+        'bg-green-light text-green-dark': openCallApplication.funded,
+      })}
+    >
+      {value}
+    </span>
+  );
+};
+
+export default CellStatus;

--- a/frontend/containers/dashboard/open-call-details/table/cells/status/index.ts
+++ b/frontend/containers/dashboard/open-call-details/table/cells/status/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { CellStatusProps } from './types';

--- a/frontend/containers/dashboard/open-call-details/table/cells/status/types.ts
+++ b/frontend/containers/dashboard/open-call-details/table/cells/status/types.ts
@@ -1,0 +1,12 @@
+import { OpenCallApplication } from 'types/open-call-applications';
+
+export type CellStatusProps = {
+  cell: {
+    value: string;
+  };
+  row: {
+    original: {
+      openCallApplication: OpenCallApplication;
+    };
+  };
+};

--- a/frontend/containers/dashboard/open-call-details/table/component.tsx
+++ b/frontend/containers/dashboard/open-call-details/table/component.tsx
@@ -1,0 +1,142 @@
+import { FC } from 'react';
+
+import { FormattedMessage, useIntl } from 'react-intl';
+
+import { useRouter } from 'next/router';
+
+import dayjs from 'dayjs';
+
+import { useQueryParams } from 'helpers/pages';
+
+import NoSearchResults from 'containers/dashboard/no-search-results';
+import SearchAndInfo from 'containers/dashboard/search-and-info';
+
+import Button from 'components/button';
+import Table from 'components/table';
+import { Paths } from 'enums';
+
+import { useAccountOpenCallApplicationsList } from 'services/open-call/application-service';
+
+import CellActions from './cells/actions';
+import CellProjectDeveloper from './cells/project-developer';
+import CellStatus from './cells/status';
+
+import { OpenCallDetailsTableProps } from '.';
+
+export const OpenCallDetailsTable: FC<OpenCallDetailsTableProps> = () => {
+  const intl = useIntl();
+  const router = useRouter();
+  const { search } = useQueryParams();
+
+  const {
+    openCallApplications,
+    isLoading: isLoadingOpenCallApplications,
+    isFetching: isFetchingOpenCallApplications,
+  } = useAccountOpenCallApplicationsList({
+    includes: ['project_developer', 'project', 'open_call'],
+    filters: {
+      search,
+      openCall: router.query.openCallId as string,
+    },
+  });
+
+  const isSearching = !!search;
+  const isLoading = isLoadingOpenCallApplications || isFetchingOpenCallApplications;
+  const hasOpenCallApplications = !!openCallApplications?.length;
+
+  const tableProps = {
+    columns: [
+      {
+        Header: intl.formatMessage({ defaultMessage: 'Project', id: 'k36uSw' }),
+        accessor: 'project',
+      },
+      {
+        Header: intl.formatMessage({ defaultMessage: 'Project developer', id: 'yF82he' }),
+        accessor: 'projectDeveloperName',
+        Cell: CellProjectDeveloper,
+      },
+      {
+        Header: intl.formatMessage({ defaultMessage: 'Application date', id: 'kUEzKa' }),
+        accessor: 'applicationDate',
+        Cell: ({ cell: { value } }) => dayjs(value).format('DD MMM YYYY'),
+      },
+      {
+        Header: intl.formatMessage({ defaultMessage: 'Status', id: 'tzMNF3' }),
+        accessor: 'fundingStatus',
+        Cell: CellStatus,
+      },
+      {
+        Header: intl.formatMessage({ defaultMessage: 'Actions', id: 'wL7VAE' }),
+        canSort: false,
+        hideHeader: true,
+        width: 0,
+        Cell: CellActions,
+      },
+    ],
+    data: openCallApplications?.map((openCallApplication) => {
+      const {
+        open_call: openCall,
+        project_developer: projectDeveloper,
+        project,
+      } = openCallApplication;
+
+      return {
+        project: project.name,
+        projectDeveloperName: projectDeveloper.name,
+        applicationDate: openCallApplication.created_at,
+        fundingStatus: openCallApplication.funded
+          ? intl.formatMessage({ defaultMessage: 'Funding', id: 'fZb224' })
+          : intl.formatMessage({ defaultMessage: 'Not funding', id: 'Llk7Pe' }),
+        openCall,
+        projectDeveloper,
+        openCallApplication,
+      };
+    }),
+    loading: isLoading,
+    sortingEnabled: true,
+    manualSorting: false,
+    className: 'h-screen',
+  };
+
+  return (
+    <>
+      <SearchAndInfo className="mt-4 mb-6">
+        {!isLoading && (
+          <FormattedMessage
+            defaultMessage="Total <span>{numOpenCallApplications}</span> {numOpenCallApplications, plural, one {application} other {applications}}"
+            id="DYbC4X"
+            values={{
+              span: (chunks: string) => <span className="px-1 font-semibold">{chunks}</span>,
+              numOpenCallApplications: openCallApplications?.length || 0,
+            }}
+          />
+        )}
+      </SearchAndInfo>
+      {hasOpenCallApplications && <Table {...tableProps} />}
+      {!hasOpenCallApplications && !isLoading && (
+        <div className="flex flex-col items-center mt-10 lg:mt-20">
+          {isSearching ? (
+            <NoSearchResults />
+          ) : (
+            <>
+              <p className="text-lg text-gray-800 lg:text-xl">
+                <FormattedMessage
+                  defaultMessage="Currently you don’t have any <b>Open Call Applications</b>."
+                  id="c3w2Rt"
+                  values={{
+                    b: (chunks: string) => <span className="font-semibold">{chunks}</span>,
+                  }}
+                />
+              </p>
+              <Button className="mt-8" to={Paths.DashboardOpenCalls}>
+                <FormattedMessage defaultMessage="Back to open calls" id="v2wxEw" />
+              </Button>
+            </>
+          )}
+        </div>
+      )}
+    </>
+  );
+};
+
+export default OpenCallDetailsTable;

--- a/frontend/containers/dashboard/open-call-details/table/index.ts
+++ b/frontend/containers/dashboard/open-call-details/table/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { OpenCallDetailsTableProps } from './types';

--- a/frontend/containers/dashboard/open-call-details/table/types.ts
+++ b/frontend/containers/dashboard/open-call-details/table/types.ts
@@ -1,0 +1,1 @@
+export type OpenCallDetailsTableProps = {};

--- a/frontend/containers/dashboard/open-calls/table/cells/actions/component.tsx
+++ b/frontend/containers/dashboard/open-calls/table/cells/actions/component.tsx
@@ -40,6 +40,9 @@ export const CellActions: FC<CellActionsProps> = ({
           `${Paths.OpenCall}/${slug}/edit`
         );
         return;
+      case 'view-applications':
+        router.push(`${Paths.DashboardOpenCallDetails}/${slug}`);
+        return;
       case 'preview':
         router.push(`${Paths.OpenCall}/${slug}/preview`);
         return;
@@ -104,6 +107,11 @@ export const CellActions: FC<CellActionsProps> = ({
         <RowMenuItem key="edit">
           <FormattedMessage defaultMessage="Edit" id="wEQDC6" />
         </RowMenuItem>
+        {status !== OpenCallStatus.Draft && (
+          <RowMenuItem key="view-applications">
+            <FormattedMessage defaultMessage="View all applications" id="i1R/il" />
+          </RowMenuItem>
+        )}
         {status === OpenCallStatus.Draft ? (
           <RowMenuItem key="preview">
             <FormattedMessage defaultMessage="Preview open call page" id="iR1WoG" />

--- a/frontend/containers/dashboard/open-calls/table/cells/applications/component.tsx
+++ b/frontend/containers/dashboard/open-calls/table/cells/applications/component.tsx
@@ -1,0 +1,30 @@
+import { FC } from 'react';
+
+import Link from 'next/link';
+
+import { OpenCallStatus, Paths } from 'enums';
+
+import { CellApplicationsProps } from './types';
+
+export const CellApplications: FC<CellApplicationsProps> = ({
+  row,
+  value,
+}: CellApplicationsProps) => {
+  const {
+    original: { slug, status },
+  } = row;
+
+  if (status === OpenCallStatus.Draft) return null;
+
+  return (
+    <>
+      <Link href={`${Paths.DashboardOpenCallDetails}/${slug}`}>
+        <a className="inline-flex gap-2 px-2 underline transition-all rounded-full text-green-light focus-visible:outline focus-visible:outline-green-dark focus-visible:outline-2 focus-visible:outline-offset-2">
+          {value}
+        </a>
+      </Link>
+    </>
+  );
+};
+
+export default CellApplications;

--- a/frontend/containers/dashboard/open-calls/table/cells/applications/index.ts
+++ b/frontend/containers/dashboard/open-calls/table/cells/applications/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { CellApplicationsProps } from './types';

--- a/frontend/containers/dashboard/open-calls/table/cells/applications/types.ts
+++ b/frontend/containers/dashboard/open-calls/table/cells/applications/types.ts
@@ -1,0 +1,10 @@
+import { OpenCall } from 'types/open-calls';
+
+export type CellApplicationsProps = {
+  /** Number of open call applications */
+  value: number;
+  row: {
+    /** Open call */
+    original: OpenCall;
+  };
+};

--- a/frontend/containers/dashboard/open-calls/table/component.tsx
+++ b/frontend/containers/dashboard/open-calls/table/component.tsx
@@ -17,6 +17,7 @@ import { useEnums } from 'services/enums/enumService';
 import { useAccountOpenCallList } from 'services/open-call/open-call-service';
 
 import CellActions from './cells/actions';
+import CellApplications from './cells/applications';
 import CellInstrumentTypes from './cells/instrument-types';
 import CellStatus from './cells/status';
 
@@ -46,6 +47,7 @@ export const OpenCallsTable: FC<OpenCallsTableProps> = () => {
       'instrument_types',
       'maximum_funding_per_project',
       'status',
+      'open_call_applications_count',
     ],
     filter: search,
   });
@@ -82,6 +84,11 @@ export const OpenCallsTable: FC<OpenCallsTableProps> = () => {
         Cell: ({ cell: { value } }) => `$${value?.toLocaleString(locale)}`,
       },
       {
+        Header: intl.formatMessage({ defaultMessage: 'Applications', id: 'DqD1yK' }),
+        accessor: 'applicationsCount',
+        Cell: CellApplications,
+      },
+      {
         Header: intl.formatMessage({ defaultMessage: 'Status', id: 'tzMNF3' }),
         accessor: 'status',
         Cell: CellStatus,
@@ -104,6 +111,7 @@ export const OpenCallsTable: FC<OpenCallsTableProps> = () => {
         ?.filter(({ id }) => openCall.instrument_types?.includes(id))
         .map(({ name }, idx) => (idx === 0 ? name : name.toLowerCase())),
       maximumFundingPerProject: openCall.maximum_funding_per_project,
+      applicationsCount: openCall.open_call_applications_count,
     })),
     loading: isLoading,
     sortingEnabled: true,

--- a/frontend/containers/dashboard/search-and-info/component.tsx
+++ b/frontend/containers/dashboard/search-and-info/component.tsx
@@ -5,7 +5,7 @@ import { FormattedMessage, useIntl } from 'react-intl';
 
 import { useRouter } from 'next/router';
 
-import { pickBy } from 'lodash-es';
+import { omit } from 'lodash-es';
 
 import { useQueryParams } from 'helpers/pages';
 
@@ -44,19 +44,20 @@ export const SearchAndInfo: FC<SearchAndInfoProps> = ({
 
     router.push({
       query: {
-        // ? Endpoints don't support filtering, sorting
-        // ...queryParams,
-        search: e.target[0].value || '',
+        // Endpoints don't support paging, sorting
+        ...omit(queryParams, ['sorting', 'page', 'search']),
+        ...(searchValue && { search: searchValue }),
       },
     });
   };
 
   const handleClearSearch = () => {
-    // const newQuery = pickBy(queryParams, (value, key) => !!value && key !== 'search');
-    // If we add the pagination, use the line above instead of the line below
-    const newQuery = {};
     router.push({
-      query: newQuery,
+      query: {
+        // We can't completely clear the query because nextJs will still need certain query params, such as
+        // openCallId, etc. It'll cause this issue: https://nextjs.org/docs/messages/href-interpolation-failed
+        ...omit(queryParams, ['sorting', 'page', 'search']),
+      },
     });
   };
 

--- a/frontend/enums/index.ts
+++ b/frontend/enums/index.ts
@@ -22,6 +22,7 @@ export enum Paths {
   DashboardFavoritesInvestors = '/dashboard/favorites/investors',
   DashboardFavoritesProjectDevelopers = '/dashboard/favorites/project-developers',
   DashboardOpenCalls = '/dashboard/open-calls',
+  DashboardOpenCallDetails = '/dashboard/open-call',
   DashboardOpenCallApplications = '/dashboard/open-call-applications',
   DashboardUsers = '/dashboard/users',
   DashboardAccountInfo = '/dashboard/account-information',

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -1860,9 +1860,6 @@
   "aT5Ajq": {
     "string": "Start drawing"
   },
-  "aa5EE8": {
-    "string": "applications"
-  },
   "adPUXO": {
     "string": "Until approval you can continue exploring our database."
   },
@@ -2660,6 +2657,9 @@
   },
   "rfVDxL": {
     "string": "Please enter your details below."
+  },
+  "rg2Seh": {
+    "string": "{openCall} applications"
   },
   "rginRA": {
     "string": "Project categories"

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -1155,6 +1155,9 @@
   "Ll72W/": {
     "string": "Currently not looking for funding"
   },
+  "Llk7Pe": {
+    "string": "Not funding"
+  },
   "LmHPHR": {
     "string": "Select the topics/sector categories that you work on"
   },
@@ -2082,6 +2085,9 @@
   "fX9u5/": {
     "string": "Contribute to addressing the effects of climate change through investments to reduce CO2 emissions and conserve or restore forest-related carbon sinks. <br></br><br></br> Nature based solutions have been estimated to have the potential of contributing to compensate for up to 30% of global emissions."
   },
+  "fZb224": {
+    "string": "Funding"
+  },
   "fZpvTQ": {
     "string": "Delete my user"
   },
@@ -2825,6 +2831,9 @@
   },
   "uyxTSu": {
     "string": "Select the impacts that you prioritize"
+  },
+  "v2wxEw": {
+    "string": "Back to open calls"
   },
   "v9GdgG": {
     "string": "File {fileName} is larger than {fileSize}MB"

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -767,6 +767,9 @@
   "Dm1lEK": {
     "string": "A score of expected impact along the four sustainability dimensions is assigned to every project. These scores are calculated using a combination of landscape-level variables (<b>Demand</b>) and self-reported project data (<b>Supply</b>)."
   },
+  "DqD1yK": {
+    "string": "Applications"
+  },
   "DrtKvj": {
     "string": "Impact of projects on biodiversity conservation, calculated from indicators of endemism, land conservation/restoration, connectivity, and development of sustainable social projects."
   },
@@ -2180,6 +2183,9 @@
   },
   "hxIQ/8": {
     "string": "Projects waiting funding"
+  },
+  "i1R/il": {
+    "string": "View all applications"
   },
   "i2AgQl": {
     "string": "Which of these topics/sector categories better describe your project?"

--- a/frontend/pages/dashboard/open-call/[openCallId]/index.tsx
+++ b/frontend/pages/dashboard/open-call/[openCallId]/index.tsx
@@ -4,9 +4,9 @@ import { useRouter } from 'next/router';
 
 import { withLocalizedRequests } from 'hoc/locale';
 
-import { groupBy } from 'lodash-es';
-
 import { loadI18nMessages } from 'helpers/i18n';
+
+import OpenCallDetailsTable from 'containers/dashboard/open-call-details/table';
 
 import Head from 'components/head';
 import { Paths, UserRoles } from 'enums';
@@ -64,19 +64,20 @@ export const OpenCallApplicationsPage: PageComponent<
   return (
     <ProtectedPage permissions={[UserRoles.Investor]}>
       <Head
-        title={`${
-          openCall?.name || intl.formatMessage({ defaultMessage: 'Open call', id: 'FvveL5' })
-        } ${intl.formatMessage({
-          defaultMessage: 'applications',
-          id: 'aa5EE8',
-        })}`}
+        title={intl.formatMessage(
+          { defaultMessage: '{openCallName} applications', id: 'lMjl92' },
+          {
+            openCallName:
+              openCall?.name || intl.formatMessage({ defaultMessage: 'Open call', id: 'FvveL5' }),
+          }
+        )}
       />
       <DashboardLayout
         isLoading={isLoading}
         header="breadcrumbs"
         breadcrumbsProps={breadcrumbsProps}
       >
-        Open call applications table
+        <OpenCallDetailsTable />
       </DashboardLayout>
     </ProtectedPage>
   );

--- a/frontend/services/open-call/application-service.ts
+++ b/frontend/services/open-call/application-service.ts
@@ -64,13 +64,14 @@ export function useOpenCallApplication(
  **/
 const getAccountOpenCallApplicationsList = async ({
   fields,
-  filter,
+  filters: { search, openCall },
   includes,
 }: OpenCallApplicationParams): Promise<OpenCallApplication[]> => {
   const params = {
     'fields[open_call]': fields?.join(','),
     includes: includes?.join(','),
-    'filter[full_text]': filter,
+    'filter[full_text]': search,
+    'filter[open_call_id]': openCall,
   };
 
   const options: AxiosRequestConfig = {

--- a/frontend/types/open-call-applications.ts
+++ b/frontend/types/open-call-applications.ts
@@ -19,7 +19,10 @@ export type OpenCallApplication = {
 export type OpenCallApplicationParams = {
   fields?: string[];
   includes?: string[];
-  filter?: string;
+  filters?: {
+    search?: string;
+    openCall?: string;
+  };
 };
 
 export type OpenCallApplicationForm = {

--- a/frontend/types/open-calls.ts
+++ b/frontend/types/open-calls.ts
@@ -16,6 +16,7 @@ export type OpenCall = {
   funding_exclusions: string;
   impact_description: string;
   maximum_funding_per_project: number;
+  open_call_applications_count: number;
   closing_at: string;
   language: Languages;
   account_language: Languages;


### PR DESCRIPTION
## Description

**In this PR:**  
- OpenCalls table  
  - Added column with number of open call applications  
    _Links the the open call details view (where a table with the applications is visible)_    
  - Added a _"View all applications"_ link to the 3 dot row menu  
  **Note:** links are only visible if the open call is not a draft  
- OpenCall details / list of open call applications view  
  - Added a table listing the open call applications to a particular open call  
  The 3 dot menu with the option to mark an application as being funded or not is to be included in [LET-986](https://vizzuality.atlassian.net/browse/LET-986)
  - Columns are sortable (frontend implementation)    
  - List of open call applications is searchable (endpoint)  
  - Each application's row links to their details page  
    _Where the application, respective project & project developer details are shown_
- Dashboard searching changes  
  - Slight code refactoring on how the query params were handled
    _I faced this issue when trying to access an open call details page; the previous code implementation would remove the `openCallId` from the query params, which would cause next/router interpolation issues [https://nextjs.org/docs/messages/href-interpolation-failed](described here)._
    _The `filters`, `sorting`, `search` queryParams are not used in the dashboard, but the `useQueryParams` hook is used globally and makes provisions for those queryParams, so I've kept them to avoid a bigger code refactoring_

## Testing instructions

Verify that: 
- An investor can still see a list of open calls
  - the open calls table has an applications column with the correct number of open call applications  
  - The user can click to "View all open call applications" and is taken to a page where a list of open call applications (made to that particular open call) is shown   
    - The application details is correct  
    - The application's table is sortable  
    - Clicking "details" will take the user to the open call application details view  

## Tracking

[LET-911 | FE - Investor users can see the list of projects which have applied to an open call in Dashboard](https://vizzuality.atlassian.net/browse/LET-911)
[LET-974 | FE - Investor users can sort the project applications to their open calls](https://vizzuality.atlassian.net/browse/LET-974)

## Screenshots

<img width="1679" alt="Screenshot 2022-09-02 at 13 32 05" src="https://user-images.githubusercontent.com/6273795/188143384-b91b83aa-1c0e-4a69-9893-ab7c09be15d1.png">

<img width="1680" alt="Screenshot 2022-09-02 at 13 32 32" src="https://user-images.githubusercontent.com/6273795/188143443-574e6e1f-5028-43ed-b08f-01b07f9b33c4.png">
