### PR TITLE
Display a cookie banner to ask for the user's consent

### DIFF
--- a/frontend/components/privacy-notice/component.tsx
+++ b/frontend/components/privacy-notice/component.tsx
@@ -1,0 +1,37 @@
+import { FC, useState, useEffect } from 'react';
+
+import { OverlayContainer } from '@react-aria/overlays';
+
+import { useCookiesConsent } from 'hooks/use-cookies-consent';
+
+import NoticeContent from './notice-content';
+import { PrivacyNoticeProps } from './types';
+
+export const PrivacyNotice: FC<PrivacyNoticeProps> = ({}: PrivacyNoticeProps) => {
+  const [mounted, setMounted] = useState(false);
+
+  const { consentDate } = useCookiesConsent();
+
+  // When the component is mounted, we store that information
+  useEffect(() => {
+    setMounted(true);
+  }, [setMounted]);
+
+  // We avoid a flash of the privacy notice by not displaying it  until the component has mounted
+  if (!mounted) {
+    return null;
+  }
+
+  // Whether the user has allowed the cookies or not, the notice should not be displayed again
+  if (consentDate) {
+    return null;
+  }
+
+  return (
+    <OverlayContainer>
+      <NoticeContent />
+    </OverlayContainer>
+  );
+};
+
+export default PrivacyNotice;

--- a/frontend/components/privacy-notice/index.ts
+++ b/frontend/components/privacy-notice/index.ts
@@ -1,0 +1,2 @@
+export type { PrivacyNoticeProps } from './types';
+export { default } from './component';

--- a/frontend/components/privacy-notice/notice-content/component.tsx
+++ b/frontend/components/privacy-notice/notice-content/component.tsx
@@ -1,0 +1,90 @@
+import { FC, useRef, useCallback } from 'react';
+
+import { FormattedMessage } from 'react-intl';
+
+import Link from 'next/link';
+
+import { useDialog } from '@react-aria/dialog';
+import { FocusScope } from '@react-aria/focus';
+import { useModal } from '@react-aria/overlays';
+
+import { useCookiesConsent } from 'hooks/use-cookies-consent';
+
+import Button from 'components/button';
+import LayoutContainer from 'components/layout-container';
+import { Paths } from 'enums';
+
+import { NoticeContentProps } from './types';
+
+// This is the actual content of the notice. It needs to be in a separate component because
+// `useModal` uses the context API provided by `OverlayContainer` to properly hide the rest of the
+// content of the page from the screen reader.
+const NoticeContent: FC<NoticeContentProps> = ({}: NoticeContentProps) => {
+  const { updateConsent } = useCookiesConsent();
+
+  const dialogRef = useRef(null);
+  const { modalProps } = useModal();
+  const { dialogProps, titleProps } = useDialog({ 'aria-labelledby': 'privacy-notice' }, dialogRef);
+
+  const onAcceptCookies = useCallback(() => updateConsent(true, +new Date()), [updateConsent]);
+
+  const onRefuseCookies = useCallback(() => updateConsent(false, +new Date()), [updateConsent]);
+
+  return (
+    <div className="fixed bottom-0 left-0 z-10 w-full bg-beige">
+      <LayoutContainer>
+        <FocusScope
+          // eslint-disable-next-line jsx-a11y/no-autofocus
+          autoFocus
+          restoreFocus
+        >
+          <div
+            {...modalProps}
+            {...dialogProps}
+            ref={dialogRef}
+            className="py-3 text-sm sm:py-6 sm:flex"
+          >
+            <div>
+              <h1 {...titleProps} id="privacy-notice" className="sr-only">
+                <FormattedMessage defaultMessage="Privacy notice" id="b8sVDI" />
+              </h1>
+              <p>
+                <FormattedMessage
+                  defaultMessage="We use cookies for analytics, personalization, and marketing purposes. Only essential cookies are active by default to ensure you get the best experience. Please read our <a>Cookie Policy</a> to learn more."
+                  id="RrcFtD"
+                  values={{
+                    a: (chunks) => (
+                      <Link href={Paths.PrivacyPolicy}>
+                        <a
+                          className="underline focus-visible:outline focus-visible:outline-green-dark focus-visible:outline-2 focus-visible:outline-offset-2"
+                          target="_blank"
+                        >
+                          {chunks}
+                        </a>
+                      </Link>
+                    ),
+                  }}
+                />
+              </p>
+            </div>
+            <div className="flex flex-col items-stretch mt-4 gap-y-2 sm:mt-0 sm:ml-4 lg:ml-6 sm:flex-shrink-0 lg:flex-row-reverse lg:items-start lg:gap-x-6">
+              <Button type="button" className="justify-center" onClick={onAcceptCookies}>
+                <FormattedMessage defaultMessage="Accept all cookies" id="jvP3C2" />
+              </Button>
+              <Button
+                type="button"
+                theme="secondary-green"
+                className="justify-center"
+                onClick={onRefuseCookies}
+              >
+                <FormattedMessage defaultMessage="Reject non-essential cookies" id="UH7Vx0" />
+              </Button>
+            </div>
+          </div>
+        </FocusScope>
+      </LayoutContainer>
+    </div>
+  );
+};
+
+export default NoticeContent;

--- a/frontend/components/privacy-notice/notice-content/index.ts
+++ b/frontend/components/privacy-notice/notice-content/index.ts
@@ -1,0 +1,2 @@
+export type { NoticeContentProps } from './types';
+export { default } from './component';

--- a/frontend/components/privacy-notice/notice-content/types.ts
+++ b/frontend/components/privacy-notice/notice-content/types.ts
@@ -1,0 +1,1 @@
+export interface NoticeContentProps {}

--- a/frontend/components/privacy-notice/types.ts
+++ b/frontend/components/privacy-notice/types.ts
@@ -1,0 +1,1 @@
+export interface PrivacyNoticeProps {}

--- a/frontend/containers/layouts/beta-version-disclaimer/component.tsx
+++ b/frontend/containers/layouts/beta-version-disclaimer/component.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { FC, useEffect, useState } from 'react';
 
 import { X as CloseIcon } from 'react-feather';
 import { FormattedMessage } from 'react-intl';
@@ -7,7 +7,9 @@ import cx from 'classnames';
 
 import Button from 'components/button';
 
-const BetaVersionDisclaimer = () => {
+import { BetaVersionDisclaimerProps } from './types';
+
+const BetaVersionDisclaimer: FC<BetaVersionDisclaimerProps> = ({ className }) => {
   const [hidden, setHidden] = useState(true);
 
   useEffect(() => {
@@ -23,10 +25,11 @@ const BetaVersionDisclaimer = () => {
   return (
     <div
       className={cx(
-        'w-full z-50 flex bg-background-middle justify-center transform-all ease-in-out duration-300 overflow-hidden text-black fixed bottom-0 sm:static sm:bottom-auto',
+        'w-full z-50 flex bg-background-middle justify-center transform-all ease-in-out duration-300 overflow-hidden text-black static',
         {
           'h-0': hidden,
           'h-auto p-3': !hidden,
+          [className]: !!className,
         }
       )}
     >

--- a/frontend/containers/layouts/beta-version-disclaimer/index.ts
+++ b/frontend/containers/layouts/beta-version-disclaimer/index.ts
@@ -1,1 +1,2 @@
+export type { BetaVersionDisclaimerProps } from './types';
 export { default } from './component';

--- a/frontend/containers/layouts/beta-version-disclaimer/types.ts
+++ b/frontend/containers/layouts/beta-version-disclaimer/types.ts
@@ -1,0 +1,4 @@
+export interface BetaVersionDisclaimerProps {
+  /** Class to apply to the container */
+  className?: string;
+}

--- a/frontend/hooks/use-cookies-consent.ts
+++ b/frontend/hooks/use-cookies-consent.ts
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { useSyncedState } from 'hooks/use-synced-state';
+
+interface CookiesConsent {
+  /** Whether the user consented to the use of cookies */
+  allowCookies: boolean | null;
+  /** The date at which the user consented to the use of or refused the cookies */
+  consentDate?: number | null;
+  /**
+   * Update the consent status of the cookies
+   */
+  updateConsent: (allowCookies: boolean, consentDate: number) => void;
+}
+
+/** Key of the allowCookie setting in the `localStorage` */
+export const ALLOW_COOKIE_KEY = 'allowCookies';
+/** Key of the cookiesConsentDate setting in the `localStorage` */
+export const CONSENT_DATE_KEY = 'cookiesConsentDate';
+
+/**
+ * Return the privacy settings stored in the `localStorage`
+ */
+export const getSettingsFromLocalStorage = () => {
+  try {
+    const storedAllowCookies = localStorage.getItem(ALLOW_COOKIE_KEY);
+    const storedConsentDate = localStorage.getItem(CONSENT_DATE_KEY);
+
+    const allowCookies = storedAllowCookies === 'true';
+    const consentDate =
+      typeof storedConsentDate === 'string' &&
+      storedConsentDate.length > 0 &&
+      !Number.isNaN(+storedConsentDate)
+        ? +storedConsentDate
+        : null;
+
+    if (consentDate !== null) {
+      return { allowCookies, consentDate };
+    }
+  } catch (e) {
+    console.error('Unable to access the localStorage.');
+  }
+
+  return null;
+};
+
+/**
+ * Save the privacy settings in the `localStorage`
+ * @param allowCookies Whether the user consents to the use of cookies
+ * @param consentDate Dates at which the user consented or refused the use of cookies
+ * @returns True if the settings have been saved successfully
+ */
+export const saveSettingsInLocalStorage = (allowCookies: boolean, consentDate: number) => {
+  try {
+    localStorage.setItem(ALLOW_COOKIE_KEY, `${allowCookies}`);
+    localStorage.setItem(CONSENT_DATE_KEY, `${consentDate}`);
+    return true;
+  } catch (e) {
+    console.error('Unable to access the localStorage');
+  }
+
+  return false;
+};
+
+export const useCookiesConsent = (): CookiesConsent => {
+  const [allowCookies, setAllowCookies] = useState<boolean>(null);
+  const [consentDate, setConsentDate] = useState<number>(null);
+
+  /** Callback executed when the synced state has received an update */
+  const onUpdateSyncedState = useCallback(({ allowCookies, consentDate }) => {
+    setAllowCookies(allowCookies);
+    setConsentDate(consentDate);
+
+    if (allowCookies !== null && consentDate !== null) {
+      saveSettingsInLocalStorage(allowCookies, consentDate);
+    }
+  }, []);
+
+  // We synchronise the state of all the components that rely on `useCookiesConsent` so that they
+  // all have the most updated information about the consent
+  const updateSyncedState = useSyncedState(
+    {
+      allowCookies: null,
+      consentDate: null,
+    },
+    onUpdateSyncedState
+  );
+
+  /** Callback executed when the user updates their consent */
+  const onUpdateConsent: CookiesConsent['updateConsent'] = useCallback(
+    (allowCookies, consentDate) => {
+      updateSyncedState({ allowCookies, consentDate });
+    },
+    [updateSyncedState]
+  );
+
+  // On mount, we check if the user has already consented to the use of cookies
+  useEffect(() => {
+    const settings = getSettingsFromLocalStorage();
+    if (!!settings) {
+      updateSyncedState(settings);
+    }
+  }, [updateSyncedState]);
+
+  return {
+    allowCookies,
+    consentDate,
+    updateConsent: onUpdateConsent,
+  };
+};

--- a/frontend/hooks/use-synced-state.ts
+++ b/frontend/hooks/use-synced-state.ts
@@ -1,0 +1,52 @@
+import { useCallback, useEffect } from 'react';
+
+type Listener<State> = (state: State) => void;
+
+export const useSyncedState = (function () {
+  let _state = null;
+  let _listeners = [];
+
+  /**
+   * Synchronize state between several components
+   * @param initialState Initial synced state
+   * @param callback Callback executed when the synced state has changed
+   * @returns Callback to modify the synced state
+   */
+  return <State>(initialState: State, callback: Listener<State>) => {
+    const addListener = useCallback((listener: Listener<State>) => {
+      _listeners.push(listener);
+    }, []);
+
+    const removeListener = useCallback((listener: Listener<State>) => {
+      const index = _listeners.findIndex((l) => l === listener);
+      if (index !== null) {
+        _listeners.splice(index, 1);
+      }
+    }, []);
+
+    const broadcastState = useCallback(() => {
+      _listeners.forEach((listener) => listener(_state));
+    }, []);
+
+    const updateState = useCallback(
+      (newState: State) => {
+        _state = newState;
+        broadcastState();
+      },
+      [broadcastState]
+    );
+
+    useEffect(() => {
+      addListener(callback);
+
+      if (_state === null) {
+        _state = initialState;
+        broadcastState();
+      }
+
+      return () => removeListener(callback);
+    }, [initialState, callback, addListener, removeListener, broadcastState]);
+
+    return updateState;
+  };
+})();

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -1464,6 +1464,9 @@
   "Rb/hb9": {
     "string": "LinkedIn"
   },
+  "RrcFtD": {
+    "string": "We use cookies for analytics, personalization, and marketing purposes. Only essential cookies are active by default to ensure you get the best experience. Please read our <a>Cookie Policy</a> to learn more."
+  },
   "RyOOZR": {
     "string": "Have access to all of the contacts of <n>Investors</n> and <n>Project Developers</n>. Easily reach and connect so you can find the best investment or partnership."
   },
@@ -1565,6 +1568,9 @@
   },
   "UG5qoS": {
     "string": "No data"
+  },
+  "UH7Vx0": {
+    "string": "Reject non-essential cookies"
   },
   "UIQdVc": {
     "string": "Are you sure you want to delete “<strong>{projectName}</strong>”?"
@@ -1898,6 +1904,9 @@
   },
   "b6bipu": {
     "string": "Choose one of your projects to apply to the open call."
+  },
+  "b8sVDI": {
+    "string": "Privacy notice"
   },
   "bNpbHr": {
     "string": "Find other people with similar interests. Join forces, secure more investment and create a greater impact."
@@ -2321,6 +2330,9 @@
   },
   "jvHO6d": {
     "string": "By accepting this invitation you will belong to the {accountName} account."
+  },
+  "jvP3C2": {
+    "string": "Accept all cookies"
   },
   "jvb6yi": {
     "string": "This is a global, wall-to-wall map of aboveground biomass (AGB) at approximately 30-meter resolution. This data product expands on the methodology presented in Baccini et al. (2012) to generate a global map of aboveground live woody biomass (AGB) density (megagrams biomass per ha) at 0.00025-degree (approximately 30-meter) resolution for the year 2000. Aboveground biomass was estimated using a multi-step process of calculating AGB at more than seven hundred thousand points with LiDAR with regional allometric equations, then using those to train a wall-to-wall model based on Landsat imagery. Pixels without tree canopy were assigned a biomass density of 0 Mg/ha."

--- a/frontend/layouts/static-page/header/component.tsx
+++ b/frontend/layouts/static-page/header/component.tsx
@@ -23,39 +23,48 @@ export const Header: React.FC<HeaderProps> = ({
   const showBackground = !transparent || isScrolledY;
 
   return (
-    <header
-      className={cx({
-        'fixed top-0 w-full z-20 transition-colors': true,
-        'text-white': !showBackground,
-        'bg-background-light/90 backdrop-blur-sm': showBackground,
-        [className]: !!className,
-      })}
-    >
-      <BetaVersionDisclaimer />
-      <LayoutContainer>
-        <div className="flex items-center justify-between pt-3 pb-3 md:pt-6 md:pb-4 lg:space-x-10">
-          <Logo />
-          <div className="flex">
-            <Navigation className="hidden lg:flex-1 lg:flex lg:items-center lg:justify-end lg:mr-4" />
-            <div className="flex items-center gap-2 lg:gap-4">
-              <LanguageSelector />
-              <UserMenu
-                className="hidden lg:ml-4 sm:flex"
-                theme={showBackground ? 'primary-green' : 'primary-white'}
-              />
-              <NavigationMenuButton
-                className={cx({
-                  'flex lg:hidden': true,
-                  'text-white': !showBackground,
-                  'text-green-dark': showBackground,
-                })}
-                theme="naked"
-              />
+    <>
+      <BetaVersionDisclaimer className="sm:hidden" />
+      <header
+        className={cx({
+          'sticky sm:fixed h-0 sm:h-auto top-0 w-full z-20 transition-colors': true,
+          'text-white': !showBackground,
+          [className]: !!className,
+        })}
+      >
+        <BetaVersionDisclaimer className="hidden sm:flex" />
+        <div
+          className={cx({
+            'transition-colors': true,
+            'bg-background-light/90 backdrop-blur-sm': showBackground,
+          })}
+        >
+          <LayoutContainer>
+            <div className="flex items-center justify-between pt-3 pb-3 md:pt-6 md:pb-4 lg:space-x-10">
+              <Logo />
+              <div className="flex">
+                <Navigation className="hidden lg:flex-1 lg:flex lg:items-center lg:justify-end lg:mr-4" />
+                <div className="flex items-center gap-2 lg:gap-4">
+                  <LanguageSelector />
+                  <UserMenu
+                    className="hidden lg:ml-4 sm:flex"
+                    theme={showBackground ? 'primary-green' : 'primary-white'}
+                  />
+                  <NavigationMenuButton
+                    className={cx({
+                      'flex lg:hidden': true,
+                      'text-white': !showBackground,
+                      'text-green-dark': showBackground,
+                    })}
+                    theme="naked"
+                  />
+                </div>
+              </div>
             </div>
-          </div>
+          </LayoutContainer>
         </div>
-      </LayoutContainer>
-    </header>
+      </header>
+    </>
   );
 };
 

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -15,6 +15,7 @@ import { Hydrate } from 'react-query/hydration';
 import { getCookie, setCookie } from 'helpers/cookies';
 
 import Analytics from 'components/analytics';
+import PrivacyNotice from 'components/privacy-notice';
 import StaticPageLayout from 'layouts/static-page';
 import store from 'store';
 import { LayoutStaticProp } from 'types';
@@ -100,6 +101,7 @@ const HeCoApp: React.FC<AppProps> = ({ Component, pageProps }: Props) => {
               <I18nProvider locale={locale}>
                 <OverlayProvider>
                   <Analytics />
+                  <PrivacyNotice />
                   <Layout {...layoutProps}>
                     <Component {...pageProps} />
                   </Layout>


### PR DESCRIPTION
This PR adds a banner on the platform to ask for the user's consent to allow non-necessary cookies.

This PR does not block loading GA and Hotjar yet as this is part of [LET-1107](https://vizzuality.atlassian.net/browse/LET-1107).

## Testing instructions

- The cookie banner is displayed on all the pages
- It looks good on mobile
- It can be displayed at the same time as the beta disclaimer (especially on mobile)
- The user's consent is saved

## Tracking

[LET-1106](https://vizzuality.atlassian.net/browse/LET-1106)
