### PR TITLE
Make the account profile pictures fully visible (fit their container)

### DIFF
--- a/frontend/components/forms/image-uploader/component.tsx
+++ b/frontend/components/forms/image-uploader/component.tsx
@@ -87,7 +87,7 @@ export const ImageUploader = <FormValues extends FieldValues>({
             src={imagePreview || defaultImage || '/images/avatar.svg'}
             alt={formatMessage({ defaultMessage: 'Preview', id: 'TJo5E6' })}
             layout="fill"
-            objectFit="cover"
+            objectFit="contain"
           />
         </div>
       )}

--- a/frontend/containers/dashboard/users/table/cells/user/component.tsx
+++ b/frontend/containers/dashboard/users/table/cells/user/component.tsx
@@ -13,13 +13,15 @@ export const CellUser = ({ row }: CellUserProps) => {
   } = row;
   return (
     <div className="flex items-center space-x-6">
-      <Image
-        src={picture || DEFAULT_IMAGE_PNG}
-        alt={first_name}
-        width={32}
-        height={32}
-        className="rounded-full"
-      />
+      <div className="flex-shrink-0">
+        <Image
+          src={picture || DEFAULT_IMAGE_PNG}
+          alt={first_name}
+          width={32}
+          height={32}
+          className="rounded-full"
+        />
+      </div>
 
       <p>{`${first_name || ''} ${last_name || ''}`}</p>
     </div>

--- a/frontend/containers/open-call-card/component.tsx
+++ b/frontend/containers/open-call-card/component.tsx
@@ -170,7 +170,7 @@ export const OpenCallCard: FC<OpenCallCardProps> = ({ className, openCall }: Ope
                   { name }
                 )}
                 layout="fill"
-                objectFit="cover"
+                objectFit="contain"
                 onError={() => setPicture(placeholderPicture)}
               />
             </span>

--- a/frontend/containers/profile-card/component.tsx
+++ b/frontend/containers/profile-card/component.tsx
@@ -91,7 +91,7 @@ export const ProfileCard: FC<ProfileCardProps> = ({
               src={picture}
               alt={intl.formatMessage({ defaultMessage: '{name} picture', id: 'rLzWx9' }, { name })}
               layout="fill"
-              objectFit="cover"
+              objectFit="contain"
               onError={() => setPicture(placeholderPicture)}
             />
           </div>

--- a/frontend/containers/profile-header/component.tsx
+++ b/frontend/containers/profile-header/component.tsx
@@ -63,7 +63,7 @@ export const ProfileHeader: FC<ProfileHeaderProps> = ({
                   { organization: title }
                 )}
                 layout="fill"
-                objectFit="cover"
+                objectFit="contain"
                 onError={() => setLogo('/images/placeholders/profile-logo.png')}
               />
             </div>

--- a/frontend/containers/project-details/component.tsx
+++ b/frontend/containers/project-details/component.tsx
@@ -193,7 +193,7 @@ export const ProjectDetails: FC<ProjectDetailsProps> = ({
               src={projectDeveloperImage}
               alt={intl.formatMessage({ defaultMessage: 'Project developer photo', id: 'BZkcBV' })}
               layout="fill"
-              objectFit="cover"
+              objectFit="contain"
               onError={handleProjectDeveloperImageError}
             />
           </span>

--- a/frontend/containers/social-contact/contact-information-modal/contact-item/component.tsx
+++ b/frontend/containers/social-contact/contact-information-modal/contact-item/component.tsx
@@ -36,13 +36,13 @@ export const ContactItem: FC<ContactItemProps> = ({
               src={picture}
               alt={intl.formatMessage({ defaultMessage: '{name} picture', id: 'rLzWx9' }, { name })}
               layout="fill"
-              objectFit="cover"
+              objectFit="contain"
               onError={() => setPicture(placeholderPicture)}
             />
           </div>
         </div>
       )}
-      <div className="flex flex-col items-start w-full max-w-md gap-5">
+      <div className="flex flex-col items-start w-full max-w-md gap-5 break-all">
         {email && (
           <span
             className="flex items-center"

--- a/frontend/layouts/dashboard/account-picture/component.tsx
+++ b/frontend/layouts/dashboard/account-picture/component.tsx
@@ -20,13 +20,13 @@ export const AccountPicture: FC<AccountPictureProps> = ({
   }, [pictureSrc]);
 
   return (
-    <div className="w-20 h-20 overflow-hidden rounded-lg drop-shadow-xl">
+    <div className="w-20 h-20 overflow-hidden bg-white rounded-lg drop-shadow-xl">
       <Image
         className="rounded-lg"
         src={picture}
         alt={intl.formatMessage({ defaultMessage: '{name} picture', id: 'rLzWx9' }, { name: name })}
         layout="fill"
-        objectFit="cover"
+        objectFit="contain"
         onError={() => setPicture(placeholderPictureSrc)}
       />
     </div>

--- a/frontend/pages/dashboard/open-call/[openCallId]/application/[applicationId].tsx
+++ b/frontend/pages/dashboard/open-call/[openCallId]/application/[applicationId].tsx
@@ -210,7 +210,7 @@ export const OpenCallDetailsPage: PageComponent<OpenCallDetailsPageProps, Dashbo
                           { name: projectDeveloper?.name }
                         )}
                         layout="fill"
-                        objectFit="cover"
+                        objectFit="contain"
                         onError={() => setProjectDeveloperPhoto(placeholderPicture)}
                       />
                     </span>

--- a/frontend/pages/investor/[id]/index.tsx
+++ b/frontend/pages/investor/[id]/index.tsx
@@ -106,6 +106,7 @@ const InvestorPage: PageComponent<InvestorPageProps, StaticPageLayoutProps> = ({
     email: contact_email,
     phone: contact_phone,
     name,
+    picture: picture?.medium,
   };
 
   const logo = picture?.small || '/images/avatar.svg';

--- a/frontend/pages/project-developer/[id]/index.tsx
+++ b/frontend/pages/project-developer/[id]/index.tsx
@@ -100,6 +100,7 @@ const ProjectDeveloperPage: PageComponent<ProjectDeveloperPageProps, StaticPageL
     name: projectDeveloper.name,
     email: projectDeveloper.contact_email,
     phone: projectDeveloper.contact_phone,
+    picture: projectDeveloper.picture?.medium,
   };
 
   const tagsRows: TagsGridRowType[] = [


### PR DESCRIPTION
In this PR, instead of having the account profile picture cover their container, they now fit them so that non-square images are fully visible, even if it looks less aesthetical pleasing.

Further changes (different task) will give the users recommendations for the picture.

## Testing instructions

Here are all the places affected by the change:
- Discover
    - Project details card
        - PD picture
        - Contact modal
    - Open call card (investor picture)
    - PD card
    - Investor card
- Investor public page
    - Header picture
    - Contact modal
- PD public page
    - Header picture
    - Contact modal
- Project public page
    - PD cards at the bottom (PD picture)
    - Contact modal
- Open call public page
    - Investor card at the bottom (investor picture)
- Investor dashboard
    - Header picture
    - Open calls application details (PD picture)
    - Favourites (open calls, investors, PDs)
    - Creation/edition form (preview picture)
- PD dashboard
    - Header picture
    - Favourites (open calls, investors, PDs)
    - Creation/edition form (preview picture)

## Tracking

[LET-949](https://vizzuality.atlassian.net/browse/LET-949)
