### PR TITLE
Display the dashboard scaled out on mobile

### DIFF
--- a/frontend/layouts/dashboard/component.tsx
+++ b/frontend/layouts/dashboard/component.tsx
@@ -2,6 +2,8 @@ import { FC, useRef } from 'react';
 
 import cx from 'classnames';
 
+import Head from 'next/head';
+
 import Breadcrumbs from 'containers/breadcrumbs';
 
 import LayoutContainer from 'components/layout-container';
@@ -32,6 +34,9 @@ export const DashboardLayout: FC<DashboardLayoutProps> = ({
 
   return (
     <ProtectedPage permissions={[UserRoles.ProjectDeveloper, UserRoles.Investor]}>
+      <Head>
+        <meta name="viewport" content="width=1024, initial-scale=1" />
+      </Head>
       <div className="min-h-screen bg-background-dark">
         <div className="flex flex-col lg:h-screen ">
           <div className="z-30 flex flex-col bg-radial-green-dark bg-green-dark lg:backdrop-blur-sm">

--- a/frontend/layouts/settings/component.tsx
+++ b/frontend/layouts/settings/component.tsx
@@ -1,5 +1,7 @@
 import { FC, useRef } from 'react';
 
+import Head from 'next/head';
+
 import useMe from 'hooks/me';
 
 import LayoutContainer from 'components/layout-container';
@@ -24,6 +26,9 @@ export const SettingsLayout: FC<SettingsLayoutProps> = ({
 
   return (
     <ProtectedPage permissions={[UserRoles.ProjectDeveloper, UserRoles.Investor]}>
+      <Head>
+        <meta name="viewport" content="width=1024, initial-scale=1" />
+      </Head>
       <div className="min-h-screen bg-background-dark">
         <div className="flex flex-col lg:h-screen ">
           <div className="z-10 flex flex-col bg-radial-green-dark bg-green-dark lg:backdrop-blur-sm">


### PR DESCRIPTION
This PR improves the way the Dashboard looks on mobile by scaling it down to the equivalent of a 1280px wide screen.

## Testing instructions

All the dashboard pages looks scaled down on mobile.

## Tracking

[LET-1125](https://vizzuality.atlassian.net/browse/LET-1125)
