### PR TITLE
Fix account information not displaying correctly in the Dashboard header

### DIFF
--- a/frontend/containers/users/invite-users-modal/component.tsx
+++ b/frontend/containers/users/invite-users-modal/component.tsx
@@ -30,7 +30,7 @@ export const InviteUsersModal: FC<InviteUsersModalProps> = ({
 }: InviteUsersModalProps) => {
   const { formatMessage } = useIntl();
   const inviteUsers = useInviteUsers();
-  const { userAccount } = useAccount({ includes: 'owner' });
+  const { userAccount } = useAccount();
   const { name } = userAccount || {};
   const queryClient = useQueryClient();
 

--- a/frontend/containers/users/invite-users-modal/component.tsx
+++ b/frontend/containers/users/invite-users-modal/component.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useEffect } from 'react';
+import { FC, useCallback } from 'react';
 
 import { X as CloseIcon } from 'react-feather';
 import { FieldError, SubmitErrorHandler, useForm } from 'react-hook-form';
@@ -51,38 +51,41 @@ export const InviteUsersModal: FC<InviteUsersModalProps> = ({
     defaultValues: { emails: [] },
   });
 
-  const getInviteUsersErrorMessage = (errorCode: number, email: string) => {
-    switch (errorCode) {
-      case 409:
-        return formatMessage(
-          {
-            defaultMessage: 'User with email {email} already has an account in HeCo.',
-            id: 'sK7G1d',
-          },
-          {
-            email,
-          }
-        );
-      case 422:
-        return formatMessage(
-          { defaultMessage: 'Email {email} is invalid.', id: 'jG0v72' },
-          {
-            email,
-          }
-        );
-      default:
-        return formatMessage(
-          {
-            defaultMessage:
-              'Something went wrong while sending an invitation to the email {email}.',
-            id: '9dtx+L',
-          },
-          {
-            email,
-          }
-        );
-    }
-  };
+  const getInviteUsersErrorMessage = useCallback(
+    (errorCode: number, email: string) => {
+      switch (errorCode) {
+        case 409:
+          return formatMessage(
+            {
+              defaultMessage: 'User with email {email} already has an account in HeCo.',
+              id: 'sK7G1d',
+            },
+            {
+              email,
+            }
+          );
+        case 422:
+          return formatMessage(
+            { defaultMessage: 'Email {email} is invalid.', id: 'jG0v72' },
+            {
+              email,
+            }
+          );
+        default:
+          return formatMessage(
+            {
+              defaultMessage:
+                'Something went wrong while sending an invitation to the email {email}.',
+              id: '9dtx+L',
+            },
+            {
+              email,
+            }
+          );
+      }
+    },
+    [formatMessage]
+  );
 
   const resetForm = useCallback(() => {
     reset({ email: '', emails: [] });
@@ -114,7 +117,7 @@ export const InviteUsersModal: FC<InviteUsersModalProps> = ({
           },
         }
       ),
-    [getValues, inviteUsers, resetForm, setError, setValue, queryClient]
+    [inviteUsers, getValues, queryClient, setError, getInviteUsersErrorMessage, setValue, resetForm]
   );
 
   const onSubmit = (values: UsersInvitationForm) => {

--- a/frontend/layouts/dashboard/component.tsx
+++ b/frontend/layouts/dashboard/component.tsx
@@ -28,7 +28,7 @@ export const DashboardLayout: FC<DashboardLayoutProps> = ({
 }: DashboardLayoutProps) => {
   const mainContainerRef = useRef(null);
 
-  const { user, userAccount } = useAccount({ includes: 'owner' });
+  const { user, userAccount } = useAccount();
 
   return (
     <ProtectedPage permissions={[UserRoles.ProjectDeveloper, UserRoles.Investor]}>


### PR DESCRIPTION
## Description

This PR fixes the account name, picture not appearing the dashboard header, as well as the public profile link not working. 

**Details** 

A mistake was made on #421 (see [here](https://github.com/Vizzuality/heco-invest/pull/421/files#diff-6777b05812d657c00806958b6b981697d58653181794fe278fa05dd94fec101aL24-R25)), when the services were refactored to accept extra options. `includes` should have been an array of relationships to include, not a string. However, while debugging this, I noticed the relationship isn't actually used at all, so I've removed it.

Same applies to the user invitation modal. I also took the chance to fix the linting on that component. 

## Testing instructions

Verify that:  
- When logged in with an Investor account, the Dashboard header is displayed correctly  
- When logged in with a Project Developer account, the Dashboard header is displayed correctly  
- Inviting users to a PD/Investor account still works correctly  

## Tracking

[LET-1056](https://vizzuality.atlassian.net/browse/LET-1056)

## Screenshot  

<img width="1680" alt="Screenshot 2022-09-06 at 11 30 23" src="https://user-images.githubusercontent.com/6273795/188613133-4ae00e16-cc33-4ecc-9b9c-e1b0f605f429.png">

