### PR TITLE
Add message to image uploaders

### DIFF
--- a/frontend/containers/investor-form/pages/profile.tsx
+++ b/frontend/containers/investor-form/pages/profile.tsx
@@ -83,6 +83,15 @@ export const Profile: FC<ProfileProps> = ({
             />
           </p>
         </div>
+        <p className="mt-4 text-sm text-gray-600">
+          <FormattedMessage
+            defaultMessage="<b>Note:</b> After submitting the form, images may take some time to be visible in your page."
+            id="xXIT0v"
+            values={{
+              b: (chunks: string) => <span className="font-semibold">{chunks}</span>,
+            }}
+          />
+        </p>
         <ErrorMessage id="picture-error" errorText={errors?.picture?.message} />
       </div>
       <div className="md:flex gap-x-6 mb-6.5">

--- a/frontend/containers/open-call-form/pages/information.tsx
+++ b/frontend/containers/open-call-form/pages/information.tsx
@@ -139,6 +139,15 @@ export const OpenCallInformation: FC<OpenCallInformationProps> = ({
               aria-labelledby="picture-label"
             />
           )}
+          <p className="mt-4 text-sm text-gray-600">
+            <FormattedMessage
+              defaultMessage="<b>Note:</b> After submitting the form, images may take some time to be visible in your page."
+              id="xXIT0v"
+              values={{
+                b: (chunks: string) => <span className="font-semibold">{chunks}</span>,
+              }}
+            />
+          </p>
           <ErrorMessage id="picture-error" errorText={errors?.picture?.message} />
         </div>
         <div className="mt-7">

--- a/frontend/containers/project-developer-form/pages/profile.tsx
+++ b/frontend/containers/project-developer-form/pages/profile.tsx
@@ -83,6 +83,15 @@ export const Profile: FC<ProfileProps> = ({
             />
           </p>
         </div>
+        <p className="mt-4 text-sm text-gray-600">
+          <FormattedMessage
+            defaultMessage="<b>Note:</b> After submitting the form, images may take some time to be visible in your page."
+            id="xXIT0v"
+            values={{
+              b: (chunks: string) => <span className="font-semibold">{chunks}</span>,
+            }}
+          />
+        </p>
         <ErrorMessage id="picture-error" errorText={errors?.picture?.message} />
       </div>
       <div className="md:flex gap-x-6 mb-6.5">

--- a/frontend/containers/project-form/pages/general-information.tsx
+++ b/frontend/containers/project-form/pages/general-information.tsx
@@ -192,6 +192,15 @@ const GeneralInformation = ({
               />
             </div>
           </div>
+          <p className="mt-4 text-sm text-gray-600">
+            <FormattedMessage
+              defaultMessage="<b>Note:</b> After submitting the form, images may take some time to be visible in your page."
+              id="xXIT0v"
+              values={{
+                b: (chunks: string) => <span className="font-semibold">{chunks}</span>,
+              }}
+            />
+          </p>
           <ErrorMessage
             id="project-images-attributes-error"
             errorText={

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -3015,6 +3015,9 @@
   "viXE32": {
     "string": "Private"
   },
+  "vrCHpK": {
+    "string": "Powered by <a>Resource Watch</a>"
+  },
   "vygPIS": {
     "string": "Leave project creation form"
   },
@@ -3101,6 +3104,9 @@
   },
   "xUR9nd": {
     "string": "people live in the Amazon region."
+  },
+  "xXIT0v": {
+    "string": "<b>Note:</b> After submitting the form, images may take some time to be visible in your page."
   },
   "xXbJso": {
     "string": "Sign out"


### PR DESCRIPTION
This PR adds the message "Note: After submitting the form, images may take some time to be visible in your page." to the image uploader inputs 

## Testing instructions

The message should be displayed at the bottom of the image uploader inputs: 

1. project-developer create/update picture;
2. investor create/update picture;
3. project create/update project gallery;
4. open-call create/update picture;


## Tracking

[LET-1145](https://vizzuality.atlassian.net/browse/LET-1145)
