### PR TITLE
Add instructions for account profile pictures

### DIFF
--- a/frontend/containers/investor-form/pages/profile.tsx
+++ b/frontend/containers/investor-form/pages/profile.tsx
@@ -61,17 +61,28 @@ export const Profile: FC<ProfileProps> = ({
             })}
           />
         </div>
-        <ImageUploader
-          setError={setError}
-          name="picture"
-          id="picture"
-          setValue={setValue}
-          control={control}
-          clearErrors={clearErrors}
-          preview
-          aria-describedby="picture-error"
-          defaultImage={picture}
-        />
+        <div className="flex items-center gap-x-6">
+          <ImageUploader
+            setError={setError}
+            name="picture"
+            id="picture"
+            setValue={setValue}
+            control={control}
+            clearErrors={clearErrors}
+            preview
+            aria-describedby="picture-error"
+            defaultImage={picture}
+          />
+          <p className="text-sm text-gray-700">
+            <FormattedMessage
+              defaultMessage="Upload a <b>square</b> image, <b>PNG</b> or <b>JPG</b>. Max size of <b>5MB</b>."
+              id="eVWrC4"
+              values={{
+                b: (chunks: string) => <span className="font-semibold">{chunks}</span>,
+              }}
+            />
+          </p>
+        </div>
         <ErrorMessage id="picture-error" errorText={errors?.picture?.message} />
       </div>
       <div className="md:flex gap-x-6 mb-6.5">

--- a/frontend/containers/project-developer-form/pages/profile.tsx
+++ b/frontend/containers/project-developer-form/pages/profile.tsx
@@ -62,16 +62,27 @@ export const Profile: FC<ProfileProps> = ({
             })}
           />
         </div>
-        <ImageUploader
-          setError={setError}
-          setValue={setValue}
-          name="picture"
-          id="picture"
-          control={control}
-          preview
-          clearErrors={clearErrors}
-          defaultImage={picture}
-        />
+        <div className="flex items-center gap-x-6">
+          <ImageUploader
+            setError={setError}
+            setValue={setValue}
+            name="picture"
+            id="picture"
+            control={control}
+            preview
+            clearErrors={clearErrors}
+            defaultImage={picture}
+          />
+          <p className="text-sm text-gray-700">
+            <FormattedMessage
+              defaultMessage="Upload a <b>square</b> image, <b>PNG</b> or <b>JPG</b>. Max size of <b>5MB</b>."
+              id="eVWrC4"
+              values={{
+                b: (chunks: string) => <span className="font-semibold">{chunks}</span>,
+              }}
+            />
+          </p>
+        </div>
         <ErrorMessage id="picture-error" errorText={errors?.picture?.message} />
       </div>
       <div className="md:flex gap-x-6 mb-6.5">

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -1083,9 +1083,6 @@
   "Jfw90a": {
     "string": "Publish draft"
   },
-  "JhuBos": {
-    "string": "Your avatar"
-  },
   "JkLHGw": {
     "string": "Website"
   },
@@ -2060,6 +2057,9 @@
   },
   "eSLLyC": {
     "string": "To complete you registration and make full use of the platform, please select which account you would like to create."
+  },
+  "eVWrC4": {
+    "string": "Upload a <b>square</b> image, <b>PNG</b> or <b>JPG</b>. Max size of <b>5MB</b>."
   },
   "eXDHt0": {
     "string": "Describe the project or solution and describe clearly why you consider it is innovative, different from others and how it can generate an important change and impact towards the target groups. Highlight the characteristics that may attract partners, clients, or investors."


### PR DESCRIPTION
This PR adds instructions for the account profile pictures.

Note there is more space between the input button and the instructions because the input is native and reserves more space. If you select an image, you will see that the space reduces. Suggestions welcome!

## Testing instructions

Have a look at the first page of the investor and PD forms.

## Tracking

[LET-1099](https://vizzuality.atlassian.net/browse/LET-1099)
