### PR TITLE
Fix a wrong maximum image size on the project and open call forms

### DIFF
--- a/frontend/containers/open-call-form/pages/information.tsx
+++ b/frontend/containers/open-call-form/pages/information.tsx
@@ -135,7 +135,6 @@ export const OpenCallInformation: FC<OpenCallInformationProps> = ({
               // https://react-dropzone.org/#section-accepting-specific-file-types
               fileTypes={{ 'image/*': ['.png', '.jpg', '.jpeg'] }}
               maxFiles={6}
-              maxSize={5 * 1024 * 1025}
               onUpload={handleUploadImages}
               aria-labelledby="picture-label"
             />

--- a/frontend/containers/project-form/pages/general-information.tsx
+++ b/frontend/containers/project-form/pages/general-information.tsx
@@ -176,7 +176,6 @@ const GeneralInformation = ({
                 // https://react-dropzone.org/#section-accepting-specific-file-types
                 fileTypes={{ 'image/*': ['.png', '.jpg', '.jpeg'] }}
                 maxFiles={6}
-                maxSize={5 * 1024 * 1025}
                 onUpload={handleUploadImages}
               />
             </div>


### PR DESCRIPTION
In the project and open call forms, a mistake in converting megabytes to bytes allowed users to upload images 5 KB heavier than what the back-end accepts.

## Testing instructions

Check that you can still upload images up to 5 MB.

## Tracking

[LET-1160](https://vizzuality.atlassian.net/browse/LET-1160)
