### PR TITLE
refactoring: Message of OpenCallApplication is no more translated

### DIFF
--- a/backend/app/controllers/api/v1/accounts/open_call_applications_controller.rb
+++ b/backend/app/controllers/api/v1/accounts/open_call_applications_controller.rb
@@ -2,7 +2,6 @@ module API
   module V1
     module Accounts
       class OpenCallApplicationsController < BaseController
-        around_action(only: %i[create update]) { |_, action| set_locale(language: current_user&.account&.language, &action) }
         load_and_authorize_resource
 
         def index
@@ -69,13 +68,7 @@ module API
         private
 
         def create_params
-          params.permit(
-            :open_call_id,
-            :project_id,
-            :message
-          ).merge(
-            language: current_user.account&.language
-          )
+          params.permit :open_call_id, :project_id, :message
         end
 
         def update_params

--- a/backend/app/models/open_call_application.rb
+++ b/backend/app/models/open_call_application.rb
@@ -2,10 +2,6 @@ class OpenCallApplication < ApplicationRecord
   belongs_to :open_call, counter_cache: true
   belongs_to :project
 
-  translates :message
-
-  validates :language, inclusion: {in: Language::TYPES, allow_blank: true}, presence: true
-
   validates_presence_of :message
 
   validates :funded, inclusion: [true, false]

--- a/backend/db/migrate/20220909092937_remove_translated_message_from_open_call_applications.rb
+++ b/backend/db/migrate/20220909092937_remove_translated_message_from_open_call_applications.rb
@@ -1,0 +1,15 @@
+class RemoveTranslatedMessageFromOpenCallApplications < ActiveRecord::Migration[7.0]
+  def change
+    add_column :open_call_applications, :message, :text
+    migrate_translated_messages!
+    remove_columns :open_call_applications, :message_en, :message_es, :message_pt, :language
+  end
+
+  private
+
+  def migrate_translated_messages!
+    OpenCallApplication.all.each do |application|
+      application.update! message: application.public_send("message_#{application.language}")
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_06_084050) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_09_092937) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -213,13 +213,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_06_084050) do
   create_table "open_call_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "open_call_id", null: false
     t.uuid "project_id", null: false
-    t.text "message_en"
-    t.text "message_es"
-    t.text "message_pt"
-    t.string "language", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "funded", default: false, null: false
+    t.text "message"
     t.index ["open_call_id", "project_id"], name: "open_call_applications_open_call_id_on_project_id", unique: true
     t.index ["open_call_id"], name: "index_open_call_applications_on_open_call_id"
     t.index ["project_id"], name: "index_open_call_applications_on_project_id"
@@ -369,6 +366,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_06_084050) do
     t.text "relevant_links_pt"
     t.string "category", null: false
     t.jsonb "geometry", default: {}
+    t.geometry "centroid", limit: {:srid=>0, :type=>"st_point"}
     t.decimal "municipality_biodiversity_impact", precision: 25, scale: 20
     t.decimal "municipality_climate_impact", precision: 25, scale: 20
     t.decimal "municipality_water_impact", precision: 25, scale: 20
@@ -384,7 +382,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_06_084050) do
     t.decimal "priority_landscape_water_impact", precision: 25, scale: 20
     t.decimal "priority_landscape_community_impact", precision: 25, scale: 20
     t.decimal "priority_landscape_total_impact", precision: 25, scale: 20
-    t.geometry "centroid", limit: {:srid=>0, :type=>"st_point"}
     t.uuid "priority_landscape_id"
     t.boolean "impact_calculated", default: false
     t.index ["country_id"], name: "index_projects_on_country_id"

--- a/backend/spec/factories/open_call_applications.rb
+++ b/backend/spec/factories/open_call_applications.rb
@@ -7,7 +7,5 @@ FactoryBot.define do
       Faker::Config.random = Random.new(n)
       Faker::Lorem.paragraph(sentence_count: 4)
     end
-
-    language { "en" }
   end
 end

--- a/backend/spec/fixtures/snapshots/api/v1/account/open-call-applications-create.json
+++ b/backend/spec/fixtures/snapshots/api/v1/account/open-call-applications-create.json
@@ -156,13 +156,13 @@
       "attributes": {
         "name": "Kutch-Spencer",
         "slug": "kutch-spencer",
-        "about": null,
+        "about": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
         "website": "https://kutch-spencer.com",
         "instagram": "https://instagram.com/kutch-spencer",
         "facebook": "https://facebook.com/kutch-spencer",
         "linkedin": "https://linkedin.com/kutch-spencer",
         "twitter": "https://twitter.com/kutch-spencer",
-        "mission": null,
+        "mission": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
         "project_developer_type": "ngo",
         "categories": [
           "forestry-and-agroforestry",

--- a/backend/spec/models/open_call_application_spec.rb
+++ b/backend/spec/models/open_call_application_spec.rb
@@ -20,16 +20,6 @@ RSpec.describe OpenCallApplication, type: :model do
     expect(subject).to have(1).errors_on(:message)
   end
 
-  it "should not be valid with wrong language" do
-    subject.language = "fr"
-    expect(subject).to have(1).errors_on(:language)
-  end
-
-  it "should not be valid without language" do
-    subject.language = nil
-    expect(subject).to have(1).errors_on(:language)
-  end
-
   it "should not be valid when application already exists" do
     application = create :open_call_application
     subject.assign_attributes application.attributes

--- a/backend/spec/requests/api/v1/accounts/open_call_applications_spec.rb
+++ b/backend/spec/requests/api/v1/accounts/open_call_applications_spec.rb
@@ -204,14 +204,6 @@ RSpec.describe "API V1 Account Open Call Applications", type: :request do
           }.to change(OpenCallApplication, :count).by(1)
           expect(response.body).to match_snapshot("api/v1/account/open-call-applications-create")
         end
-
-        it "saves data to account language attributes" do |example|
-          submit_request example.metadata
-          open_call = OpenCallApplication.find response_json["data"]["id"]
-          OpenCallApplication.translatable_attributes.each do |attr|
-            expect(open_call.public_send("#{attr}_#{user.account.language}")).to eq(open_call_application_params[attr])
-          end
-        end
       end
 
       response "403", :forbidden do
@@ -361,13 +353,6 @@ RSpec.describe "API V1 Account Open Call Applications", type: :request do
 
         it "matches snapshot", generate_swagger_example: true do
           expect(response.body).to match_snapshot("api/v1/account/open-call-applications-update")
-        end
-
-        it "saves data to account language attributes" do
-          open_call_application.reload
-          OpenCallApplication.translatable_attributes.each do |attr|
-            expect(open_call_application.public_send("#{attr}_#{user.account.language}")).to eq(open_call_application_params[attr])
-          end
         end
       end
 


### PR DESCRIPTION
Name of the PR is pretty self-explanatory. This PR removes translation from `message` attribute of open call application model.

## Testing instructions

I think it should be enough to test via rswag that new open call application can be still created.

## Tracking

https://vizzuality.atlassian.net/browse/LET-1065
