### PR TITLE
Add message indicating the public and confidential form fields

### DIFF
--- a/frontend/containers/investor-form/pages/impacts.tsx
+++ b/frontend/containers/investor-form/pages/impacts.tsx
@@ -10,6 +10,7 @@ import FieldInfo from 'components/forms/field-info';
 import Label from 'components/forms/label';
 import Tag from 'components/forms/tag';
 import TagGroup from 'components/forms/tag-group';
+import TextTag from 'components/tag';
 
 import { ImpactProps } from '../types';
 
@@ -26,22 +27,25 @@ export const Impact: FC<ImpactProps> = ({
       <h1 className="font-serif text-3xl font-semibold mb-2.5">
         <FormattedMessage defaultMessage="Impact" id="W2JBdp" />
       </h1>
-      <p className="mb-10 text-gray-600">
+      <p className="mb-10 text-gray-900">
         <FormattedMessage
-          defaultMessage="This information will help us understand what is the impact you want to have."
-          id="puek63"
+          defaultMessage="This information will help us understand what is the impact you want to have. This information will be <n>public</n> except the one marked as <n>private</n> which will only be visible for admins."
+          id="F6axhK"
+          values={{
+            n: (chunk: string) => <span className="font-semibold">{chunk}</span>,
+          }}
         />
       </p>
       <form noValidate>
         <div className="mb-6.5">
-          <fieldset className="flex">
-            <div className="flex items-center">
-              <legend className="font-sans text-sm font-semibold text-gray-800">
-                <FormattedMessage
-                  defaultMessage="Have you previously invested in impact?"
-                  id="8XJceA"
-                />
-              </legend>
+          <fieldset className="flex items-center">
+            <legend className="float-left font-sans text-sm font-semibold text-gray-800">
+              <FormattedMessage
+                defaultMessage="Have you previously invested in impact?"
+                id="8XJceA"
+              />
+            </legend>
+            <div className="flex">
               <div className="flex items-center mx-4 font-normal">
                 <input
                   id="previously-invested-yes"
@@ -65,11 +69,17 @@ export const Impact: FC<ImpactProps> = ({
                 </Label>
               </div>
             </div>
+            <TextTag
+              size="smallest"
+              className="font-medium leading-[14px] text-sm  text-gray-800 bg-beige ml-6"
+            >
+              <FormattedMessage defaultMessage="Private" id="viXE32" />
+            </TextTag>
+            <ErrorMessage
+              id="previously-invested-error"
+              errorText={errors?.previously_invested?.message}
+            />
           </fieldset>
-          <ErrorMessage
-            id="previously-invested-error"
-            errorText={errors?.previously_invested?.message}
-          />
         </div>
 
         <div className="mb-6.5">

--- a/frontend/containers/investor-form/pages/impacts.tsx
+++ b/frontend/containers/investor-form/pages/impacts.tsx
@@ -71,7 +71,7 @@ export const Impact: FC<ImpactProps> = ({
             </div>
             <TextTag
               size="smallest"
-              className="font-medium leading-[14px] text-sm  text-gray-800 bg-beige ml-6"
+              className="font-medium leading-[14px] text-sm border-beige text-gray-800 bg-beige ml-6"
             >
               <FormattedMessage defaultMessage="Private" id="viXE32" />
             </TextTag>

--- a/frontend/containers/investor-form/pages/investment.tsx
+++ b/frontend/containers/investor-form/pages/investment.tsx
@@ -27,10 +27,13 @@ const InvestmentInformation: FC<InvestmentInformationProps> = ({
       <h1 className="font-serif text-3xl font-semibold mb-2.5">
         <FormattedMessage defaultMessage="Investment information" id="770IIS" />
       </h1>
-      <p className="mb-10 text-gray-600">
+      <p className="mb-10 text-gray-900">
         <FormattedMessage
-          defaultMessage="This information will help us understand what you are interested in invest or funding."
-          id="M7261y"
+          defaultMessage="This information will help us understand what you are interested in invest or funding. This information will be <n>public</n>."
+          id="f5UaDG"
+          values={{
+            n: (chunk: string) => <span className="font-semibold">{chunk}</span>,
+          }}
         />
       </p>
       <form noValidate>

--- a/frontend/containers/investor-form/pages/other-information.tsx
+++ b/frontend/containers/investor-form/pages/other-information.tsx
@@ -20,12 +20,21 @@ export const OtherInformations: FC<OtherInformationsProps> = ({ register, errors
         <div>
           <Label
             htmlFor="other-information"
-            className="block mb-2 text-base font-normal text-gray-600"
+            className="block text-base font-normal text-gray-900 mb-9"
           >
             <FormattedMessage
               defaultMessage="Complete your profile with relevant information to make your relationship with project developers as precise as possible. For example the very particular topics you are interested in or the activities and items you definitely do not finance or invest in. "
               id="I2VJMv"
             />
+            <span className="block mt-4">
+              <FormattedMessage
+                defaultMessage="This information will be <n>public</n>."
+                id="rBC2yr"
+                values={{
+                  n: (chunk: string) => <span className="font-semibold">{chunk}</span>,
+                }}
+              />
+            </span>
           </Label>
           <Textarea
             id="other-information"

--- a/frontend/containers/investor-form/pages/other-information.tsx
+++ b/frontend/containers/investor-form/pages/other-information.tsx
@@ -20,7 +20,7 @@ export const OtherInformations: FC<OtherInformationsProps> = ({ register, errors
         <div>
           <Label
             htmlFor="other-information"
-            className="block text-base font-normal text-gray-900 mb-9"
+            className="block !text-base font-normal text-gray-900 mb-9"
           >
             <FormattedMessage
               defaultMessage="Complete your profile with relevant information to make your relationship with project developers as precise as possible. For example the very particular topics you are interested in or the activities and items you definitely do not finance or invest in. "

--- a/frontend/containers/investor-form/pages/priority.tsx
+++ b/frontend/containers/investor-form/pages/priority.tsx
@@ -23,7 +23,7 @@ export const Priority: FC<PriorityProps> = ({ register, errors }) => {
         <div>
           <Label
             htmlFor="prioritized-projects-description"
-            className="block text-base font-normal text-gray-900 mb-9"
+            className="block !text-base font-normal text-gray-900 mb-9"
           >
             <FormattedMessage
               defaultMessage="Tell us what you value in the projects you invest in / what will make you invest in projects This information will be <n>public</n>."

--- a/frontend/containers/investor-form/pages/priority.tsx
+++ b/frontend/containers/investor-form/pages/priority.tsx
@@ -23,11 +23,14 @@ export const Priority: FC<PriorityProps> = ({ register, errors }) => {
         <div>
           <Label
             htmlFor="prioritized-projects-description"
-            className="block mb-2 text-base font-normal text-gray-600"
+            className="block text-base font-normal text-gray-900 mb-9"
           >
             <FormattedMessage
-              defaultMessage="Tell us what you value in the projects you invest in / what will make you invest in projects"
-              id="0DNR+D"
+              defaultMessage="Tell us what you value in the projects you invest in / what will make you invest in projects This information will be <n>public</n>."
+              id="9R4Msc"
+              values={{
+                n: (chunk: string) => <span className="font-semibold">{chunk}</span>,
+              }}
             />
           </Label>
           <Textarea

--- a/frontend/containers/investor-form/pages/profile.tsx
+++ b/frontend/containers/investor-form/pages/profile.tsx
@@ -36,10 +36,13 @@ export const Profile: FC<ProfileProps> = ({
         <h1 className="mb-2 font-serif text-3xl font-semibold">
           <FormattedMessage defaultMessage="Investor/Funder profile" id="BHJZyR" />
         </h1>
-        <p className="font-sans text-base text-gray-600">
+        <p className="font-sans text-base text-gray-900">
           <FormattedMessage
-            defaultMessage="General information about the investor/funder."
-            id="gjBW8J"
+            defaultMessage="General information about the investor/funder. This information will be <n>public</n>."
+            id="5mX4u0"
+            values={{
+              n: (chunk: string) => <span className="font-semibold">{chunk}</span>,
+            }}
           />
         </p>
       </div>

--- a/frontend/containers/open-call-form/pages/closing-date.tsx
+++ b/frontend/containers/open-call-form/pages/closing-date.tsx
@@ -37,8 +37,14 @@ export const OpenCallClosingDate: FC<OpenCallClosingDateProps> = ({
             id="BeVl3b"
           />
         </h1>
-        <p className="text-gray-600">
-          <FormattedMessage defaultMessage="Select the deadline for this open call." id="KcJ5IK" />
+        <p className="text-gray-900">
+          <FormattedMessage
+            defaultMessage="Select the deadline for this open call. This information will be <n>public</n>."
+            id="sh7TMQ"
+            values={{
+              n: (chunk: string) => <span className="font-semibold">{chunk}</span>,
+            }}
+          />
         </p>
       </div>
       <div>

--- a/frontend/containers/open-call-form/pages/expected-impact.tsx
+++ b/frontend/containers/open-call-form/pages/expected-impact.tsx
@@ -26,10 +26,13 @@ export const OpenCallExpectedImpact: FC<OpenCallExpectedImpactProps> = ({
         <h1 className="mb-2 font-serif text-3xl font-semibold">
           <FormattedMessage defaultMessage="Expected impact" id="XgaRPC" />
         </h1>
-        <p className="text-gray-600">
+        <p className="text-gray-900">
           <FormattedMessage
-            defaultMessage="Tell us what’s the impact that you expect with this open call."
-            id="N5k7R7"
+            defaultMessage="Tell us what’s the impact that you expect with this open call. This information will be <n>public</n>."
+            id="6dk02D"
+            values={{
+              n: (chunk: string) => <span className="font-semibold">{chunk}</span>,
+            }}
           />
         </p>
       </div>

--- a/frontend/containers/open-call-form/pages/funding-information.tsx
+++ b/frontend/containers/open-call-form/pages/funding-information.tsx
@@ -27,10 +27,13 @@ export const OpenCallFundingInformation: FC<OpenCallFundingInformationProps> = (
         <h1 className="mb-2 font-serif text-3xl font-semibold">
           <FormattedMessage defaultMessage="Funding information" id="mEYG82" />
         </h1>
-        <p className="text-gray-600">
+        <p className="text-gray-900">
           <FormattedMessage
-            defaultMessage="How much money do you intend to give to this open call."
-            id="bXy++M"
+            defaultMessage="How much money do you intend to give to this open call. This information will be <n>public</n>."
+            id="k8US3O"
+            values={{
+              n: (chunk: string) => <span className="font-semibold">{chunk}</span>,
+            }}
           />
         </p>
       </div>

--- a/frontend/containers/open-call-form/pages/information.tsx
+++ b/frontend/containers/open-call-form/pages/information.tsx
@@ -73,10 +73,13 @@ export const OpenCallInformation: FC<OpenCallInformationProps> = ({
         <h1 className="mb-2 font-serif text-3xl font-semibold">
           <FormattedMessage defaultMessage="Information about the open call" id="1pQoFr" />
         </h1>
-        <p className="text-gray-600">
+        <p className="text-gray-900">
           <FormattedMessage
-            defaultMessage="This information will be displayed in the open call page."
-            id="Ac9oiY"
+            defaultMessage="This information will be displayed and <n>public</n> in the open call page."
+            id="8gmRp0"
+            values={{
+              n: (chunk: string) => <span className="font-semibold">{chunk}</span>,
+            }}
           />
         </p>
       </div>

--- a/frontend/containers/project-developer-form/pages/about.tsx
+++ b/frontend/containers/project-developer-form/pages/about.tsx
@@ -54,10 +54,13 @@ export const About: FC<AboutProps> = ({
         <h1 className="mb-2 font-serif text-3xl font-semibold">
           <FormattedMessage defaultMessage="About your work" id="kEXoaQ" />
         </h1>
-        <p className="font-sans text-base text-gray-600">
+        <p className="font-sans text-base text-gray-900">
           <FormattedMessage
-            defaultMessage="Tell us about your work and impact priorities."
-            id="ViF88C"
+            defaultMessage="Tell us about your work and impact priorities. This information will be <n>public</n> except the one marked as <n>private</n> which will only be visible for admins."
+            id="1zU/+8"
+            values={{
+              n: (chunk: string) => <span className="font-semibold">{chunk}</span>,
+            }}
           />
         </p>
       </div>

--- a/frontend/containers/project-developer-form/pages/about.tsx
+++ b/frontend/containers/project-developer-form/pages/about.tsx
@@ -56,8 +56,8 @@ export const About: FC<AboutProps> = ({
         </h1>
         <p className="font-sans text-base text-gray-900">
           <FormattedMessage
-            defaultMessage="Tell us about your work and impact priorities. This information will be <n>public</n> except the one marked as <n>private</n> which will only be visible for admins."
-            id="1zU/+8"
+            defaultMessage="Tell us about your work and impact priorities. This information will be <n>public</n>."
+            id="EoyBnX"
             values={{
               n: (chunk: string) => <span className="font-semibold">{chunk}</span>,
             }}

--- a/frontend/containers/project-developer-form/pages/profile.tsx
+++ b/frontend/containers/project-developer-form/pages/profile.tsx
@@ -143,7 +143,7 @@ export const Profile: FC<ProfileProps> = ({
           </span>
           <Tag
             size="smallest"
-            className="font-medium leading-[14px] text-sm  text-gray-800 bg-beige"
+            className="font-medium leading-[14px] border-beige text-sm  text-gray-800 bg-beige"
           >
             <FormattedMessage defaultMessage="Private" id="viXE32" />
           </Tag>

--- a/frontend/containers/project-developer-form/pages/profile.tsx
+++ b/frontend/containers/project-developer-form/pages/profile.tsx
@@ -12,6 +12,7 @@ import FieldInfo from 'components/forms/field-info';
 import Input from 'components/forms/input';
 import Label from 'components/forms/label';
 import TextArea from 'components/forms/textarea';
+import Tag from 'components/tag';
 
 import { ProfileProps } from '../types';
 
@@ -36,10 +37,13 @@ export const Profile: FC<ProfileProps> = ({
         <h1 className="mb-2 font-serif text-3xl font-semibold">
           <FormattedMessage defaultMessage="Project developer profile" id="twK/jv" />
         </h1>
-        <p className="font-sans text-base text-gray-600">
+        <p className="font-sans text-base text-gray-900">
           <FormattedMessage
-            defaultMessage="General information about the the project developer."
-            id="CiBvks"
+            defaultMessage="General information about the project developer. This information will be <n>public</n> except the one marked as <n>private</n> which will only be visible for admins."
+            id="gbWTGl"
+            values={{
+              n: (chunk: string) => <span className="font-semibold">{chunk}</span>,
+            }}
           />
         </p>
       </div>
@@ -123,12 +127,12 @@ export const Profile: FC<ProfileProps> = ({
         </div>
       </div>
       <div className="mb-6.5">
-        <Label htmlFor="entity-legal-registration">
-          <FormattedMessage
-            defaultMessage="Entity legal registration number (NIT or RUT)"
-            id="AiagLY"
-          />
-          <span className="ml-2.5">
+        <Label htmlFor="entity-legal-registration" className="flex items-center justify-between">
+          <span className="flex gap-2.5">
+            <FormattedMessage
+              defaultMessage="Entity legal registration number (NIT or RUT)"
+              id="AiagLY"
+            />
             <FieldInfo
               content={formatMessage({
                 defaultMessage:
@@ -137,20 +141,26 @@ export const Profile: FC<ProfileProps> = ({
               })}
             />
           </span>
-          <Input
-            type="text"
-            id="entity-legal-registration"
-            className="mt-2.5"
-            register={register}
-            aria-required
-            name="entity_legal_registration_number"
-            placeholder={formatMessage({
-              defaultMessage: 'insert the number',
-              id: 'tS6cAK',
-            })}
-            aria-describedby="entity-legal-registration-error"
-          />
+          <Tag
+            size="smallest"
+            className="font-medium leading-[14px] text-sm  text-gray-800 bg-beige"
+          >
+            <FormattedMessage defaultMessage="Private" id="viXE32" />
+          </Tag>
         </Label>
+        <Input
+          type="text"
+          id="entity-legal-registration"
+          className="mt-2.5"
+          register={register}
+          aria-required
+          name="entity_legal_registration_number"
+          placeholder={formatMessage({
+            defaultMessage: 'insert the number',
+            id: 'tS6cAK',
+          })}
+          aria-describedby="entity-legal-registration-error"
+        />
         <ErrorMessage
           id="entity-legal-registration-error"
           errorText={errors?.entity_legal_registration_number?.message}

--- a/frontend/containers/project-form/pages/funding.tsx
+++ b/frontend/containers/project-form/pages/funding.tsx
@@ -314,7 +314,7 @@ const Funding = ({
               <div>
                 <TextTag
                   size="smallest"
-                  className="ml-4 font-medium leading-[14px] text-sm text-gray-800 bg-beige"
+                  className="ml-4 border-beige font-medium leading-[14px] text-sm text-gray-800 bg-beige"
                 >
                   <FormattedMessage defaultMessage="Private" id="viXE32" />
                 </TextTag>

--- a/frontend/containers/project-form/pages/funding.tsx
+++ b/frontend/containers/project-form/pages/funding.tsx
@@ -10,6 +10,7 @@ import FieldInfo from 'components/forms/field-info';
 import Input from 'components/forms/input';
 import Label from 'components/forms/label';
 import Tag from 'components/forms/tag';
+import TextTag from 'components/tag';
 import TagGroup from 'components/forms/tag-group';
 import Textarea from 'components/forms/textarea';
 
@@ -55,32 +56,35 @@ const Funding = ({
       <h1 className="font-serif text-3xl font-semibold mb-2.5">
         <FormattedMessage defaultMessage="Funding information" id="mEYG82" />
       </h1>
-      <p className="mb-10 text-gray-600">
+      <p className="mb-10 text-gray-900">
         <FormattedMessage
-          defaultMessage="Financial information about your project and what are the needs"
-          id="pcRRCK"
+          defaultMessage="Financial information about your project and what are the needs. This information will be <n>public</n> except the one marked as <n>private</n> which will only be visible for admins."
+          id="+hdaRx"
+          values={{
+            n: (chunk: string) => <span className="font-semibold">{chunk}</span>,
+          }}
         />
       </p>
       <form noValidate>
         <div>
           <div>
-            <fieldset>
-              <div className="flex items-center">
-                <legend className="inline mr-4 font-sans text-sm font-semibold text-gray-800">
-                  <span className="mr-2.5">
-                    <FormattedMessage
-                      defaultMessage="Are you currently looking for funding?"
-                      id="u/E7xG"
-                    />
-                  </span>
-                  <FieldInfo
-                    content={formatMessage({
-                      defaultMessage:
-                        'If you are not looking for funding and just want to publish your project, select No.',
-                      id: 'OWnChd',
-                    })}
+            <fieldset className="flex items-center mt-4.5">
+              <legend className="float-left mr-4 font-sans text-sm font-semibold text-gray-800">
+                <span className="mr-2.5">
+                  <FormattedMessage
+                    defaultMessage="Are you currently looking for funding?"
+                    id="u/E7xG"
                   />
-                </legend>
+                </span>
+                <FieldInfo
+                  content={formatMessage({
+                    defaultMessage:
+                      'If you are not looking for funding and just want to publish your project, select No.',
+                    id: 'OWnChd',
+                  })}
+                />
+              </legend>
+              <div className="flex items-center">
                 <Label
                   htmlFor="looking_for_funding-yes"
                   className="flex items-center pt-0.5 font-normal"
@@ -253,14 +257,14 @@ const Funding = ({
           </div>
 
           <div>
-            <fieldset>
-              <div className="flex items-center mt-4.5">
-                <legend className="inline mr-4 font-sans text-sm font-semibold text-gray-800">
-                  <FormattedMessage
-                    defaultMessage="Has this project been funded before?"
-                    id="GdS9Mk"
-                  />
-                </legend>
+            <fieldset className="flex items-center mt-4.5">
+              <legend className="float-left mr-4 font-sans text-sm font-semibold text-gray-800">
+                <FormattedMessage
+                  defaultMessage="Has this project been funded before?"
+                  id="GdS9Mk"
+                />
+              </legend>
+              <div className="flex items-center">
                 <Label
                   htmlFor="received_funding-yes"
                   className="flex items-center pt-0.5 font-normal"
@@ -306,6 +310,14 @@ const Funding = ({
                   ></Controller>
                   <FormattedMessage defaultMessage="No" id="oUWADl" />
                 </Label>
+              </div>
+              <div>
+                <TextTag
+                  size="smallest"
+                  className="ml-4 font-medium leading-[14px] text-sm text-gray-800 bg-beige"
+                >
+                  <FormattedMessage defaultMessage="Private" id="viXE32" />
+                </TextTag>
               </div>
               <div>
                 <ErrorMessage

--- a/frontend/containers/project-form/pages/general-information.tsx
+++ b/frontend/containers/project-form/pages/general-information.tsx
@@ -112,7 +112,7 @@ const GeneralInformation = ({
       <h1 className="font-serif text-3xl font-semibold mb-2.5">
         <FormattedMessage defaultMessage="Project information" id="5c08Qp" />
       </h1>
-      <p className="mb-10 text-gray-600">
+      <p className="mb-10 text-gray-900">
         <FormattedMessage
           defaultMessage="This information will be visible in the project page when you launch it."
           id="avVMND"

--- a/frontend/containers/project-form/pages/impact.tsx
+++ b/frontend/containers/project-form/pages/impact.tsx
@@ -56,10 +56,13 @@ export const Impact = ({
       <h1 className="font-serif text-3xl font-semibold mb-2.5">
         <FormattedMessage defaultMessage="Impact" id="W2JBdp" />
       </h1>
-      <p className="mb-10 text-gray-600">
+      <p className="mb-10 text-gray-900">
         <FormattedMessage
-          defaultMessage="What’s the impact of your project and what do you want to achieve"
-          id="BkLlj6"
+          defaultMessage="What’s the impact of your project and what do you want to achieve. This information will be <n>public</n>."
+          id="OQ/tJs"
+          values={{
+            n: (chunk: string) => <span className="font-semibold">{chunk}</span>,
+          }}
         />
       </p>
       <form noValidate>

--- a/frontend/containers/project-form/pages/other-information.tsx
+++ b/frontend/containers/project-form/pages/other-information.tsx
@@ -17,10 +17,13 @@ const OtherInformation = ({ register, errors }: ProjectFormPagesProps<ProjectFor
       <h1 className="font-serif text-3xl font-semibold mb-2.5">
         <FormattedMessage defaultMessage="Other information" id="kX7oGR" />
       </h1>
-      <p className="mb-10 text-gray-600">
+      <p className="mb-10 text-gray-900">
         <FormattedMessage
-          defaultMessage="This description should sumarize your project in a few words."
-          id="BcZVZW"
+          defaultMessage="This description should sumarize your project in a few words. This information will be <n>public</n>."
+          id="8SBW1H"
+          values={{
+            n: (chunk: string) => <span className="font-semibold">{chunk}</span>,
+          }}
         />
       </p>
       <form noValidate>

--- a/frontend/containers/project-form/pages/project-description.tsx
+++ b/frontend/containers/project-form/pages/project-description.tsx
@@ -34,10 +34,13 @@ const ProjectDescription = ({
       <h1 className="font-serif text-3xl font-semibold mb-2.5">
         <FormattedMessage defaultMessage="Description of the project" id="35YoEI" />
       </h1>
-      <p className="mb-10 text-gray-600">
+      <p className="mb-10 text-gray-900">
         <FormattedMessage
-          defaultMessage="Tell us what is the project about the problem and the solution to solve it"
-          id="/m/QYW"
+          defaultMessage="Tell us what is the project about the problem and the solution to solve it. This information will be <n>public</n>."
+          id="defge8"
+          values={{
+            n: (chunk: string) => <span className="font-semibold">{chunk}</span>,
+          }}
         />
       </p>
       <form noValidate>

--- a/frontend/containers/project-form/pages/project-grow.tsx
+++ b/frontend/containers/project-form/pages/project-grow.tsx
@@ -16,10 +16,13 @@ export const ProjectGrow = ({ register, errors }: ProjectFormPagesProps<ProjectF
       <h1 className="font-serif text-3xl font-semibold mb-2.5">
         <FormattedMessage defaultMessage="How your project will grow" id="u87XOB" />
       </h1>
-      <p className="mb-10 text-gray-600">
+      <p className="mb-10 text-gray-900">
         <FormattedMessage
-          defaultMessage="Tell us what how do you expect to grow your project , how will you measure progress and impact."
-          id="SNBzCW"
+          defaultMessage="Tell us what how do you expect to grow your project , how will you measure progress and impact. This information will be <n>public</n>."
+          id="W69F0D"
+          values={{
+            n: (chunk: string) => <span className="font-semibold">{chunk}</span>,
+          }}
         />
       </p>
       <form noValidate>

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -20,6 +20,9 @@
   "+USuwC": {
     "string": "Funding available per project"
   },
+  "+hdaRx": {
+    "string": "Financial information about your project and what are the needs. This information will be <n>public</n> except the one marked as <n>private</n> which will only be visible for admins."
+  },
   "+mzZak": {
     "string": "About {name}"
   },
@@ -74,9 +77,6 @@
   "/apC0L": {
     "string": "SDG’s"
   },
-  "/m/QYW": {
-    "string": "Tell us what is the project about the problem and the solution to solve it"
-  },
   "/oLNw7": {
     "string": "The impact score of this project is 0."
   },
@@ -100,9 +100,6 @@
   },
   "0CAqpl": {
     "string": "About the partners"
-  },
-  "0DNR+D": {
-    "string": "Tell us what you value in the projects you invest in / what will make you invest in projects"
   },
   "0L/mZC": {
     "string": "Target group"
@@ -278,6 +275,9 @@
   "4+kVuu": {
     "string": "Indigenous peoples"
   },
+  "44nONQ": {
+    "string": "clear search"
+  },
   "47FYwb": {
     "string": "Cancel"
   },
@@ -362,6 +362,9 @@
   "5l/FHl": {
     "string": "You can choose from a variety of opportunities that range from sustainable landscape management tools and solutions, to forest-friendly products and business models. From social welfare solutions, to climate solutions and sustainable businesses."
   },
+  "5mX4u0": {
+    "string": "General information about the investor/funder. This information will be <n>public</n>."
+  },
   "5mkG4O": {
     "string": "This description should succently explain your project. It should be a catching text since it's the first thing investors will read."
   },
@@ -406,6 +409,9 @@
   },
   "6cU2pG": {
     "string": "The project gallery will be the first thing other users will see on your page, it will help you to showcase your project."
+  },
+  "6dk02D": {
+    "string": "Tell us what’s the impact that you expect with this open call. This information will be <n>public</n>."
   },
   "6hS0se": {
     "string": "Are you sure you want to delete the account?"
@@ -497,6 +503,9 @@
   "8R8Or7": {
     "string": "Search community"
   },
+  "8SBW1H": {
+    "string": "This description should sumarize your project in a few words. This information will be <n>public</n>."
+  },
   "8SayhS": {
     "string": "{placeholder}"
   },
@@ -514,6 +523,9 @@
   },
   "8gJV79": {
     "string": "What are HeCo priority landscapes?"
+  },
+  "8gmRp0": {
+    "string": "This information will be displayed and <n>public</n> in the open call page."
   },
   "8i6S4q": {
     "string": "Connecting investors, donors and philanthropists with carefully identified investment opportunities."
@@ -556,6 +568,9 @@
   },
   "9I1zvK": {
     "string": "Municipality"
+  },
+  "9R4Msc": {
+    "string": "Tell us what you value in the projects you invest in / what will make you invest in projects This information will be <n>public</n>."
   },
   "9VLFbQ": {
     "string": "Landscape photo"
@@ -614,9 +629,6 @@
   "APjPYs": {
     "string": "I want to write my content in"
   },
-  "Ac9oiY": {
-    "string": "This information will be displayed in the open call page."
-  },
   "AdAi3x": {
     "string": "Emails"
   },
@@ -659,14 +671,8 @@
   "BZkcBV": {
     "string": "Project developer photo"
   },
-  "BcZVZW": {
-    "string": "This description should sumarize your project in a few words."
-  },
   "BeVl3b": {
     "string": "How long will the open call be available?"
-  },
-  "BkLlj6": {
-    "string": "What’s the impact of your project and what do you want to achieve"
   },
   "BqrQ5O": {
     "string": "At the <b>Landscape level</b>, a composite index combining the set of indicators identified for each dimension is used to calculate <b>Context scores</b>, with values ranging from 0 to 1. <b>Demand</b> is then computed as 1 - <b>Context score</b>, representing the “quantity” missing to reach 1, where 1 assumes the best sustainability conditions. Because the demand can be considered at multiple scales (namely, municipality, hydrological basins, and HeCo Priority Landscapes), the demand score is computed using zonal statistics at a user-specified scale, with the municipality level being the default. Unlike municipalities and hydrographic basins, the HeCo Priority Landscapes don’t cover the entire country, and therefore <b>if the project area doesn't fall into any of the Priority Landscapes, the impact of that project will be zero at that particular scale</b>."
@@ -703,9 +709,6 @@
   },
   "Cf2YAW": {
     "string": "Open calls are funding offers from investors requesting project developer proposals to grow their businesses. Note that these open proposals are available for a limited time and have unique application requirements."
-  },
-  "CiBvks": {
-    "string": "General information about the the project developer."
   },
   "CiYFzk": {
     "string": "SME and MSME"
@@ -833,6 +836,9 @@
   "EmpHyB": {
     "string": "Facebook"
   },
+  "EoyBnX": {
+    "string": "Tell us about your work and impact priorities. This information will be <n>public</n>."
+  },
   "EpzS3H": {
     "string": "The HeCo priority landscapes or conservation mosaics are geographic spaces of unique biodiversity conditions with sustainability and management plans developed by Herencia Colombia to ensure quality ecosystem services. The HeCo priority landscapes result from modeling and technical prioritization where the common interest prevailed in favor of the conservation and sustainable use of biodiversity and vital ecosystem services for national development. More information about these regions <link>here</link>."
   },
@@ -862,6 +868,9 @@
   },
   "F4gyn3": {
     "string": "Clear filters"
+  },
+  "F6axhK": {
+    "string": "This information will help us understand what is the impact you want to have. This information will be <n>public</n> except the one marked as <n>private</n> which will only be visible for admins."
   },
   "F76hVG": {
     "string": "insert current password"
@@ -1095,14 +1104,8 @@
   "KGREXT": {
     "string": "Total of projects"
   },
-  "KJE+sC": {
-    "string": "Search full catalogue"
-  },
   "KYymTZ": {
     "string": "{quantity, plural, one {project} other {projects}}"
-  },
-  "KcJ5IK": {
-    "string": "Select the deadline for this open call."
   },
   "Kg0xQM": {
     "string": "Integration of project impact in each dimension (climate, biodiversity, water community) into a single score, ranging from 0 to 10."
@@ -1188,9 +1191,6 @@
   "M4pZPN": {
     "string": "Go to open call page"
   },
-  "M7261y": {
-    "string": "This information will help us understand what you are interested in invest or funding."
-  },
   "MEywfd": {
     "string": "Human capital and Inclusion"
   },
@@ -1238,9 +1238,6 @@
   },
   "MxllAO": {
     "string": "What is an open call?"
-  },
-  "N5k7R7": {
-    "string": "Tell us what’s the impact that you expect with this open call."
   },
   "N9+9Fi": {
     "string": "select the project developer type"
@@ -1307,6 +1304,9 @@
   },
   "OKhRC6": {
     "string": "Share"
+  },
+  "OQ/tJs": {
+    "string": "What’s the impact of your project and what do you want to achieve. This information will be <n>public</n>."
   },
   "OSAxiC": {
     "string": "The solution or opportunity proposed"
@@ -1482,9 +1482,6 @@
   "SMrXWc": {
     "string": "Favorites"
   },
-  "SNBzCW": {
-    "string": "Tell us what how do you expect to grow your project , how will you measure progress and impact."
-  },
   "SNyd7j": {
     "string": "Currently you don’t have any <b>Open calls</b> in your favorites."
   },
@@ -1635,9 +1632,6 @@
   "Vi/HrX": {
     "string": "Projects target investors. They are set up whenever a project developer is seeking visibility or needing investment. The project is intended to contribute to the environmental conservation of a specific region and benefit nature and people."
   },
-  "ViF88C": {
-    "string": "Tell us about your work and impact priorities."
-  },
   "VkljLs": {
     "string": "Insert the phone number in case you would like to be contacted by phone."
   },
@@ -1655,6 +1649,9 @@
   },
   "W5x0GV": {
     "string": "Water impact"
+  },
+  "W69F0D": {
+    "string": "Tell us what how do you expect to grow your project , how will you measure progress and impact. This information will be <n>public</n>."
   },
   "W6nwjo": {
     "string": "Draft"
@@ -1902,9 +1899,6 @@
   "bWygLM": {
     "string": "insert the amount of money"
   },
-  "bXy++M": {
-    "string": "How much money do you intend to give to this open call."
-  },
   "bh4rlK": {
     "string": "Government"
   },
@@ -2013,6 +2007,9 @@
   "deHJ3+": {
     "string": "Riverine flood risk"
   },
+  "defge8": {
+    "string": "Tell us what is the project about the problem and the solution to solve it. This information will be <n>public</n>."
+  },
   "des5Rg": {
     "string": "Discover projects by category"
   },
@@ -2078,6 +2075,9 @@
   },
   "ewx2b7": {
     "string": "Launch"
+  },
+  "f5UaDG": {
+    "string": "This information will help us understand what you are interested in invest or funding. This information will be <n>public</n>."
   },
   "f6GN1M": {
     "string": "<b>Community</b>: areas with production systems and sustainable practices where local and indigenous communities can thrive while enhancing their adaptation to climate change."
@@ -2148,11 +2148,11 @@
   "gbBVhv": {
     "string": "sustainable timber extraction and forest management practices, including reforestation and restoration."
   },
+  "gbWTGl": {
+    "string": "General information about the project developer. This information will be <n>public</n> except the one marked as <n>private</n> which will only be visible for admins."
+  },
   "ghj0+t": {
     "string": "Geographies"
-  },
-  "gjBW8J": {
-    "string": "General information about the investor/funder."
   },
   "gpOeXW": {
     "string": "Priority Layers"
@@ -2336,6 +2336,9 @@
   },
   "k62/kN": {
     "string": "Fit bounds"
+  },
+  "k8US3O": {
+    "string": "How much money do you intend to give to this open call. This information will be <n>public</n>."
   },
   "kEXoaQ": {
     "string": "About your work"
@@ -2568,9 +2571,6 @@
   "paBpxN": {
     "string": "Ignore"
   },
-  "pcRRCK": {
-    "string": "Financial information about your project and what are the needs"
-  },
   "pgfBG8": {
     "string": "As a Project Developer"
   },
@@ -2585,9 +2585,6 @@
   },
   "psXhQO": {
     "string": "Funding & development"
-  },
-  "puek63": {
-    "string": "This information will help us understand what is the impact you want to have."
   },
   "q0vlJx": {
     "string": "project or solution already in implementation that seeks to be strengthened and consolidated."
@@ -2660,6 +2657,9 @@
   },
   "r333tD": {
     "string": "<b>Water</b>:"
+  },
+  "rBC2yr": {
+    "string": "This information will be <n>public</n>."
   },
   "rE2fon": {
     "string": "Are you sure you want to withdraw from the “<strong>{openCallName}</strong>“ open call?"
@@ -2753,6 +2753,9 @@
   },
   "sfFhiy": {
     "string": "Maximum value"
+  },
+  "sh7TMQ": {
+    "string": "Select the deadline for this open call. This information will be <n>public</n>."
   },
   "si4NjO": {
     "string": "Select the account language in which you want to write the content of this account (including profile information and future projects). This will avoid mixed content in the platform."
@@ -2906,6 +2909,9 @@
   },
   "vdJRZj": {
     "string": "More filters"
+  },
+  "viXE32": {
+    "string": "Private"
   },
   "vygPIS": {
     "string": "Leave project creation form"


### PR DESCRIPTION
This PR adds a description to the form fields indicating the public and confidential information

## Description
Make a general message that all info is public except where indicated (don’t list the fields in the message)

There will be a way to know that the confidential fields will be visible for platform admins

Applies to all forms

- PD creation/edition
- Investor creation edition
- Project creation/edition
- Open call creation/edition 

## Testing instructions

Go to all forms indicated above 

- be sure that the pages subtitles indicates if there are fields with private information and that those fields are marked with a 'private' tag. 

## Tracking

[1051](https://vizzuality.atlassian.net/browse/LET-1051)
