### PR TITLE
refactoring: Renaming trusted column to verified

### DIFF
--- a/backend/app/controllers/api/v1/projects/maps_controller.rb
+++ b/backend/app/controllers/api/v1/projects/maps_controller.rb
@@ -4,7 +4,7 @@ module API
       class MapsController < BaseController
         def show
           projects = Project.accessible_by(current_ability)
-            .select(:id, :trusted, :centroid, :category).order(created_at: :desc)
+            .select(:id, :verified, :centroid, :category).order(created_at: :desc)
           projects = API::Filterer.new(projects, filter_params.to_h).call
           render json: ProjectMapSerializer.new(projects).serializable_hash
         end

--- a/backend/app/controllers/backoffice/open_calls_controller.rb
+++ b/backend/app/controllers/backoffice/open_calls_controller.rb
@@ -45,13 +45,13 @@ module Backoffice
     end
 
     def verify
-      @open_call.update! trusted: true
+      @open_call.update! verified: true
 
       redirect_back fallback_location: backoffice_open_calls_path
     end
 
     def unverify
-      @open_call.update! trusted: false
+      @open_call.update! verified: false
 
       redirect_back fallback_location: backoffice_open_calls_path
     end
@@ -72,7 +72,7 @@ module Backoffice
         :maximum_funding_per_project,
         :funding_priorities,
         :funding_exclusions,
-        :trusted,
+        :verified,
         instrument_types: [],
         sdgs: []
       )

--- a/backend/app/controllers/backoffice/projects_controller.rb
+++ b/backend/app/controllers/backoffice/projects_controller.rb
@@ -71,7 +71,7 @@ module Backoffice
         :progress_impact_tracking,
         :description,
         :relevant_links,
-        :trusted,
+        :verified,
         instrument_types: [],
         impact_areas: [],
         sdgs: [],

--- a/backend/app/models/open_call.rb
+++ b/backend/app/models/open_call.rb
@@ -36,7 +36,7 @@ class OpenCall < ApplicationRecord
 
   validates_presence_of :name, :description, :funding_priorities, :funding_exclusions, :impact_description, :closing_at
 
-  validates :trusted, inclusion: [true, false]
+  validates :verified, inclusion: [true, false]
 
   validates_uniqueness_of [*locale_columns(:name)], scope: [:investor_id], case_sensitive: false, allow_blank: true
   validate :location_types

--- a/backend/app/models/project.rb
+++ b/backend/app/models/project.rb
@@ -53,7 +53,7 @@ class Project < ApplicationRecord
     :geometry
 
   validates :estimated_duration_in_months, numericality: {only_integer: true, greater_than: 0, less_than: 37}, presence: true
-  validates :trusted, inclusion: [true, false]
+  validates :verified, inclusion: [true, false]
   validates :received_funding, inclusion: [true, false]
   validates :looking_for_funding, inclusion: [true, false]
   validates :project_images, length: {maximum: 6}

--- a/backend/app/serializers/api/v1/open_call_serializer.rb
+++ b/backend/app/serializers/api/v1/open_call_serializer.rb
@@ -16,9 +16,10 @@ module API
         :status,
         :language,
         :account_language,
-        :trusted,
+        :verified,
         :created_at,
         :open_call_applications_count
+      attribute :trusted, &:verified
 
       belongs_to :investor
       belongs_to :country, serializer: LocationSerializer

--- a/backend/app/serializers/api/v1/project_map_serializer.rb
+++ b/backend/app/serializers/api/v1/project_map_serializer.rb
@@ -1,7 +1,8 @@
 module API
   module V1
     class ProjectMapSerializer < BaseSerializer
-      attributes :trusted, :category
+      attributes :verified, :category
+      attribute :trusted, &:verified
 
       attribute :latitude do |object, _params|
         object.centroid&.y

--- a/backend/app/serializers/api/v1/project_serializer.rb
+++ b/backend/app/serializers/api/v1/project_serializer.rb
@@ -29,7 +29,7 @@ module API
         :language,
         :account_language,
         :geometry,
-        :trusted,
+        :verified,
         :created_at,
         :municipality_biodiversity_impact,
         :municipality_climate_impact,
@@ -47,6 +47,7 @@ module API
         :priority_landscape_community_impact,
         :priority_landscape_total_impact,
         :impact_calculated
+      attribute :trusted, &:verified
 
       belongs_to :project_developer
       belongs_to :country, serializer: LocationSerializer

--- a/backend/app/services/api/filterer.rb
+++ b/backend/app/services/api/filterer.rb
@@ -60,9 +60,9 @@ module API
     end
 
     def filter_by_only_verified
-      return unless filters[:only_verified] && column_names.include?("trusted")
+      return unless filters[:only_verified] && column_names.include?("verified")
 
-      self.query = query.where trusted: true
+      self.query = query.where verified: true
     end
 
     def filter_by_relations

--- a/backend/app/services/backoffice/csv/open_call_exporter.rb
+++ b/backend/app/services/backoffice/csv/open_call_exporter.rb
@@ -8,7 +8,7 @@ module Backoffice
           column(I18n.t("backoffice.open_calls.index.location")) { |r| [r.municipality&.name, r.department&.name, r.country&.name].compact.join(", ") }
           column(I18n.t("backoffice.open_calls.index.applications")) { |r| r.open_call_applications_count }
           column(I18n.t("backoffice.common.status")) { |r|
-            r.trusted? ? I18n.t("backoffice.common.verified") : I18n.t("backoffice.common.unverified")
+            r.verified? ? I18n.t("backoffice.common.verified") : I18n.t("backoffice.common.unverified")
           }
         end
       end

--- a/backend/app/services/backoffice/csv/project_exporter.rb
+++ b/backend/app/services/backoffice/csv/project_exporter.rb
@@ -8,7 +8,7 @@ module Backoffice
           column(I18n.t("backoffice.common.category")) { |r| Category.find(r.category).name }
           column(I18n.t("backoffice.projects.index.priority_landscape")) { |r| r.priority_landscape&.name }
           column(I18n.t("backoffice.common.status")) { |r|
-            r.trusted? ? I18n.t("backoffice.common.verified") : I18n.t("backoffice.common.unverified")
+            r.verified? ? I18n.t("backoffice.common.verified") : I18n.t("backoffice.common.unverified")
           }
         end
       end

--- a/backend/app/views/backoffice/open_calls/_filters.html.erb
+++ b/backend/app/views/backoffice/open_calls/_filters.html.erb
@@ -1,7 +1,7 @@
 <%= render "backoffice/base/filters", q: q do |f| %>
   <%= render partial: "backoffice/base/full_text_filter", locals: { f: f, filter_key: :name_or_investor_account_name_or_country_name_or_department_name_or_municipality_name_i_cont } %>
   <div class="w-30 inline-block mr-3">
-    <%= f.input :trusted_eq, as: :select, required: false, label: false, include_blank: I18n.t("backoffice.common.status"),
+    <%= f.input :verified_eq, as: :select, required: false, label: false, include_blank: I18n.t("backoffice.common.status"),
                 collection: [[t("backoffice.common.verified"), true], [t("backoffice.common.unverified"), false]] %>
   </div>
 <% end %>

--- a/backend/app/views/backoffice/open_calls/_section_status.html.erb
+++ b/backend/app/views/backoffice/open_calls/_section_status.html.erb
@@ -9,7 +9,7 @@
     <%= t("backoffice.open_calls.status_description") %>
   </p>
 
-  <%= f.input :trusted, label: "", collection: [[t("backoffice.common.verified"), true], [t("backoffice.common.unverified"), false]], as: :radio_buttons %>
+  <%= f.input :verified, label: "", collection: [[t("backoffice.common.verified"), true], [t("backoffice.common.unverified"), false]], as: :radio_buttons %>
 
   <div class="mt-3 flex justify-end gap-3">
     <%= link_to t("backoffice.common.cancel"), backoffice_projects_path, class: "button button-secondary-green" %>

--- a/backend/app/views/backoffice/open_calls/index.html.erb
+++ b/backend/app/views/backoffice/open_calls/index.html.erb
@@ -19,7 +19,7 @@
       <%= sort_link @q, :open_call_applications_count, t("backoffice.open_calls.index.applications") %>
     </th>
     <th>
-      <%= sort_link @q, :trusted, t("backoffice.common.status") %>
+      <%= sort_link @q, :verified, t("backoffice.common.status") %>
     </th>
     <th>
     </th>
@@ -36,18 +36,18 @@
       <td><%= [open_call.municipality&.name, open_call.department&.name, open_call.country&.name].compact.join(", ") %></td>
       <td><%= open_call.open_call_applications_count %></td>
       <td>
-        <%= status_tag :verified, t('backoffice.common.verified') if open_call.trusted?  %>
-        <%= status_tag :unverified, t('backoffice.common.unverified') unless open_call.trusted?  %>
+        <%= status_tag :verified, t('backoffice.common.verified') if open_call.verified?  %>
+        <%= status_tag :unverified, t('backoffice.common.unverified') unless open_call.verified?  %>
       </td>
       <td><%= link_to t("backoffice.common.edit"), edit_backoffice_open_call_path(open_call.id), class: "link-button" %></td>
       <td>
         <%= render "menu" do %>
-          <% if open_call.trusted? %>
+          <% if open_call.verified? %>
             <%= render "backoffice/base/menu/item" do %>
               <%= button_to t("backoffice.common.unverify"), unverify_backoffice_open_call_path(open_call.id), method: :post %>
             <% end %>
           <% end %>
-          <% unless open_call.trusted? %>
+          <% unless open_call.verified? %>
             <%= render "backoffice/base/menu/item" do %>
               <%= button_to t("backoffice.common.verify"), verify_backoffice_open_call_path(open_call.id), method: :post %>
             <% end %>

--- a/backend/app/views/backoffice/projects/_filters.html.erb
+++ b/backend/app/views/backoffice/projects/_filters.html.erb
@@ -1,7 +1,7 @@
 <%= render "backoffice/base/filters", q: q do |f| %>
   <%= render partial: "backoffice/base/full_text_filter", locals: { f: f } %>
   <div class="w-30 inline-block mr-3">
-    <%= f.input :trusted_eq, as: :select, required: false, label: false, include_blank: I18n.t("backoffice.common.status"),
+    <%= f.input :verified_eq, as: :select, required: false, label: false, include_blank: I18n.t("backoffice.common.status"),
                 collection: [[t("backoffice.common.verified"), true], [t("backoffice.common.unverified"), false]] %>
   </div>
   <div class="w-30 inline-block mr-3">

--- a/backend/app/views/backoffice/projects/_section_status.html.erb
+++ b/backend/app/views/backoffice/projects/_section_status.html.erb
@@ -9,7 +9,7 @@
     <%= t("backoffice.projects.status_description") %>
   </p>
 
-  <%= f.input :trusted, label: "", collection: [[t("backoffice.common.verified"), true], [t("backoffice.common.unverified"), false]], as: :radio_buttons %>
+  <%= f.input :verified, label: "", collection: [[t("backoffice.common.verified"), true], [t("backoffice.common.unverified"), false]], as: :radio_buttons %>
 
   <div class="mt-3 flex justify-end gap-3">
     <%= link_to t("backoffice.common.cancel"), backoffice_projects_path, class: "button button-secondary-green" %>

--- a/backend/app/views/backoffice/projects/index.html.erb
+++ b/backend/app/views/backoffice/projects/index.html.erb
@@ -19,7 +19,7 @@
         <%= sort_link @q, :priority_landscape_name, t("backoffice.projects.index.priority_landscape") %>
       </th>
       <th>
-        <%= sort_link @q, :trusted, t("backoffice.common.status") %>
+        <%= sort_link @q, :verified, t("backoffice.common.status") %>
       </th>
       <th>
       </th>
@@ -33,8 +33,8 @@
         <td><%= Category.find(p.category).name %></td>
         <td><%= p.priority_landscape&.name %></td>
         <td>
-          <%= status_tag :verified, t('backoffice.common.verified') if p.trusted?  %>
-          <%= status_tag :unverified, t('backoffice.common.unverified') unless p.trusted?  %>
+          <%= status_tag :verified, t('backoffice.common.verified') if p.verified?  %>
+          <%= status_tag :unverified, t('backoffice.common.unverified') unless p.verified?  %>
         </td>
         <td><%= link_to t("backoffice.common.edit"), edit_backoffice_project_path(p.id), class: "link-button" %></td>
       </tr>

--- a/backend/db/migrate/20220906084050_rename_trusted_to_verified.rb
+++ b/backend/db/migrate/20220906084050_rename_trusted_to_verified.rb
@@ -1,0 +1,6 @@
+class RenameTrustedToVerified < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :projects, :trusted, :verified
+    rename_column :open_calls, :trusted, :verified
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_25_081811) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_06_084050) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -237,7 +237,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_081811) do
     t.text "impact_description_en"
     t.text "impact_description_es"
     t.text "impact_description_pt"
-    t.boolean "trusted", default: false, null: false
+    t.boolean "verified", default: false, null: false
     t.integer "sdgs", array: true
     t.string "language", null: false
     t.datetime "closing_at", null: false
@@ -332,7 +332,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_081811) do
     t.text "sustainability_en"
     t.text "sustainability_es"
     t.text "sustainability_pt"
-    t.boolean "trusted", default: false, null: false
+    t.boolean "verified", default: false, null: false
     t.text "website"
     t.text "linkedin"
     t.text "facebook"

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -59,7 +59,7 @@ if Rails.env.development?
       FactoryBot.create(
         :project,
         status: :published,
-        trusted: [true, false].sample,
+        verified: [true, false].sample,
         name: "#{Faker::Lorem.sentence} #{SecureRandom.hex(4)}",
         category: Category::TYPES.sample,
         project_developer: project_developer,

--- a/backend/spec/factories/open_call.rb
+++ b/backend/spec/factories/open_call.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
     sdgs { [1, 4, 5] }
     instrument_types { ["loan"] }
 
-    trusted { false }
+    verified { false }
 
     maximum_funding_per_project { 100_000 }
 

--- a/backend/spec/factories/project.rb
+++ b/backend/spec/factories/project.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
     target_groups { %w[urban-populations indigenous-peoples] }
     impact_areas { %w[pollutants-reduction carbon-emission-reduction] }
 
-    trusted { false }
+    verified { false }
 
     estimated_duration_in_months { 13 }
 

--- a/backend/spec/fixtures/snapshots/api/v1/account/open-call-applications-create.json
+++ b/backend/spec/fixtures/snapshots/api/v1/account/open-call-applications-create.json
@@ -107,7 +107,8 @@
         "impact_calculated": false,
         "latitude": 2.0,
         "longitude": 1.0,
-        "favourite": false
+        "favourite": false,
+        "verified": false
       },
       "relationships": {
         "project_developer": {

--- a/backend/spec/fixtures/snapshots/api/v1/account/open-calls-create.json
+++ b/backend/spec/fixtures/snapshots/api/v1/account/open-calls-create.json
@@ -30,7 +30,8 @@
       },
       "status": "draft",
       "favourite": false,
-      "open_call_applications_count": 0
+      "open_call_applications_count": 0,
+      "verified": false
     },
     "relationships": {
       "investor": {

--- a/backend/spec/fixtures/snapshots/api/v1/account/open-calls-favourites-include-relationships.json
+++ b/backend/spec/fixtures/snapshots/api/v1/account/open-calls-favourites-include-relationships.json
@@ -31,7 +31,8 @@
         },
         "status": "launched",
         "favourite": true,
-        "open_call_applications_count": 0
+        "open_call_applications_count": 0,
+        "verified": false
       },
       "relationships": {
         "investor": {

--- a/backend/spec/fixtures/snapshots/api/v1/account/open-calls-favourites-sparse-fieldset.json
+++ b/backend/spec/fixtures/snapshots/api/v1/account/open-calls-favourites-sparse-fieldset.json
@@ -31,7 +31,8 @@
         },
         "status": "launched",
         "favourite": true,
-        "open_call_applications_count": 0
+        "open_call_applications_count": 0,
+        "verified": false
       },
       "relationships": {
         "investor": {

--- a/backend/spec/fixtures/snapshots/api/v1/account/open-calls-favourites.json
+++ b/backend/spec/fixtures/snapshots/api/v1/account/open-calls-favourites.json
@@ -31,7 +31,8 @@
         },
         "status": "launched",
         "favourite": true,
-        "open_call_applications_count": 0
+        "open_call_applications_count": 0,
+        "verified": false
       },
       "relationships": {
         "investor": {

--- a/backend/spec/fixtures/snapshots/api/v1/account/open-calls-update.json
+++ b/backend/spec/fixtures/snapshots/api/v1/account/open-calls-update.json
@@ -29,7 +29,8 @@
       },
       "status": "launched",
       "favourite": false,
-      "open_call_applications_count": 0
+      "open_call_applications_count": 0,
+      "verified": false
     },
     "relationships": {
       "investor": {

--- a/backend/spec/fixtures/snapshots/api/v1/account/open-calls.json
+++ b/backend/spec/fixtures/snapshots/api/v1/account/open-calls.json
@@ -31,7 +31,8 @@
           "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoWXpJeVpETXlaUzAyT0RnekxUUmhaR010T0RVd1pTMWxZVEF6WWprek0yVTJORGtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--20c10a8c0b47ea9dff04c0edbb1b127bda34290d/picture.jpg"
         },
         "favourite": false,
-        "open_call_applications_count": 0
+        "open_call_applications_count": 0,
+        "verified": false
       },
       "relationships": {
         "investor": {
@@ -91,7 +92,8 @@
           "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTnpRd1pEbGlNQzB3T0RGbUxUUTJaR010WW1Oak1TMHdOelk0WVdKaE9XRTFNVFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--766e78148df6242d51fd1598b697ca7bdabda629/picture.jpg"
         },
         "favourite": false,
-        "open_call_applications_count": 0
+        "open_call_applications_count": 0,
+        "verified": false
       },
       "relationships": {
         "investor": {
@@ -151,7 +153,8 @@
           "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4TVRNMllXUmhaUzFrTmpnM0xUUXhNekV0T0RBM1ppMHpNRGMzTWprek16RTNaRE1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0896be0319d6008c3e7c725aebdd9346238c95fb/picture.jpg"
         },
         "favourite": false,
-        "open_call_applications_count": 0
+        "open_call_applications_count": 0,
+        "verified": false
       },
       "relationships": {
         "investor": {
@@ -211,7 +214,8 @@
           "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtTXpkak5EZ3lNQzB3T0RJekxUUmhOV0V0WWpSa05DMWxaamhqWTJWbFlXTmlZV01HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--b380a2466683564612ab9d2fc25eeb9ee57aeb39/picture.jpg"
         },
         "favourite": false,
-        "open_call_applications_count": 0
+        "open_call_applications_count": 0,
+        "verified": false
       },
       "relationships": {
         "investor": {
@@ -271,7 +275,8 @@
           "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6WmpBNE1ESXpOeTB5TUdWakxUUmtaVGd0T1Rsak15MDVNMk15T0RKak16SmhObU1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a78a5af349404a9109f283ce0e3b645c6e82ea6e/picture.jpg"
         },
         "favourite": false,
-        "open_call_applications_count": 0
+        "open_call_applications_count": 0,
+        "verified": false
       },
       "relationships": {
         "investor": {
@@ -331,7 +336,8 @@
           "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4TkRZeE1UYzNZeTB6WkRZeUxUUXdZVGd0WVRObE5DMDRObUZoWkRnM05qUTRaRFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--9bd22bf6a07d9e8e6f94d647b89b34df7e3e54f2/picture.jpg"
         },
         "favourite": false,
-        "open_call_applications_count": 0
+        "open_call_applications_count": 0,
+        "verified": false
       },
       "relationships": {
         "investor": {

--- a/backend/spec/fixtures/snapshots/api/v1/account/projects-favourites.json
+++ b/backend/spec/fixtures/snapshots/api/v1/account/projects-favourites.json
@@ -71,7 +71,8 @@
         "latitude": 2.0,
         "longitude": 1.0,
         "favourite": true,
-        "impact_calculated": false
+        "impact_calculated": false,
+        "verified": false
       },
       "relationships": {
         "project_developer": {

--- a/backend/spec/fixtures/snapshots/api/v1/account/projects.json
+++ b/backend/spec/fixtures/snapshots/api/v1/account/projects.json
@@ -71,7 +71,8 @@
         "created_at": "2022-06-27T09:04:33.005Z",
         "status": "draft",
         "account_language": "es",
-        "impact_calculated": false
+        "impact_calculated": false,
+        "verified": false
       },
       "relationships": {
         "project_developer": {
@@ -184,7 +185,8 @@
         "created_at": "2022-06-27T09:04:32.944Z",
         "status": "published",
         "account_language": "es",
-        "impact_calculated": false
+        "impact_calculated": false,
+        "verified": false
       },
       "relationships": {
         "project_developer": {
@@ -297,7 +299,8 @@
         "longitude": 1.0,
         "favourite": false,
         "account_language": "es",
-        "impact_calculated": false
+        "impact_calculated": false,
+        "verified": false
       },
       "relationships": {
         "project_developer": {

--- a/backend/spec/fixtures/snapshots/api/v1/accounts-project-create.json
+++ b/backend/spec/fixtures/snapshots/api/v1/accounts-project-create.json
@@ -99,7 +99,8 @@
       "created_at": "2022-06-24T09:06:23.534Z",
       "status": "published",
       "account_language": "es",
-      "impact_calculated": false
+      "impact_calculated": false,
+      "verified": false
     },
     "relationships": {
       "project_developer": {

--- a/backend/spec/fixtures/snapshots/api/v1/accounts-project-update.json
+++ b/backend/spec/fixtures/snapshots/api/v1/accounts-project-update.json
@@ -69,7 +69,8 @@
       "created_at": "2022-06-24T09:06:27.599Z",
       "status": "published",
       "account_language": "en",
-      "impact_calculated": false
+      "impact_calculated": false,
+      "verified": false
     },
     "relationships": {
       "project_developer": {

--- a/backend/spec/fixtures/snapshots/api/v1/get-open-call.json
+++ b/backend/spec/fixtures/snapshots/api/v1/get-open-call.json
@@ -30,7 +30,8 @@
       },
       "status": "launched",
       "favourite": null,
-      "open_call_applications_count": 0
+      "open_call_applications_count": 0,
+      "verified": false
     },
     "relationships": {
       "investor": {

--- a/backend/spec/fixtures/snapshots/api/v1/get-project-developer-include-relationships.json
+++ b/backend/spec/fixtures/snapshots/api/v1/get-project-developer-include-relationships.json
@@ -92,7 +92,8 @@
         "created_at": "2022-06-24T09:06:30.522Z",
         "status": "published",
         "account_language": "en",
-        "impact_calculated": false
+        "impact_calculated": false,
+        "verified": false
       },
       "relationships": {
         "project_developer": {
@@ -208,7 +209,8 @@
         "created_at": "2022-06-24T09:06:30.643Z",
         "status": "published",
         "account_language": "en",
-        "impact_calculated": false
+        "impact_calculated": false,
+        "verified": false
       },
       "relationships": {
         "project_developer": {

--- a/backend/spec/fixtures/snapshots/api/v1/get-project.json
+++ b/backend/spec/fixtures/snapshots/api/v1/get-project.json
@@ -90,7 +90,8 @@
       "impact_calculated": false,
       "latitude": 0.5,
       "longitude": 0.5,
-      "favourite": null
+      "favourite": null,
+      "verified": false
     },
     "relationships": {
       "project_developer": {

--- a/backend/spec/fixtures/snapshots/api/v1/open-calls.json
+++ b/backend/spec/fixtures/snapshots/api/v1/open-calls.json
@@ -31,7 +31,8 @@
         },
         "status": "launched",
         "favourite": null,
-        "open_call_applications_count": 0
+        "open_call_applications_count": 0,
+        "verified": false
       },
       "relationships": {
         "investor": {
@@ -91,7 +92,8 @@
         },
         "status": "launched",
         "favourite": null,
-        "open_call_applications_count": 0
+        "open_call_applications_count": 0,
+        "verified": false
       },
       "relationships": {
         "investor": {
@@ -151,7 +153,8 @@
         },
         "status": "launched",
         "favourite": null,
-        "open_call_applications_count": 0
+        "open_call_applications_count": 0,
+        "verified": false
       },
       "relationships": {
         "investor": {
@@ -211,7 +214,8 @@
         },
         "status": "launched",
         "favourite": null,
-        "open_call_applications_count": 0
+        "open_call_applications_count": 0,
+        "verified": false
       },
       "relationships": {
         "investor": {
@@ -271,7 +275,8 @@
         },
         "status": "launched",
         "favourite": null,
-        "open_call_applications_count": 0
+        "open_call_applications_count": 0,
+        "verified": false
       },
       "relationships": {
         "investor": {
@@ -331,7 +336,8 @@
         },
         "status": "launched",
         "favourite": null,
-        "open_call_applications_count": 0
+        "open_call_applications_count": 0,
+        "verified": false
       },
       "relationships": {
         "investor": {
@@ -391,7 +397,8 @@
         },
         "status": "launched",
         "favourite": null,
-        "open_call_applications_count": 0
+        "open_call_applications_count": 0,
+        "verified": false
       },
       "relationships": {
         "investor": {
@@ -451,7 +458,8 @@
         },
         "status": "launched",
         "favourite": null,
-        "open_call_applications_count": 0
+        "open_call_applications_count": 0,
+        "verified": false
       },
       "relationships": {
         "investor": {

--- a/backend/spec/fixtures/snapshots/api/v1/project-developers-include-relationships.json
+++ b/backend/spec/fixtures/snapshots/api/v1/project-developers-include-relationships.json
@@ -220,7 +220,8 @@
         "created_at": "2022-06-24T09:06:30.522Z",
         "status": "published",
         "account_language": "en",
-        "impact_calculated": false
+        "impact_calculated": false,
+        "verified": false
       },
       "relationships": {
         "project_developer": {
@@ -336,7 +337,8 @@
         "created_at": "2022-06-24T09:06:30.643Z",
         "status": "published",
         "account_language": "en",
-        "impact_calculated": false
+        "impact_calculated": false,
+        "verified": false
       },
       "relationships": {
         "project_developer": {

--- a/backend/spec/fixtures/snapshots/api/v1/project-maps.json
+++ b/backend/spec/fixtures/snapshots/api/v1/project-maps.json
@@ -7,7 +7,8 @@
         "trusted": false,
         "latitude": 2.0,
         "longitude": 1.0,
-        "category": "forestry-and-agroforestry"
+        "category": "forestry-and-agroforestry",
+        "verified": false
       }
     },
     {
@@ -17,7 +18,8 @@
         "trusted": false,
         "latitude": 2.0,
         "longitude": 1.0,
-        "category": "forestry-and-agroforestry"
+        "category": "forestry-and-agroforestry",
+        "verified": false
       }
     },
     {
@@ -27,7 +29,8 @@
         "trusted": false,
         "latitude": 2.0,
         "longitude": 1.0,
-        "category": "forestry-and-agroforestry"
+        "category": "forestry-and-agroforestry",
+        "verified": false
       }
     },
     {
@@ -37,7 +40,8 @@
         "trusted": false,
         "latitude": 2.0,
         "longitude": 1.0,
-        "category": "forestry-and-agroforestry"
+        "category": "forestry-and-agroforestry",
+        "verified": false
       }
     },
     {
@@ -47,7 +51,8 @@
         "trusted": false,
         "latitude": 2.0,
         "longitude": 1.0,
-        "category": "forestry-and-agroforestry"
+        "category": "forestry-and-agroforestry",
+        "verified": false
       }
     },
     {
@@ -57,7 +62,8 @@
         "trusted": false,
         "latitude": 2.0,
         "longitude": 1.0,
-        "category": "forestry-and-agroforestry"
+        "category": "forestry-and-agroforestry",
+        "verified": false
       }
     },
     {
@@ -67,7 +73,8 @@
         "trusted": false,
         "category": "non-timber-forest-production",
         "latitude": 0.5,
-        "longitude": 0.5
+        "longitude": 0.5,
+        "verified": false
       }
     }
   ]

--- a/backend/spec/fixtures/snapshots/api/v1/projects.json
+++ b/backend/spec/fixtures/snapshots/api/v1/projects.json
@@ -91,7 +91,8 @@
         "impact_calculated": false,
         "latitude": 0.5,
         "longitude": 0.5,
-        "favourite": null
+        "favourite": null,
+        "verified": false
       },
       "relationships": {
         "project_developer": {
@@ -221,7 +222,8 @@
         "impact_calculated": false,
         "latitude": 2.0,
         "longitude": 1.0,
-        "favourite": null
+        "favourite": null,
+        "verified": false
       },
       "relationships": {
         "project_developer": {
@@ -334,7 +336,8 @@
         "impact_calculated": false,
         "latitude": 2.0,
         "longitude": 1.0,
-        "favourite": null
+        "favourite": null,
+        "verified": false
       },
       "relationships": {
         "project_developer": {
@@ -447,7 +450,8 @@
         "impact_calculated": false,
         "latitude": 2.0,
         "longitude": 1.0,
-        "favourite": null
+        "favourite": null,
+        "verified": false
       },
       "relationships": {
         "project_developer": {
@@ -560,7 +564,8 @@
         "impact_calculated": false,
         "latitude": 2.0,
         "longitude": 1.0,
-        "favourite": null
+        "favourite": null,
+        "verified": false
       },
       "relationships": {
         "project_developer": {
@@ -673,7 +678,8 @@
         "impact_calculated": false,
         "latitude": 2.0,
         "longitude": 1.0,
-        "favourite": null
+        "favourite": null,
+        "verified": false
       },
       "relationships": {
         "project_developer": {
@@ -786,7 +792,8 @@
         "impact_calculated": false,
         "latitude": 2.0,
         "longitude": 1.0,
-        "favourite": null
+        "favourite": null,
+        "verified": false
       },
       "relationships": {
         "project_developer": {
@@ -899,7 +906,8 @@
         "impact_calculated": false,
         "latitude": 2.0,
         "longitude": 1.0,
-        "favourite": null
+        "favourite": null,
+        "verified": false
       },
       "relationships": {
         "project_developer": {

--- a/backend/spec/models/open_call_spec.rb
+++ b/backend/spec/models/open_call_spec.rb
@@ -56,9 +56,9 @@ RSpec.describe OpenCall, type: :model do
     expect(subject).to have(1).errors_on(:impact_description)
   end
 
-  it "should not be valid without trusted" do
-    subject.trusted = nil
-    expect(subject).to have(1).errors_on(:trusted)
+  it "should not be valid without verified" do
+    subject.verified = nil
+    expect(subject).to have(1).errors_on(:verified)
   end
 
   it "should not be valid with wrong language" do

--- a/backend/spec/models/project_spec.rb
+++ b/backend/spec/models/project_spec.rb
@@ -103,9 +103,9 @@ RSpec.describe Project, type: :model do
     expect(subject).to have(1).errors_on(:progress_impact_tracking)
   end
 
-  it "should not be valid without trusted" do
-    subject.trusted = nil
-    expect(subject).to have(1).errors_on(:trusted)
+  it "should not be valid without verified" do
+    subject.verified = nil
+    expect(subject).to have(1).errors_on(:verified)
   end
 
   it "should not be valid without received funding" do

--- a/backend/spec/requests/api/v1/projects/maps_spec.rb
+++ b/backend/spec/requests/api/v1/projects/maps_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe "API V1 Project Maps", type: :request do
               attributes: {
                 type: :object,
                 properties: {
+                  verified: {type: :boolean},
                   trusted: {type: :boolean},
                   latitude: {type: :number},
                   longitude: {type: :number}

--- a/backend/spec/services/api/filterer_spec.rb
+++ b/backend/spec/services/api/filterer_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe API::Filterer do
 
       context "when filtered by only verified flag" do
         let(:filters) { {only_verified: true} }
-        let!(:verified_project) { create :project, trusted: true }
-        let!(:unverified_project) { create :project, trusted: false }
+        let!(:verified_project) { create :project, verified: true }
+        let!(:unverified_project) { create :project, verified: false }
 
         it "returns only verified records" do
           expect(subject.call).to eq([verified_project])
@@ -178,8 +178,8 @@ RSpec.describe API::Filterer do
 
       context "when filtered by only verified flag" do
         let(:filters) { {only_verified: true} }
-        let!(:verified_open_call) { create :open_call, trusted: true }
-        let!(:unverified_open_call) { create :open_call, trusted: false }
+        let!(:verified_open_call) { create :open_call, verified: true }
+        let!(:unverified_open_call) { create :open_call, verified: false }
 
         it "returns only verified records" do
           expect(subject.call).to eq([verified_open_call])

--- a/backend/spec/services/backoffice/csv/open_call_exporter_spec.rb
+++ b/backend/spec/services/backoffice/csv/open_call_exporter_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Backoffice::CSV::OpenCallExporter do
   subject { described_class.new(query) }
 
-  let(:query) { create_list :open_call, 4, trusted: true }
+  let(:query) { create_list :open_call, 4, verified: true }
   let(:parsed_csv) { CSV.parse(subject.call) }
 
   describe "#call" do

--- a/backend/spec/services/backoffice/csv/project_exporter_spec.rb
+++ b/backend/spec/services/backoffice/csv/project_exporter_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Backoffice::CSV::ProjectExporter do
   subject { described_class.new(query) }
 
-  let(:query) { create_list :project, 4, trusted: true }
+  let(:query) { create_list :project, 4, verified: true }
   let(:parsed_csv) { CSV.parse(subject.call) }
 
   describe "#call" do

--- a/backend/spec/swagger_helper.rb
+++ b/backend/spec/swagger_helper.rb
@@ -141,7 +141,9 @@ RSpec.configure do |config|
                   impact_description: {type: :string},
                   closing_at: {type: :string},
                   language: {type: :string},
-                  created_at: {type: :string}
+                  created_at: {type: :string},
+                  trusted: {type: :boolean},
+                  verified: {type: :boolean}
                 }
               },
               relationships: {
@@ -192,6 +194,7 @@ RSpec.configure do |config|
                   longitude: {type: :number},
                   category: {type: :string},
                   trusted: {type: :boolean},
+                  verified: {type: :boolean},
                   created_at: {type: :string},
                   target_groups: {type: :array, items: {type: :string}},
                   impact_areas: {type: :array, items: {type: :string}},

--- a/backend/spec/system/backoffice/open_calls_spec.rb
+++ b/backend/spec/system/backoffice/open_calls_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Backoffice: Open Calls", type: :system do
       :open_call,
       name: "Open Call ultra name",
       investor: create(:investor, account: create(:account, name: "Ultra investor name")),
-      trusted: true
+      verified: true
     )
   }
   let!(:open_call_application) { create :open_call_application, open_call: open_call }
@@ -50,13 +50,13 @@ RSpec.describe "Backoffice: Open Calls", type: :system do
         end
       end
 
-      context "when filtered by trusted flag" do
-        before { open_call.update! trusted: true }
+      context "when filtered by verified flag" do
+        before { open_call.update! verified: true }
 
         it "returns records at correct state" do
           expect(page).to have_text(open_call.name)
           open_calls.each { |o| expect(page).to have_text(o.name) }
-          select t("backoffice.common.verified"), from: :q_trusted_eq
+          select t("backoffice.common.verified"), from: :q_verified_eq
           click_on t("backoffice.common.apply")
           expect(page).to have_text(open_call.name)
           open_calls.each { |o| expect(page).not_to have_text(o.name) }
@@ -91,7 +91,7 @@ RSpec.describe "Backoffice: Open Calls", type: :system do
 
     context "when verifying open call via menu" do
       before do
-        open_call.update! trusted: false
+        open_call.update! verified: false
         visit "/backoffice/open_calls"
       end
 
@@ -179,11 +179,11 @@ RSpec.describe "Backoffice: Open Calls", type: :system do
       before { within_sidebar { click_on t("backoffice.open_calls.status") } }
 
       it "can update verification status" do
-        expect(page).to have_checked_field("open_call[trusted]")
-        choose t("backoffice.common.unverified"), name: "open_call[trusted]"
+        expect(page).to have_checked_field("open_call[verified]")
+        choose t("backoffice.common.unverified"), name: "open_call[verified]"
         click_on t("backoffice.common.save")
         expect(page).to have_text(t("backoffice.messages.success_update", model: t("backoffice.common.open_call")))
-        expect(open_call.reload.trusted).to be_falsey
+        expect(open_call.reload.verified).to be_falsey
       end
     end
 

--- a/backend/spec/system/backoffice/projects_spec.rb
+++ b/backend/spec/system/backoffice/projects_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Backoffice: Projects", type: :system do
       name: "Project ultra name",
       project_developer: create(:project_developer, account: create(:account, name: "Ultra project developer name")),
       geometry: geometry,
-      trusted: true
+      verified: true
     )
   }
   let!(:projects) { create_list(:project, 4) }
@@ -59,13 +59,13 @@ RSpec.describe "Backoffice: Projects", type: :system do
     end
 
     context "when searching by ransack filter" do
-      context "when filtered by trusted flag" do
-        before { project.update! trusted: true }
+      context "when filtered by verified flag" do
+        before { project.update! verified: true }
 
         it "returns records at correct state" do
           expect(page).to have_text(project.name)
           projects.each { |p| expect(page).to have_text(p.name) }
-          select t("backoffice.common.verified"), from: :q_trusted_eq
+          select t("backoffice.common.verified"), from: :q_verified_eq
           click_on t("backoffice.common.apply")
           expect(page).to have_text(project.name)
           projects.each { |p| expect(page).not_to have_text(p.name) }
@@ -256,11 +256,11 @@ RSpec.describe "Backoffice: Projects", type: :system do
       before { within_sidebar { click_on t("backoffice.projects.status") } }
 
       it "can update verification status" do
-        expect(page).to have_checked_field("project[trusted]")
-        choose t("backoffice.common.unverified"), name: "project[trusted]"
+        expect(page).to have_checked_field("project[verified]")
+        choose t("backoffice.common.unverified"), name: "project[verified]"
         click_on t("backoffice.common.save")
         expect(page).to have_text(t("backoffice.messages.success_update", model: t("backoffice.common.project")))
-        expect(project.reload.trusted).to be_falsey
+        expect(project.reload.verified).to be_falsey
       end
     end
 


### PR DESCRIPTION
Renaming `trusted` column of OpenCall and Project model to `verified`.

## Testing instructions

Theoretically all influenced parts of code should be retested, but practically, I think automatic tests should be enough.

## Tracking

https://vizzuality.atlassian.net/browse/LET-587
