### PR TITLE
feat: Backoffice allows to verify/unverify/delete Project from menu

### DIFF
--- a/backend/app/views/backoffice/projects/index.html.erb
+++ b/backend/app/views/backoffice/projects/index.html.erb
@@ -23,6 +23,9 @@
       </th>
       <th>
       </th>
+      <th class="opacity-25">
+        <%= svg "menu" %>
+      </th>
     </tr>
   </thead>
   <tbody>
@@ -37,6 +40,27 @@
           <%= status_tag :unverified, t('backoffice.common.unverified') unless p.verified?  %>
         </td>
         <td><%= link_to t("backoffice.common.edit"), edit_backoffice_project_path(p.id), class: "link-button" %></td>
+        <td>
+          <%= render "menu" do %>
+            <% if p.verified? %>
+              <%= render "backoffice/base/menu/item" do %>
+                <%= button_to t("backoffice.common.unverify"), unverify_backoffice_project_path(p.id), method: :post %>
+              <% end %>
+            <% end %>
+            <% unless p.verified? %>
+              <%= render "backoffice/base/menu/item" do %>
+                <%= button_to t("backoffice.common.verify"), verify_backoffice_project_path(p.id), method: :post %>
+              <% end %>
+            <% end %>
+            <%= render "backoffice/base/menu/item" do %>
+              <%= link_to t("backoffice.common.delete"), backoffice_project_path(p.id),
+                 data: {
+                   turbo_method: :delete,
+                   turbo_confirm: t("backoffice.messages.delete_confirmation", model: t("backoffice.common.project").downcase)
+                 } %>
+            <% end %>
+          <% end %>
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/backend/config/routes/backoffice.rb
+++ b/backend/config/routes/backoffice.rb
@@ -18,7 +18,12 @@ namespace :backoffice do
   end
   resources :investors, only: [:index, :edit, :update, :destroy]
   resources :project_developers, only: [:index, :edit, :update, :destroy]
-  resources :projects, only: [:index, :edit, :update, :destroy]
+  resources :projects, only: [:index, :edit, :update, :destroy] do
+    member do
+      post :verify
+      post :unverify
+    end
+  end
   resources :open_calls, only: [:index, :edit, :update, :destroy] do
     member do
       post :verify

--- a/backend/spec/system/backoffice/projects_spec.rb
+++ b/backend/spec/system/backoffice/projects_spec.rb
@@ -96,6 +96,47 @@ RSpec.describe "Backoffice: Projects", type: :system do
         end
       end
     end
+
+    context "when deleting project via menu" do
+      it "deletes project" do
+        within_row(project.name) do
+          find("button.rounded-full").click
+          expect {
+            accept_confirm do
+              click_on t("backoffice.common.delete")
+            end
+          }.to have_enqueued_mail(ProjectDeveloperMailer, :project_destroyed).with(project.project_developer, project.name)
+            .and have_enqueued_mail(ProjectDeveloperMailer, :project_destroyed).with(project.involved_project_developers.first, project.name)
+            .and have_enqueued_mail(InvestorMailer, :project_destroyed).with(open_call_application.investor, project.name, open_call_application.open_call)
+        end
+        expect(page).not_to have_text(project.name)
+      end
+    end
+
+    context "when unverifying project via menu" do
+      it "unverifies project" do
+        within_row(project.name) do
+          find("button.rounded-full").click
+          click_on t("backoffice.common.unverify")
+          expect(page).to have_text(I18n.t("backoffice.common.unverified"))
+        end
+      end
+    end
+
+    context "when verifying project via menu" do
+      before do
+        project.update! verified: false
+        visit "/backoffice/projects"
+      end
+
+      it "verifies project" do
+        within_row(project.name) do
+          find("button.rounded-full").click
+          click_on t("backoffice.common.verify")
+          expect(page).to have_text(I18n.t("backoffice.common.verified"))
+        end
+      end
+    end
   end
 
   describe "Edit" do


### PR DESCRIPTION
Adding small menu to every Project at backoffice which allows to:
 - verify project
 - unverify project
 - delete project

## Testing instructions

Open backoffice and try to verify/unverify/delete project from menu.

## Tracking

https://vizzuality.atlassian.net/browse/LET-1010
https://vizzuality.atlassian.net/browse/LET-1011
