### PR TITLE
Making it explicit in the account creation/edition forms that the fie…

### DIFF
--- a/frontend/containers/investor-form/pages/profile.tsx
+++ b/frontend/containers/investor-form/pages/profile.tsx
@@ -74,7 +74,7 @@ export const Profile: FC<ProfileProps> = ({
       <div className="md:flex gap-x-6 mb-6.5">
         <div className="md:w-1/2 mb-6.5 md:m-0">
           <Label htmlFor="name">
-            <FormattedMessage defaultMessage="Investor/Funder name" id="6MEtAZ" />
+            <FormattedMessage defaultMessage="Account name" id="Gcv7QB" />
           </Label>
           <Input
             name="name"

--- a/frontend/containers/project-developer-form/pages/profile.tsx
+++ b/frontend/containers/project-developer-form/pages/profile.tsx
@@ -73,7 +73,7 @@ export const Profile: FC<ProfileProps> = ({
       <div className="md:flex gap-x-6 mb-6.5">
         <div className="md:w-1/2 mb-6.5 md:m-0">
           <Label htmlFor="profile">
-            <FormattedMessage defaultMessage="Project developer name" id="Sv/Mtz" />
+            <FormattedMessage defaultMessage="Account name" id="Gcv7QB" />
           </Label>
           <Input
             name="name"

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -398,9 +398,6 @@
   "6IKs4G": {
     "string": "wood and soil biomass, application of sustainable forest measures;"
   },
-  "6MEtAZ": {
-    "string": "Investor/Funder name"
-  },
   "6MoU6D": {
     "string": "Explain how the solution or project can be replicated in other contexts and geographies. Think practically about the existing opportunities, the partners and allies needed as well as the barriers that this replication effort may face such as climate issues, regulations and legal frameworks, land tenure, institutional capacity, etc."
   },
@@ -922,6 +919,9 @@
   },
   "GYkIYE": {
     "string": "Insert your last name"
+  },
+  "Gcv7QB": {
+    "string": "Account name"
   },
   "GdS9Mk": {
     "string": "Has this project been funded before?"
@@ -1505,9 +1505,6 @@
   },
   "Si0U4V": {
     "string": "Relevant links"
-  },
-  "Sv/Mtz": {
-    "string": "Project developer name"
   },
   "Swj4mJ": {
     "string": "Select the {name} account"


### PR DESCRIPTION
## Description

This PR renames the PD/Investor "Name" fields in the PD/Investor forms (both creation and edition) to "Account name". 

## Testing instructions

Verify that when creating/editing a PD or Investor profiles, the field has been renamed correctly. 

## Tracking

[LET-1049](https://vizzuality.atlassian.net/browse/LET-1049)

## Screenshots

**Project developer**
<img width="1015" alt="pd" src="https://user-images.githubusercontent.com/6273795/188887850-a91e42f5-df7a-45b5-aca3-054a68762fc4.png">

**Investor**
<img width="1015" alt="investor" src="https://user-images.githubusercontent.com/6273795/188887838-71ff0af6-1ae0-4370-9cb3-7f3adbdc7931.png">

