### PR TITLE
Update map help texts

### DIFF
--- a/frontend/containers/discover-map/map-help/component.tsx
+++ b/frontend/containers/discover-map/map-help/component.tsx
@@ -37,7 +37,7 @@ export const MapHelp: FC<MapHelpProps> = () => {
             <FormattedMessage defaultMessage="Help" id="SENRqu" />
           </h1>
         </div>
-        <div className="relative h-full px-1 pt-6 pb-24 overflow-y-scroll top-12 sm:pb-44">
+        <div className="relative h-full px-1 pt-6 pb-24 overflow-y-auto top-12 sm:pb-44">
           <p>
             <FormattedMessage
               defaultMessage="The map allows you to quickly see the location of each project and understand the context of the different projects."

--- a/frontend/containers/discover-map/map-help/component.tsx
+++ b/frontend/containers/discover-map/map-help/component.tsx
@@ -97,16 +97,15 @@ export const MapHelp: FC<MapHelpProps> = () => {
             </div>
             <p>
               <FormattedMessage
-                defaultMessage="You can activate a varity of data layers to help you to understand the context of each project. These layers may be of 3 types:"
-                id="FPr3FX"
+                defaultMessage="To help you understand the context of each project, we provide a range of contextual layers. These layers are divided in three different groups, and you can only activate one layer per group in order to keep the legibility of the map. The layers are:"
+                id="hRsu1I"
               />
             </p>
             <ul className="pl-5 mt-6 space-y-1 list-disc">
               <li>
                 <FormattedMessage
-                  defaultMessage="<n>Base layers:</n> Heco priority landscapes, Watersheds, Sub-basin boundaries, Protected
-                areas;"
-                  id="d2h8L7"
+                  defaultMessage="<n>Base layers:</n> Heco priority landscapes, Sub-basin boundaries, Protected areas;"
+                  id="ZERB8x"
                   values={{
                     n: (chunk: string) => <span className="my-2 font-medium">{chunk}</span>,
                   }}
@@ -114,9 +113,8 @@ export const MapHelp: FC<MapHelpProps> = () => {
               </li>
               <li>
                 <FormattedMessage
-                  defaultMessage="<n>Priority layers:</n> Biodiversity intactness, Tree biomass density, Wetlands, Population
-                density;"
-                  id="8fVxjR"
+                  defaultMessage="<n>Contextual layers:</n> Biodiversity intactness, Tree biomass density, Wetlands, Population density;"
+                  id="uzMeos"
                   values={{
                     n: (chunk: string) => <span className="my-2 font-medium">{chunk}</span>,
                   }}
@@ -124,9 +122,8 @@ export const MapHelp: FC<MapHelpProps> = () => {
               </li>
               <li>
                 <FormattedMessage
-                  defaultMessage="<n>Hopeful Layers:</n> Priority for conservation, Carbon sequestration potential, Flooding
-                preventions."
-                  id="Vp1beW"
+                  defaultMessage="<n>Priority layers:</n> Endangered species and critical habitats, Tree cover loss, Riverine flood risk, Indigenous Reserves."
+                  id="YXI1nH"
                   values={{
                     n: (chunk: string) => <span className="my-2 font-medium">{chunk}</span>,
                   }}

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -530,9 +530,6 @@
   "8dGhWP": {
     "string": "Browse or drag and drop"
   },
-  "8fVxjR": {
-    "string": "<n>Priority layers:</n> Biodiversity intactness, Tree biomass density, Wetlands, Population density;"
-  },
   "8gJV79": {
     "string": "What are HeCo priority landscapes?"
   },
@@ -907,9 +904,6 @@
   },
   "FN+0yY": {
     "string": "Unable to parse the file. Please try uploading a different format."
-  },
-  "FPr3FX": {
-    "string": "You can activate a varity of data layers to help you to understand the context of each project. These layers may be of 3 types:"
   },
   "FVcGqA": {
     "string": "The HeCo Invest platform connects governments, investors, donors, and philanthropists with selected investment opportunities and projects in high-priority areas for Herencia Colombia. If you find a project that matches your investment goals you can contact its project developer. The contact details will only be available for platform registered users. So if you want to reach out to a project developer, you first need to create an account or join an existing account. The beta version of the HeCo Invest platform does not include the actual attainment of the business deals. To fund a project, investors must carry out all business procedures outside the platform."
@@ -1692,9 +1686,6 @@
   "VkljLs": {
     "string": "Insert the phone number in case you would like to be contacted by phone."
   },
-  "Vp1beW": {
-    "string": "<n>Hopeful Layers:</n> Priority for conservation, Carbon sequestration potential, Flooding preventions."
-  },
   "VsNoGp": {
     "string": "How much money did the project received or raised? (optional)"
   },
@@ -1842,6 +1833,9 @@
   "YWQkk+": {
     "string": "Short description of the project"
   },
+  "YXI1nH": {
+    "string": "<n>Priority layers:</n> Endangered species and critical habitats, Tree cover loss, Riverine flood risk, Indigenous Reserves."
+  },
   "YYMUK5": {
     "string": "Expects to have impact on"
   },
@@ -1862,6 +1856,9 @@
   },
   "ZATT08": {
     "string": "Pagination"
+  },
+  "ZERB8x": {
+    "string": "<n>Base layers:</n> Heco priority landscapes, Sub-basin boundaries, Protected areas;"
   },
   "ZKsAVY": {
     "string": "This project isn’t currently looking for funding."
@@ -2039,9 +2036,6 @@
   },
   "d1OgED": {
     "string": "(optional)"
-  },
-  "d2h8L7": {
-    "string": "<n>Base layers:</n> Heco priority landscapes, Watersheds, Sub-basin boundaries, Protected areas;"
   },
   "d3TPmn": {
     "string": "SDG's"
@@ -2252,6 +2246,9 @@
   },
   "hRcpAt": {
     "string": "max 1 layer"
+  },
+  "hRsu1I": {
+    "string": "To help you understand the context of each project, we provide a range of contextual layers. These layers are divided in three different groups, and you can only activate one layer per group in order to keep the legibility of the map. The layers are:"
   },
   "hWhIuU": {
     "string": "Select the intrument type(s)"
@@ -2970,6 +2967,9 @@
   "uyxTSu": {
     "string": "Select the impacts that you prioritize"
   },
+  "uzMeos": {
+    "string": "<n>Contextual layers:</n> Biodiversity intactness, Tree biomass density, Wetlands, Population density;"
+  },
   "v2wxEw": {
     "string": "Back to open calls"
   },
@@ -3014,6 +3014,9 @@
   },
   "viXE32": {
     "string": "Private"
+  },
+  "vrCHpK": {
+    "string": "Powered by <a>Resource Watch</a>"
   },
   "vygPIS": {
     "string": "Leave project creation form"


### PR DESCRIPTION
This PR updates the map help texts

More context in this comment and the following: [LET-658: Visitors can get general information/instructions about the map in the search results page (projects tab)IN PROGRESS](https://vizzuality.atlassian.net/browse/LET-658?focusedCommentId=19835).

## Testing instructions

Make sure the content of the map help modal is updated with  what’s in this Figma: [HeCo - Work in progress](https://www.figma.com/proto/KC49uMR9t1YARmFR0Sr6aN/HeCo---Work-in-progress?page-id=2%3A4&node-id=8698%3A115407&viewport=6908%2C-984%2C0.47&scaling=scale-down&starting-point-node-id=2%3A2923)

<img width="602" alt="Screenshot 2022-09-30 at 16 32 16" src="https://user-images.githubusercontent.com/48164343/193293151-c3661d51-a060-49a1-81b7-ebaba488f9c9.png">


## Tracking

[LET-1190](https://vizzuality.atlassian.net/browse/LET-1190)
