### PR TITLE
Allow investor users to indicate which projects they're funding in Dashboard

### DIFF
--- a/frontend/containers/dashboard/open-call-details/funding-switch/component.tsx
+++ b/frontend/containers/dashboard/open-call-details/funding-switch/component.tsx
@@ -1,0 +1,85 @@
+import { FC, useEffect, useState } from 'react';
+
+import { usePress } from 'react-aria';
+import { useForm } from 'react-hook-form';
+import { FormattedMessage } from 'react-intl';
+
+import { useGetAlert } from 'helpers/pages';
+
+import Alert from 'components/alert';
+import Switch from 'components/forms/switch';
+
+import { useOpenCallApplicationFunding } from 'services/open-call/application-service';
+
+import { FundingSwitchProps } from './types';
+
+export const FundingSwitch: FC<FundingSwitchProps> = ({
+  openCallApplication,
+}: FundingSwitchProps) => {
+  const [prevFunded, setPrevFunded] = useState<boolean>(null);
+
+  const fundingOpenCallMutation = useOpenCallApplicationFunding();
+
+  const { register, watch, setValue, getValues, reset } = useForm({
+    defaultValues: {
+      funding: null,
+    },
+  });
+
+  const funding = !!watch('funding');
+
+  useEffect(() => {
+    if (!openCallApplication) return;
+
+    if (openCallApplication.funded !== prevFunded) {
+      setPrevFunded(openCallApplication.funded);
+      setValue('funding', openCallApplication.funded);
+    }
+  }, [openCallApplication, prevFunded, setValue]);
+
+  const { pressProps } = usePress({
+    onPress: () => {
+      fundingOpenCallMutation.mutate(
+        { id: openCallApplication.id, isFunding: !funding },
+        {
+          onSuccess: () => {
+            fundingOpenCallMutation.reset();
+          },
+          onError: () => {
+            setValue('funding', openCallApplication.funded);
+          },
+        }
+      );
+    },
+  });
+
+  return (
+    <form>
+      <label
+        htmlFor="funding"
+        className="flex items-center gap-2 text-sm font-semibold text-gray-800 cursor-pointer"
+      >
+        <Switch
+          id="funding"
+          name="funding"
+          switchSize="smallest"
+          register={register}
+          value={true}
+          checked={funding}
+          {...pressProps}
+        />
+        <FormattedMessage defaultMessage="I'm financing this project" id="kICTEM" />
+      </label>
+      {fundingOpenCallMutation.error && (
+        <Alert type="warning" className="mt-4 rounded">
+          <FormattedMessage
+            defaultMessage="There was an error processing your request. Please try again."
+            id="URkYUE"
+          />
+        </Alert>
+      )}
+    </form>
+  );
+};
+
+export default FundingSwitch;

--- a/frontend/containers/dashboard/open-call-details/funding-switch/component.tsx
+++ b/frontend/containers/dashboard/open-call-details/funding-switch/component.tsx
@@ -19,6 +19,7 @@ export const FundingSwitch: FC<FundingSwitchProps> = ({
   const [prevFunded, setPrevFunded] = useState<boolean>(null);
 
   const fundingOpenCallMutation = useOpenCallApplicationFunding();
+  const alert = useGetAlert(fundingOpenCallMutation.error);
 
   const { register, watch, setValue, getValues, reset } = useForm({
     defaultValues: {
@@ -70,12 +71,10 @@ export const FundingSwitch: FC<FundingSwitchProps> = ({
         />
         <FormattedMessage defaultMessage="I'm financing this project" id="kICTEM" />
       </label>
-      {fundingOpenCallMutation.error && (
+      {alert && (
         <Alert type="warning" className="mt-4 rounded">
-          <FormattedMessage
-            defaultMessage="There was an error processing your request. Please try again."
-            id="URkYUE"
-          />
+          {/* useGetAlert returns an array, but the endpoint only sends one error message at a time. */}
+          {alert[0]}
         </Alert>
       )}
     </form>

--- a/frontend/containers/dashboard/open-call-details/funding-switch/index.ts
+++ b/frontend/containers/dashboard/open-call-details/funding-switch/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { FundingSwitchProps } from './types';

--- a/frontend/containers/dashboard/open-call-details/funding-switch/types.ts
+++ b/frontend/containers/dashboard/open-call-details/funding-switch/types.ts
@@ -1,0 +1,5 @@
+import { OpenCallApplication } from 'types/open-call-applications';
+
+export type FundingSwitchProps = {
+  openCallApplication: OpenCallApplication;
+};

--- a/frontend/containers/dashboard/open-call-details/table/cells/actions/component.tsx
+++ b/frontend/containers/dashboard/open-call-details/table/cells/actions/component.tsx
@@ -4,7 +4,11 @@ import { FormattedMessage } from 'react-intl';
 
 import Link from 'next/link';
 
+import RowMenu, { RowMenuItem } from 'containers/dashboard/row-menu';
+
 import { Paths } from 'enums';
+
+import { useOpenCallApplicationFunding } from 'services/open-call/application-service';
 
 import { CellActionsProps } from './types';
 
@@ -13,6 +17,19 @@ export const CellActions: FC<CellActionsProps> = ({
     original: { openCall, openCallApplication },
   },
 }: CellActionsProps) => {
+  const fundingOpenCallMutation = useOpenCallApplicationFunding();
+
+  const handleRowMenuItemClick = (key: string) => {
+    switch (key) {
+      case 'funding':
+        fundingOpenCallMutation.mutate({ id: openCallApplication?.id, isFunding: true });
+        return;
+      case 'not-funding':
+        fundingOpenCallMutation.mutate({ id: openCallApplication?.id, isFunding: false });
+        return;
+    }
+  };
+
   return (
     <div className="flex items-center justify-center gap-3">
       <Link
@@ -22,6 +39,14 @@ export const CellActions: FC<CellActionsProps> = ({
           <FormattedMessage defaultMessage="Details" id="Lv0zJu" />
         </a>
       </Link>
+      <RowMenu onAction={handleRowMenuItemClick}>
+        <RowMenuItem key="funding">
+          <FormattedMessage defaultMessage="Funding" id="fZb224" />
+        </RowMenuItem>
+        <RowMenuItem key="not-funding">
+          <FormattedMessage defaultMessage="Not funding" id="Llk7Pe" />
+        </RowMenuItem>
+      </RowMenu>
     </div>
   );
 };

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -1566,6 +1566,9 @@
   "URdlN+": {
     "string": "Invest in small, medium or big project opportunities."
   },
+  "URkYUE": {
+    "string": "There was an error processing your request. Please try again."
+  },
   "Ub+AGc": {
     "string": "Sign In"
   },
@@ -2324,6 +2327,9 @@
   },
   "kHpaMt": {
     "string": "Edit Open Call"
+  },
+  "kICTEM": {
+    "string": "I'm financing this project"
   },
   "kN5g/0": {
     "string": "Indigenous Reserves"

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -1566,9 +1566,6 @@
   "URdlN+": {
     "string": "Invest in small, medium or big project opportunities."
   },
-  "URkYUE": {
-    "string": "There was an error processing your request. Please try again."
-  },
   "Ub+AGc": {
     "string": "Sign In"
   },

--- a/frontend/pages/dashboard/open-call/[openCallId]/application/[applicationId].tsx
+++ b/frontend/pages/dashboard/open-call/[openCallId]/application/[applicationId].tsx
@@ -79,10 +79,6 @@ export const OpenCallDetailsPage: PageComponent<OpenCallDetailsPageProps, Dashbo
     setProjectDeveloperPhoto(projectDeveloper?.picture?.small);
   }, [projectDeveloper]);
 
-  const handleFundingSwitchChange = () => {
-    if (isLoadingOpenCallApplication || isRefetchingOpenCallApplication) return;
-  };
-
   const breadcrumbsProps = {
     substitutions: {
       'open-call': {

--- a/frontend/pages/dashboard/open-call/[openCallId]/application/[applicationId].tsx
+++ b/frontend/pages/dashboard/open-call/[openCallId]/application/[applicationId].tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 
-import { ExternalLink as ExternalLinkIcon, X as XIcon } from 'react-feather';
+import { ExternalLink as ExternalLinkIcon } from 'react-feather';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import Image from 'next/image';
@@ -14,7 +14,7 @@ import { groupBy } from 'lodash-es';
 
 import { loadI18nMessages } from 'helpers/i18n';
 
-import WithdrawApplicationModal from 'containers/dashboard/open-call-applications/withdraw-application-modal';
+import FundingSwitch from 'containers/dashboard/open-call-details/funding-switch';
 
 import Head from 'components/head';
 import LayoutContainer from 'components/layout-container';
@@ -61,8 +61,9 @@ export const OpenCallDetailsPage: PageComponent<OpenCallDetailsPageProps, Dashbo
 
   const {
     data: openCallApplication,
-    isLoading,
-    isLoadingError,
+    isLoading: isLoadingOpenCallApplication,
+    isLoadingError: isLoadingOpenCallApplicationError,
+    isRefetching: isRefetchingOpenCallApplication,
   } = useOpenCallApplication(router.query.applicationId as string, {
     includes: ['open_call', 'project', 'project_developer'],
   });
@@ -77,6 +78,10 @@ export const OpenCallDetailsPage: PageComponent<OpenCallDetailsPageProps, Dashbo
     if (!projectDeveloper?.picture?.small) return;
     setProjectDeveloperPhoto(projectDeveloper?.picture?.small);
   }, [projectDeveloper]);
+
+  const handleFundingSwitchChange = () => {
+    if (isLoadingOpenCallApplication || isRefetchingOpenCallApplication) return;
+  };
 
   const breadcrumbsProps = {
     substitutions: {
@@ -103,7 +108,7 @@ export const OpenCallDetailsPage: PageComponent<OpenCallDetailsPageProps, Dashbo
 
   // If we can't load the open call, it may have been removed or the user not have access to it. Let's
   // redirect the user to the Dashboard open calls list.
-  if (isLoadingError) {
+  if (isLoadingOpenCallApplicationError) {
     router.push(Paths.DashboardOpenCalls);
     return null;
   }
@@ -121,7 +126,7 @@ export const OpenCallDetailsPage: PageComponent<OpenCallDetailsPageProps, Dashbo
       />
       <DashboardLayout
         header="breadcrumbs"
-        isLoading={isLoading}
+        isLoading={isLoadingOpenCallApplication}
         breadcrumbsProps={breadcrumbsProps}
       >
         <LayoutContainer layout="narrow">
@@ -220,6 +225,9 @@ export const OpenCallDetailsPage: PageComponent<OpenCallDetailsPageProps, Dashbo
                     <span className="mt-1">{projectDeveloper?.about}</span>
                   </div>
                 </div>
+              </div>
+              <div className="mt-12">
+                <FundingSwitch openCallApplication={openCallApplication} />
               </div>
             </div>
           </div>

--- a/frontend/services/open-call/application-service.ts
+++ b/frontend/services/open-call/application-service.ts
@@ -166,3 +166,37 @@ export const useDeleteOpenCallApplication = (): UseMutationResult<
     },
   });
 };
+
+/**
+ * Hook with mutation to mark an open call application as being funded or not funded
+ **/
+export const useOpenCallApplicationFunding = () => {
+  const queryClient = useQueryClient();
+
+  const fundingOpenCall = (
+    openCallApplicationId: string,
+    isFunding: boolean
+  ): Promise<AxiosResponse> => {
+    const endpoint = isFunding
+      ? `/api/v1/account/open_call_applications/${openCallApplicationId}/funding`
+      : `/api/v1/account/open_call_applications/${openCallApplicationId}/not_funding`;
+
+    const config: AxiosRequestConfig = {
+      method: 'POST',
+      url: endpoint,
+      data: { id: openCallApplicationId },
+    };
+
+    return API(config);
+  };
+
+  return useMutation(
+    ({ id, isFunding }: { id: string; isFunding: boolean }) => fundingOpenCall(id, isFunding),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(Queries.AccountOpenCallApplication);
+        queryClient.invalidateQueries(Queries.AccountOpenCallApplicationsList);
+      },
+    }
+  );
+};

--- a/frontend/services/open-call/application-service.ts
+++ b/frontend/services/open-call/application-service.ts
@@ -170,7 +170,10 @@ export const useDeleteOpenCallApplication = (): UseMutationResult<
 /**
  * Hook with mutation to mark an open call application as being funded or not funded
  **/
-export const useOpenCallApplicationFunding = () => {
+export const useOpenCallApplicationFunding = (): UseMutationResult<
+  AxiosResponse<ResponseData<OpenCall>>,
+  AxiosError<ErrorResponse>
+> => {
   const queryClient = useQueryClient();
 
   const fundingOpenCall = (


### PR DESCRIPTION
## Description

Allow investors to indicate whether they're funding a project, via the dashboard. 

## Testing instructions

1. Using an investor account:
    - Create an open call and publish it  

2. Using a project developer account: 
    - Create a project  (and publish it)  
    - Visit the open call (created on 1) public page, click "Apply now"  
    - Select the project created, add a message, apply to the open call  

3. Log back in with the investor account used on 1
    - Visit the dashboard, open calls tab  
    - On the open call row, click the 3 dots menu and choose "View all applications"  
    - Using the 3 dots menu on the open call applications screen, ensure that "Funding" and "Not funding" works  
    - Click "Details" to see the open call application details page  
    - Use the "I'm financing this project" toggle and ensure it works (one can go back to the list to make sure it updates)  


## Tracking

[LET-986](https://vizzuality.atlassian.net/browse/LET-986)

## Screenshots  
<img width="1538" alt="Screenshot 2022-09-06 at 10 08 50" src="https://user-images.githubusercontent.com/6273795/188595490-7a1a7891-539c-4981-a1f3-34971ca60566.png">
<img width="1559" alt="Screenshot 2022-09-06 at 10 08 57" src="https://user-images.githubusercontent.com/6273795/188595503-6e6d3d8a-e8d4-4cbe-bd39-66b346f0eb0a.png">

