### PR TITLE
Fix overflow issues with the menus inside the tables

### DIFF
--- a/frontend/components/menu/component.stories.tsx
+++ b/frontend/components/menu/component.stories.tsx
@@ -13,7 +13,7 @@ export default {
 } as Meta;
 
 const Template: Story<MenuProps> = (props: MenuProps) => (
-  <div className="px-4 pt-4 pb-52">
+  <div className="px-4 pt-32 pb-52">
     <Menu {...props}>
       <MenuItem key="copy">Copy</MenuItem>
       <MenuItem key="cut">Cut</MenuItem>
@@ -36,7 +36,7 @@ Default.args = {
 };
 
 const TemplateWithHiddenSections: Story<MenuProps> = (props: MenuProps) => (
-  <div className="px-4 pt-4 pb-52">
+  <div className="px-4 pt-32 pb-52">
     <Menu {...props}>
       <MenuItem key="copy">Copy</MenuItem>
       <MenuItem key="cut">Cut</MenuItem>
@@ -61,7 +61,7 @@ WithHiddenSections.args = {
 };
 
 const TemplateWithHeader: Story<MenuProps> = (props: MenuProps) => (
-  <div className="px-4 pt-4 pb-52">
+  <div className="px-4 pt-56 pb-52">
     <Menu {...props}>
       <MenuItem key="copy">Copy</MenuItem>
       <MenuItem key="cut">Cut</MenuItem>

--- a/frontend/components/menu/component.tsx
+++ b/frontend/components/menu/component.tsx
@@ -1,5 +1,7 @@
 import React, { cloneElement, useEffect } from 'react';
 
+import { OverlayContainer, useOverlayPosition } from 'react-aria';
+
 import cx from 'classnames';
 
 import { useButton } from '@react-aria/button';
@@ -24,6 +26,7 @@ export const Menu: React.FC<MenuProps> = ({
   ...rest
 }: MenuProps) => {
   const triggerRef = React.useRef(null);
+  const overlayRef = React.useRef(null);
 
   const state = useMenuTriggerState(rest);
   const { menuTriggerProps, menuProps } = useMenuTrigger({}, state, triggerRef);
@@ -34,6 +37,17 @@ export const Menu: React.FC<MenuProps> = ({
     },
     triggerRef
   );
+
+  const align = rest.align ?? 'start';
+  const direction = rest.direction ?? 'bottom';
+
+  let { overlayProps: positionProps } = useOverlayPosition({
+    targetRef: triggerRef,
+    overlayRef,
+    placement: `${direction} ${align}`,
+    offset: 8,
+    isOpen: state.isOpen,
+  });
 
   useEffect(() => {
     if (state.isOpen) {
@@ -47,22 +61,24 @@ export const Menu: React.FC<MenuProps> = ({
     <div className={cx('relative', className)}>
       {cloneElement(Trigger, { ref: triggerRef, ...buttonProps })}
       {state.isOpen && (
-        <Popup
-          triggerRef={triggerRef}
-          align={rest.align ?? 'start'}
-          direction={rest.direction ?? 'bottom'}
-          domProps={menuProps}
-          // eslint-disable-next-line jsx-a11y/no-autofocus
-          autoFocus={state.focusStrategy}
-          disabledKeys={disabledKeys}
-          expandedKeys={expandedKeys}
-          onClose={() => state.close()}
-          onAction={onAction}
-          header={header}
-          hiddenSections={hiddenSections}
-        >
-          {children}
-        </Popup>
+        <OverlayContainer>
+          <Popup
+            {...positionProps}
+            overlayRef={overlayRef}
+            triggerRef={triggerRef}
+            domProps={menuProps}
+            // eslint-disable-next-line jsx-a11y/no-autofocus
+            autoFocus={state.focusStrategy}
+            disabledKeys={disabledKeys}
+            expandedKeys={expandedKeys}
+            onClose={() => state.close()}
+            onAction={onAction}
+            header={header}
+            hiddenSections={hiddenSections}
+          >
+            {children}
+          </Popup>
+        </OverlayContainer>
       )}
     </div>
   );

--- a/frontend/components/menu/popup/component.tsx
+++ b/frontend/components/menu/popup/component.tsx
@@ -15,8 +15,7 @@ import { PopupProps } from './types';
 
 export const Popup: React.FC<PopupProps> = ({
   triggerRef,
-  align,
-  direction,
+  overlayRef,
   autoFocus,
   domProps,
   children,
@@ -26,9 +25,9 @@ export const Popup: React.FC<PopupProps> = ({
   onAction,
   header,
   hiddenSections = {},
+  ...otherProps
 }: PopupProps) => {
   const ref = React.useRef(null);
-  const overlayRef = React.useRef(null);
 
   const state = useTreeState({ children, selectionMode: 'none', disabledKeys, expandedKeys });
   const { menuProps } = useMenu({ autoFocus, children }, state, ref);
@@ -55,16 +54,12 @@ export const Popup: React.FC<PopupProps> = ({
 
   return (
     <FocusScope restoreFocus>
-      <div {...overlayProps} ref={overlayRef}>
+      <div {...mergeProps(overlayProps, otherProps)} ref={overlayRef} className="!z-30">
         <DismissButton onDismiss={onClose} />
         <div
           {...mergeProps(menuProps, domProps)}
           ref={ref}
-          className={cx(
-            'z-30 absolute transform whitespace-nowrap bg-white shadow-2xl rounded-md overflow-hidden',
-            align === 'start' ? 'left-0' : 'right-0',
-            direction === 'top' ? '-top-2 -translate-y-full' : '-bottom-2 translate-y-full'
-          )}
+          className="overflow-hidden bg-white rounded-md shadow-2xl whitespace-nowrap"
         >
           {header && (
             <div id="popup-header" className="p-4 pb-0">

--- a/frontend/components/menu/popup/types.ts
+++ b/frontend/components/menu/popup/types.ts
@@ -9,10 +9,8 @@ import { SectionProps } from '../section';
 export interface PopupProps {
   /** Reference to the popup's trigger element */
   triggerRef: React.MutableRefObject<HTMLElement>;
-  /** Horizontal alignment of the popup relative to the trigger */
-  align: Alignment;
-  /** Vertical alignment of the popup relative to the trigger */
-  direction: MenuTriggerProps['direction'];
+  /** Reference to the popup's overlay element */
+  overlayRef: React.MutableRefObject<HTMLDivElement>;
   /** Props for the popup's container */
   domProps: HTMLAttributes<HTMLElement>;
   /** Focus strategy applied to the popup's items */

--- a/frontend/components/menu/types.ts
+++ b/frontend/components/menu/types.ts
@@ -3,9 +3,8 @@ import React from 'react';
 import { MenuTriggerProps } from '@react-types/menu';
 
 import { PopupProps } from './popup';
-import { SectionProps } from './section';
 
-export type MenuProps = MenuTriggerProps & {
+export type MenuProps = Omit<MenuTriggerProps, 'direction'> & {
   /** Classes to apply to the menu */
   className?: string;
   /** Trigger button for the menu */
@@ -16,6 +15,8 @@ export type MenuProps = MenuTriggerProps & {
   disabledKeys?: React.Key[];
   /** List of the keys of the items that are expanded */
   expandedKeys?: React.Key[];
+  /** Where the Menu opens relative to its trigger. Defaults to `'bottom'`. */
+  direction?: 'top' | 'bottom';
   /** Callback executed when the user clicks on a menu's item */
   onAction: PopupProps['onAction'];
   /** Header displayed at the top of the menu */

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -1701,6 +1701,9 @@
   "XOLAV7": {
     "string": "Withdraw from the open call?"
   },
+  "XPruqs": {
+    "string": "Order"
+  },
   "XQuzr9": {
     "string": "Identified priorities by the HeCo program"
   },
@@ -1856,6 +1859,9 @@
   },
   "agJGNx": {
     "string": "How much funding do you have available for this open call? ($)"
+  },
+  "aleGqT": {
+    "string": "Descending"
   },
   "apgkuO": {
     "string": "More about ARIES"
@@ -2798,6 +2804,9 @@
   },
   "u2WlCd": {
     "string": "Pollutants reduction"
+  },
+  "u7djqV": {
+    "string": "Ascending"
   },
   "u87XOB": {
     "string": "How your project will grow"


### PR DESCRIPTION
This PR fixes issues where the menus shown in the tables may not be fully visible because of the overflow applied to the tables.

To address this, all the menus are now rendered inside portals.

## Testing instructions

- The menus are not cut inside the tables (you can check the tooltip of the last row)
- All the application's menus are still positioned correctly related to their trigger

## Tracking

[LET-1079](https://vizzuality.atlassian.net/browse/LET-1079)
