### PR TITLE
refactoring: enable email confirmation at API

### DIFF
--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -4,10 +4,7 @@ module API
       before_action :authenticate_user!, only: [:update, :show, :change_password]
 
       def create
-        user = params[:invitation_token].present? ? preload_invited_user : User.new(create_params)
-        user.skip_confirmation!
-        user.save!
-        sign_in user
+        user = params[:invitation_token].present? ? preload_invited_user : User.create!(create_params)
         render json: UserSerializer.new(user)
       end
 
@@ -49,6 +46,8 @@ module API
 
           user.assign_attributes create_params.except(:email)
           user.skip_confirmation!
+          user.save!
+          sign_in user
         end
       end
     end

--- a/backend/app/views/users/mailer/confirmation_instructions.html.erb
+++ b/backend/app/views/users/mailer/confirmation_instructions.html.erb
@@ -2,4 +2,4 @@
 
 <p><%= t("devise.mailer.confirmation_instructions.instruction") %></p>
 
-<p><%= link_to t("devise.mailer.confirmation_instructions.action"), api_v1_email_confirmation_url(confirmation_token: @token) %></p>
+<p><%= link_to t("devise.mailer.confirmation_instructions.action"), "#{ENV["FRONTEND_URL"]}/sign-up?confirmation_token=#{@token}" %></p>

--- a/backend/spec/fixtures/snapshots/api/v1/user-create.json
+++ b/backend/spec/fixtures/snapshots/api/v1/user-create.json
@@ -7,7 +7,7 @@
       "last_name": "Kowalski",
       "email": "jankowalski@example.com",
       "role": "light",
-      "confirmed": true,
+      "confirmed": false,
       "approved": null,
       "invitation": null,
       "created_at": "2022-06-24T09:06:20.081Z",

--- a/backend/spec/requests/api/v1/user_spec.rb
+++ b/backend/spec/requests/api/v1/user_spec.rb
@@ -47,17 +47,10 @@ RSpec.describe "API V1 User", type: :request do
             expect(response.body).to match_snapshot("api/v1/user-create")
           end
 
-          # it "sends confirmation email" do
-          #   mail = ActionMailer::Base.deliveries.last
-          #   expect(mail.subject).to eq("Confirmation instructions")
-          #   expect(mail.to.first).to eq("jankowalski@example.com")
-          # end
-
-          it "does not send confirmation email and signs user in" do |example|
+          it "sends confirmation email and does not sign user in" do |example|
             expect {
               submit_request example.metadata
-            }.not_to have_enqueued_mail(DeviseMailer, :confirmation_instructions)
-            expect(session["warden.user.user.key"]).to be_present
+            }.to have_enqueued_mail(DeviseMailer, :confirmation_instructions)
           end
         end
 


### PR DESCRIPTION
PR which enforces user to confirm his email address after registration (applies only for new registered users, not invited ones). User is not able to login, before they finish email confirmation.

Users should receive email after registration with following link `#{ENV["FRONTEND_URL"]}/sign-up?confirmation_token=#{@token}`.  API used to confirm email is already implemented and documented at Rswag doc (`/api/v1/email_confirmation`). There is also possibility to re-send confirmation email via API.

@clementprdhomme @barbara-chaves  

## Testing

Use rswag documentation
 - register new user --> you should receive email which allows you to confirm your email address
 - take token from url inside email
 - and send it to `GET /api/v1/email_confirmation` and confirm
 - your user should get confirmed and you should get logged in (session is created)

## Tracking

Part of https://vizzuality.atlassian.net/browse/LET-203 -- enabling email confirmation
