### PR TITLE
Update the styles of the tabs and sorting options on Discover

### DIFF
--- a/frontend/components/badge-navigation/component.stories.tsx
+++ b/frontend/components/badge-navigation/component.stories.tsx
@@ -48,6 +48,14 @@ Default.args = {
   items: navigationItems,
 };
 
+export const Pill: Story<BadgeNavigationProps> = Template.bind({});
+
+Pill.args = {
+  activeId: 'second-id',
+  type: 'pill',
+  items: navigationItems,
+};
+
 export const BadgeLeft: Story<BadgeNavigationProps> = Template.bind({});
 
 BadgeLeft.args = {

--- a/frontend/components/badge-navigation/component.tsx
+++ b/frontend/components/badge-navigation/component.tsx
@@ -1,7 +1,5 @@
 import { FC } from 'react';
 
-import { useIntl } from 'react-intl';
-
 import cx from 'classnames';
 
 import Link from 'next/link';
@@ -13,25 +11,28 @@ import { BadgeNavigationProps } from './types';
 export const BadgeNavigation: FC<BadgeNavigationProps> = ({
   className,
   theme = 'default',
+  type = 'square',
   orientation = 'horizontal',
   badgePosition = 'right',
   activeId,
   items,
 }: BadgeNavigationProps) => {
-  const intl = useIntl();
-
   const badgeElement = (number: number, isActive: boolean) => {
     if (Number.isNaN(number)) return null;
 
     return (
       <span
         className={cx({
-          'flex items-center justify-center w-6 h-6 px-1 border text-xs font-semibold text-black rounded-full min-w-min border-beige':
-            true,
-          'bg-background-dark': theme !== 'simple',
-          'bg-white': isActive && theme === 'simple',
-          'ml-2': badgePosition === 'right',
-          'mr-2': badgePosition === 'left',
+          'flex items-center justify-center  text-sm font-medium min-w-min': true,
+          'bg-green-dark text-white w-5 h-5': theme === 'default',
+          'w-6 h-6 px-1': theme === 'simple',
+          'rounded-sm': type === 'square',
+          'rounded-full border border-beige': type === 'pill',
+          'bg-beige text-gray-800': !isActive && theme === 'default',
+          border: theme === 'simple',
+          'bg-white text-black': isActive && theme === 'simple',
+          'ml-2.5': badgePosition === 'right',
+          'mr-2.5': badgePosition === 'left',
         })}
       >
         {number}
@@ -42,12 +43,11 @@ export const BadgeNavigation: FC<BadgeNavigationProps> = ({
   return (
     <div className={className}>
       <nav className="relative mx-2">
-        {orientation === 'horizontal' && theme !== 'simple' && (
-          <span className="absolute left-0 right-0 border rounded-full top-2 bottom-2 border-beige" />
-        )}
         <ol
           className={cx({
-            'flex gap-2 py-2 whitespace-nowrap': true,
+            'flex py-2 whitespace-nowrap': true,
+            'gap-2': type === 'pill',
+            'gap-px': type === 'square',
             'flex-col': orientation === 'vertical',
           })}
         >
@@ -55,19 +55,40 @@ export const BadgeNavigation: FC<BadgeNavigationProps> = ({
             const isActive = id === activeId;
 
             return (
-              <li key={link} className="transition-all">
+              <li
+                key={link}
+                className={cx({
+                  'relative transition-all': true,
+                  'after:inline after:bg-green-dark after:absolute after:left-0 after:bottom-0':
+                    isActive && theme === 'default' && type === 'square',
+                  'after:h-full after:w-0.5':
+                    isActive && theme === 'default' && orientation === 'vertical',
+                  'after:w-full after:h-0.5':
+                    isActive && theme === 'default' && orientation === 'horizontal',
+                })}
+              >
                 <Link href={link}>
                   <a
-                    className="inline-flex rounded-full focus-visible:outline focus-visible:outline-green-dark focus-visible:outline-2 focus-visible:outline-offset-2"
+                    className={cx({
+                      'relative inline-flex focus-visible:outline focus-visible:outline-green-dark focus-visible:outline-2 focus-visible:outline-offset-2':
+                        true,
+                      'rounded-sm': type === 'square',
+                      'rounded-full': type === 'pill',
+                    })}
                     aria-current={isActive ? 'location' : false}
                   >
                     <Tag
+                      border={false}
                       className={cx({
-                        'text-sm hover:font-medium hover:text-black': true,
-                        'font-semibold text-black': isActive,
-                        'bg-white shadow-sm': isActive && theme !== 'simple',
-                        'text-green-dark p-px': !isActive,
-                        'border-none': !isActive || theme === 'simple',
+                        'text-sm': true,
+                        'border border-beige': type === 'pill' && theme !== 'simple',
+                        'bg-white shadow-sm': isActive && type === 'pill' && theme === 'default',
+                        'hover:text-green-dark': theme === 'default',
+                        'text-green-dark': isActive && theme === 'default',
+                        'text-gray-600': !isActive && theme === 'default',
+                        'hover:text-black': theme === 'simple',
+                        'text-black': isActive && theme === 'simple',
+                        'font-medium': theme === 'default' || (isActive && theme === 'simple'),
                       })}
                     >
                       {badgePosition === 'left' && badgeElement(number, isActive)}

--- a/frontend/components/badge-navigation/component.tsx
+++ b/frontend/components/badge-navigation/component.tsx
@@ -30,7 +30,8 @@ export const BadgeNavigation: FC<BadgeNavigationProps> = ({
           'rounded-full border border-beige': type === 'pill',
           'bg-beige text-gray-800': !isActive && theme === 'default',
           border: theme === 'simple',
-          'bg-white text-black': isActive && theme === 'simple',
+          'bg-white ': isActive && theme === 'simple',
+          'text-black': theme === 'simple',
           'ml-2.5': badgePosition === 'right',
           'mr-2.5': badgePosition === 'left',
         })}
@@ -84,7 +85,8 @@ export const BadgeNavigation: FC<BadgeNavigationProps> = ({
                         'border border-beige': type === 'pill' && theme !== 'simple',
                         'bg-white shadow-sm': isActive && type === 'pill' && theme === 'default',
                         'hover:text-green-dark': theme === 'default',
-                        'text-green-dark': isActive && theme === 'default',
+                        'text-green-dark':
+                          (isActive && theme === 'default') || (!isActive && theme === 'simple'),
                         'text-gray-600': !isActive && theme === 'default',
                         'hover:text-black': theme === 'simple',
                         'text-black': isActive && theme === 'simple',

--- a/frontend/components/badge-navigation/component.tsx
+++ b/frontend/components/badge-navigation/component.tsx
@@ -23,12 +23,12 @@ export const BadgeNavigation: FC<BadgeNavigationProps> = ({
     return (
       <span
         className={cx({
-          'flex items-center justify-center  text-sm font-medium min-w-min': true,
+          'flex items-center justify-center  text-sm font-semibold min-w-min': true,
           'bg-green-dark text-white w-5 h-5': theme === 'default',
           'w-6 h-6 px-1': theme === 'simple',
           'rounded-sm': type === 'square',
           'rounded-full border border-beige': type === 'pill',
-          'bg-beige text-gray-800': !isActive && theme === 'default',
+          'bg-beige text-gray-700': !isActive && theme === 'default',
           border: theme === 'simple',
           'bg-white ': isActive && theme === 'simple',
           'text-black': theme === 'simple',
@@ -87,10 +87,10 @@ export const BadgeNavigation: FC<BadgeNavigationProps> = ({
                         'hover:text-green-dark': theme === 'default',
                         'text-green-dark':
                           (isActive && theme === 'default') || (!isActive && theme === 'simple'),
-                        'text-gray-600': !isActive && theme === 'default',
+                        'text-gray-700': !isActive && theme === 'default',
                         'hover:text-black': theme === 'simple',
                         'text-black': isActive && theme === 'simple',
-                        'font-medium': theme === 'default' || (isActive && theme === 'simple'),
+                        'font-semibold': theme === 'default' || (isActive && theme === 'simple'),
                       })}
                     >
                       {badgePosition === 'left' && badgeElement(number, isActive)}

--- a/frontend/components/badge-navigation/types.ts
+++ b/frontend/components/badge-navigation/types.ts
@@ -10,6 +10,8 @@ export type BadgeNavigationProps = {
   className?: string;
   /** Theme to use. Defaults to `default` */
   theme?: 'default' | 'simple';
+  /** Format of the badges. Defaults to `square` */
+  type?: 'square' | 'pill';
   /** Orientation of the navigation. Defaults to `horizontal` */
   orientation?: 'horizontal' | 'vertical';
   /** Badge position. Defaults to `right` */

--- a/frontend/components/sorting-buttons/component.stories.tsx
+++ b/frontend/components/sorting-buttons/component.stories.tsx
@@ -26,13 +26,25 @@ const Template: Story<SortingButtonsProps> = ({ ...props }: SortingButtonsProps)
   };
 
   return (
-    <SortingButtons sortBy={sortBy} sortOrder={sortOrder} onChange={handleOnChange} {...props} />
+    <div className="flex items-center justify-center h-48 p-12 bg-background-dark">
+      <SortingButtons sortBy={sortBy} sortOrder={sortOrder} onChange={handleOnChange} {...props} />
+    </div>
   );
 };
 
 export const Default: Story<SortingButtonsProps> = Template.bind({});
 
 Default.args = {
+  options: [
+    { key: 'name', label: 'Name' },
+    { key: 'created_at', label: 'Created at' },
+  ],
+};
+
+export const Pill: Story<SortingButtonsProps> = Template.bind({});
+
+Pill.args = {
+  theme: 'pill',
   options: [
     { key: 'name', label: 'Name' },
     { key: 'created_at', label: 'Created at' },

--- a/frontend/components/sorting-buttons/component.tsx
+++ b/frontend/components/sorting-buttons/component.tsx
@@ -57,7 +57,7 @@ export const SortingButtons: FC<SortingButtonsProps> = ({
               {...buttonProps}
             >
               <span className="py-0.5 -mx-2 flex items-center">
-                <span className="text-sm text-gray-600">
+                <span className="text-sm font-medium text-gray-700">
                   <FormattedMessage defaultMessage="Sort by" id="hDI+JM" />
                   {theme === 'text' && ':'}
                 </span>
@@ -130,7 +130,7 @@ export const SortingButtons: FC<SortingButtonsProps> = ({
             )}
             {theme === 'text' && (
               <>
-                <span className="text-sm text-gray-600">
+                <span className="text-sm font-medium text-gray-700">
                   <FormattedMessage defaultMessage="Order" id="XPruqs" />:
                 </span>
                 <span className="ml-2 text-sm font-medium text-green-dark">

--- a/frontend/components/sorting-buttons/component.tsx
+++ b/frontend/components/sorting-buttons/component.tsx
@@ -11,13 +11,14 @@ import cx from 'classnames';
 
 import { noop } from 'lodash-es';
 
-import Button from 'components/button';
+import Button, { ButtonProps } from 'components/button';
 import Menu, { MenuItem, MenuSection } from 'components/menu';
 
 import { SortingButtonsProps } from './types';
 
 export const SortingButtons: FC<SortingButtonsProps> = ({
   className,
+  theme = 'text',
   sortBy,
   sortOrder,
   options,
@@ -32,30 +33,50 @@ export const SortingButtons: FC<SortingButtonsProps> = ({
     [options, sortBy]
   );
 
+  const buttonProps = {
+    ...(theme === 'pill' && { size: 'small', theme: 'primary-white' }),
+    ...(theme === 'text' && { size: 'smallest', theme: 'naked' }),
+  } as ButtonProps;
+
   return (
     <div className={className}>
       <div className="flex gap-3">
         <Menu
           Trigger={
             <Button
-              className="whitespace-nowrap"
-              size="small"
-              theme="primary-white"
+              className={cx({
+                'whitespace-nowrap': true,
+                '!px-3 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-dark':
+                  theme === 'text',
+              })}
               aria-label={intl.formatMessage({
                 defaultMessage: 'Choose the field to sort by',
                 id: 'DCAMZh',
               })}
               aria-expanded={sortByMenuOpen}
+              {...buttonProps}
             >
               <span className="py-0.5 -mx-2 flex items-center">
-                <span className="text-gray-600">
+                <span className="text-sm text-gray-600">
                   <FormattedMessage defaultMessage="Sort by" id="hDI+JM" />
+                  {theme === 'text' && ':'}
                 </span>
-                <span className="ml-2 text-black">{selectedSortByOption.label.toLowerCase()}</span>
+                {theme === 'pill' && (
+                  <span className="ml-2 text-sm text-black">
+                    {selectedSortByOption.label.toLowerCase()}
+                  </span>
+                )}
+                {theme === 'text' && (
+                  <span className="ml-2 text-sm font-medium text-green-dark">
+                    {selectedSortByOption.label}
+                  </span>
+                )}
                 <ChevronDownIcon
                   className={cx({
-                    'w-4 h-4 ml-2 text-black transition-transform': true,
+                    'w-4 h-4  transition-transform': true,
                     '-rotate-180': sortByMenuOpen,
+                    'ml-2 text-black': theme === 'pill',
+                    'ml-1 text-green-dark': theme === 'text',
                   })}
                 />
               </span>
@@ -65,7 +86,6 @@ export const SortingButtons: FC<SortingButtonsProps> = ({
           onAction={(key: string) => onChange({ sortBy: key })}
           onOpen={() => setSortByMenuOpen(true)}
           onClose={() => setSortByMenuOpen(false)}
-          className="min-w-fit"
           expandedKeys={[selectedSortByOption.key]}
         >
           <MenuSection>
@@ -75,9 +95,12 @@ export const SortingButtons: FC<SortingButtonsProps> = ({
           </MenuSection>
         </Menu>
         <Button
-          theme="primary-white"
-          className="!px-3"
-          size="small"
+          className={cx({
+            'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-dark':
+              theme === 'text',
+            '!px-3': theme === 'pill',
+            '!px-1': theme === 'text',
+          })}
           onClick={() => onChange({ sortOrder: sortOrder === 'asc' ? 'desc' : 'asc' })}
           aria-label={
             sortOrder === 'asc'
@@ -90,16 +113,39 @@ export const SortingButtons: FC<SortingButtonsProps> = ({
                   id: 'C23He5',
                 })
           }
+          {...buttonProps}
         >
-          <span className="relative mr-px -ml-px">
-            <ListIcon className="w-4 h-4 text-black -scale-x-100" />
-            <ArrowDownIcon
-              className={cx({
-                'w-4 h-4 text-black -ml-1 absolute -right-1.5': true,
-                '-top-1 -rotate-180': sortOrder === 'asc',
-                '-bottom-1': sortOrder === 'desc',
-              })}
-            />
+          <span className="relative">
+            {theme === 'pill' && (
+              <>
+                <ListIcon className="w-4 h-4 text-black -scale-x-100" />
+                <ArrowDownIcon
+                  className={cx({
+                    'w-4 h-4 text-black -ml-1 absolute -right-1.5 text-sm': true,
+                    '-top-1 -rotate-180': sortOrder === 'asc',
+                    '-bottom-1': sortOrder === 'desc',
+                  })}
+                />
+              </>
+            )}
+            {theme === 'text' && (
+              <>
+                <span className="text-sm text-gray-600">
+                  <FormattedMessage defaultMessage="Order" id="XPruqs" />:
+                </span>
+                <span className="ml-2 text-sm font-medium text-green-dark">
+                  {sortOrder === 'asc'
+                    ? intl.formatMessage({
+                        defaultMessage: 'Ascending',
+                        id: 'u7djqV',
+                      })
+                    : intl.formatMessage({
+                        defaultMessage: 'Descending',
+                        id: 'aleGqT',
+                      })}
+                </span>
+              </>
+            )}
           </span>
         </Button>
       </div>

--- a/frontend/components/sorting-buttons/types.ts
+++ b/frontend/components/sorting-buttons/types.ts
@@ -17,9 +17,16 @@ export type SortingOptionType = {
 export type SortingOrderType = 'asc' | 'desc';
 
 export type SortingButtonsProps = {
+  /** Classnames to apply to the container */
   className?: string;
+  /** Theme to apply to the buttons. Defaults to `text` */
+  theme?: 'text' | 'pill';
+  /** Current sorting by key */
   sortBy: string;
+  /** Current sorting order key */
   sortOrder: SortingOrderType;
+  /** Options to display */
   options: SortingOptionType[];
+  /** Callback called when the user clicks the sorting buttons */
   onChange?: ({ sortBy, sortOrder }: { sortBy?: string; sortOrder?: SortingOrderType }) => void;
 };

--- a/frontend/components/tag/component.tsx
+++ b/frontend/components/tag/component.tsx
@@ -4,10 +4,16 @@ import cx from 'classnames';
 
 import type { TagProps } from './types';
 
-export const Tag: FC<TagProps> = ({ children, className, size = 'small' }: TagProps) => (
+export const Tag: FC<TagProps> = ({
+  children,
+  className,
+  size = 'small',
+  border = true,
+}: TagProps) => (
   <div
     className={cx({
-      'relative inline-flex border rounded-full': true,
+      'relative inline-flex rounded-full': true,
+      border: border,
       [`${className}`]: !!className,
       'text-black': !className,
     })}

--- a/frontend/components/tag/types.d.ts
+++ b/frontend/components/tag/types.d.ts
@@ -3,6 +3,8 @@ export interface TagProps {
   children: React.ReactNode;
   /** Classes to apply to the container */
   className?: string | unknown;
-  /** Size of the tag */
+  /** Size of the tag. Defaults to `small` */
   size?: 'small' | 'smallest';
+  /** Whether to display a border. Defaults to `true` */
+  border?: boolean;
 }

--- a/frontend/layouts/dashboard-favorites/navigation/component.tsx
+++ b/frontend/layouts/dashboard-favorites/navigation/component.tsx
@@ -55,9 +55,8 @@ export const Navigation: FC<NavigationProps> = ({ className, stats }: Navigation
   }, [deleteFavorites]);
 
   return (
-    <>
+    <div className={className}>
       <BadgeNavigation
-        className={className}
         orientation="vertical"
         badgePosition="left"
         theme="simple"
@@ -68,12 +67,12 @@ export const Navigation: FC<NavigationProps> = ({ className, stats }: Navigation
       <Button
         size="smallest"
         theme="naked"
-        className="mt-6 text-sm underline text-green-dark focus-visible:outline-green-dark"
+        className="mt-6 ml-6 text-sm underline text-green-dark focus-visible:outline-green-dark"
         onClick={handleRemoveAllClick}
       >
         <FormattedMessage defaultMessage="Remove all" id="jNai7b" />
       </Button>
-    </>
+    </div>
   );
 };
 

--- a/frontend/layouts/dashboard-favorites/navigation/component.tsx
+++ b/frontend/layouts/dashboard-favorites/navigation/component.tsx
@@ -61,6 +61,7 @@ export const Navigation: FC<NavigationProps> = ({ className, stats }: Navigation
         orientation="vertical"
         badgePosition="left"
         theme="simple"
+        type="pill"
         activeId={activeId}
         items={navigationItems}
       />

--- a/frontend/layouts/dashboard/component.tsx
+++ b/frontend/layouts/dashboard/component.tsx
@@ -68,7 +68,7 @@ export const DashboardLayout: FC<DashboardLayoutProps> = ({
           >
             <LayoutContainer
               className={cx({
-                'relative flex flex-col gap-20 py-8 md:flex-row': true,
+                'relative flex flex-col gap-10 md:gap-20 py-8 md:flex-row': true,
                 'h-full': isLoading,
               })}
             >

--- a/frontend/layouts/discover-page/component.tsx
+++ b/frontend/layouts/discover-page/component.tsx
@@ -135,13 +135,10 @@ export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
           </LayoutContainer>
         </div>
         <main className="z-0 flex flex-col flex-grow h-screen overflow-y-auto">
-          <LayoutContainer className="xl:mt-6">
-            <div className="flex flex-col items-center gap-2 mt-4 mb-4 lg:mt-2 lg:gap-6 lg:flex-row space-between">
-              <SortingButtons className="flex-1" {...sortingButtonsProps} />
-              <div className="flex justify-center w-full">
-                <Navigation stats={stats} />
-              </div>
-              <div className="flex-1">{/*Share*/}</div>
+          <LayoutContainer className="xl:mt-6 ">
+            <div className="relative flex flex-col items-center gap-2 mx-2 mt-4 mb-4 -ml-1 -mr-1 lg:mt-2 lg:gap-6 lg:flex-row space-between after:left-2 after:right-2 after:bottom-2 after:h-px after:bg-gray-800 after:bg-opacity-40 after:absolute after:hidden after:md:inline">
+              <Navigation stats={stats} />
+              <SortingButtons {...sortingButtonsProps} />
             </div>
           </LayoutContainer>
           <LayoutContainer

--- a/frontend/layouts/discover-page/component.tsx
+++ b/frontend/layouts/discover-page/component.tsx
@@ -136,7 +136,7 @@ export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
         </div>
         <main className="z-0 flex flex-col flex-grow h-screen overflow-y-auto">
           <LayoutContainer className="xl:mt-6 ">
-            <div className="relative flex flex-col items-center gap-2 pb-2 mx-2 mt-4 mb-6 -ml-1 -mr-1 after:left-2 after:right-2 after:h-px after:bg-gray-800 after:bg-opacity-40 after:absolute after:-bottom-2 after:lg:bottom-2 lg:mb-1 lg:mt-2 lg:gap-6 lg:flex-row space-between lg:pb-0">
+            <div className="relative flex flex-col items-center gap-2 pb-2 mx-2 mt-4 mb-6 -ml-1 -mr-1 after:left-2 after:right-2 after:h-px after:bg-[#D3CDC4] after:bg-opacity-40 after:absolute after:-bottom-2 after:lg:bottom-2 lg:mb-1 lg:mt-2 lg:gap-6 lg:flex-row space-between lg:pb-0">
               <Navigation stats={stats} />
               <SortingButtons {...sortingButtonsProps} />
             </div>

--- a/frontend/layouts/discover-page/component.tsx
+++ b/frontend/layouts/discover-page/component.tsx
@@ -136,7 +136,7 @@ export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
         </div>
         <main className="z-0 flex flex-col flex-grow h-screen overflow-y-auto">
           <LayoutContainer className="xl:mt-6 ">
-            <div className="relative flex flex-col items-center gap-2 mx-2 mt-4 mb-4 -ml-1 -mr-1 lg:mt-2 lg:gap-6 lg:flex-row space-between after:left-2 after:right-2 after:bottom-2 after:h-px after:bg-gray-800 after:bg-opacity-40 after:absolute after:hidden after:md:inline">
+            <div className="relative flex flex-col items-center gap-2 pb-2 mx-2 mt-4 mb-6 -ml-1 -mr-1 after:left-2 after:right-2 after:h-px after:bg-gray-800 after:bg-opacity-40 after:absolute after:-bottom-2 after:lg:bottom-2 lg:mb-1 lg:mt-2 lg:gap-6 lg:flex-row space-between lg:pb-0">
               <Navigation stats={stats} />
               <SortingButtons {...sortingButtonsProps} />
             </div>

--- a/frontend/layouts/discover-page/navigation/component.tsx
+++ b/frontend/layouts/discover-page/navigation/component.tsx
@@ -52,12 +52,8 @@ export const Navigation: FC<NavigationProps> = ({ stats }: NavigationProps) => {
   const activeId = navigationItems.find(({ path }) => asPath.startsWith(path))?.id;
 
   return (
-    <div className="flex items-center w-full pb-3 -mb-3 overflow-x-auto">
-      <BadgeNavigation
-        className="flex items-center justify-center flex-grow"
-        activeId={activeId}
-        items={navigationItems}
-      />
+    <div className="flex w-full overflow-x-auto">
+      <BadgeNavigation activeId={activeId} items={navigationItems} />
     </div>
   );
 };


### PR DESCRIPTION
## Description

This PR implements the redesign of the Discover navigation tabs & sorting buttons. 

**In this PR**  
- `BadgeNavigation` component:  
  - Added a `type` prop (`pill` or `square`)  
    _so we can choose between round (pills) or redesigned (square) tabs/badges_   
  - Restyled the default tabs to match the designs
- `SortingButtons` component: 
  - Added `theme`ing support  
  - Added a new `text` theme, shows the redesigned buttons
- `DiscoverLayout` 
  - Redesigned to match the... designs. 

## Testing instructions

What to test? How to do it?

## Tracking

[LET-1045](https://vizzuality.atlassian.net/browse/LET-1045)

## Screenshot

<img width="1680" alt="Screenshot 2022-09-07 at 20 46 58" src="https://user-images.githubusercontent.com/6273795/188963984-82e1f107-c029-4627-a7d3-5cd08c5ee309.png">
