### PR TITLE
Limit the selected layers to one of each group

### DIFF
--- a/frontend/components/map/legend/types.d.ts
+++ b/frontend/components/map/legend/types.d.ts
@@ -17,4 +17,5 @@ export type Legend = {
   name: string;
   items: LegendItem[];
   type: LegendType;
+  group: LAYER_GROUPS;
 };

--- a/frontend/containers/discover-map/component.tsx
+++ b/frontend/containers/discover-map/component.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useMemo, useState } from 'react';
+import { ChangeEvent, FC, useCallback, useMemo, useState } from 'react';
 
 import { useForm } from 'react-hook-form';
 
@@ -45,13 +45,18 @@ export const DiscoverMap: FC<DiscoverMapProps> = ({ onSelectProjectPin }) => {
     options: { padding: 0 },
   });
 
-  const { register, watch, setValue } = useForm<MapLayersSelectorForm>({
-    defaultValues: {
-      activeLayers: [],
-    },
-  });
+  const { register, watch, resetField, setValue } = useForm<MapLayersSelectorForm>();
 
-  const visibleLayers = watch('activeLayers');
+  const layerInputs = watch();
+
+  /** An array with the values of the selected layers */
+  const visibleLayers: string[] = useMemo(
+    () =>
+      Object.values(layerInputs).reduce((prev, curr) => {
+        return !!curr && curr.length ? [...prev, curr[0]] : prev;
+      }, []),
+    [layerInputs]
+  );
 
   const handleViewportChange = useCallback((vw) => {
     setViewport(vw);
@@ -61,6 +66,7 @@ export const DiscoverMap: FC<DiscoverMapProps> = ({ onSelectProjectPin }) => {
     setBounds({ ...bounds, bbox });
   };
 
+  /** An array with the selected layers legends */
   const layerLegends: Legend[] = useMemo(
     () =>
       visibleLayers
@@ -76,6 +82,16 @@ export const DiscoverMap: FC<DiscoverMapProps> = ({ onSelectProjectPin }) => {
         .reverse(),
     [layers, visibleLayers]
   );
+
+  const handleChangeVisibleLayer = (e: ChangeEvent<HTMLInputElement>) => {
+    // The layer inputs are groups of checkboxes. To limit one value per group, the value is always updated to an array of one item with the last selected value. If the checkbox is already selected (the user unchecked the checkbox), the field is reseted.
+    const { name, value } = e.currentTarget;
+    if (visibleLayers.includes(value)) {
+      resetField(name as keyof MapLayersSelectorForm);
+    } else {
+      setValue(name as keyof MapLayersSelectorForm, [value]);
+    }
+  };
 
   return (
     <>
@@ -115,9 +131,11 @@ export const DiscoverMap: FC<DiscoverMapProps> = ({ onSelectProjectPin }) => {
           className="absolute flex items-start gap-2 inset-3.5 bottom-12 text-gray-800 text-sm pointer-events-none"
         >
           <MapLayersSelector
-            initialActiveLayers={visibleLayers}
             className="pointer-events-auto"
             register={register}
+            registeOptions={{
+              onChange: handleChangeVisibleLayer,
+            }}
           />
           <LocationSearcher
             className="pointer-events-auto"
@@ -128,12 +146,7 @@ export const DiscoverMap: FC<DiscoverMapProps> = ({ onSelectProjectPin }) => {
         <Controls className="absolute h-fit max-h-[45%] bottom-4 right-4 overflow-y-auto">
           <LayerLegend
             className="bg-white"
-            onCloseLegend={(id) =>
-              setValue(
-                'activeLayers',
-                visibleLayers.filter((layer) => layer !== id)
-              )
-            }
+            onCloseLegend={(layerGroup) => resetField(layerGroup)}
             layersLegends={layerLegends}
           />
         </Controls>

--- a/frontend/containers/discover-map/layer-legend/component.tsx
+++ b/frontend/containers/discover-map/layer-legend/component.tsx
@@ -76,13 +76,13 @@ export const LayerLegend: FC<LayerLegendProps> = ({
       >
         <Legend>
           {layersLegends.map((i) => {
-            const { type, items, id, name } = i;
+            const { type, items, id, name, group } = i;
             return (
               <LegendItem
                 key={i.id}
                 name={name}
                 id={id}
-                handleCloseLegend={() => onCloseLegend(id)}
+                handleCloseLegend={() => onCloseLegend(group)}
                 icon={
                   type === 'monocolor' && (
                     <span

--- a/frontend/containers/discover-map/layer-legend/types.ts
+++ b/frontend/containers/discover-map/layer-legend/types.ts
@@ -1,8 +1,10 @@
+import { LAYER_GROUPS } from 'hooks/useLayers';
+
 import { Legend } from 'components/map/legend/types';
 
 export type LayerLegendProps = {
   layersLegends: Legend[];
   className: string;
   maxHeight?: number | string;
-  onCloseLegend: (id: string) => void;
+  onCloseLegend: (layerGroup: LAYER_GROUPS) => void;
 };

--- a/frontend/containers/discover-map/map-layers-selector/component.tsx
+++ b/frontend/containers/discover-map/map-layers-selector/component.tsx
@@ -22,6 +22,7 @@ import type { MapLayersSelectorProps, SelectedLayerTooltip } from './types';
 export const MapLayersSelector: FC<MapLayersSelectorProps> = ({
   className,
   register,
+  registeOptions,
 }: MapLayersSelectorProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [selectedLayer, setSelectedlayer] = useState<SelectedLayerTooltip>();
@@ -104,7 +105,15 @@ export const MapLayersSelector: FC<MapLayersSelectorProps> = ({
                     >
                       <ol className="flex flex-col gap-3.5 text-xs text-black py-2">
                         {layerGroup.layers.map(
-                          ({ id, name, description, overview, dataSource, dataSourceUrl }) => (
+                          ({
+                            id,
+                            name,
+                            description,
+                            overview,
+                            dataSource,
+                            dataSourceUrl,
+                            group,
+                          }) => (
                             <li key={id} className="flex items-center gap-1.5">
                               <label
                                 key={id}
@@ -113,10 +122,11 @@ export const MapLayersSelector: FC<MapLayersSelectorProps> = ({
                               >
                                 <Switch
                                   id={id}
-                                  name="activeLayers"
+                                  name={group}
                                   switchSize="smallest"
                                   value={id}
                                   register={register}
+                                  registerOptions={registeOptions}
                                 />
                                 {name}
                               </label>

--- a/frontend/containers/discover-map/map-layers-selector/types.ts
+++ b/frontend/containers/discover-map/map-layers-selector/types.ts
@@ -1,16 +1,18 @@
-import { UseFormRegister } from 'react-hook-form';
+import { RegisterOptions, UseFormRegister } from 'react-hook-form';
+
+import { LAYER_GROUPS } from 'hooks/useLayers';
 
 export type MapLayersSelectorProps = {
   /** Classes to apply to the container */
   className?: string;
-  /** List of active layers */
-  initialActiveLayers: string[];
-
-  register: UseFormRegister<any>;
+  /** UseForm register function */
+  register: UseFormRegister<MapLayersSelectorForm>;
+  /** UseForm register options */
+  registeOptions: RegisterOptions<MapLayersSelectorForm>;
 };
 
 export type MapLayersSelectorForm = {
-  activeLayers: string[];
+  [key in LAYER_GROUPS]: [string];
 };
 
 export type SelectedLayerTooltip = {


### PR DESCRIPTION
This PR limits the selectable map layers to one of each group 

## Testing instructions

Go to discover/projects and select map layers

- You should be able to select just one layer of each group.
- If the group already has a selected layer, it will change to the last selected value
- If you click twice on a layer option, the input should uncheck 

- Make sure that the layers legend are displayed in the correct order and if you close a layer through the legend it will unselect properly 

## Tracking

[LET-1053](https://vizzuality.atlassian.net/browse/LET-1053)
