### PR TITLE
feat: Memoize filters/sorting/pagination at backoffice

### DIFF
--- a/backend/app/controllers/backoffice/base_controller.rb
+++ b/backend/app/controllers/backoffice/base_controller.rb
@@ -3,6 +3,7 @@ module Backoffice
     include Pagy::Backend
     include Breadcrumbs
     include Localization
+    include FilterMemoization
 
     layout "backoffice"
 

--- a/backend/app/controllers/concerns/backoffice/filter_memoization.rb
+++ b/backend/app/controllers/concerns/backoffice/filter_memoization.rb
@@ -1,0 +1,22 @@
+module Backoffice
+  module FilterMemoization
+    def self.included(base)
+      base.before_action :save_filters, only: :index
+      base.before_action :load_filters, only: :index
+    end
+
+    private
+
+    def save_filters
+      session[:table_filters] ||= {}
+      session[:table_filters][controller_name] ||= {}
+      session[:table_filters][controller_name]["page"] = params[:page] == "" ? nil : params[:page] unless params[:page].nil?
+      session[:table_filters][controller_name]["q"] = params[:q] == "" ? nil : params[:q].to_unsafe_h unless params[:q].nil?
+    end
+
+    def load_filters
+      params[:page] = session[:table_filters][controller_name]["page"]
+      params[:q] = session[:table_filters][controller_name]["q"]
+    end
+  end
+end

--- a/backend/app/views/backoffice/base/_filters.html.erb
+++ b/backend/app/views/backoffice/base/_filters.html.erb
@@ -3,7 +3,7 @@
     <%= yield(f) if yield(f).present? %>
     <div class="inline-flex gap-2">
       <%= f.button :submit, value: I18n.t("backoffice.common.apply"), class: "button button-primary-green" %>
-      <%= link_to I18n.t("backoffice.common.reset"), url_for(only_path: false), class: "button button-secondary-green" %>
+      <%= link_to I18n.t("backoffice.common.reset"), url_for(page: "", q: "", only_path: false), class: "button button-secondary-green" %>
     </div>
   <% end %>
 </div>

--- a/backend/app/views/backoffice/base/_filters.html.erb
+++ b/backend/app/views/backoffice/base/_filters.html.erb
@@ -1,5 +1,6 @@
 <div class="w-full">
   <%= search_form_for [:backoffice, q], builder: SimpleForm::FormBuilder do |f| %>
+    <%= hidden_field_tag :page, "" %>
     <%= yield(f) if yield(f).present? %>
     <div class="inline-flex gap-2">
       <%= f.button :submit, value: I18n.t("backoffice.common.apply"), class: "button button-primary-green" %>

--- a/backend/app/views/backoffice/base/_navigation.html.erb
+++ b/backend/app/views/backoffice/base/_navigation.html.erb
@@ -1,8 +1,8 @@
 <nav class="flex gap-4.5 py-3">
-  <%= nav_link_to t("backoffice.layout.projects"), backoffice_projects_path %>
-  <%= nav_link_to t("backoffice.layout.open_calls"), backoffice_open_calls_path %>
-  <%= nav_link_to t("backoffice.layout.investors"), backoffice_investors_path %>
-  <%= nav_link_to t("backoffice.layout.project_developers"), backoffice_project_developers_path %>
-  <%= nav_link_to t("backoffice.layout.users"), backoffice_users_path %>
-  <%= nav_link_to t("backoffice.layout.admins"), backoffice_admins_url %>
+  <%= nav_link_to t("backoffice.layout.projects"), backoffice_projects_path(page: "", q: "") %>
+  <%= nav_link_to t("backoffice.layout.open_calls"), backoffice_open_calls_path(page: "", q: "") %>
+  <%= nav_link_to t("backoffice.layout.investors"), backoffice_investors_path(page: "", q: "") %>
+  <%= nav_link_to t("backoffice.layout.project_developers"), backoffice_project_developers_path(page: "", q: "") %>
+  <%= nav_link_to t("backoffice.layout.users"), backoffice_users_path(page: "", q: "") %>
+  <%= nav_link_to t("backoffice.layout.admins"), backoffice_admins_url(page: "", q: "") %>
 </nav>

--- a/backend/spec/system/backoffice/filter_memoization_spec.rb
+++ b/backend/spec/system/backoffice/filter_memoization_spec.rb
@@ -1,0 +1,34 @@
+require "system_helper"
+
+RSpec.describe "Backoffice: Localization", type: :system do
+  let_it_be(:admin) { create(:admin, email: "admin@example.com", password: "SuperSecret6", first_name: "Admin", last_name: "Example", ui_language: "en") }
+
+  let!(:investor) { create :investor }
+  let!(:extra_investors) { create_list :investor, 20 }
+
+  before do
+    sign_in admin
+    visit "/backoffice/investors"
+  end
+
+  it "keeps ransacker option" do
+    expect(page).to have_css "table.backoffice-table tbody tr", count: 10
+    fill_in :q_filter_full_text, with: investor.name
+    find("form.investor_search button").click
+    expect(page).to have_css "table.backoffice-table tbody tr", count: 1
+    expect(page).to have_text(investor.name)
+
+    visit "/backoffice/investors"
+    expect(page).to have_css "table.backoffice-table tbody tr", count: 1
+    expect(page).to have_text(investor.name)
+  end
+
+  it "keeps page option" do
+    expect(page).to have_css "nav.pagination li span.active", text: "1"
+    all("nav.pagination a[rel='next']").first.click
+    expect(page).to have_css "nav.pagination li span.active", text: "2"
+
+    visit "/backoffice/investors"
+    expect(page).to have_css "nav.pagination li span.active", text: "2"
+  end
+end


### PR DESCRIPTION
Task was about maintaining sorting during opening/editing, but basically same problem happens during canceling, deletion of records, etc. At beginning, I have started to put to every influenced link or form `q` param so this gets remembered, but it got quickly out of hand --> there is just too many places where this param needs to be added and  it is so easy to forget to add it to every new piece of code. In the end, I have decided to use `session` which keeps saved used filters and last page of table per every controller. Until you reset filters manually (or you logout --> login again) `q` and `page` params are kept at session and pull out from there everytime when you open some Backoffice table.

## Testing instructions

Open backoffice and verify that sorting/pagination/filters are remembered between jumps to edit forms.

## Tracking

https://vizzuality.atlassian.net/browse/LET-955
