### PR TITLE
fix: Adding missing encryption variables to docker compose test

### DIFF
--- a/backend/docker-compose-test.yml
+++ b/backend/docker-compose-test.yml
@@ -14,6 +14,9 @@ services:
       - CLOUD_TASKS_TEST_QUEUE_NAME=test
       - FRONTEND_URL=http://localhost:4000
       - IS_JOBS_INSTANCE=true
+      - ENCRYPTION_PRIMARY_KEY=TEST
+      - ENCRYPTION_DETERMINISTIC_KEY=TEST
+      - ENCRYPTION_DERIVATION_SALT=TEST
     depends_on:
       - db
   db:


### PR DESCRIPTION
Fix of deployment, I have forgot to add new env variables to docker compose test which is run as part of deployment.