### PR TITLE
Link ARIES to some explanation

### DIFF
--- a/frontend/containers/home/priorities/component.tsx
+++ b/frontend/containers/home/priorities/component.tsx
@@ -1,6 +1,9 @@
 import { FormattedMessage } from 'react-intl';
 
+import Link from 'next/link';
+
 import LayoutContainer from 'components/layout-container';
+import { Paths } from 'enums';
 
 export const Priorities = () => (
   <>
@@ -56,9 +59,16 @@ export const Priorities = () => (
       </h2>
       <p className="max-w-md mx-auto mt-6 text-base sm:text-center md:mt-8 sm:max-w-xl md:max-w-5xl sm:text-lg md:text-xl">
         <FormattedMessage
-          defaultMessage="Through accessing <span>ARIES</span> (Artificial Intelligence for Environmental Sustainability) and using Machine Reasoning modelling algorithms, this platform accesses the most relevant information to inform you on project and investment potential impact along four key dimensions: <span>Biodiversity</span>, <span>Climate</span>, <span>Community</span> and <span>Water</span>."
-          id="yJVljq"
+          defaultMessage="Through accessing <a>ARIES (Artificial Intelligence for Environmental Sustainability)</a> and using Machine Reasoning modelling algorithms, this platform accesses the most relevant information to inform you on project and investment potential impact along four key dimensions: <span>Biodiversity</span>, <span>Climate</span>, <span>Community</span> and <span>Water</span>."
+          id="af90UN"
           values={{
+            a: (chunks) => (
+              <Link href={`${Paths.About}#aries`}>
+                <a className="underline focus-visible:outline focus-visible:outline-green-dark focus-visible:outline-2 focus-visible:outline-offset-2">
+                  {chunks}
+                </a>
+              </Link>
+            ),
             span: (chunks) => <span className="font-semibold">{chunks}</span>,
           }}
         />

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -1851,8 +1851,14 @@
   "adPUXO": {
     "string": "Until approval you can continue exploring our database."
   },
+  "af90UN": {
+    "string": "Through accessing <a>ARIES (Artificial Intelligence for Environmental Sustainability)</a> and using Machine Reasoning modelling algorithms, this platform accesses the most relevant information to inform you on project and investment potential impact along four key dimensions: <span>Biodiversity</span>, <span>Climate</span>, <span>Community</span> and <span>Water</span>."
+  },
   "agJGNx": {
     "string": "How much funding do you have available for this open call? ($)"
+  },
+  "apgkuO": {
+    "string": "More about ARIES"
   },
   "avVMND": {
     "string": "This information will be visible in the project page when you launch it."
@@ -2969,9 +2975,6 @@
   },
   "yF82he": {
     "string": "Project developer"
-  },
-  "yJVljq": {
-    "string": "Through accessing <span>ARIES</span> (Artificial Intelligence for Environmental Sustainability) and using Machine Reasoning modelling algorithms, this platform accesses the most relevant information to inform you on project and investment potential impact along four key dimensions: <span>Biodiversity</span>, <span>Climate</span>, <span>Community</span> and <span>Water</span>."
   },
   "yP7Lrl": {
     "string": "What is a project?"

--- a/frontend/pages/about.tsx
+++ b/frontend/pages/about.tsx
@@ -263,7 +263,7 @@ const AboutPage: PageComponent<AboutPageProps, StaticPageLayoutProps> = () => {
         </div>
       </LayoutContainer>
 
-      <div className="bg-green-dark">
+      <div id="aries" className="scroll-mt-24 bg-green-dark">
         <LayoutContainer className="py-16 mt-12 text-white md:mt-20 sm:pt-24 sm:pb-20 md:grid md:grid-cols-2 md:gap-12 xl:gap-6">
           <div className="lg:pr-12 xl:pr-24">
             <h2 className="font-serif text-2xl font-bold sm:text-3xl lg:text-4xl">
@@ -296,6 +296,16 @@ const AboutPage: PageComponent<AboutPageProps, StaticPageLayoutProps> = () => {
               defaultMessage="This is why ARIES is developing a 'Wikipedia-like' platform, that is collaborative, open-source and enables interoperable models and data. For the first time, this generates new knowledge through integrating the existing platform with the ultimate scope of building a more sustainable and resilient future for all."
               id="JIehAU"
             />
+            <br />
+            <br />
+            <a
+              href="https://aries.integratedmodelling.org/"
+              target="_blank"
+              rel="noreferrer noopener"
+              className="underline focus-visible:outline focus-visible:outline-white focus-visible:outline-2 focus-visible:outline-offset-2"
+            >
+              <FormattedMessage defaultMessage="More about ARIES" id="apgkuO" />
+            </a>
           </p>
         </LayoutContainer>
       </div>


### PR DESCRIPTION
This PR links the homepage's ARIES section to the About page's and adds a link to ARIES homepage on the latter. 

## Testing instructions

- On the homepage, “ARIES (Artificial Intelligence for Environmental Sustainability)” links to the About page's ARIES section
- On the About page, “More about ARIES” links to its homepage

## Tracking

[LET-1041](https://vizzuality.atlassian.net/browse/LET-1041)
