### PR TITLE
Fix project form map zoom buttons not working after the user uses the location search

### DIFF
--- a/frontend/containers/forms/geometry/component.tsx
+++ b/frontend/containers/forms/geometry/component.tsx
@@ -169,7 +169,7 @@ export const GeometryInput = <FormValues extends FieldValues>({
             <Map
               bounds={bounds}
               viewport={viewport}
-              onMapViewportChange={(v) => setViewport(v)}
+              onMapViewportChange={(v) => setViewport({ ...viewport, ...v })}
               getCursor={({ isHovering, isDragging }) => {
                 if (drawing) {
                   return 'crosshair';


### PR DESCRIPTION
## Description

This PR fixes the issue where, in the project form, the map's zoom buttons do not work after the user uses the location search. 

## Testing instructions

1. Sign in with a project developer account  
2. Start to create a project (dashboard -> projects)
3. On the map, enter a search search location (eg. _"La macarena"_) and hit enter
4. Without using the zoom on the mouse, try to use the zoom controls (+/-)

Verify that the zoom controls *do* work. 

## Tracking

[LET-950](https://vizzuality.atlassian.net/browse/LET-950)

## Screen recording 


https://user-images.githubusercontent.com/6273795/188928510-b2e84857-4196-42aa-97f3-b171a0fb7710.mp4

