### PR TITLE
refactoring: Prefer usage of account name at backoffice

### DIFF
--- a/backend/app/views/backoffice/investors/index.html.erb
+++ b/backend/app/views/backoffice/investors/index.html.erb
@@ -7,7 +7,7 @@
   <thead>
     <tr>
       <th>
-        <%= sort_link @q, :account_name, t("backoffice.common.name") %>
+        <%= sort_link @q, :account_name, t("backoffice.common.account_name") %>
       </th>
       <th>
         <%= sort_link @q, :account_owner_full_name, t("backoffice.common.account_owner") %>

--- a/backend/app/views/backoffice/project_developers/index.html.erb
+++ b/backend/app/views/backoffice/project_developers/index.html.erb
@@ -7,7 +7,7 @@
   <thead>
     <tr>
       <th>
-        <%= sort_link @q, :account_name, t("backoffice.common.name") %>
+        <%= sort_link @q, :account_name, t("backoffice.common.account_name") %>
       </th>
       <th>
         <%= sort_link @q, :account_owner_full_name, t("backoffice.common.account_owner") %>

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -29,7 +29,7 @@ zu:
         password_confirmation: Confirm your new password
       account:
         picture: Picture
-        name: Profile name
+        name: Account name
         about: About
         website: Website
         contact_phone: Contact phone
@@ -154,6 +154,7 @@ zu:
     common:
       account_owner: Account owner
       account_users: Account users
+      account_name: Account name
       language: Language
       name: Name
       status: Status

--- a/backend/spec/system/backoffice/investors_spec.rb
+++ b/backend/spec/system/backoffice/investors_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Backoffice: Investors", type: :system do
 
     it_behaves_like "with table pagination", expected_total: 2
     it_behaves_like "with table sorting", columns: [
-      I18n.t("backoffice.common.name"),
+      I18n.t("backoffice.common.account_name"),
       I18n.t("backoffice.common.account_owner"),
       I18n.t("backoffice.common.contact_email"),
       I18n.t("backoffice.common.contact_phone"),

--- a/backend/spec/system/backoffice/project_developers_spec.rb
+++ b/backend/spec/system/backoffice/project_developers_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Backoffice: Project Developers", type: :system do
 
     it_behaves_like "with table pagination", expected_total: 2
     it_behaves_like "with table sorting", columns: [
-      I18n.t("backoffice.common.name"),
+      I18n.t("backoffice.common.account_name"),
       I18n.t("backoffice.common.account_owner"),
       I18n.t("backoffice.common.contact_email"),
       I18n.t("backoffice.common.contact_phone"),


### PR DESCRIPTION
Ticket mention that `Investor name` and `Project developer name` should be renamed to `Account name`, but none of these two strings are used at backoffice at all. On other hand, we are using `Name` or `Profile name` at backoffice so I have decided to rename these two strings to `Account name` so we follow same logic which is probably gonna be implemented by FE.

## Testing instructions

Just briefly check backoffice ;)

## Tracking

https://vizzuality.atlassian.net/browse/LET-1035
