### PR TITLE
Display the correct image for the investor in the open call cards

### DIFF
--- a/frontend/containers/open-call-card/component.tsx
+++ b/frontend/containers/open-call-card/component.tsx
@@ -31,7 +31,6 @@ export const OpenCallCard: FC<OpenCallCardProps> = ({ className, openCall }: Ope
     instrument_types,
     maximum_funding_per_project: maxFunding,
     closing_at: closingAt,
-    picture: pictureProp,
   } = openCall;
   const placeholderPicture = '/images/placeholders/profile-logo.png';
 
@@ -41,7 +40,7 @@ export const OpenCallCard: FC<OpenCallCardProps> = ({ className, openCall }: Ope
     data: { instrument_type: allInstrumentTypes, ticket_size: allTicketSizes, impact: allImpacts },
   } = useEnums();
 
-  const [picture, setPicture] = useState<string>(pictureProp?.small || placeholderPicture);
+  const [picture, setPicture] = useState<string>(investor.picture?.small || placeholderPicture);
   const [isFocusWithin, setIsFocusWithin] = useState<boolean>(false);
 
   const link = `${Paths.OpenCall}/${slug}`;
@@ -167,7 +166,7 @@ export const OpenCallCard: FC<OpenCallCardProps> = ({ className, openCall }: Ope
                 src={picture}
                 alt={intl.formatMessage(
                   { defaultMessage: '{name} picture', id: 'rLzWx9' },
-                  { name }
+                  { name: investor.name }
                 )}
                 layout="fill"
                 objectFit="cover"


### PR DESCRIPTION
This PR fixes an issue where the image of the open call would be used to represent the investor of an open call in the Discover page.

## Testing instructions

Make sure the correct image (and alternative text) is used in the open call card component.

## Tracking

[LET-1159](https://vizzuality.atlassian.net/browse/LET-1159)
