### PR TITLE
feat: Backoffice supports Open Call editation

### DIFF
--- a/backend/app/controllers/backoffice/open_calls_controller.rb
+++ b/backend/app/controllers/backoffice/open_calls_controller.rb
@@ -1,6 +1,12 @@
 module Backoffice
   class OpenCallsController < BaseController
-    before_action :fetch_open_call, only: [:destroy, :verify, :unverify]
+    include Sections
+    include ContentLanguage
+
+    before_action :fetch_open_call, only: [:edit, :update, :destroy, :verify, :unverify]
+    before_action :set_breadcrumbs, only: [:edit, :update]
+    before_action :set_sections, only: [:edit, :update]
+    before_action :set_content_language_default, only: [:edit, :update]
 
     def index
       @q = OpenCall.ransack params[:q]
@@ -16,6 +22,20 @@ module Backoffice
             filename: "open_calls.csv",
             type: "text/csv; charset=utf-8"
         end
+      end
+    end
+
+    def edit
+    end
+
+    def update
+      if I18n.with_locale(content_language) { @open_call.update(update_params) }
+        redirect_back(
+          fallback_location: edit_backoffice_open_call_path(@open_call.id),
+          notice: t("backoffice.messages.success_update", model: t("backoffice.common.open_call"))
+        )
+      else
+        render :edit, status: :unprocessable_entity
       end
     end
 
@@ -40,8 +60,41 @@ module Backoffice
 
     private
 
+    def update_params
+      params.require(:open_call).permit(
+        :name,
+        :picture,
+        :investor_id,
+        :description,
+        :impact_description,
+        :closing_at,
+        :country_id,
+        :department_id,
+        :municipality_id,
+        :maximum_funding_per_project,
+        :funding_priorities,
+        :funding_exclusions,
+        :trusted,
+        instrument_types: [],
+        sdgs: []
+      )
+    end
+
     def fetch_open_call
       @open_call = OpenCall.find(params[:id])
+    end
+
+    def set_breadcrumbs
+      add_breadcrumb(I18n.t("backoffice.layout.open_calls"), backoffice_open_calls_path)
+      add_breadcrumb(@open_call.name)
+    end
+
+    def set_sections
+      sections %w[information status investor], default: "information"
+    end
+
+    def set_content_language_default
+      @content_language_default = @open_call.language
     end
   end
 end

--- a/backend/app/models/open_call.rb
+++ b/backend/app/models/open_call.rb
@@ -38,7 +38,7 @@ class OpenCall < ApplicationRecord
 
   validates_uniqueness_of [*locale_columns(:name)], scope: [:investor_id], case_sensitive: false, allow_blank: true
   validate :location_types
-  validate :closing_at_is_in_the_future, if: -> { closing_at_changed? }
+  validate :closing_at_is_in_the_future, if: -> { closing_at.present? && closing_at_changed? }
 
   after_save :change_closing_at_to_current_time, if: -> { saved_change_to_status? && closed? }
 

--- a/backend/app/views/backoffice/open_calls/_form.html.erb
+++ b/backend/app/views/backoffice/open_calls/_form.html.erb
@@ -1,0 +1,51 @@
+<%= simple_form_for [:backoffice, open_call], url: backoffice_open_call_path(open_call.id) do |f| %>
+  <%= f.error_notification %>
+  <%= hidden_field_tag :content_lang, params[:content_lang] %>
+  <%= hidden_field_tag :section, params[:section] %>
+
+  <h2 class="mb-4 mt-6 text-gray-600 font-semibold text-xl">
+    <%= t(".general") %>
+  </h2>
+
+  <%= localized_input f, :name, content_language, as: :string %>
+  <%= render "image_with_thumbnail", f: f, blob: :picture %>
+  <div class="grid grid-cols-3 gap-4">
+    <%= f.input :country_id, collection: Location.country.order(["name", content_language].join("_")), include_blank: false %>
+    <%= f.input :department_id, collection: Location.department.order(["name", content_language].join("_")) %>
+    <%= f.input :municipality_id, collection: Location.municipality.order(["name", content_language].join("_")) %>
+  </div>
+  <%= localized_input f, :description, content_language, as: :text, input_html: {rows: 5} %>
+
+  <h2 class="mb-4 mt-6 text-gray-600 font-semibold text-xl">
+    <%= t(".investor") %>
+  </h2>
+
+  <%= f.input :investor_id, collection: Investor.includes(:account).order("accounts.name"), include_blank: false %>
+
+  <h2 class="mb-4 mt-6 text-gray-600 font-semibold text-xl">
+    <%= t(".impact") %>
+  </h2>
+
+  <%= localized_input f, :impact_description, content_language, as: :text, input_html: {rows: 5} %>
+  <%= f.input :sdgs, collection: Sdg.all, as: :check_boxes %>
+
+  <h2 class="mb-4 mt-6 text-gray-600 font-semibold text-xl">
+    <%= t(".funding") %>
+  </h2>
+
+  <%= f.input :maximum_funding_per_project, as: :integer %>
+  <%= f.input :instrument_types, collection: InstrumentType.all, as: :check_boxes %>
+  <%= localized_input f, :funding_priorities, content_language, as: :text, input_html: {rows: 5} %>
+  <%= localized_input f, :funding_exclusions, content_language, as: :text, input_html: {rows: 5} %>
+
+  <h2 class="mb-4 mt-6 text-gray-600 font-semibold text-xl">
+    <%= t(".date") %>
+  </h2>
+
+  <%= f.input :closing_at, as: :date, html5: true %>
+
+  <div class="mt-3 flex justify-end gap-3">
+    <%= link_to t("backoffice.common.cancel"), backoffice_projects_path, class: "button button-secondary-green" %>
+    <%= f.button :submit, t("backoffice.common.save"), class: "button button-primary-green" %>
+  </div>
+<% end %>

--- a/backend/app/views/backoffice/open_calls/_section_information.html.erb
+++ b/backend/app/views/backoffice/open_calls/_section_information.html.erb
@@ -1,0 +1,2 @@
+<%= render "content_language_selector" %>
+<%= render "form", open_call: @open_call %>

--- a/backend/app/views/backoffice/open_calls/_section_investor.html.erb
+++ b/backend/app/views/backoffice/open_calls/_section_investor.html.erb
@@ -1,0 +1,22 @@
+<h2 class="mb-2 text-gray-900 font-semibold">
+  <%= t("backoffice.open_calls.investor_description") %>
+</h2>
+
+<table class="text-left">
+  <tr>
+    <th class="pr-8"><%= t("backoffice.common.name") %></th>
+    <td class="text-green-dark underline"><%= link_to @open_call.investor.name, edit_backoffice_investor_path(@open_call.investor.id) %></td>
+  </tr>
+  <tr>
+    <th class="pr-8"><%= t("simple_form.labels.account.type") %></th>
+    <td><%= InvestorType.find(@open_call.investor.investor_type).name %></td>
+  </tr>
+  <tr>
+    <th class="pr-8"><%= t("simple_form.labels.account.email") %></th>
+    <td class="text-green-dark underline"><%= mail_to @open_call.investor.contact_email %></td>
+  </tr>
+  <tr>
+    <th class="pr-8"><%= t("simple_form.labels.account.phone") %></th>
+    <td class="text-green-dark underline"><%= phone_to @open_call.investor.contact_phone %></td>
+  </tr>
+</table>

--- a/backend/app/views/backoffice/open_calls/_section_status.html.erb
+++ b/backend/app/views/backoffice/open_calls/_section_status.html.erb
@@ -1,0 +1,18 @@
+<%= simple_form_for [:backoffice, @open_call], url: backoffice_open_call_path(@open_call.id) do |f| %>
+  <%= f.error_notification %>
+  <%= hidden_field_tag :section, params[:section] %>
+
+  <h2 class="mb-2 text-gray-900 font-semibold">
+    <%= t("backoffice.open_calls.status") %>
+  </h2>
+  <p class="mb-8 text-gray-600">
+    <%= t("backoffice.open_calls.status_description") %>
+  </p>
+
+  <%= f.input :trusted, label: "", collection: [[t("backoffice.common.verified"), true], [t("backoffice.common.unverified"), false]], as: :radio_buttons %>
+
+  <div class="mt-3 flex justify-end gap-3">
+    <%= link_to t("backoffice.common.cancel"), backoffice_projects_path, class: "button button-secondary-green" %>
+    <%= f.button :submit, t("backoffice.common.save"), class: "button button-primary-green" %>
+  </div>
+<% end %>

--- a/backend/app/views/backoffice/open_calls/edit.html.erb
+++ b/backend/app/views/backoffice/open_calls/edit.html.erb
@@ -1,0 +1,25 @@
+<div class="flex">
+  <aside class="w-2/6">
+    <h1 class="font-semibold text-xl text-black mb-8">
+      <%= @open_call.name %>
+    </h1>
+
+    <ul class="flex flex-col gap-8 mb-8">
+      <li><%= section_link_to t("backoffice.open_calls.information"), edit_backoffice_open_call_path, :information, default: true %></li>
+      <li><%= section_link_to t("backoffice.open_calls.status"), edit_backoffice_open_call_path, :status %></li>
+      <li><%= section_link_to t("backoffice.open_calls.investor"), edit_backoffice_open_call_path, :investor %></li>
+    </ul>
+    <%= link_to backoffice_open_call_path(@open_call.id),
+       data: {
+         turbo_method: :delete,
+         turbo_confirm: t("backoffice.messages.delete_confirmation", model: t("backoffice.common.open_call").downcase)
+       },
+       class: "button button-secondary-green button-with-icon" do %>
+      <%= svg "trash" %>
+      <%= t("backoffice.open_calls.delete") %>
+    <% end %>
+  </aside>
+  <div class="w-full h-full bg-white rounded-xl p-6">
+    <%= render section_partial %>
+  </div>
+</div>

--- a/backend/app/views/backoffice/open_calls/index.html.erb
+++ b/backend/app/views/backoffice/open_calls/index.html.erb
@@ -21,6 +21,8 @@
     <th>
       <%= sort_link @q, :trusted, t("backoffice.common.status") %>
     </th>
+    <th>
+    </th>
     <th class="opacity-25">
       <%= svg "menu" %>
     </th>
@@ -37,6 +39,7 @@
         <%= status_tag :verified, t('backoffice.common.verified') if open_call.trusted?  %>
         <%= status_tag :unverified, t('backoffice.common.unverified') unless open_call.trusted?  %>
       </td>
+      <td><%= link_to t("backoffice.common.edit"), edit_backoffice_open_call_path(open_call.id), class: "link-button" %></td>
       <td>
         <%= render "menu" do %>
           <% if open_call.trusted? %>

--- a/backend/config/initializers/simple_form_tailwind.rb
+++ b/backend/config/initializers/simple_form_tailwind.rb
@@ -101,12 +101,12 @@ SimpleForm.setup do |config|
   config.wrappers :vertical_multi_select, tag: "div", class: "my-4", error_class: "f", valid_class: "" do |b|
     b.use :html5
     b.optional :readonly
-    b.wrapper :legend_tag, tag: "legend", class: "text-sm font-medium text-gray-600", error_class: "text-red-500" do |ba|
+    b.wrapper :legend_tag, tag: "legend", class: "font-sans text-gray-800 font-semibold text-sm", error_class: "text-red-500" do |ba|
       ba.use :label_text
     end
     b.wrapper tag: "div", class: "inline-flex space-x-1" do |ba|
       # ba.use :input, class: 'flex w-auto w-auto text-gray-500 text-sm border-gray-300 rounded p-2', error_class: 'text-red-500', valid_class: 'text-green-400'
-      ba.use :input, class: "flex w-auto w-auto shadow appearance-none border border-gray-300 rounded w-full p-2 bg-white focus:outline-none focus:border-blue-500 text-gray-400 leading-4 transition-colors duration-200 ease-in-out"
+      ba.use :input, class: "flex w-auto w-auto shadow appearance-none border border-gray-300 rounded w-full p-2 bg-white focus:outline-none focus:border-blue-500 text-gray-900 leading-4 transition-colors duration-200 ease-in-out"
     end
     b.use :full_error, wrap_with: {tag: "p", class: "mt-2 text-red-500 text-xs italic"}
     b.use :hint, wrap_with: {tag: "p", class: "mt-2 text-grey-700 text-xs italic"}

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -83,6 +83,21 @@ zu:
         progress_impact_tracking: Progress and impact tracking
         description: Short description of the project
         relevant_links: Relevant links (optional)
+      open_call:
+        name: Open call name
+        picture: Picture
+        country_id: Country
+        department_id: State (optional)
+        municipality_id: Municipality (optional)
+        description: What is the open call about?
+        investor_id: Owner
+        impact_description: Expected impact
+        sdgs: Select the SDG's you expect to have impact (optional)
+        maximum_funding_per_project: How much funding do you have available for this open call? ($)
+        instrument_types: Financial instrument available
+        funding_priorities: Funding priorities
+        funding_exclusions: Funding exclusions
+        closing_at: End
       defaults:
         categories: Select the categories that you work on
         mission: What's your mission?
@@ -256,10 +271,22 @@ zu:
           not_supported: This file is not supported. Please try uploading a different format.
           unable_to_parse: Unable to parse the file. Please try uploading a different format.
     open_calls:
+      information: Information
+      status: Verification status
+      status_description: The verification status allow the open call to have a verification badge. By default all the open calls are set to "Unverified". Please review the information and change it to "Verified".
+      investor: Investor
+      investor_description: "Investor that created open call:"
+      delete: Delete open call
       index:
         name: Open Call name
         location: Location
         applications: Applications
+      form:
+        general: General
+        investor: Investor
+        impact: Impact
+        funding: Funding information
+        date: Date
     layout:
       header: Backoffice
       sign_out: Sign out

--- a/backend/config/routes/backoffice.rb
+++ b/backend/config/routes/backoffice.rb
@@ -19,7 +19,7 @@ namespace :backoffice do
   resources :investors, only: [:index, :edit, :update, :destroy]
   resources :project_developers, only: [:index, :edit, :update, :destroy]
   resources :projects, only: [:index, :edit, :update, :destroy]
-  resources :open_calls, only: [:index, :destroy] do
+  resources :open_calls, only: [:index, :edit, :update, :destroy] do
     member do
       post :verify
       post :unverify

--- a/backend/spec/system/backoffice/open_calls_spec.rb
+++ b/backend/spec/system/backoffice/open_calls_spec.rb
@@ -102,4 +102,133 @@ RSpec.describe "Backoffice: Open Calls", type: :system do
       end
     end
   end
+
+  describe "Edit" do
+    let!(:country) { create :location, :with_municipalities }
+    let!(:investor) { create :investor }
+
+    before do
+      visit "/backoffice/open_calls"
+      within_row("Open Call ultra name") do
+        click_on t("backoffice.common.edit")
+      end
+    end
+
+    context "information section" do
+      context "when content is correct" do
+        let(:closing_at) { 10.days.from_now.to_date }
+
+        it "can update open call information" do
+          fill_in t("simple_form.labels.open_call.name"), with: "New name"
+          attach_file t("simple_form.labels.open_call.picture"), Rails.root.join("spec/fixtures/files/picture.jpg")
+          select country.name, from: t("simple_form.labels.open_call.country_id")
+          select country.locations.first.name, from: t("simple_form.labels.open_call.department_id")
+          select country.locations.first.locations.first.name, from: t("simple_form.labels.open_call.municipality_id")
+          fill_in t("simple_form.labels.open_call.description"), with: "New description"
+          select investor.name, from: t("simple_form.labels.open_call.investor_id")
+          fill_in t("simple_form.labels.open_call.impact_description"), with: "New impact description"
+          check t("enums.sdg.1.name")
+          check t("enums.sdg.2.name")
+          uncheck t("enums.sdg.4.name")
+          fill_in t("simple_form.labels.open_call.maximum_funding_per_project"), with: 10_000
+          check t("enums.instrument_type.equity.name")
+          check t("enums.instrument_type.grant.name")
+          uncheck t("enums.instrument_type.loan.name")
+          fill_in t("simple_form.labels.open_call.funding_priorities"), with: "New funding priorities"
+          fill_in t("simple_form.labels.open_call.funding_exclusions"), with: "New funding exclusions"
+          fill_in "open_call[closing_at]", with: closing_at
+          click_on t("backoffice.common.save")
+
+          expect(page).to have_text(t("backoffice.messages.success_update", model: t("backoffice.common.open_call")))
+          open_call.reload
+          expect(open_call.name).to eq("New name")
+          expect(open_call.picture).to be_attached
+          expect(open_call.country).to eq(country)
+          expect(open_call.department).to eq(country.locations.first)
+          expect(open_call.municipality).to eq(country.locations.first.locations.first)
+          expect(open_call.description).to eq("New description")
+          expect(open_call.investor).to eq(investor)
+          expect(open_call.impact_description).to eq("New impact description")
+          expect(open_call.sdgs).to include(1)
+          expect(open_call.sdgs).to include(2)
+          expect(open_call.sdgs).not_to include(4)
+          expect(open_call.maximum_funding_per_project).to eq(10_000)
+          expect(open_call.instrument_types).to include("equity")
+          expect(open_call.instrument_types).to include("grant")
+          expect(open_call.instrument_types).not_to include("loan")
+          expect(open_call.funding_priorities).to eq("New funding priorities")
+          expect(open_call.funding_exclusions).to eq("New funding exclusions")
+          expect(open_call.closing_at).to eq(closing_at)
+        end
+      end
+
+      context "when content is incorrect" do
+        it "shows validation errors" do
+          fill_in t("simple_form.labels.open_call.maximum_funding_per_project"), with: -10
+          click_on t("backoffice.common.save")
+
+          expect(page).to have_text(t("simple_form.error_notification.default_message"))
+          expect(page).to have_text("Maximum funding per project must be greater than 0")
+        end
+      end
+    end
+
+    context "verification status section" do
+      before { within_sidebar { click_on t("backoffice.open_calls.status") } }
+
+      it "can update verification status" do
+        expect(page).to have_checked_field("open_call[trusted]")
+        choose t("backoffice.common.unverified"), name: "open_call[trusted]"
+        click_on t("backoffice.common.save")
+        expect(page).to have_text(t("backoffice.messages.success_update", model: t("backoffice.common.open_call")))
+        expect(open_call.reload.trusted).to be_falsey
+      end
+    end
+
+    context "investor section" do
+      before { within_sidebar { click_on t("backoffice.open_calls.investor") } }
+
+      it "shows owner information" do
+        expect(page).to have_text(t("backoffice.open_calls.investor_description"))
+        expect(page).to have_text(open_call.investor.name)
+        expect(page).to have_text(InvestorType.find(open_call.investor.investor_type).name)
+        expect(page).to have_text(open_call.investor.contact_email)
+        expect(page).to have_text(open_call.investor.contact_phone)
+      end
+    end
+
+    context "when changing translations" do
+      it "saves translated content" do
+        select "Spanish", from: t("backoffice.common.view_content_in")
+        sleep 1 # have to wait as dunno why it does not wait for turbo to reload page
+        fill_in t("simple_form.labels.open_call.name"), with: "New name - Spanish"
+        fill_in t("simple_form.labels.open_call.description"), with: "New description - Spanish"
+        fill_in t("simple_form.labels.open_call.impact_description"), with: "New impact description - Spanish"
+        fill_in t("simple_form.labels.open_call.funding_priorities"), with: "New funding priorities - Spanish"
+        fill_in t("simple_form.labels.open_call.funding_exclusions"), with: "New funding exclusions - Spanish"
+        click_on t("backoffice.common.save")
+
+        expect(page).to have_text(t("backoffice.messages.success_update", model: t("backoffice.common.open_call")))
+        open_call.reload
+        expect(open_call.name_es).to eq("New name - Spanish")
+        expect(open_call.description_es).to eq("New description - Spanish")
+        expect(open_call.impact_description_es).to eq("New impact description - Spanish")
+        expect(open_call.funding_priorities_es).to eq("New funding priorities - Spanish")
+        expect(open_call.funding_exclusions_es).to eq("New funding exclusions - Spanish")
+      end
+    end
+
+    context "when removing open call" do
+      it "removes open call" do
+        expect {
+          accept_confirm do
+            click_on t("backoffice.open_calls.delete")
+          end
+        }.to have_enqueued_mail(InvestorMailer, :open_call_destroyed).with(open_call.investor, open_call.name)
+        expect(page).to have_text(t("backoffice.messages.success_delete", model: t("backoffice.common.open_call")))
+        expect(current_path).to eql(backoffice_open_calls_path)
+        expect(page).not_to have_text(open_call.name)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adding forms to backoffice which allows to edit Open Calls.

![Screenshot 2022-09-05 at 12 33 57](https://user-images.githubusercontent.com/20660167/188462782-b00fa7e3-178f-4aaf-8ab4-45619e8423cc.png)

## Testing instructions

Open backoffice and try to edit some existing Open Call.

## Tracking

https://vizzuality.atlassian.net/browse/LET-906
