### PR TITLE
Better show the position and geometry of a project on its public page

### DIFF
--- a/frontend/components/map/layers/cluster/component.tsx
+++ b/frontend/components/map/layers/cluster/component.tsx
@@ -34,7 +34,13 @@ export const ClusterLayer: FC<ClusterLayerProps> = ({
 
         if (cluster) {
           return (
-            <Marker key={id} latitude={latitude} longitude={longitude}>
+            <Marker
+              key={id}
+              latitude={latitude}
+              longitude={longitude}
+              offsetLeft={-20}
+              offsetTop={-20}
+            >
               {cloneElement(ClusterComponent, {
                 ...properties,
                 superclusterInstance: SUPERCLUSTER,
@@ -48,6 +54,8 @@ export const ClusterLayer: FC<ClusterLayerProps> = ({
             key={id}
             latitude={latitude}
             longitude={longitude}
+            offsetLeft={-10}
+            offsetTop={-23}
             onClick={() => onSelectProjectPin(`${id}`)}
           >
             {cloneElement(MarkerComponent, properties)}

--- a/frontend/components/map/layers/cluster/component.tsx
+++ b/frontend/components/map/layers/cluster/component.tsx
@@ -1,4 +1,4 @@
-import { cloneElement, FC, useMemo } from 'react';
+import { FC, useMemo } from 'react';
 
 import { Marker } from 'react-map-gl';
 
@@ -41,10 +41,7 @@ export const ClusterLayer: FC<ClusterLayerProps> = ({
               offsetLeft={-20}
               offsetTop={-20}
             >
-              {cloneElement(ClusterComponent, {
-                ...properties,
-                superclusterInstance: SUPERCLUSTER,
-              })}
+              <ClusterComponent {...properties} superclusterInstance={SUPERCLUSTER} />
             </Marker>
           );
         }
@@ -58,7 +55,7 @@ export const ClusterLayer: FC<ClusterLayerProps> = ({
             offsetTop={-23}
             onClick={() => onSelectProjectPin(`${id}`)}
           >
-            {cloneElement(MarkerComponent, properties)}
+            <MarkerComponent {...properties} />
           </Marker>
         );
       })}

--- a/frontend/components/map/layers/cluster/types.ts
+++ b/frontend/components/map/layers/cluster/types.ts
@@ -1,9 +1,11 @@
+import React from 'react';
+
 import { ProjectsMapGeojson } from 'types/project';
 
 export type ClusterLayerProps = {
   data: ProjectsMapGeojson;
   map: any; // TODO: change type
-  MarkerComponent: JSX.Element;
-  ClusterComponent: JSX.Element;
+  MarkerComponent: React.FC<any>;
+  ClusterComponent: React.FC<any>;
   onSelectProjectPin: (projectId: string) => void;
 };

--- a/frontend/components/project-map-pin/component.tsx
+++ b/frontend/components/project-map-pin/component.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, Fragment } from 'react';
 
 import { FormattedMessage } from 'react-intl';
 
@@ -11,20 +11,29 @@ import MapPinIcon from 'svgs/project/marker.svg';
 // VERIFICATION PROJECTS: HIDDEN
 // import TrustedMapPinIcon from 'svgs/project/trusted-marker.svg';
 
-import { MapPinProps } from './types';
+import { ProjectMapPinProps } from './types';
 
-export const MapPin: FC<MapPinProps> = (props) => {
-  const { category, trusted } = props;
+export const ProjectMapPin: FC<ProjectMapPinProps> = ({ category, interactive = true }) => {
+  const Container = ({ children }) =>
+    interactive ? (
+      <Button theme="naked" size="smallest" className="focus-visible:outline-green-dark">
+        {children}
+      </Button>
+    ) : (
+      <Fragment>{children}</Fragment>
+    );
 
   return (
-    <Button theme="naked" size="smallest" className="focus-visible:outline-green-dark">
-      <span className="sr-only">
-        {/* VERIFICATION PROJECTS: HIDDEN
+    <Container>
+      {interactive && (
+        <span className="sr-only">
+          {/* VERIFICATION PROJECTS: HIDDEN
         {trusted && <FormattedMessage defaultMessage="Open verified project" id="9fHGyd" />}
         {!trusted && <FormattedMessage defaultMessage="Open project" id="fUM67k" />}
         */}
-        <FormattedMessage defaultMessage="Open project" id="fUM67k" />
-      </span>
+          <FormattedMessage defaultMessage="Open project" id="fUM67k" />
+        </span>
+      )}
       <Icon
         // VERIFICATION PROJECTS: HIDDEN
         // icon={trusted ? TrustedMapPinIcon : MapPinIcon}
@@ -39,8 +48,8 @@ export const MapPin: FC<MapPinProps> = (props) => {
           'fill-category-human text-category-human': category === 'human-capital-and-inclusion',
         })}
       />
-    </Button>
+    </Container>
   );
 };
 
-export default MapPin;
+export default ProjectMapPin;

--- a/frontend/components/project-map-pin/index.ts
+++ b/frontend/components/project-map-pin/index.ts
@@ -1,0 +1,2 @@
+export type { ProjectMapPinProps } from './types';
+export { default } from './component';

--- a/frontend/components/project-map-pin/types.ts
+++ b/frontend/components/project-map-pin/types.ts
@@ -1,0 +1,9 @@
+export interface ProjectMapPinProps {
+  /** Category of the project */
+  category: string;
+  // VERIFICATION PROJECTS: HIDDEN
+  // /** Whether the project is verified */
+  // trusted: boolean;
+  /** Whether the marker can be interacted with. Default to `true`. */
+  interactive?: boolean;
+}

--- a/frontend/containers/discover-map/component.tsx
+++ b/frontend/containers/discover-map/component.tsx
@@ -14,13 +14,13 @@ import Map from 'components/map';
 import Controls from 'components/map/controls';
 import ClusterLayer from 'components/map/layers/cluster';
 import ProjectLegend from 'components/map/project-legend';
+import ProjectMapPin from 'components/project-map-pin';
 import { ProjectMapParams } from 'types/project';
 
 import { useProjectsMap } from 'services/projects/projectService';
 
 import LocationSearcher from './location-searcher';
 import MapLayersSelector from './map-layers-selector';
-import MapPin from './pin';
 import MapPinCluster from './pin-cluster';
 import { DiscoverMapProps } from './types';
 
@@ -72,8 +72,8 @@ export const DiscoverMap: FC<DiscoverMapProps> = ({ onSelectProjectPin }) => {
               <ClusterLayer
                 data={projectsMap}
                 map={map}
-                MarkerComponent={<MapPin />}
-                ClusterComponent={<MapPinCluster />}
+                MarkerComponent={ProjectMapPin}
+                ClusterComponent={MapPinCluster}
                 onSelectProjectPin={onSelectProjectPin}
               />
             </>

--- a/frontend/containers/discover-map/pin/index.ts
+++ b/frontend/containers/discover-map/pin/index.ts
@@ -1,2 +1,0 @@
-export type { MapPinProps } from './types';
-export { default } from './component';

--- a/frontend/containers/discover-map/pin/types.ts
+++ b/frontend/containers/discover-map/pin/types.ts
@@ -1,4 +1,0 @@
-export interface MapPinProps {
-  category?: string;
-  trusted?: boolean;
-}

--- a/frontend/containers/project-page/overview/component.tsx
+++ b/frontend/containers/project-page/overview/component.tsx
@@ -59,6 +59,12 @@ export const Overview: React.FC<OverviewProps> = ({
               onMapViewportChange={handleViewportChange}
               bounds={zoomedIn ? zoomedInBounds : zoomedOutBounds}
               viewport={viewport}
+              scrollZoom={false}
+              touchZoom={false}
+              touchRotate={false}
+              dragPan={false}
+              dragRotate={false}
+              getCursor={() => 'default'}
             >
               {(map) => (
                 <LayerManager map={map} plugin={PluginMapboxGl}>

--- a/frontend/containers/project-page/overview/component.tsx
+++ b/frontend/containers/project-page/overview/component.tsx
@@ -1,28 +1,48 @@
 import React, { useCallback, useState } from 'react';
 
+import { ZoomIn as ZoomInIcon, ZoomOut as ZoomOutIcon } from 'react-feather';
 import { FormattedMessage } from 'react-intl';
 import { Marker } from 'react-map-gl';
 
+import bbox from '@turf/bbox';
 import PluginMapboxGl from '@vizzuality/layer-manager-plugin-mapboxgl';
 import { LayerManager, Layer } from '@vizzuality/layer-manager-react';
 
 import { OverviewProps } from 'containers/project-page/overview/types';
 
+import Button from 'components/button';
 import LayoutContainer from 'components/layout-container';
 import Map from 'components/map';
 import ProjectMapPin from 'components/project-map-pin';
 
 import { getLayer } from './helpers';
 
-export const Overview: React.FC<OverviewProps> = ({ project }: OverviewProps) => {
-  const { country, municipality, geometry, category, priority_landscape, latitude, longitude } =
-    project;
+export const Overview: React.FC<OverviewProps> = ({
+  project: {
+    country,
+    municipality,
+    geometry,
+    category,
+    priority_landscape,
+    latitude,
+    longitude,
+    problem,
+    solution,
+  },
+}: OverviewProps) => {
   const layer = getLayer(geometry, category);
 
-  const [bounds, setBounds] = useState({
+  const [zoomedOutBounds] = useState({
     bbox: [-81.99, -4.35, -65.69, 12.54],
     options: { padding: 0 },
   });
+
+  const [zoomedInBounds] = useState({
+    bbox: bbox(geometry),
+    options: { padding: 60 },
+  });
+
+  const [zoomedIn, setZoomedIn] = useState(false);
 
   const [viewport, setViewport] = useState({});
 
@@ -34,28 +54,40 @@ export const Overview: React.FC<OverviewProps> = ({ project }: OverviewProps) =>
     <LayoutContainer className="mb-14 lg:mb-20 mt-18 space-y-36">
       <section className="p-4 mt-32 font-serif text-white sm:p-6 lg:mt-48 lg:p-16 bg-green-dark rounded-2xl">
         <div className="relative grid w-full grid-cols-1 gap-12 lg:grid-cols-2">
-          <Map
-            className="absolute z-10 -mb-32 border-8 border-white drop-shadow-xl h-96 -top-28 lg:-top-44 lg:overflow-hidden rounded-xl"
-            onMapViewportChange={handleViewportChange}
-            bounds={bounds}
-            viewport={viewport}
-          >
-            {(map) => (
-              <LayerManager map={map} plugin={PluginMapboxGl}>
-                <Layer {...layer} />
-                {typeof latitude === 'number' && typeof longitude === 'number' && (
-                  <Marker
-                    latitude={latitude}
-                    longitude={longitude}
-                    offsetLeft={-10}
-                    offsetTop={-23}
-                  >
-                    <ProjectMapPin category={category} interactive={false} />
-                  </Marker>
-                )}
-              </LayerManager>
-            )}
-          </Map>
+          <div className="relative z-10 -mb-32 border-8 border-white drop-shadow-xl h-96 -top-28 lg:-top-44 lg:overflow-hidden rounded-xl">
+            <Map
+              onMapViewportChange={handleViewportChange}
+              bounds={zoomedIn ? zoomedInBounds : zoomedOutBounds}
+              viewport={viewport}
+            >
+              {(map) => (
+                <LayerManager map={map} plugin={PluginMapboxGl}>
+                  <Layer {...layer} />
+                  {typeof latitude === 'number' && typeof longitude === 'number' && (
+                    <Marker
+                      latitude={latitude}
+                      longitude={longitude}
+                      offsetLeft={-10}
+                      offsetTop={-23}
+                    >
+                      <ProjectMapPin category={category} interactive={false} />
+                    </Marker>
+                  )}
+                </LayerManager>
+              )}
+            </Map>
+            <Button
+              theme="naked"
+              size="smallest"
+              className="absolute gap-2.5 px-2 py-1 text-sm text-gray-800 -translate-x-1/2 bg-white border-white rounded shadow-sm outline-none border-xl hover:ring-green-dark hover:ring-1 hover:text-green-dark focus-visible:ring-green-dark focus-visible:ring-2 bottom-1 left-1/2"
+              onClick={() => setZoomedIn((v) => !v)}
+            >
+              {!zoomedIn && <ZoomInIcon className="w-4 h-4" />}
+              {zoomedIn && <ZoomOutIcon className="w-4 h-4" />}
+              {!zoomedIn && <FormattedMessage defaultMessage="Zoom in" id="xbi38c" />}
+              {zoomedIn && <FormattedMessage defaultMessage="Zoom out" id="/UnJ3S" />}
+            </Button>
+          </div>
           <div className="flex flex-col space-y-4 lg:col-start-2">
             <h2 className="text-2xl lg:text-3xl">
               <FormattedMessage defaultMessage="Location" id="rvirM2" />
@@ -88,13 +120,13 @@ export const Overview: React.FC<OverviewProps> = ({ project }: OverviewProps) =>
             <h2 className="text-2xl lg:text-3xl">
               <FormattedMessage defaultMessage="The problem we are solving" id="MXykbb" />
             </h2>
-            <p className="font-sans text-base">{project.problem}</p>
+            <p className="font-sans text-base">{problem}</p>
           </div>
           <div className="flex flex-col space-y-4">
             <h2 className="text-2xl lg:text-3xl">
               <FormattedMessage defaultMessage="The solution proposed" id="9CDBQg" />
             </h2>
-            <p className="font-sans text-base">{project.solution}</p>
+            <p className="font-sans text-base">{solution}</p>
           </div>
         </div>
       </section>

--- a/frontend/containers/project-page/overview/component.tsx
+++ b/frontend/containers/project-page/overview/component.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useState } from 'react';
 
 import { FormattedMessage } from 'react-intl';
+import { Marker } from 'react-map-gl';
 
 import PluginMapboxGl from '@vizzuality/layer-manager-plugin-mapboxgl';
 import { LayerManager, Layer } from '@vizzuality/layer-manager-react';
@@ -9,12 +10,13 @@ import { OverviewProps } from 'containers/project-page/overview/types';
 
 import LayoutContainer from 'components/layout-container';
 import Map from 'components/map';
+import ProjectMapPin from 'components/project-map-pin';
 
 import { getLayer } from './helpers';
 
 export const Overview: React.FC<OverviewProps> = ({ project }: OverviewProps) => {
-  const { country, municipality, geometry, category, priority_landscape } = project;
-
+  const { country, municipality, geometry, category, priority_landscape, latitude, longitude } =
+    project;
   const layer = getLayer(geometry, category);
 
   const [bounds, setBounds] = useState({
@@ -41,6 +43,16 @@ export const Overview: React.FC<OverviewProps> = ({ project }: OverviewProps) =>
             {(map) => (
               <LayerManager map={map} plugin={PluginMapboxGl}>
                 <Layer {...layer} />
+                {typeof latitude === 'number' && typeof longitude === 'number' && (
+                  <Marker
+                    latitude={latitude}
+                    longitude={longitude}
+                    offsetLeft={-10}
+                    offsetTop={-23}
+                  >
+                    <ProjectMapPin category={category} interactive={false} />
+                  </Marker>
+                )}
               </LayerManager>
             )}
           </Map>

--- a/frontend/containers/project-page/overview/helpers.ts
+++ b/frontend/containers/project-page/overview/helpers.ts
@@ -21,7 +21,7 @@ export const getLayer = (feature: ValidGeometryType, category: string) => {
           type: 'fill',
           paint: {
             'fill-color': color,
-            'fill-opacity': 0.5,
+            'fill-opacity': 0.25,
           },
         },
         {

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -1701,6 +1701,9 @@
   "XOLAV7": {
     "string": "Withdraw from the open call?"
   },
+  "XPruqs": {
+    "string": "Order"
+  },
   "XQuzr9": {
     "string": "Identified priorities by the HeCo program"
   },
@@ -1856,6 +1859,9 @@
   },
   "agJGNx": {
     "string": "How much funding do you have available for this open call? ($)"
+  },
+  "aleGqT": {
+    "string": "Descending"
   },
   "apgkuO": {
     "string": "More about ARIES"
@@ -2798,6 +2804,9 @@
   },
   "u2WlCd": {
     "string": "Pollutants reduction"
+  },
+  "u7djqV": {
+    "string": "Ascending"
   },
   "u87XOB": {
     "string": "How your project will grow"


### PR DESCRIPTION
This PR improves the map displayed on a project's public page by:
- Adding a marker to help the user locate the project when the map is zoomed out
- Adding a quick toggle to see the project's geometry
- Disabling interaction with the map (especially zooming on scrolling)

## Testing instructions

Go to the public page of any project and make sure of the following:
- You can't interact with the map
- When zoomed out, you can see the position of the project thanks to a marker
- When zoomed in, you can clearly see the geometry of the project
- You can toggle between the two zoom states with a button located at the bottom of the map

## Tracking

[LET-1038](https://vizzuality.atlassian.net/browse/LET-1038)
