### PR TITLE
Add contact information to the investor public page

### DIFF
--- a/frontend/pages/investor/[id]/index.tsx
+++ b/frontend/pages/investor/[id]/index.tsx
@@ -68,6 +68,7 @@ const InvestorPage: PageComponent<InvestorPageProps, StaticPageLayoutProps> = ({
     instagram,
     contact_email,
     contact_phone,
+    website,
     categories,
     picture,
     ticket_sizes,
@@ -160,8 +161,8 @@ const InvestorPage: PageComponent<InvestorPageProps, StaticPageLayoutProps> = ({
           title={name}
           subtitle={investorTypeName}
           text={about}
-          // website={website}
-          // social={getSocialInfo()}
+          website={website}
+          social={getSocialInfo()}
           contact={contact}
           originalLanguage={language}
           isFavorite={investor.favourite}


### PR DESCRIPTION
This PR adds the contact information to the investor public page.

## Testing instructions

- Open an investor page with contact information and make sure it's displayed (e.g. `/en/investor/el-lute-fund`)
- Open an investor page without contact information and make sure the page looks good (e.g. `/en/investor/agnieszka-figiel-investor-2`)

## Tracking

[LET-1030](https://vizzuality.atlassian.net/browse/LET-1030)
