### PR TITLE
Add update user information form

### DIFF
--- a/frontend/components/confirmation-prompt/component.tsx
+++ b/frontend/components/confirmation-prompt/component.tsx
@@ -25,6 +25,7 @@ export const ConfirmationPrompt: FC<ConfirmationPromptProps> = ({
   confirmationError,
   onConfirmDisabled = false,
   onConfirmText,
+  confirmButtonTheme = 'primary-red',
 }: ConfirmationPromptProps) => (
   <Modal open={open} title={title} size="default" dismissable={dismissible} onDismiss={onDismiss}>
     <div className="flex flex-col items-center px-8 py-4">
@@ -55,7 +56,7 @@ export const ConfirmationPrompt: FC<ConfirmationPromptProps> = ({
           <FormattedMessage defaultMessage="Cancel" id="47FYwb" />
         </Button>
         <Button
-          theme="primary-red"
+          theme={confirmButtonTheme}
           size="small"
           className="flex-shrink-0 sm:mr-5"
           onClick={onAccept}

--- a/frontend/components/confirmation-prompt/types.d.ts
+++ b/frontend/components/confirmation-prompt/types.d.ts
@@ -1,5 +1,6 @@
 import { IconProps } from 'components/icon';
 import { ModalProps } from 'components/modal';
+import { ButtonProps } from 'components/button';
 
 export interface ConfirmationPromptProps {
   /**
@@ -45,4 +46,6 @@ export interface ConfirmationPromptProps {
   onDismiss: ModalProps['onDismiss'];
   /** Text to show on the confirm button. Defaults to 'Delete' */
   onConfirmText?: string;
+  /** Theme of the confirm button */
+  confirmButtonTheme?: ButtonProps['theme'];
 }

--- a/frontend/components/forms/image-uploader/component.tsx
+++ b/frontend/components/forms/image-uploader/component.tsx
@@ -24,6 +24,7 @@ export const ImageUploader = <FormValues extends FieldValues>({
   maxSize = FILE_UPLOADER_MAX_SIZE,
   clearErrors,
   defaultImage,
+  theme = 'primary-green',
 }: ImageUploaderProps<FormValues>) => {
   const { formatMessage } = useIntl();
   const [imagePreview, setImagePreview] = useState<string>();
@@ -94,7 +95,15 @@ export const ImageUploader = <FormValues extends FieldValues>({
       {/* File input to upload the file */}
       <input
         id={id}
-        className="p-1 font-sans outline-none appearance-none file:transition-all file:mr-4 file:px-6 file:font-medium file:text-sm file file:py-2 file:rounded-full file:border-0 file:bg-green-dark file:text-white file:hover:text-green-light file:hover:disabled:text-white disabled:opacity-60 file:cursor-pointer file:disabled:pointer-events-none file:focus-visible:outline file:focus-visible:outline-2 file:focus-visible:outline-offset-2 file:focus-visible:outline-green-dark"
+        className={cx(
+          'p-1 font-sans outline-none appearance-none file:transition-all file:mr-4 file:px-6 file:font-medium file:text-sm file file:py-2 file:rounded-full disabled:opacity-60 file:cursor-pointer file:disabled:pointer-events-none file:focus-visible:outline file:focus-visible:outline-2 file:focus-visible:outline-offset-2 file:focus-visible:outline-green-dark',
+          {
+            'file:text-white file:hover:text-green-light file:bg-green-dark file:border-0 file:hover:disabled:text-white':
+              theme === 'primary-green',
+            'file:text-green-dark  file:bg-white file:border file:border-green-dark file:hover:bg-green-light file:hover:bg-opacity-20 file:hover:disabled:text-gray-600':
+              theme === 'secondary-green',
+          }
+        )}
         type="file"
         accept="image/png, image/jpeg"
         onChange={handleUploadImage}

--- a/frontend/components/forms/image-uploader/types.ts
+++ b/frontend/components/forms/image-uploader/types.ts
@@ -30,4 +30,6 @@ export type ImageUploaderProps<FormValues> = {
   maxSize?: number;
   /** Default image url to show */
   defaultImage?: string;
+  /** The upload button theme */
+  theme?: 'primary-green' | 'secondary-green';
 };

--- a/frontend/components/forms/input/component.tsx
+++ b/frontend/components/forms/input/component.tsx
@@ -35,7 +35,7 @@ export const Input = <FormValues extends FieldValues>({
         'block w-full px-4 py-2 text-base text-gray-900 placeholder-gray-400 placeholder-opacity-100 border border-solid border-beige hover:shadow-sm focus:shadow-sm focus:border-green-dark outline-none bg-white rounded-lg disabled:opacity-60 transition':
           true,
         [className]: !!className,
-        'invalid:border-red-700': invalid,
+        'invalid:border-red-700 focus:invalid:border-red-700': invalid,
       })}
       {...register(name, registerOptions)}
       onInvalid={() => setInvalid(true)}

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -659,6 +659,9 @@
   "BeVl3b": {
     "string": "How long will the open call be available?"
   },
+  "BfXxmC": {
+    "string": "The first name is required"
+  },
   "BqrQ5O": {
     "string": "At the <b>Landscape level</b>, a composite index combining the set of indicators identified for each dimension is used to calculate <b>Context scores</b>, with values ranging from 0 to 1. <b>Demand</b> is then computed as 1 - <b>Context score</b>, representing the “quantity” missing to reach 1, where 1 assumes the best sustainability conditions. Because the demand can be considered at multiple scales (namely, municipality, hydrological basins, and HeCo Priority Landscapes), the demand score is computed using zonal statistics at a user-specified scale, with the municipality level being the default. Unlike municipalities and hydrographic basins, the HeCo Priority Landscapes don’t cover the entire country, and therefore <b>if the project area doesn't fall into any of the Priority Landscapes, the impact of that project will be zero at that particular scale</b>."
   },
@@ -1071,6 +1074,9 @@
   "Jfw90a": {
     "string": "Publish draft"
   },
+  "JhuBos": {
+    "string": "Your avatar"
+  },
   "JkLHGw": {
     "string": "Website"
   },
@@ -1226,6 +1232,9 @@
   },
   "MxllAO": {
     "string": "What is an open call?"
+  },
+  "N2IrpM": {
+    "string": "Confirm"
   },
   "N9+9Fi": {
     "string": "select the project developer type"
@@ -2391,6 +2400,9 @@
   "lda5xz": {
     "string": "My users"
   },
+  "lewlDm": {
+    "string": "The last name is required"
+  },
   "lfXAQ2": {
     "string": "Hydrometeorological risk reduction"
   },
@@ -2906,6 +2918,9 @@
   },
   "w1Fanr": {
     "string": "Business"
+  },
+  "w5UvPh": {
+    "string": "Update user information?"
   },
   "w7tf2z": {
     "string": "Published"

--- a/frontend/pages/settings/information.tsx
+++ b/frontend/pages/settings/information.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { useForm } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
@@ -58,12 +58,28 @@ const Information: PageComponent<InformationPageProps, SettingsLayoutProps> = ()
   const deleteUser = useDeleteUser();
   const [showConfirmDelete, setShowConfirmDelete] = useState(false);
 
-  const { control, clearErrors, setError, setValue, register, reset, handleSubmit, formState } =
-    useForm<UpdateUserDto>({
-      shouldUseNativeValidation: true,
-      shouldFocusError: true,
-      reValidateMode: 'onChange',
-    });
+  const {
+    control,
+    clearErrors,
+    setError,
+    setValue,
+    register,
+    reset,
+    handleSubmit,
+    formState,
+    watch,
+  } = useForm<UpdateUserDto>({
+    shouldUseNativeValidation: true,
+    shouldFocusError: true,
+    reValidateMode: 'onChange',
+  });
+
+  const userInfo = watch();
+
+  const informationChanged = useMemo(
+    () => userInfo?.first_name !== user?.first_name || userInfo.last_name !== user?.last_name,
+    [user?.first_name, user?.last_name, userInfo.first_name, userInfo.last_name]
+  );
 
   useEffect(() => {
     setValue('first_name', user?.first_name);
@@ -78,7 +94,7 @@ const Information: PageComponent<InformationPageProps, SettingsLayoutProps> = ()
   };
 
   const handleDismissConfirmUpdate = () => {
-    reset();
+    reset(user);
     setShowConfirmUpdate(false);
   };
 
@@ -224,7 +240,7 @@ const Information: PageComponent<InformationPageProps, SettingsLayoutProps> = ()
                 </div>
               )}
               <div className="flex justify-end mt-12">
-                <Button onClick={handleClickUpdate}>
+                <Button onClick={handleClickUpdate} disabled={!informationChanged}>
                   <FormattedMessage defaultMessage="Update information" id="4iPaIz" />
                 </Button>
               </div>
@@ -233,7 +249,7 @@ const Information: PageComponent<InformationPageProps, SettingsLayoutProps> = ()
           <ConfirmationPrompt
             onAccept={handleSubmit(onSubmit)}
             onRefuse={handleDismissConfirmUpdate}
-            onDismiss={() => setShowConfirmUpdate(false)}
+            onDismiss={handleDismissConfirmUpdate}
             open={showConfirmUpdate}
             title={formatMessage({ defaultMessage: 'Update user information?', id: 'w5UvPh' })}
             onConfirmText={formatMessage({ defaultMessage: 'Confirm', id: 'N2IrpM' })}

--- a/frontend/pages/settings/information.tsx
+++ b/frontend/pages/settings/information.tsx
@@ -1,27 +1,40 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
+import { useForm } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useQueryClient } from 'react-query';
 
+// import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 
 import { withLocalizedRequests } from 'hoc/locale';
 
+import { isEmpty } from 'lodash-es';
 import { InferGetStaticPropsType } from 'next';
 
 import { loadI18nMessages } from 'helpers/i18n';
+import { getServiceErrors } from 'helpers/pages';
 
+import Alert from 'components/alert';
 import Button from 'components/button';
 import ConfirmationPrompt from 'components/confirmation-prompt';
+import ErrorMessage from 'components/forms/error-message';
+import Input from 'components/forms/input';
+import Label from 'components/forms/label';
 import Head from 'components/head';
 import LayoutContainer from 'components/layout-container';
 import { Paths, UserRoles } from 'enums';
+// import AccountPicture from 'layouts/dashboard/account-picture';
 import NakedLayout from 'layouts/naked';
 import ProtectedPage from 'layouts/protected-page';
 import SettingsLayout, { SettingsLayoutProps } from 'layouts/settings';
 import { PageComponent } from 'types';
+import { UpdateUserDto } from 'types/user';
 
 import { useAccount, useDeleteUser } from 'services/account';
+import { useUpdateUser } from 'services/users/userService';
+
+// const ImageUploader = dynamic(() => import('components/forms/image-uploader'), { ssr: false });
 
 export const getStaticProps = withLocalizedRequests(async ({ locale }) => {
   return {
@@ -38,8 +51,60 @@ const Information: PageComponent<InformationPageProps, SettingsLayoutProps> = ()
   const { push } = useRouter();
   const { user, userAccount } = useAccount();
   const queryClient = useQueryClient();
+
+  const updateUser = useUpdateUser();
+  const [showConfirmUpdate, setShowConfirmUpdate] = useState(false);
+
   const deleteUser = useDeleteUser();
-  const [showConfirmation, setShowConfirmation] = useState(false);
+  const [showConfirmDelete, setShowConfirmDelete] = useState(false);
+
+  const { control, clearErrors, setError, setValue, register, reset, handleSubmit, formState } =
+    useForm<UpdateUserDto>({
+      shouldUseNativeValidation: true,
+      shouldFocusError: true,
+      reValidateMode: 'onChange',
+    });
+
+  useEffect(() => {
+    setValue('first_name', user?.first_name);
+    setValue('last_name', user?.last_name);
+  }, [user?.first_name, user?.last_name, setValue]);
+
+  const handleClickUpdate = (e) => {
+    e.preventDefault();
+    if (isEmpty(formState.errors)) {
+      setShowConfirmUpdate(true);
+    }
+  };
+
+  const handleDismissConfirmUpdate = () => {
+    reset();
+    setShowConfirmUpdate(false);
+  };
+
+  const onSubmit = (data: UpdateUserDto) => {
+    updateUser.mutate(data, {
+      onError: (error) => {
+        const { fieldErrors } = getServiceErrors<UpdateUserDto>(error, [
+          ['first_name', 'last_name'],
+        ]);
+        fieldErrors?.forEach(({ fieldName, message }, index) => {
+          [
+            setError(
+              fieldName,
+              { message },
+              {
+                shouldFocus: index === 0,
+              }
+            ),
+          ];
+        });
+      },
+      onSettled: () => {
+        setShowConfirmUpdate(false);
+      },
+    });
+  };
 
   const handleDeleteUser = () => {
     if (user && !user.owner) {
@@ -56,16 +121,130 @@ const Information: PageComponent<InformationPageProps, SettingsLayoutProps> = ()
     <ProtectedPage permissions={[UserRoles.ProjectDeveloper, UserRoles.Investor, UserRoles.Light]}>
       <Head title={formatMessage({ defaultMessage: 'Account information', id: 'CzsYIe' })} />
       <SettingsLayout>
-        <LayoutContainer layout={'narrow'} className="flex flex-col gap-4">
+        <LayoutContainer
+          layout={'narrow'}
+          className="flex flex-col gap-4 md:!max-w-2xl xl:!max-w-3xl"
+        >
           <div className="p-6 bg-white rounded-lg">
-            <div className="flex text-sm">
-              <div className="flex-grow font-semibold">
+            <form noValidate>
+              <div className="flex-grow text-xl font-semibold">
                 <FormattedMessage defaultMessage="Update information" id="4iPaIz" />
               </div>
-            </div>
+              {/* We don't have the picture on the update user dto, so I will leave it commented for now
+              <div className="mt-5">
+                <label htmlFor="picture-uploader" className="text-sm font-semibold text-gray-800">
+                  <FormattedMessage defaultMessage="Your avatar" id="JhuBos" />
+                </label>
+                <div className="flex mt-4 gap-x-5">
+                  <AccountPicture name={user?.first_name} picture={user?.avatar.medium} />
+                  <ImageUploader
+                    clearErrors={clearErrors}
+                    control={control}
+                    id="picture-uploader"
+                    name="picture"
+                    setError={setError}
+                    setValue={setValue}
+                    theme="secondary-green"
+                  />
+                </div>
+              </div> */}
+              <div className="mt-6">
+                <Label
+                  htmlFor="first-name"
+                  className="block mb-2 text-sm font-semibold text-gray-800"
+                >
+                  <FormattedMessage defaultMessage="First name" id="pONqz8" />
+                </Label>
+                <Input
+                  name="first_name"
+                  id="first-name"
+                  register={register}
+                  registerOptions={{
+                    required: formatMessage({
+                      defaultMessage: 'The first name is required',
+                      id: 'BfXxmC',
+                    }),
+                  }}
+                  type="text"
+                  aria-describedby="first-name-error"
+                  aria-required
+                />
+                <ErrorMessage
+                  id="first-name-error"
+                  errorText={formState.errors?.first_name?.message}
+                />
+              </div>
+              <div className="mt-6">
+                <Label
+                  htmlFor="last-name"
+                  className="block mb-2 text-sm font-semibold text-gray-800"
+                >
+                  <FormattedMessage defaultMessage="Last name" id="txUL0F" />
+                </Label>
+                <Input
+                  name="last_name"
+                  aria-required
+                  id="last-name"
+                  register={register}
+                  registerOptions={{
+                    required: formatMessage({
+                      defaultMessage: 'The last name is required',
+                      id: 'lewlDm',
+                    }),
+                  }}
+                  type="text"
+                  aria-describedby="last-name-error"
+                />
+                <ErrorMessage
+                  id="last-name-error"
+                  errorText={formState.errors?.last_name?.message}
+                />
+              </div>
+              <div className="mt-6">
+                <Label htmlFor="email" className="block mb-2 text-sm font-semibold text-gray-800">
+                  <FormattedMessage defaultMessage="Email" id="sy+pv5" />
+                </Label>
+                <input
+                  className="block w-full px-4 py-2 text-base text-gray-900 bg-white border border-solid rounded-lg outline-none border-beige disabled:opacity-60"
+                  name="email"
+                  disabled
+                  id="email"
+                  type="text"
+                  value={user?.email}
+                />
+              </div>
+              {updateUser.isError && (
+                <div className="mt-6">
+                  <Alert type="warning" withLayoutContainer>
+                    {Array.isArray(updateUser.error.message) &&
+                      updateUser.error.message.map((message) => (
+                        <span key="message">{message.title}</span>
+                      ))}
+                  </Alert>
+                </div>
+              )}
+              <div className="flex justify-end mt-12">
+                <Button onClick={handleClickUpdate}>
+                  <FormattedMessage defaultMessage="Update information" id="4iPaIz" />
+                </Button>
+              </div>
+            </form>
           </div>
+          <ConfirmationPrompt
+            onAccept={handleSubmit(onSubmit)}
+            onRefuse={handleDismissConfirmUpdate}
+            onDismiss={() => setShowConfirmUpdate(false)}
+            open={showConfirmUpdate}
+            title={formatMessage({ defaultMessage: 'Update user information?', id: 'w5UvPh' })}
+            onConfirmText={formatMessage({ defaultMessage: 'Confirm', id: 'N2IrpM' })}
+            confirmButtonTheme="primary-green"
+            onAcceptLoading={updateUser.isLoading}
+          />
         </LayoutContainer>
-        <LayoutContainer layout={'narrow'} className="flex flex-col gap-4 mt-6">
+        <LayoutContainer
+          layout={'narrow'}
+          className="flex flex-col gap-4 mt-6 md:!max-w-2xl xl:!max-w-3xl"
+        >
           <div className="p-6 bg-white rounded-lg">
             <div className="">
               <div className="flex-grow text-xl font-semibold text-red-700">
@@ -89,7 +268,7 @@ const Information: PageComponent<InformationPageProps, SettingsLayoutProps> = ()
                 </p>
               </div>
               <div className="flex justify-end mt-6">
-                <Button theme="primary-red" onClick={() => setShowConfirmation(true)}>
+                <Button theme="primary-red" onClick={() => setShowConfirmDelete(true)}>
                   <FormattedMessage defaultMessage="Delete" id="K3r6DQ" />
                 </Button>
               </div>
@@ -98,9 +277,9 @@ const Information: PageComponent<InformationPageProps, SettingsLayoutProps> = ()
         </LayoutContainer>
         <ConfirmationPrompt
           onAccept={handleDeleteUser}
-          onDismiss={() => setShowConfirmation(false)}
-          onRefuse={() => setShowConfirmation(false)}
-          open={showConfirmation}
+          onDismiss={() => setShowConfirmDelete(false)}
+          onRefuse={() => setShowConfirmDelete(false)}
+          open={showConfirmDelete}
           onConfirmDisabled={!user || user.owner}
           title={formatMessage({ defaultMessage: 'Delete my user', id: 'fZpvTQ' })}
           description={

--- a/frontend/services/users/userService.ts
+++ b/frontend/services/users/userService.ts
@@ -5,7 +5,7 @@ import { useRouter } from 'next/router';
 import { AxiosResponse, AxiosError } from 'axios';
 
 import { Queries } from 'enums';
-import { SignupDto, User, ChangePassword } from 'types/user';
+import { SignupDto, User, ChangePassword, UpdateUserDto } from 'types/user';
 
 import { ErrorResponse, ResponseData } from 'services/types';
 
@@ -45,6 +45,26 @@ export const useChangePassword = (): UseMutationResult<
   ChangePassword
 > => {
   return useMutation(changePassword);
+};
+
+const updateUser = (dto: UpdateUserDto) => {
+  return API.put<ResponseData<User>>('/api/v1/user', dto);
+};
+
+/** Hook to update the current user inforation */
+export const useUpdateUser = (): UseMutationResult<
+  AxiosResponse<ResponseData<User>>,
+  AxiosError<ErrorResponse>,
+  UpdateUserDto
+> => {
+  const { locale } = useRouter();
+  const queryClient = useQueryClient();
+
+  return useMutation(updateUser, {
+    onSuccess: (data) => {
+      queryClient.setQueryData([Queries.User, locale], data);
+    },
+  });
 };
 
 export const deleteFavorites = () => {

--- a/frontend/types/user.ts
+++ b/frontend/types/user.ts
@@ -58,3 +58,9 @@ export type ChangePassword = {
   password: string;
   password_confirmation: string;
 };
+
+export type UpdateUserDto = {
+  first_name: string;
+  last_name: string;
+  otp_required_for_login?: boolean;
+};


### PR DESCRIPTION
This PR adds the update user information form

OBS: the design have an avatar picture and an image uploader button, but the user form doesn’t have the picture and it is not in the scope of the task. For that reason I let that section commented for future implementation.

## Testing instructions

Go to 'my preferences'/information area.

- You should be able to update your name and last name.
- Both fields are mandatory and display an error if empty 
- The email is visible but is disabled for edition
- If you click on the 'Update password' button, a modal is displayed to confirm the action.

## Tracking
[LET-1066]https://vizzuality.atlassian.net/browse/LET-1066


[LET-1066]: https://vizzuality.atlassian.net/browse/LET-1066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ