### PR TITLE
Improve the legibility of the SDGs in the project details card

### DIFF
--- a/frontend/containers/open-call-page/funding-impact/component.tsx
+++ b/frontend/containers/open-call-page/funding-impact/component.tsx
@@ -110,7 +110,7 @@ export const OpenCallFundingImpact: FC<OpenCallFundingImpactProps> = ({
                 <h3 className="mb-6 text-xl font-semibold">
                   <FormattedMessage defaultMessage="SDG's" id="d3TPmn" />
                 </h3>
-                <SDGs sdgs={openCallSdgs} />
+                <SDGs sdgs={openCallSdgs} size="large" />
               </div>
             </div>
           </LayoutContainer>

--- a/frontend/containers/project-details/component.tsx
+++ b/frontend/containers/project-details/component.tsx
@@ -217,7 +217,7 @@ export const ProjectDetails: FC<ProjectDetailsProps> = ({
           <h2 id="sdgs" className="text-xl font-semibold">
             <FormattedMessage defaultMessage="SDGs" id="JQjEP9" />
           </h2>
-          <SDGs className="mt-3" size="smallest" sdgs={sdgs as Enum[]} />
+          <SDGs className="mt-3 lg:grid lg:grid-cols-4" size="large" sdgs={sdgs as Enum[]} />
         </div>
       </div>
       <FavoriteContact

--- a/frontend/containers/sdgs/component.tsx
+++ b/frontend/containers/sdgs/component.tsx
@@ -11,7 +11,11 @@ export const SDGs: FC<SDGsProps> = ({ className, size = 'small', sdgs = [] }: SD
   return (
     <div className={cx('flex flex-wrap items-center gap-2', className)}>
       {sdgs.map(({ id, name }) => (
-        <span key={id}>
+        <span
+          key={id}
+          // This removes an extra space displayed below the image when the container wraps
+          className="flex"
+        >
           <Image
             className="rounded"
             src={SDGS_IMAGES[id]}

--- a/frontend/containers/sdgs/component.tsx
+++ b/frontend/containers/sdgs/component.tsx
@@ -11,7 +11,7 @@ export const SDGs: FC<SDGsProps> = ({ className, size = 'small', sdgs = [] }: SD
   return (
     <div className={cx('flex flex-wrap items-center gap-2', className)}>
       {sdgs.map(({ id, name }) => (
-        <span
+        <div
           key={id}
           // This removes an extra space displayed below the image when the container wraps
           className="flex"
@@ -23,10 +23,10 @@ export const SDGs: FC<SDGsProps> = ({ className, size = 'small', sdgs = [] }: SD
             title={name}
             width={SDGS_SIZES[size]}
             height={SDGS_SIZES[size]}
-            layout="fixed"
+            layout="intrinsic"
             quality={100}
           />
-        </span>
+        </div>
       ))}
     </div>
   );

--- a/frontend/containers/sdgs/component.tsx
+++ b/frontend/containers/sdgs/component.tsx
@@ -1,35 +1,45 @@
-import { FC } from 'react';
+import { FC, Fragment } from 'react';
 
 import cx from 'classnames';
 
 import Image from 'next/image';
 
+import Tooltip from 'components/tooltip';
+
 import { SDGS_SIZES, SDGS_IMAGES } from './constants';
 import { SDGsProps } from './types';
 
-export const SDGs: FC<SDGsProps> = ({ className, size = 'small', sdgs = [] }: SDGsProps) => {
-  return (
-    <div className={cx('flex flex-wrap items-center gap-2', className)}>
-      {sdgs.map(({ id, name }) => (
-        <div
-          key={id}
-          // This removes an extra space displayed below the image when the container wraps
-          className="flex"
+export const SDGs: FC<SDGsProps> = ({ className, size = 'small', sdgs = [] }: SDGsProps) => (
+  <div className={cx('flex flex-wrap items-center gap-2', className)}>
+    {sdgs.map((sdg) => (
+      <Fragment key={sdg.id}>
+        <Tooltip
+          arrow
+          arrowClassName="bg-black"
+          content={
+            <div className="max-w-xs p-2 font-sans text-sm font-normal text-white bg-black rounded-sm">
+              {sdg.name}
+            </div>
+          }
         >
-          <Image
-            className="rounded"
-            src={SDGS_IMAGES[id]}
-            alt={name}
-            title={name}
-            width={SDGS_SIZES[size]}
-            height={SDGS_SIZES[size]}
-            layout="intrinsic"
-            quality={100}
-          />
-        </div>
-      ))}
-    </div>
-  );
-};
+          <div
+            // This removes an extra space displayed below the image when the container wraps
+            className="flex"
+          >
+            <Image
+              className="rounded"
+              src={SDGS_IMAGES[sdg.id]}
+              alt={sdg.name}
+              width={SDGS_SIZES[size]}
+              height={SDGS_SIZES[size]}
+              layout="intrinsic"
+              quality={100}
+            />
+          </div>
+        </Tooltip>
+      </Fragment>
+    ))}
+  </div>
+);
 
 export default SDGs;

--- a/frontend/containers/sdgs/constants.ts
+++ b/frontend/containers/sdgs/constants.ts
@@ -1,5 +1,4 @@
 export const SDGS_SIZES = {
-  smallest: 60,
   small: 88,
   large: 110,
 };

--- a/frontend/containers/sdgs/types.ts
+++ b/frontend/containers/sdgs/types.ts
@@ -3,7 +3,7 @@ import type { Enum } from 'types/enums';
 import { SDGS_SIZES } from './constants';
 
 export type SDGsProps = {
-  /** Classnames to apply to the wrapper */
+  /** Class to apply to the wrapper */
   className?: string;
   /** SDGs size `small` | `large`. Defaults to `small` */
   size?: keyof typeof SDGS_SIZES;

--- a/frontend/pages/investor/[id]/index.tsx
+++ b/frontend/pages/investor/[id]/index.tsx
@@ -191,6 +191,7 @@ const InvestorPage: PageComponent<InvestorPageProps, StaticPageLayoutProps> = ({
               <SDGs
                 className="my-3"
                 sdgs={allSdgs.filter(({ id }) => sdgs?.includes(Number(id)))}
+                size="large"
               />
             </>
           )}


### PR DESCRIPTION
This PR improves the legibility of the SDGs in the project details card by:

- Displaying them bigger
- Adding a tooltip on hover

Note the tooltip is also displayed on the other pages that use the same component: public project page and public open call page.

## Testing instructions

- On desktop, 4 SDGs are displayed side-by-side in the project details card. On mobile, we display as much as possible in a row (previous behaviour).
- When you hover an SDG, a tooltip with the name of the SDG is shown.

## Tracking

[LET-1133](https://vizzuality.atlassian.net/browse/LET-1133)
