### PR TITLE
Invalidate the requests made by `useMe` and `useAccount` on sign up

### DIFF
--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -2202,6 +2202,9 @@
   "hPsrc0": {
     "string": "insert your answer (max 600 characters)"
   },
+  "hRcpAt": {
+    "string": "max 1 layer"
+  },
   "hWhIuU": {
     "string": "Select the intrument type(s)"
   },

--- a/frontend/services/account/index.ts
+++ b/frontend/services/account/index.ts
@@ -81,6 +81,11 @@ export function useCreateProjectDeveloper(): UseMutationResult<
     onSuccess: (result) => {
       queryClient.invalidateQueries(Queries.ProjectDeveloper);
       queryClient.invalidateQueries(Queries.ProjectDeveloperList);
+
+      // These two make sure that `useMe` and `useAccount` return updated information
+      queryClient.invalidateQueries(Queries.User);
+      queryClient.invalidateQueries(Queries.CurrentProjectDeveloper);
+
       queryClient.setQueryData([Queries.ProjectDeveloper, locale], result.data.data);
     },
   });
@@ -243,6 +248,11 @@ export function useCreateInvestor(): UseMutationResult<
     onSuccess: (result) => {
       queryClient.invalidateQueries(Queries.Investor);
       queryClient.invalidateQueries(Queries.InvestorList);
+
+      // These two make sure that `useMe` and `useAccount` return updated information
+      queryClient.invalidateQueries(Queries.User);
+      queryClient.invalidateQueries(Queries.CurrentInvestor);
+
       queryClient.setQueryData([Queries.Investor, locale], result.data.data);
     },
   });


### PR DESCRIPTION
This PR invalidates the requests made by the `useMe` and `useAccount` requests after the user has signed up so that the “Create account” button on the For investors and For project developers is immediately hidden and the user menu offers a link to the dashboard.

## Testing instructions

Sign up as an investor or PD. When you're on the page that tells you about the account verification, click on the user menu (header). Make sure you can see the link to go to the account (Dashboard). If you go to the For * pages, make sure the “Create account” button is hidden at the bottom of the pages (green section).


## Tracking

[LET-1180](https://vizzuality.atlassian.net/browse/LET-1180)
