### PR TITLE
Add financial information disclaimer on project public page

### DIFF
--- a/frontend/containers/project-page/funding/component.tsx
+++ b/frontend/containers/project-page/funding/component.tsx
@@ -82,7 +82,7 @@ export const Funding: React.FC<FundingProps> = ({ project, enums }: FundingProps
         <h2 className="pl-6 mb-6 font-serif text-2xl text-black lg:text-4xl lg:pl-16 lg:mb-16">
           <FormattedMessage defaultMessage="Funding & development" id="psXhQO" />
         </h2>
-        <div className="flex flex-col p-6 text-white lg:p-16 lg:space-x-10 lg:flex-row bg-green-dark rounded-2xl">
+        <div className="flex flex-col p-6 text-white lg:p-16 lg:space-x-10 lg:flex-row bg-green-dark rounded-t-2xl">
           <div className="flex flex-col pb-12 pr-10 space-y-8 border-b-2 border-white lg:pb-6 pb:10 lg:border-b-0 lg:w-1/3 lg:border-r-2">
             <h3 className="font-serif text-2xl lg:text-3xl">
               {project.looking_for_funding ? (
@@ -133,6 +133,17 @@ export const Funding: React.FC<FundingProps> = ({ project, enums }: FundingProps
               </>
             )}
           </div>
+        </div>
+        <div className="flex items-center justify-center bg-green-light rounded-b-2xl bg-opacity-30">
+          <span className="px-6 py-2 text-sm text-center text-gray-800">
+            <FormattedMessage
+              defaultMessage="Due to security reasons, we are not allowed to display more <b>detailed financial information</b>. Please contact the Project Developers directly in order to obtain detailed information."
+              id="Ay+1nm"
+              values={{
+                b: (chunks: string) => <span className="font-semibold">{chunks}</span>,
+              }}
+            />
+          </span>
         </div>
         <div className="flex flex-col my-12 space-y-16 lg:my-24 lg:mx-44">
           <div className="flex flex-col items-center space-y-12 lg:space-y-0 lg:items-stretch lg:flex-row lg:space-x-24">

--- a/frontend/containers/project-page/funding/component.tsx
+++ b/frontend/containers/project-page/funding/component.tsx
@@ -82,7 +82,7 @@ export const Funding: React.FC<FundingProps> = ({ project, enums }: FundingProps
         <h2 className="pl-6 mb-6 font-serif text-2xl text-black lg:text-4xl lg:pl-16 lg:mb-16">
           <FormattedMessage defaultMessage="Funding & development" id="psXhQO" />
         </h2>
-        <div className="flex flex-col p-6 text-white lg:p-16 lg:space-x-10 lg:flex-row bg-green-dark rounded-t-2xl">
+        <div className="flex flex-col p-6 text-white lg:px-16 lg:py-12 lg:space-x-10 lg:flex-row bg-green-dark rounded-t-2xl">
           <div className="flex flex-col pb-12 pr-10 space-y-8 border-b-2 border-white lg:pb-6 pb:10 lg:border-b-0 lg:w-1/3 lg:border-r-2">
             <h3 className="font-serif text-2xl lg:text-3xl">
               {project.looking_for_funding ? (

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -629,6 +629,9 @@
   "AoHRBG": {
     "string": "Custom search"
   },
+  "Ay+1nm": {
+    "string": "Due to security reasons, we are not allowed to display more <b>detailed financial information</b>. Please contact the Project Developers directly in order to obtain detailed information."
+  },
   "BAC0rl": {
     "string": "<span>Community:</span> income, sustainable projects;"
   },


### PR DESCRIPTION
## Description

This PR adds a financial information disclaimer to the project public pages.

## Testing instructions

Verify that the disclaimer is visible in the project public pages. 

## Tracking

[LET-1048](https://vizzuality.atlassian.net/browse/LET-1048)

## Screenshot  

<img width="1406" alt="Screenshot 2022-09-07 at 12 54 06" src="https://user-images.githubusercontent.com/6273795/188872470-b6a83378-7339-4a92-b106-8af5e3377a37.png">

