### PR TITLE
Fix close filters suggestions on home page

### DIFF
--- a/frontend/containers/layouts/discover-search/component.tsx
+++ b/frontend/containers/layouts/discover-search/component.tsx
@@ -183,6 +183,7 @@ export const DiscoverSearch: FC<DiscoverSearchProps> = ({ className }) => {
             filtersData={filtersData}
             filters={filters}
             searchText={searchInputValue}
+            closeSuggestions={clearInput}
           />
         )}
         {/* Filters accordion pannel */}

--- a/frontend/containers/layouts/discover-search/component.tsx
+++ b/frontend/containers/layouts/discover-search/component.tsx
@@ -129,7 +129,7 @@ export const DiscoverSearch: FC<DiscoverSearchProps> = ({ className }) => {
                 onClick={handleClickInput}
               />
             </div>
-            {showSuggestion && (
+            {(showSuggestion || openFilters) && (
               <div>
                 <Button
                   aria-label={formatMessage({ defaultMessage: 'clear search', id: '44nONQ' })}

--- a/frontend/containers/layouts/discover-search/component.tsx
+++ b/frontend/containers/layouts/discover-search/component.tsx
@@ -129,7 +129,7 @@ export const DiscoverSearch: FC<DiscoverSearchProps> = ({ className }) => {
                 onClick={handleClickInput}
               />
             </div>
-            {(showSuggestion || openFilters) && (
+            {!!searchInputValue?.length && (
               <div>
                 <Button
                   aria-label={formatMessage({ defaultMessage: 'clear search', id: '44nONQ' })}

--- a/frontend/containers/layouts/discover-search/component.tsx
+++ b/frontend/containers/layouts/discover-search/component.tsx
@@ -183,7 +183,9 @@ export const DiscoverSearch: FC<DiscoverSearchProps> = ({ className }) => {
             filtersData={filtersData}
             filters={filters}
             searchText={searchInputValue}
-            closeSuggestions={clearInput}
+            closeSuggestions={() => {
+              setShowSuggestions(false);
+            }}
           />
         )}
         {/* Filters accordion pannel */}

--- a/frontend/containers/layouts/discover-search/component.tsx
+++ b/frontend/containers/layouts/discover-search/component.tsx
@@ -67,7 +67,9 @@ export const DiscoverSearch: FC<DiscoverSearchProps> = ({ className }) => {
   const clearInput = () => {
     setSearchInputValue('');
     setShowSuggestions(false);
-    doSearch('', filters);
+    if (pathname !== Paths.Home) {
+      doSearch('', filters);
+    }
   };
 
   const handleClickFilters = () => {
@@ -140,7 +142,7 @@ export const DiscoverSearch: FC<DiscoverSearchProps> = ({ className }) => {
                 </Button>
               </div>
             )}
-            {pathname === Paths.Home && (
+            {pathname === Paths.Home && !showSuggestion && (
               <div className="hidden md:block">
                 <Button className="text-green-dark" theme="naked" to={Paths.Discover}>
                   <FormattedMessage defaultMessage="See full catalogue" id="oG/A0q" />

--- a/frontend/containers/search-auto-suggestion/component.tsx
+++ b/frontend/containers/search-auto-suggestion/component.tsx
@@ -20,6 +20,7 @@ export const SearchAutoSuggestion: FC<SeachAutoSuggestionProps> = ({
   searchText,
   filters,
   filtersData,
+  closeSuggestions,
 }) => {
   const selectedFilters = useMemo(() => Object.values(filters), [filters]);
   const doSearch = useSearch();
@@ -43,6 +44,7 @@ export const SearchAutoSuggestion: FC<SeachAutoSuggestionProps> = ({
 
   const handleSearchSuggestion = () => {
     doSearch(searchText, filters);
+    closeSuggestions();
   };
 
   const autoSuggestions = useMemo(() => {

--- a/frontend/containers/search-auto-suggestion/types.ts
+++ b/frontend/containers/search-auto-suggestion/types.ts
@@ -9,4 +9,6 @@ export type SeachAutoSuggestionProps = {
   filters: Partial<FilterParams>;
   /** Enums of filters */
   filtersData: Enum[];
+  /** Function to clear search input and close suggestions */
+  closeSuggestions: () => void;
 };


### PR DESCRIPTION
This PR fixes the homepage close autosuggestions button behaviour.

## Testing instructions

- On the home page, type some characters on the search input to open the autosuggestions
- Click on the close button 
The input should be cleared and the autosusegstion closed, keeping at the home page

## Tracking

[LET-1147](https://vizzuality.atlassian.net/browse/LET-1147)