### PR TITLE
Synchronise the map's markers with the project search results (Discover)

### DIFF
--- a/frontend/containers/discover-map/component.tsx
+++ b/frontend/containers/discover-map/component.tsx
@@ -1,5 +1,7 @@
 import { FC, useCallback, useState } from 'react';
 
+import omit from 'lodash-es/omit';
+
 import { useRouter } from 'next/router';
 
 import MapboxGLPlugin from '@vizzuality/layer-manager-plugin-mapboxgl';
@@ -28,7 +30,11 @@ export const DiscoverMap: FC<DiscoverMapProps> = ({ onSelectProjectPin }) => {
   const [visibleLayers, setVisibleLayers] = useState<string[]>([]);
   const { layers } = useLayers();
   const { query } = useRouter();
-  const { projectsMap } = useProjectsMap(query as ProjectMapParams);
+
+  const { projectsMap } = useProjectsMap({
+    ...(omit(query, 'search') as ProjectMapParams),
+    'filter[full_text]': query.search as string,
+  });
 
   const [viewport, setViewport] = useState({});
   const [bounds, setBounds] = useState({

--- a/frontend/services/projects/projectService.ts
+++ b/frontend/services/projects/projectService.ts
@@ -114,7 +114,7 @@ const getProjectsMap = (params) =>
 export const useProjectsMap = (
   params: ProjectMapParams
 ): UseQueryResult<ResponseData<ProjectsMap[]>, unknown> & { projectsMap: ProjectsMapGeojson } => {
-  const query = useLocalizedQuery([Queries.ProjectsMap], () => getProjectsMap(params), {
+  const query = useLocalizedQuery([Queries.ProjectsMap, params], () => getProjectsMap(params), {
     placeholderData: {
       data: [],
     },


### PR DESCRIPTION
On the Discover page, this PR makes sure that the map's markers and project search results are synchronised.

## Testing instructions

1. Go to the Discover page, “Projects” tab
2. Search by keywords and/or apply some filters

The number of results should correspond to the number of markers on the map.

3. Perform another search without reloading the page

Make sure the map is still synchronised with the results.

## Tracking

[LET-1036](https://vizzuality.atlassian.net/browse/LET-1036)
