### PR TITLE
Change project details card style

### DIFF
--- a/frontend/containers/project-details/component.tsx
+++ b/frontend/containers/project-details/component.tsx
@@ -143,7 +143,7 @@ export const ProjectDetails: FC<ProjectDetailsProps> = ({
         </div>
         <h1 className="mt-6 mb-2 font-serif text-3xl">
           <Link href={link}>
-            <a className="px-2 -mx-2 text-black transition-all rounded-full hover:text-green-light focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-dark">
+            <a className="text-black transition-all duration-500 ease-in-out border-b-2 border-b-transparent hover:border-b-black focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-dark">
               {project.name}
             </a>
           </Link>
@@ -199,11 +199,6 @@ export const ProjectDetails: FC<ProjectDetailsProps> = ({
           </span>
           <span>{projectDeveloper.name}</span>
         </div>
-        <FavoriteContact
-          className="mt-10 mb-6"
-          project={project}
-          onFavoriteClick={handleFavoriteClick}
-        />
         <div className="my-2 text-gray-900" aria-describedby="estimated-impact">
           <h2 id="estimated-impact" className="text-xl font-semibold">
             <FormattedMessage defaultMessage="Estimated impact" id="Jl9QMO" />
@@ -224,12 +219,12 @@ export const ProjectDetails: FC<ProjectDetailsProps> = ({
           </h2>
           <SDGs className="mt-3" size="smallest" sdgs={sdgs as Enum[]} />
         </div>
-        <FavoriteContact
-          className="mt-4 -mb-4"
-          project={project}
-          onFavoriteClick={handleFavoriteClick}
-        />
       </div>
+      <FavoriteContact
+        className="sticky bottom-0 w-full px-8 py-4 bg-white shadow-lg drop-shadow"
+        project={project}
+        onFavoriteClick={handleFavoriteClick}
+      />
     </div>
   );
 };

--- a/frontend/containers/project-details/favorite-contact/component.tsx
+++ b/frontend/containers/project-details/favorite-contact/component.tsx
@@ -1,6 +1,6 @@
 import { FC, useState } from 'react';
 
-import { Heart as HeartIcon } from 'react-feather';
+import { ArrowRight, Heart as HeartIcon } from 'react-feather';
 import { FormattedMessage } from 'react-intl';
 
 import cx from 'classnames';
@@ -33,27 +33,36 @@ export const FavoriteContact: FC<FavoriteContactProps> = ({
 
   return (
     <div className={className}>
-      <div className="flex flex-col items-start gap-4 mt-5 xl:items-center xl:flex-row">
-        <Button
-          disabled={!user || !contacts.length}
-          className="justify-start"
-          theme="primary-green"
-          onClick={() => setIsContactInfoModalOpen(true)}
-        >
-          <FormattedMessage defaultMessage="Contact" id="zFegDD" />
-        </Button>
-        {!!user && (
-          <Button className="justify-start" theme="secondary-green" onClick={onFavoriteClick}>
-            <Icon
-              icon={HeartIcon}
-              className={cx('w-4 mr-3', { 'fill-green-dark': project.favourite })}
-            />
-            <FormattedMessage defaultMessage="Favorite" id="5Hzwqs" />
+      <div className="flex flex-col items-start justify-between gap-4 md:items-center md:flex-row">
+        <div className="flex justify-center gap-4 sm:justify-start">
+          <Button
+            disabled={!user || !contacts.length}
+            className="px-4 py-2 text-sm sm:px-6 sm:py-2"
+            theme="primary-green"
+            onClick={() => setIsContactInfoModalOpen(true)}
+          >
+            <FormattedMessage defaultMessage="Contact" id="zFegDD" />
           </Button>
-        )}
+          {!!user && (
+            <Button
+              className="px-4 py-2 text-sm sm:px-6 sm:py-2"
+              theme="secondary-green"
+              onClick={onFavoriteClick}
+            >
+              <Icon
+                icon={HeartIcon}
+                className={cx('w-4 mr-3', { 'fill-green-dark': project.favourite })}
+              />
+              <FormattedMessage defaultMessage="Favorite" id="5Hzwqs" />
+            </Button>
+          )}
+        </div>
         <Link href={`${Paths.Project}/${project.slug}`}>
-          <a className="px-1 text-sm transition-all text-green-dark hover:text-green-light rounded-2xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-dark">
-            <FormattedMessage defaultMessage="Know more" id="+JVDMC" />
+          <a className="flex items-center text-sm leading-6 text-green-dark hover:text-green-light focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-dark group">
+            <span className="border-b border-b-green-dark group-hover:border-b-green-light">
+              <FormattedMessage defaultMessage="Project details" id="7gMEKc" />
+            </span>
+            <Icon icon={ArrowRight} className="w-4 h-4 ml-1.5" />
           </a>
         </Link>
       </div>

--- a/frontend/pages/discover/projects.tsx
+++ b/frontend/pages/discover/projects.tsx
@@ -153,7 +153,7 @@ const ProjectsPage: PageComponent<ProjectsPageProps, DiscoverPageLayoutProps> = 
                     animate={{ opacity: 1 }}
                     exit={{ opacity: 0 }}
                   >
-                    <aside className="absolute top-0 z-10 w-7/12 xl:w-5/12 mt-1 mb-0 -ml-2.5 -bottom-4 left-5/12 rounded-t-2xl">
+                    <aside className="absolute top-0 z-10 w-7/12 xl:w-5/12 mt-1 mb-0 -ml-2.5 left-5/12 bottom-1 rounded-2xl">
                       <div className="max-h-full overflow-y-auto bg-white border rounded-2xl">
                         <ProjectDetails
                           project={selectedProject}


### PR DESCRIPTION
This PR changes the style of the project details card 

## Testing instructions

Go to discover/projects
Click on a project card
The project details card opened style should be in accordance with [HeCo - Design System](https://www.figma.com/file/3epSYh4KQZBCyh4Y5OzmHw/HeCo---Design-System?node-id=3095%3A9008)
The behaviour in [figma](https://www.figma.com/proto/KC49uMR9t1YARmFR0Sr6aN/HeCo---Work-in-progress?page-id=2%3A4&node-id=2%3A4582&scaling=scale-down&starting-point-node-id=6183%3A207104&show-proto-sidebar=1)

## Tracking

[LET-867](https://vizzuality.atlassian.net/browse/LET-867)

