### PR TITLE
Add entries in the FAQ about the account deletion

### DIFF
--- a/frontend/containers/faq-page/answers/account/investor-account-deletion/component.tsx
+++ b/frontend/containers/faq-page/answers/account/investor-account-deletion/component.tsx
@@ -1,0 +1,28 @@
+import { FC } from 'react';
+
+import { FormattedMessage } from 'react-intl';
+
+export const InvestorAccountDeletion: FC = () => (
+  <ol className="ml-6 list-disc">
+    <li>
+      <FormattedMessage
+        defaultMessage="All information associated with the account will be deleted."
+        id="mZF8ZA"
+      />
+    </li>
+    <li>
+      <FormattedMessage
+        defaultMessage="All users associated with the account will be deleted."
+        id="0u3Vzf"
+      />
+    </li>
+    <li>
+      <FormattedMessage
+        defaultMessage="All content associated with the account will be deleted. If you have created Open Calls to which some Projects have applied, the owners of these Projects will be automatically notified that the Open Call no longer exists."
+        id="CqohYm"
+      />
+    </li>
+  </ol>
+);
+
+export default InvestorAccountDeletion;

--- a/frontend/containers/faq-page/answers/account/investor-account-deletion/index.ts
+++ b/frontend/containers/faq-page/answers/account/investor-account-deletion/index.ts
@@ -1,0 +1,1 @@
+export { default } from './component';

--- a/frontend/containers/faq-page/answers/account/project-developer-account-deletion/component.tsx
+++ b/frontend/containers/faq-page/answers/account/project-developer-account-deletion/component.tsx
@@ -1,0 +1,28 @@
+import { FC } from 'react';
+
+import { FormattedMessage } from 'react-intl';
+
+export const ProjectDeveloperAccountDeletion: FC = () => (
+  <ol className="ml-6 list-disc">
+    <li>
+      <FormattedMessage
+        defaultMessage="All information associated with the account will be deleted."
+        id="mZF8ZA"
+      />
+    </li>
+    <li>
+      <FormattedMessage
+        defaultMessage="All users associated with the account will be deleted."
+        id="0u3Vzf"
+      />
+    </li>
+    <li>
+      <FormattedMessage
+        defaultMessage="All content associated with the account will be deleted. If your Projects have applied to Open Calls, the owners of the Open Calls will be automatically notified that the Project no longer exists."
+        id="xmwVn+"
+      />
+    </li>
+  </ol>
+);
+
+export default ProjectDeveloperAccountDeletion;

--- a/frontend/containers/faq-page/answers/account/project-developer-account-deletion/index.ts
+++ b/frontend/containers/faq-page/answers/account/project-developer-account-deletion/index.ts
@@ -1,0 +1,1 @@
+export { default } from './component';

--- a/frontend/hooks/useFaq.tsx
+++ b/frontend/hooks/useFaq.tsx
@@ -2,7 +2,9 @@ import { useMemo } from 'react';
 
 import { useIntl } from 'react-intl';
 
+import InvestorAccountDeletion from 'containers/faq-page/answers/account/investor-account-deletion';
 import InvestorInfo from 'containers/faq-page/answers/account/investor-info';
+import ProjectDeveloperAccountDeletion from 'containers/faq-page/answers/account/project-developer-account-deletion';
 import ProjectDeveloperInfo from 'containers/faq-page/answers/account/project-developer-info';
 import OpenCallInfo from 'containers/faq-page/answers/open-calls/open-call-info';
 import ProjectImpact from 'containers/faq-page/answers/projects/project-impact';
@@ -27,6 +29,8 @@ export enum FaqQuestions {
   WhyAccountIsPendingApproval = 'why-is-my-account-pending-approval',
   InfoNeededForPdAccount = 'what-information-do-i-need-to-create-a-project-developer-account',
   InfoNeededForInvestorAccount = 'what-information-do-i-need-to-create-an-investor-account',
+  WhatHappensDeletePdAccount = 'what-happens-when-i-delete-my-project-developer-account',
+  WhatHappensDeleteInvestorAccount = 'what-happens-when-i-delete-my-investor-account',
   /** Projects */
   WhatIsAProject = 'what-is-a-project',
   ForWhoIsTheProjectFor = 'for-who-is-the-project-for',
@@ -55,6 +59,8 @@ export const FaqPaths = {
   [FaqQuestions.WhyAccountIsPendingApproval]: `${Paths.FAQ}/${FaqSections.Account}/${FaqQuestions.WhyAccountIsPendingApproval}`,
   [FaqQuestions.InfoNeededForPdAccount]: `${Paths.FAQ}/${FaqSections.Account}/${FaqQuestions.InfoNeededForPdAccount}`,
   [FaqQuestions.InfoNeededForInvestorAccount]: `${Paths.FAQ}/${FaqSections.Account}/${FaqQuestions.InfoNeededForInvestorAccount}`,
+  [FaqQuestions.WhatHappensDeletePdAccount]: `${Paths.FAQ}/${FaqSections.Account}/${FaqQuestions.WhatHappensDeletePdAccount}`,
+  [FaqQuestions.WhatHappensDeleteInvestorAccount]: `${Paths.FAQ}/${FaqSections.Account}/${FaqQuestions.WhatHappensDeleteInvestorAccount}`,
   /** Projects */
   [FaqQuestions.WhatIsAProject]: `${Paths.FAQ}/${FaqSections.Projects}/${FaqQuestions.WhatIsAProject}`,
   [FaqQuestions.ForWhoIsTheProjectFor]: `${Paths.FAQ}/${FaqSections.Projects}/${FaqQuestions.ForWhoIsTheProjectFor}`,
@@ -135,6 +141,22 @@ export const useFaq = () => {
               id: 'JK13Ms',
             }),
             answer: <InvestorInfo />,
+          },
+          {
+            questionId: FaqQuestions.WhatHappensDeletePdAccount,
+            question: formatMessage({
+              defaultMessage: 'What happens when I delete my Project Developer account?',
+              id: 'ZocjEJ',
+            }),
+            answer: <ProjectDeveloperAccountDeletion />,
+          },
+          {
+            questionId: FaqQuestions.WhatHappensDeleteInvestorAccount,
+            question: formatMessage({
+              defaultMessage: 'What happens when I delete my Investor account?',
+              id: 'ub/Akh',
+            }),
+            answer: <InvestorAccountDeletion />,
           },
         ],
       },

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -143,6 +143,9 @@
   "0lKwqs": {
     "string": "Close open call?"
   },
+  "0u3Vzf": {
+    "string": "All users associated with the account will be deleted."
+  },
   "0v43t3": {
     "string": "Note that all of this information will be visible in the Investor public profile page except questions."
   },
@@ -706,6 +709,9 @@
   },
   "CiYFzk": {
     "string": "SME and MSME"
+  },
+  "CqohYm": {
+    "string": "All content associated with the account will be deleted. If you have created Open Calls to which some Projects have applied, the owners of these Projects will be automatically notified that the Open Call no longer exists."
   },
   "Cra78t": {
     "string": "© {date} HeCo Invest. All rights reserved."
@@ -1827,6 +1833,9 @@
   "ZjA6uH": {
     "string": "Welcome to HeCo Invest. Please enter your details below."
   },
+  "ZocjEJ": {
+    "string": "What happens when I delete my Project Developer account?"
+  },
   "Zt7DBA": {
     "string": "Priority landscapes of HeCo"
   },
@@ -2421,6 +2430,9 @@
   "mQk71L": {
     "string": "Why invest in the Amazon"
   },
+  "mZF8ZA": {
+    "string": "All information associated with the account will be deleted."
+  },
   "mbTJWV": {
     "string": "Biodiversity"
   },
@@ -2820,6 +2832,9 @@
   "uIp9ro": {
     "string": "Powered by ARIES: The First AI-powered 'Knowledge Commons'"
   },
+  "ub/Akh": {
+    "string": "What happens when I delete my Investor account?"
+  },
   "ufxVRM": {
     "string": "Display impact on"
   },
@@ -2957,6 +2972,9 @@
   },
   "xmcVZ0": {
     "string": "Search"
+  },
+  "xmwVn+": {
+    "string": "All content associated with the account will be deleted. If your Projects have applied to Open Calls, the owners of the Open Calls will be automatically notified that the Project no longer exists."
   },
   "xnQiBM": {
     "string": "The impact of this project isn’t available. Impact calculations may take some time to be available."


### PR DESCRIPTION
## Description

This PR adds the _"What happens when I delete my Project Developer account?"_ and _"What happens when I delete my Investor account?"_ entries to the FAQ.

## Testing instructions

Visit the FAQ page, and verify that the new entries are in the FAQ, in the _"Accounts"_ section.

## Tracking

[LET-1062](https://vizzuality.atlassian.net/browse/LET-1062)

## Screenshot

<img width="1507" alt="Screenshot 2022-09-07 at 16 51 56" src="https://user-images.githubusercontent.com/6273795/188923532-6bb5c8ad-e13c-4d34-9b6c-0f16231294d7.png">
