### PR TITLE
Adjust the application layout to account for different languages

### DIFF
--- a/frontend/components/layout-container/component.tsx
+++ b/frontend/components/layout-container/component.tsx
@@ -13,7 +13,8 @@ export const LayoutContainer: React.FC<LayoutContainerProps> = ({
     () => ({
       ...rest,
       className: cx({
-        'container mx-auto px-4 sm:px-6 lg:px-8': true,
+        'container md:max-w-screen-lg lg:max-w-screen-xl 2xl:max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8':
+          true,
         'max-w-md sm:max-w-xl md:max-w-5xl': layout === 'narrow',
         [className]: !!className,
       }),

--- a/frontend/containers/layouts/logo/component.tsx
+++ b/frontend/containers/layouts/logo/component.tsx
@@ -10,7 +10,7 @@ const Logo = () => {
   const { isScrolledY } = useScrollY();
   return (
     <Link href={Paths.Home}>
-      <a className="font-semibold">
+      <a className="text-sm font-semibold xl:text-base">
         HeCo Invest
         <span
           className={cx('text-sm ml-1 px-1 py-0.5 rounded-[4px]', {

--- a/frontend/containers/layouts/navigation/component.tsx
+++ b/frontend/containers/layouts/navigation/component.tsx
@@ -15,7 +15,7 @@ export const Navigation: FC<NavigationProps> = ({ className }: NavigationProps) 
 
   return (
     <div className={className}>
-      <nav className="flex space-x-8">
+      <nav className="flex space-x-8 text-sm xl:text-base">
         <ActiveLink href={Paths.Discover} activeClassName="font-semibold">
           <a title={intl.formatMessage({ defaultMessage: 'Search', id: 'xmcVZ0' })}>
             <Icon icon={SearchIcon} />

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -16,9 +16,9 @@ module.exports = {
       xl: ['1.3rem', '2rem'],
       '2xl': ['2rem', '2.5rem'],
       '3xl': ['2.5rem', '3rem'],
-      '4xl': ['3.5rem', '4rem'],
+      '4xl': ['3rem', '3.5rem'],
       '5xl': ['4rem', '5rem'],
-      '6xl': ['5.5rem', '6.5rem'],
+      '6xl': ['5rem', '6rem'],
     },
     colors: {
       transparent: 'transparent',


### PR DESCRIPTION
This PR makes the following adjustments:

- Reduce the font size of the 6xl and 4xl texts
- Reduce the font size of the header up until the xl breakpoint (1280px)
- Adjust the size of the layout container:
  - For screens between 768px-1024px and 1024px-1280px, the container size is not fixed anymore (responsive)
  - For screens wider than 1536px, limit the container size to 1280px (this essentially blocks the size from the xl breakpoint)   

## Testing instructions

To test locally the application in another language, follow these steps:
1. Run `curl -o- https://raw.githubusercontent.com/transifex/cli/v1.0.3/install.sh | bash`
2. Run `TX_TOKEN=TRANSIFEX_TOKEN ./tx pull -f` where `TRANSIFEX_TOKEN` is the value found on LastPass in the “Heco TF vars” note
3. Run `yarn i18n:compile`
4. Start the local server

## Tracking

[LET-964](https://vizzuality.atlassian.net/browse/LET-964)
