### PR TITLE
Refactor of the table component to solve column content overlapping

### DIFF
--- a/frontend/components/table/component.tsx
+++ b/frontend/components/table/component.tsx
@@ -71,7 +71,7 @@ export const Table: FC<TableProps> = ({
 
   return (
     <div>
-      <div className="relative rounded-2xl">
+      <div className="relative overflow-x-auto rounded-2xl">
         <table {...getTableProps()} className="relative w-full bg-white rounded-2xl">
           <thead>
             {headerGroups.map((headerGroup) => {

--- a/frontend/containers/dashboard/open-call-applications/table/cells/actions/component.tsx
+++ b/frontend/containers/dashboard/open-call-applications/table/cells/actions/component.tsx
@@ -23,7 +23,7 @@ export const CellActions: FC<CellActionsProps> = ({
 
   return (
     <>
-      <div className="flex items-center justify-center gap-10 pr-8">
+      <div className="inline-flex items-center justify-center gap-10">
         <div>
           <Tooltip
             placement="top"
@@ -50,7 +50,7 @@ export const CellActions: FC<CellActionsProps> = ({
           </Tooltip>
         </div>
         <Link href={`${Paths.DashboardOpenCallApplications}/${openCallApplication.id}`}>
-          <a className="px-2 py-1 text-sm transition-all text-green-dark focus-visible:outline-green-dark rounded-2xl">
+          <a className="px-2 py-1 -mr-2 text-sm transition-all text-green-dark focus-visible:outline-green-dark rounded-2xl">
             <FormattedMessage defaultMessage="Details" id="Lv0zJu" />
           </a>
         </Link>

--- a/frontend/containers/dashboard/open-call-applications/table/component.tsx
+++ b/frontend/containers/dashboard/open-call-applications/table/component.tsx
@@ -65,9 +65,9 @@ export const OpenCallApplicationsTable: FC<OpenCallApplicationsTableProps> = () 
       },
       {
         Header: intl.formatMessage({ defaultMessage: 'Actions', id: 'wL7VAE' }),
+        accessor: 'actions',
         canSort: false,
         hideHeader: true,
-        width: 0,
         Cell: CellActions,
       },
     ],
@@ -87,7 +87,6 @@ export const OpenCallApplicationsTable: FC<OpenCallApplicationsTableProps> = () 
     }),
     loading: isLoading,
     sortingEnabled: true,
-    manualSorting: false,
     className: 'h-screen',
   };
 

--- a/frontend/containers/dashboard/open-call-details/table/component.tsx
+++ b/frontend/containers/dashboard/open-call-details/table/component.tsx
@@ -67,9 +67,9 @@ export const OpenCallDetailsTable: FC<OpenCallDetailsTableProps> = () => {
       },
       {
         Header: intl.formatMessage({ defaultMessage: 'Actions', id: 'wL7VAE' }),
+        accessor: 'actions',
         canSort: false,
         hideHeader: true,
-        width: 0,
         Cell: CellActions,
       },
     ],
@@ -94,7 +94,6 @@ export const OpenCallDetailsTable: FC<OpenCallDetailsTableProps> = () => {
     }),
     loading: isLoading,
     sortingEnabled: true,
-    manualSorting: false,
     className: 'h-screen',
   };
 

--- a/frontend/containers/dashboard/open-calls/table/component.tsx
+++ b/frontend/containers/dashboard/open-calls/table/component.tsx
@@ -73,7 +73,7 @@ export const OpenCallsTable: FC<OpenCallsTableProps> = () => {
       {
         Header: intl.formatMessage({ defaultMessage: 'Instrument types', id: '0zLVGQ' }),
         accessor: 'instrumentTypes',
-        disableSortBy: true,
+        canSort: false,
         Cell: CellInstrumentTypes,
         width: 200,
       },
@@ -95,9 +95,8 @@ export const OpenCallsTable: FC<OpenCallsTableProps> = () => {
       },
       {
         accessor: 'actions',
-        disableSortBy: true,
+        canSort: false,
         hideHeader: true,
-        width: 0,
         Cell: CellActions,
       },
     ],
@@ -115,7 +114,6 @@ export const OpenCallsTable: FC<OpenCallsTableProps> = () => {
     })),
     loading: isLoading,
     sortingEnabled: true,
-    manualSorting: false,
     className: 'h-screen',
   };
 

--- a/frontend/containers/dashboard/projects/table/component.tsx
+++ b/frontend/containers/dashboard/projects/table/component.tsx
@@ -86,7 +86,6 @@ export const ProjectsTable: FC<ProjectsTableProps> = ({ onLoaded = noop }) => {
         accessor: 'actions',
         canSort: false,
         hideHeader: true,
-        width: 0,
         Cell: CellActions,
       },
     ],
@@ -107,7 +106,6 @@ export const ProjectsTable: FC<ProjectsTableProps> = ({ onLoaded = noop }) => {
     })),
     loading: isLoading,
     sortingEnabled: true,
-    manualSorting: false,
     className: 'h-screen',
   };
 

--- a/frontend/containers/dashboard/users/table/component.tsx
+++ b/frontend/containers/dashboard/users/table/component.tsx
@@ -66,7 +66,6 @@ export const UsersTable: FC<UsersTableProps> = ({ isOwner, accountName }) => {
     data: users || [],
     loading: isLoadingUsers || isFetchingUsers,
     sortingEnabled: true,
-    manualSorting: false,
     isOwner,
     accountName,
   };
@@ -78,9 +77,8 @@ export const UsersTable: FC<UsersTableProps> = ({ isOwner, accountName }) => {
           ...tableProps.columns,
           {
             Header: intl.formatMessage({ defaultMessage: 'Actions', id: 'wL7VAE' }),
-            className: 'capitalize text-sm',
+            accessor: 'actions',
             canSort: false,
-            width: 50,
             hideHeader: true,
             Cell: Actions,
           },


### PR DESCRIPTION
## Description

This PR fixes an issue where the content of the last two columns of a table can overlap, especially if the second to last's content is long. 

Other changes:  
- I've tweaked the table component styling so that the content/columns adapt a bit better
  _Which should help with the fact that we cannot control their content length, especially given translations in different languages_
  _It should also be easier to customise the table further in the future as well_  
- Fixed tables not overflowing with a scroll bar laterally when the screen is too small  
  _this restores the initial behaviour they had initially_
- Minor tweaks to better approximate the designs  

**Notes:**  
I tried to keep the table's component code changes to the very minimum, given that this is meant as a quick bug-fix and the fact it's used throughout the dashboard; I didn't want to risk introducing breaking changes. Most of the refactoring was to: 
  - Not use the `style` s that `react-table` introduces  
  - Avoid non-standard styling of `th`'s, `tr`'s and the likes (eg: `flex`), as this will prevent the headers and cells from being aligned (this was one of the causes)  
  - Ensure sorting still works correctly  


## Testing instructions

- Verify that the bug no longer exists and the content from different columns doesn't overlap  
- Verify that all tables display correctly, sorting works correctly and there are no crashes

## Tracking

[LET-1026](https://vizzuality.atlassian.net/browse/LET-1026)

## Screenshots  

**Before**
<img width="1421" alt="Screenshot 2022-09-06 at 15 07 30" src="https://user-images.githubusercontent.com/6273795/188656708-cd56488b-7cc3-49c0-aaf4-6dcaccea642f.png">

**After**  
<img width="1426" alt="Screenshot 2022-09-06 at 15 07 05" src="https://user-images.githubusercontent.com/6273795/188656738-3be78419-0700-475d-ba7f-2428f80233e2.png">
