### PR TITLE
Fix duplicated 'not calculated' and impact o texts

### DIFF
--- a/frontend/containers/impact-text/component.tsx
+++ b/frontend/containers/impact-text/component.tsx
@@ -67,36 +67,45 @@ export const ImpactText: FC<ImpactTextProps> = ({
 
   if (isLoadingAllImpacts) return null;
 
+  const getImpactText = () => {
+    if (!impactCalculated) {
+      return (
+        <FormattedMessage
+          defaultMessage="The impact of this project isn’t available. Impact calculations may take some time to be available."
+          id="xnQiBM"
+        />
+      );
+    }
+
+    if (highestImpactValue === 0) {
+      if (shortText) {
+        return <FormattedMessage defaultMessage="The impact of this project is 0." id="VJPvoR" />;
+      }
+      return (
+        <FormattedMessage defaultMessage="The impact score of this project is 0." id="/oLNw7" />
+      );
+    }
+
+    return (
+      <FormattedMessage
+        defaultMessage="In the {area} the highest impact of the project is on <b>{impactDimension}</b> with a <b>score</b> of {score}."
+        id="NdyMBg"
+        values={{
+          area: impactAreaStr,
+          impactDimension: highestImpactDimension,
+          score: highestImpactScore,
+          b: (chunks: string) => <span className="font-semibold">{chunks}</span>,
+        }}
+      />
+    );
+  };
+
   return (
     <div className={className}>
       <p>
-        {!impactCalculated && (
-          <FormattedMessage
-            defaultMessage="The impact of this project isn’t available. Impact calculations may take some time to be available."
-            id="xnQiBM"
-          />
-        )}
-        {highestImpactValue === 0 && shortText && (
-          <FormattedMessage defaultMessage="The impact of this project is 0." id="VJPvoR" />
-        )}
-        {highestImpactValue === 0 && !shortText && (
-          <FormattedMessage defaultMessage="The impact score of this project is 0." id="/oLNw7" />
-        )}
-        {highestImpactValue > 0 && (
-          <FormattedMessage
-            defaultMessage="In the {area} the highest impact of the project is on <b>{impactDimension}</b> with a <b>score</b> of {score}."
-            id="NdyMBg"
-            values={{
-              area: impactAreaStr,
-              impactDimension: highestImpactDimension,
-              score: highestImpactScore,
-              b: (chunks: string) => <span className="font-semibold">{chunks}</span>,
-            }}
-          />
-        )}
+        {getImpactText()}
         {linkToFAQ && (
           <>
-            {' '}
             <Link href={FaqPaths['how-is-the-impact-calculated']}>
               <a className="underline text-green-dark" target="_blank">
                 <FormattedMessage defaultMessage="Learn more" id="TdTXXf" />


### PR DESCRIPTION
This PR fixes a bug detected in [LET-1112](https://vizzuality.atlassian.net/browse/LET-1112) on [this comment](https://vizzuality.atlassian.net/browse/LET-1112?focusedCommentId=19780)

When the impact wasn’t calculated, the "not calculated" text was displayed, but the "0 impact" text was displayed too

<img width="243" alt="image-20220927-151638" src="https://user-images.githubusercontent.com/48164343/192584698-65cc2921-2f76-4378-a689-96ffe6c24f00.png">
 

## Testing instructions

- Create a project and go to the new project page. The impact calculations will not be available yet , so you can see if the text for the impact is correct

<img width="797" alt="Screenshot 2022-09-27 at 18 32 25" src="https://user-images.githubusercontent.com/48164343/192585459-dd9ae431-b647-4087-97ce-e43102462b53.png">
 

## Tracking

[LET-1175](https://vizzuality.atlassian.net/browse/LET-1175)
