### PR TITLE
Fix broken language notice when editing an open call

### DIFF
--- a/frontend/containers/open-call-form/component.tsx
+++ b/frontend/containers/open-call-form/component.tsx
@@ -15,6 +15,8 @@ import { OpenCallStatus } from 'enums';
 import { OpenCallForm as OpenFormType, OpenCallCreationPayload } from 'types/open-calls';
 import useOpenCallResolver, { formPageInputs } from 'validations/open-call';
 
+import { useAccount } from 'services/account';
+
 import { useDefaultValues } from './helpers';
 import { BasicMutationType } from './types';
 
@@ -42,6 +44,7 @@ export const OpenCallForm = <MutationType extends BasicMutationType>({
   const [showLeave, setShowLeave] = useState(false);
   const [slug, setSlug] = useState<string>();
   const resolver = useOpenCallResolver(currentPage);
+  const { userAccount } = useAccount();
 
   const defaultValues = useDefaultValues(openCall);
 
@@ -65,6 +68,7 @@ export const OpenCallForm = <MutationType extends BasicMutationType>({
 
   const isLastPage = currentPage === totalPages - 1;
   const languageNames = useLanguageNames();
+  const contentLocale = locale || openCall?.language || userAccount?.language;
   const isOutroPage = currentPage === totalPages;
 
   const alert = useGetAlert(mutation.error);
@@ -131,7 +135,7 @@ export const OpenCallForm = <MutationType extends BasicMutationType>({
         getTotalPages={(pages) => setTotalPages(pages)}
         layout="narrow"
         title={title}
-        locale={locale}
+        locale={contentLocale}
         autoNavigation={false}
         page={currentPage}
         alert={alert}
@@ -164,7 +168,7 @@ export const OpenCallForm = <MutationType extends BasicMutationType>({
               defaultMessage="<span>Note:</span>The content of this open call should be written in {language}"
               id="SUQqz6"
               values={{
-                language: languageNames[locale],
+                language: languageNames[contentLocale],
                 span: (chunks: string) => <span className="mr-2 font-semibold">{chunks}</span>,
               }}
             />

--- a/frontend/containers/open-call-form/helpers.ts
+++ b/frontend/containers/open-call-form/helpers.ts
@@ -14,6 +14,7 @@ export const useDefaultValues = (openCall: OpenCall): Partial<OpenCallForm> => {
     return {
       ...general,
       id: openCall.id,
+      language: openCall.language,
       picture: openCall.picture?.original?.split('redirect/')[1].split('/')[0] ?? undefined,
       country_id: openCall.country?.id,
       department_id: openCall.department?.id,

--- a/frontend/containers/open-call-form/types.ts
+++ b/frontend/containers/open-call-form/types.ts
@@ -29,8 +29,8 @@ export type OpenCallFormTypes<MutationType extends BasicMutationType> = {
   initialValues?: OpenCall;
   /** Enums data */
   enums: GroupedEnums;
-  /** Locale of the content */
-  locale: Languages;
+  /** Locale of the content. Defaults to the openCall locale, and if not set, the account locale */
+  locale?: Languages;
   /** Callback to execute when form has been submitted successfully */
   onComplete: () => void;
   /** Leave message to show when leaving the form */

--- a/frontend/pages/open-call/[id]/edit.tsx
+++ b/frontend/pages/open-call/[id]/edit.tsx
@@ -101,7 +101,6 @@ const EditOpenCall: PageComponent<EditOpenCallProps, FormPageLayoutProps> = ({
         onComplete={handleOnComplete}
         initialValues={openCall}
         isLoading={!openCall && isFetchingProject}
-        locale={openCall?.language}
         enums={enums as GroupedEnums}
       />
     </ProtectedPage>

--- a/frontend/pages/open-call/[id]/edit.tsx
+++ b/frontend/pages/open-call/[id]/edit.tsx
@@ -101,9 +101,7 @@ const EditOpenCall: PageComponent<EditOpenCallProps, FormPageLayoutProps> = ({
         onComplete={handleOnComplete}
         initialValues={openCall}
         isLoading={!openCall && isFetchingProject}
-        // The language of the content will be the same as the language of the account, which the
-        // API will automatically set
-        locale={null}
+        locale={openCall?.language}
         enums={enums as GroupedEnums}
       />
     </ProtectedPage>


### PR DESCRIPTION
## Description

This PR fixes an issue causing the _"The content of this open call should be written (...)"_ notice to not display the language the open call's content should be written in. 

## Testing instructions

1. Sign in with an investor account
2. Visit the dashboard, open calls tab  
3. Click to “Edit“ an open call  

Verify that the notice is no longer broken. 

## Tracking

[LET-1070](https://vizzuality.atlassian.net/browse/LET-1070)

## Screenshots  

**Before** 
<img width="1058" alt="Screenshot 2022-09-07 at 13 20 00" src="https://user-images.githubusercontent.com/6273795/188876772-fdf5ae3f-724a-4bf9-8789-aee523d3fdfb.png">

**After** 
<img width="1034" alt="Screenshot 2022-09-07 at 13 20 19" src="https://user-images.githubusercontent.com/6273795/188876835-b160d73b-bf55-45c8-908f-577c83d22501.png">
