### PR TITLE
refactoring: Setting min width for status column

### DIFF
--- a/backend/app/assets/stylesheets/application.tailwind.css
+++ b/backend/app/assets/stylesheets/application.tailwind.css
@@ -32,7 +32,7 @@
   }
 
   .backoffice-table td {
-    @apply text-left p-4
+    @apply text-left p-4 max-w-[30rem] break-words
   }
 
   .backoffice-table tr, .backoffice-table th {

--- a/backend/app/views/backoffice/investors/index.html.erb
+++ b/backend/app/views/backoffice/investors/index.html.erb
@@ -27,7 +27,7 @@
       <th>
         <%= sort_link @q, :account_language, t("backoffice.common.language") %>
       </th>
-      <th>
+      <th class="min-w-[10rem]">
         <%= sort_link @q, :account_review_status, t("backoffice.common.status") %>
       </th>
       <th>

--- a/backend/app/views/backoffice/open_calls/index.html.erb
+++ b/backend/app/views/backoffice/open_calls/index.html.erb
@@ -18,7 +18,7 @@
     <th>
       <%= sort_link @q, :open_call_applications_count, t("backoffice.open_calls.index.applications") %>
     </th>
-    <th>
+    <th class="min-w-[10rem]">
       <%= sort_link @q, :verified, t("backoffice.common.status") %>
     </th>
     <th>

--- a/backend/app/views/backoffice/project_developers/index.html.erb
+++ b/backend/app/views/backoffice/project_developers/index.html.erb
@@ -27,7 +27,7 @@
       <th>
         <%= sort_link @q, :account_language, t("backoffice.common.language") %>
       </th>
-      <th>
+      <th class="min-w-[10rem]">
         <%= sort_link @q, :account_review_status, t("backoffice.common.status") %>
       </th>
       <th>

--- a/backend/app/views/backoffice/projects/index.html.erb
+++ b/backend/app/views/backoffice/projects/index.html.erb
@@ -18,7 +18,7 @@
       <th>
         <%= sort_link @q, :priority_landscape_name, t("backoffice.projects.index.priority_landscape") %>
       </th>
-      <th>
+      <th class="min-w-[10rem]">
         <%= sort_link @q, :verified, t("backoffice.common.status") %>
       </th>
       <th>

--- a/backend/app/views/layouts/backoffice.html.erb
+++ b/backend/app/views/layouts/backoffice.html.erb
@@ -22,7 +22,7 @@
     </div>
   </header>
 
-  <main class="container mx-auto py-6 mt-1 relative">
+  <main class="container mx-auto py-6 mt-1 relative table">
     <%= render "flash_messages" %>
     <%= yield %>
     <%== render partial: "pagination", locals: {pagy: @pagy_object} if defined? @pagy_object %>


### PR DESCRIPTION
Small tweaks for backoffice css styles:
 - making sure that Status column has enough width so even translated text fits
 - setting max width to individual columns and break words so super long strings without space break automatically
 - adding `table` to `main` so pagination is always same width as rest of the table

## Testing instructions

Via backoffice

## Tracking

Link to the task(s), if any
