### PR TITLE
refactoring: Show draft projects at backoffice

### DIFF
--- a/backend/app/controllers/backoffice/projects_controller.rb
+++ b/backend/app/controllers/backoffice/projects_controller.rb
@@ -9,7 +9,7 @@ module Backoffice
     before_action :set_content_language_default, only: [:edit, :update]
 
     def index
-      @q = Project.published.ransack params[:q]
+      @q = Project.ransack params[:q]
       @projects = API::Filterer.new(@q.result, {full_text: params.dig(:q, :filter_full_text)}).call
       @projects = @projects.includes(:priority_landscape, project_developer: [:account])
 

--- a/backend/spec/system/backoffice/projects_spec.rb
+++ b/backend/spec/system/backoffice/projects_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Backoffice: Projects", type: :system do
   describe "Index" do
     before { visit "/backoffice/projects" }
 
-    it_behaves_like "with table pagination", expected_total: 5
+    it_behaves_like "with table pagination", expected_total: 6
     it_behaves_like "with table sorting", columns: [
       I18n.t("backoffice.common.project_name"),
       I18n.t("backoffice.common.project_developer"),
@@ -34,7 +34,7 @@ RSpec.describe "Backoffice: Projects", type: :system do
     it_behaves_like "with csv export", file_name: "projects.csv"
 
     it "shows projects list" do
-      expect(page).to have_xpath(".//tbody/tr", count: 5)
+      expect(page).to have_xpath(".//tbody/tr", count: 6)
       within_row("Project ultra name") do
         expect(page).to have_text("Ultra project developer name")
         expect(page).to have_text(Category.find(project.category).name)
@@ -43,8 +43,8 @@ RSpec.describe "Backoffice: Projects", type: :system do
       end
     end
 
-    it "ignores draft project" do
-      expect(page).not_to have_text(draft_project.name)
+    it "shows draft project" do
+      expect(page).to have_text(draft_project.name)
     end
 
     context "when searching" do


### PR DESCRIPTION
Small tweak of backoffice which makes draft projects visible there.

## Testing instructions

Make sure that draft project is visible at backoffice

## Tracking

https://vizzuality.atlassian.net/browse/LET-1032
