### PR TITLE
Add open calls to the dashboard favorites

### DIFF
--- a/frontend/containers/open-call-card/component.tsx
+++ b/frontend/containers/open-call-card/component.tsx
@@ -19,7 +19,7 @@ import { useEnums } from 'services/enums/enumService';
 
 import type { OpenCallCardProps } from './types';
 
-export const OpenCallCard: FC<OpenCallCardProps> = ({ openCall }: OpenCallCardProps) => {
+export const OpenCallCard: FC<OpenCallCardProps> = ({ className, openCall }: OpenCallCardProps) => {
   const {
     slug,
     name,
@@ -86,6 +86,7 @@ export const OpenCallCard: FC<OpenCallCardProps> = ({ openCall }: OpenCallCardPr
         'cursor-pointer transition rounded-2xl': true,
         'hover:ring-1 hover:ring-green-dark': true,
         'ring-2 ring-green-dark': isFocusWithin,
+        [className]: !!className,
       })}
       {...pressProps}
       {...focusWithinProps}

--- a/frontend/containers/open-call-card/component.tsx
+++ b/frontend/containers/open-call-card/component.tsx
@@ -148,7 +148,7 @@ export const OpenCallCard: FC<OpenCallCardProps> = ({ className, openCall }: Ope
           {truncatedDescription}
         </div>
         <div
-          className="flex items-center justify-between mt-2"
+          className="flex items-center justify-between gap-2 mt-2"
           aria-label={intl.formatMessage({
             defaultMessage: 'Investor information',
             id: '68i9X8',
@@ -171,7 +171,7 @@ export const OpenCallCard: FC<OpenCallCardProps> = ({ className, openCall }: Ope
           </span>
           {tags && (
             <span
-              className="flex flex-wrap items-center gap-2"
+              className="flex flex-wrap items-center justify-end gap-2"
               role="group"
               aria-label={intl.formatMessage({
                 defaultMessage: 'Expects to have impact on',

--- a/frontend/layouts/dashboard-favorites/component.tsx
+++ b/frontend/layouts/dashboard-favorites/component.tsx
@@ -37,9 +37,12 @@ export const DashboardFavoritesLayout: FC<DashboardFavoritesLayoutProps> = ({
 
   const projects = useFavoriteProjectsList(defaultQueryParams, defaultQueryOptions);
   const investors = useFavoriteInvestorsList(defaultQueryParams, defaultQueryOptions);
-  const openCalls = useFavoriteOpenCallsList(defaultQueryParams, defaultQueryOptions);
   const projectDevelopers = useFavoriteProjectDevelopersList(
     defaultQueryParams,
+    defaultQueryOptions
+  );
+  const openCalls = useFavoriteOpenCallsList(
+    { ...defaultQueryParams, includes: ['investor'] },
     defaultQueryOptions
   );
 

--- a/frontend/layouts/dashboard-favorites/component.tsx
+++ b/frontend/layouts/dashboard-favorites/component.tsx
@@ -13,6 +13,7 @@ import {
   useFavoriteInvestorsList,
   useFavoriteProjectDevelopersList,
   useFavoriteProjectsList,
+  useFavoriteOpenCallsList,
 } from 'services/account/favoritesService';
 import { PagedResponse } from 'services/types';
 
@@ -36,19 +37,10 @@ export const DashboardFavoritesLayout: FC<DashboardFavoritesLayoutProps> = ({
 
   const projects = useFavoriteProjectsList(defaultQueryParams, defaultQueryOptions);
   const investors = useFavoriteInvestorsList(defaultQueryParams, defaultQueryOptions);
+  const openCalls = useFavoriteOpenCallsList(defaultQueryParams, defaultQueryOptions);
   const projectDevelopers = useFavoriteProjectDevelopersList(
     defaultQueryParams,
     defaultQueryOptions
-  );
-
-  // TODO: Change for real open calls
-  const openCalls = useMemo(
-    () => ({
-      data: [],
-      meta: { total: 0 },
-      loading: false,
-    }),
-    []
   );
 
   const stats = useMemo(
@@ -56,9 +48,9 @@ export const DashboardFavoritesLayout: FC<DashboardFavoritesLayoutProps> = ({
       projects: projects.data?.meta.total,
       projectDevelopers: projectDevelopers.data?.meta.total,
       investors: investors.data?.meta.total,
-      openCalls: 0,
+      openCalls: openCalls.data?.meta.total,
     }),
-    [projects, investors, projectDevelopers]
+    [projects, investors, projectDevelopers, openCalls]
   );
 
   const getFavoriteCurrentData = (data: UseQueryResult<PagedResponse<any>>) => {
@@ -76,8 +68,8 @@ export const DashboardFavoritesLayout: FC<DashboardFavoritesLayoutProps> = ({
       return getFavoriteCurrentData(projectDevelopers);
     if (pathname.startsWith(Paths.DashboardFavoritesInvestors))
       return getFavoriteCurrentData(investors);
-    // TODO: Change when real open calls are implemented
-    if (pathname.startsWith(Paths.DashboardFavoritesOpenCalls)) return openCalls;
+    if (pathname.startsWith(Paths.DashboardFavoritesOpenCalls))
+      return getFavoriteCurrentData(openCalls);
   }, [pathname, projects, projectDevelopers, investors, openCalls]) || { data: [], meta: [] };
 
   const childrenWithProps = React.Children.map(children, (child) => {

--- a/frontend/pages/dashboard/favorites/investors.tsx
+++ b/frontend/pages/dashboard/favorites/investors.tsx
@@ -48,8 +48,8 @@ export const FavoritesInvestorsPage: PageComponent<
     <>
       <div className="top-0 left-0 flex justify-between w-full pb-1 pr-2 mx-1 mb-4 md:pt-10 md:-mt-10 md:px-1 lg:z-20 lg:sticky bg-background-dark">
         <div className="font-medium">
-          <FormattedMessage defaultMessage="Investors" id="zdIaHp" />{' '}
-          {meta?.total && `(${meta?.total})`}
+          <FormattedMessage defaultMessage="Investors" id="zdIaHp" /> (
+          {meta?.total && `${meta?.total}`})
         </div>
       </div>
       <div className="flex flex-col pt-2 md:pl-1 md:-mr-1">

--- a/frontend/pages/dashboard/favorites/open-calls.tsx
+++ b/frontend/pages/dashboard/favorites/open-calls.tsx
@@ -48,8 +48,8 @@ export const FavoritesOpenCallsPage: PageComponent<
     <>
       <div className="top-0 left-0 flex justify-between w-full pb-1 pr-2 mx-1 mb-4 md:pt-10 md:-mt-10 md:px-1 lg:z-20 lg:sticky bg-background-dark">
         <div className="font-medium">
-          <FormattedMessage defaultMessage="Open calls" id="OBhULP" />{' '}
-          {meta?.total && `(${meta?.total})`}
+          <FormattedMessage defaultMessage="Open calls" id="OBhULP" /> (
+          {meta?.total && `${meta?.total}`})
         </div>
       </div>
       <div className="flex flex-col pt-2 md:pl-1 md:-mr-1">

--- a/frontend/pages/dashboard/favorites/open-calls.tsx
+++ b/frontend/pages/dashboard/favorites/open-calls.tsx
@@ -5,6 +5,9 @@ import { withLocalizedRequests } from 'hoc/locale';
 
 import { loadI18nMessages } from 'helpers/i18n';
 
+import CardHoverToDelete from 'containers/dashboard/favorites/card-hover-to-delete';
+import OpenCallCard from 'containers/open-call-card';
+
 import Button from 'components/button';
 import Icon from 'components/icon';
 import { Paths } from 'enums';
@@ -13,6 +16,8 @@ import DashboardFavoritesLayout, {
 } from 'layouts/dashboard-favorites';
 import { PageComponent } from 'types';
 import { OpenCall as OpenCallType } from 'types/open-calls';
+
+import { useFavoriteOpenCall } from 'services/open-call/open-call-service';
 
 export const getStaticProps = withLocalizedRequests(async ({ locale }) => {
   return {
@@ -33,6 +38,12 @@ export const FavoritesOpenCallsPage: PageComponent<
 > = ({ data: openCalls = [], meta }) => {
   const hasOpenCalls = openCalls?.length > 0;
 
+  const favoriteOpenCall = useFavoriteOpenCall();
+
+  const handleRemoveClick = (id: string) => {
+    favoriteOpenCall.mutate({ id, isFavourite: true });
+  };
+
   return (
     <>
       <div className="top-0 left-0 flex justify-between w-full pb-1 pr-2 mx-1 mb-4 md:pt-10 md:-mt-10 md:px-1 lg:z-20 lg:sticky bg-background-dark">
@@ -43,7 +54,13 @@ export const FavoritesOpenCallsPage: PageComponent<
       </div>
       <div className="flex flex-col pt-2 md:pl-1 md:-mr-1">
         {hasOpenCalls ? (
-          <div className="grid grid-cols-1 gap-6 p-1 2xl:grid-cols-2">{/* TODO */}</div>
+          <div className="grid grid-cols-1 gap-6 p-1 2xl:grid-cols-2">
+            {openCalls.map((openCall) => (
+              <CardHoverToDelete key={openCall.slug} onClick={() => handleRemoveClick(openCall.id)}>
+                <OpenCallCard className="h-full" key={openCall.id} openCall={openCall} />
+              </CardHoverToDelete>
+            ))}
+          </div>
         ) : (
           <div className="flex flex-col items-center mt-10 lg:mt-20">
             <p className="text-lg text-gray-800 lg:text-xl">

--- a/frontend/pages/dashboard/favorites/open-calls.tsx
+++ b/frontend/pages/dashboard/favorites/open-calls.tsx
@@ -12,6 +12,7 @@ import DashboardFavoritesLayout, {
   DashboardFavoritesLayoutProps,
 } from 'layouts/dashboard-favorites';
 import { PageComponent } from 'types';
+import { OpenCall as OpenCallType } from 'types/open-calls';
 
 export const getStaticProps = withLocalizedRequests(async ({ locale }) => {
   return {
@@ -22,7 +23,7 @@ export const getStaticProps = withLocalizedRequests(async ({ locale }) => {
 });
 
 type FavoritesOpenCallsPageProps = {
-  data: any[]; // OpenCallType
+  data: OpenCallType[];
   meta: Record<string, string>;
 };
 
@@ -37,7 +38,7 @@ export const FavoritesOpenCallsPage: PageComponent<
       <div className="top-0 left-0 flex justify-between w-full pb-1 pr-2 mx-1 mb-4 md:pt-10 md:-mt-10 md:px-1 lg:z-20 lg:sticky bg-background-dark">
         <div className="font-medium">
           <FormattedMessage defaultMessage="Open calls" id="OBhULP" />{' '}
-          {/*meta?.total && `(${meta?.total})`*/}(0)
+          {meta?.total && `(${meta?.total})`}
         </div>
       </div>
       <div className="flex flex-col pt-2 md:pl-1 md:-mr-1">

--- a/frontend/pages/dashboard/favorites/project-developers.tsx
+++ b/frontend/pages/dashboard/favorites/project-developers.tsx
@@ -48,8 +48,8 @@ export const FavoritesProjectDevelopersPage: PageComponent<
     <>
       <div className="top-0 left-0 flex justify-between w-full pb-1 pr-2 mx-1 mb-4 md:pt-10 md:-mt-10 md:px-1 lg:z-20 lg:sticky bg-background-dark">
         <div className="font-medium">
-          <FormattedMessage defaultMessage="Project developers" id="0wBg9P" />{' '}
-          {meta?.total && `(${meta?.total})`}
+          <FormattedMessage defaultMessage="Project developers" id="0wBg9P" /> (
+          {meta?.total && `${meta?.total}`})
         </div>
       </div>
       <div className="flex flex-col pt-2 md:pl-1 md:-mr-1">

--- a/frontend/pages/dashboard/favorites/projects.tsx
+++ b/frontend/pages/dashboard/favorites/projects.tsx
@@ -48,8 +48,8 @@ export const FavoritesProjectsPage: PageComponent<
     <>
       <div className="top-0 flex justify-between px-2 pb-1 mb-4 -mx-2 md:pt-10 md:-mt-10 md:pl-3 md:pr-2 lg:z-20 lg:sticky bg-background-dark">
         <div className="font-medium">
-          <FormattedMessage defaultMessage="Projects" id="UxTJRa" />{' '}
-          {meta?.total && `(${meta?.total})`}
+          <FormattedMessage defaultMessage="Projects" id="UxTJRa" /> (
+          {meta?.total && `${meta?.total}`})
         </div>
       </div>
       <div className="flex flex-col gap-2 pt-2 md:pl-1 md:-mr-1">

--- a/frontend/services/account/favoritesService.ts
+++ b/frontend/services/account/favoritesService.ts
@@ -8,6 +8,7 @@ import { useLocalizedQuery } from 'hooks/query';
 
 import { Queries } from 'enums';
 import { Investor } from 'types/investor';
+import { OpenCall } from 'types/open-calls';
 import { Project } from 'types/project';
 import { ProjectDeveloper } from 'types/projectDeveloper';
 
@@ -157,6 +158,55 @@ export function useFavoriteProjectDevelopersList(
     () => ({
       ...query,
       projectDevelopers: query?.data?.data || [],
+    }),
+    [query]
+  );
+}
+
+/** ============================================================ */
+/** ======================== OPEN CALLS ======================== */
+/** ============================================================ */
+
+/** Get a paged list of favorited open calls */
+export const getFavoriteOpenCalls = async (
+  params?: PagedRequest
+): Promise<PagedResponse<OpenCall>> => {
+  const { search, page, includes, fields, ...rest } = params || {};
+
+  const config: AxiosRequestConfig = {
+    url: '/api/v1/account/open_calls/favourites',
+    method: 'GET',
+    params: {
+      ...rest,
+      includes: includes?.join(','),
+      'page[number]': page,
+      'fields[project]': fields?.join(','),
+    },
+  };
+
+  return await API.request(config).then((result) => {
+    return result.data;
+  });
+};
+
+/** Hook to use getFavoriteOpenCalls */
+export function useFavoriteOpenCallsList(
+  params?: PagedRequest,
+  options?: UseQueryOptions<PagedResponse<OpenCall>>
+): UseQueryResult<PagedResponse<OpenCall>> & { openCalls: OpenCall[] } {
+  const query = useLocalizedQuery(
+    [Queries.FavoriteOpenCallsList, params],
+    () => getFavoriteOpenCalls(params),
+    {
+      ...staticDataQueryOptions,
+      ...options,
+    }
+  );
+
+  return useMemo(
+    () => ({
+      ...query,
+      openCalls: query?.data?.data || [],
     }),
     [query]
   );


### PR DESCRIPTION
## Description

This PR adds the open calls to the dashboard favourites. 

## Testing instructions

Visit the dashboard, favourites tab. Verify that: 
- The user can see a list of favourited open calls  
- The sidebar badges display the count of favourited open calls
- Above the list there is a count of favourited open calls
- The user can unfavourite an open call by hovering the card and clicking the trash can icon
  _Same behaviour as implemented for the other cards in the favourites_

## Tracking

[LET-1063](https://vizzuality.atlassian.net/browse/LET-1063)

## Screenshot

<img width="1680" alt="Screenshot 2022-09-07 at 13 43 43" src="https://user-images.githubusercontent.com/6273795/188881515-3911b021-0446-48da-b17c-25f46f689dbc.png">

