### PR TITLE
Update the beta disclaimer to recommend the use of a desktop computer

### DIFF
--- a/frontend/containers/layouts/beta-version-disclaimer/component.tsx
+++ b/frontend/containers/layouts/beta-version-disclaimer/component.tsx
@@ -35,10 +35,10 @@ const BetaVersionDisclaimer: FC<BetaVersionDisclaimerProps> = ({ className }) =>
     >
       <p className="mr-2 text-sm text-center">
         <FormattedMessage
-          defaultMessage="HeCo Invest is currently on Beta version. We are still testing and making improvements and for that reason some features may not be fully functional."
-          id="HvSsTa"
+          defaultMessage="HeCo Invest is currently on Beta version. We are still testing and making improvements and for that reason some features may not be fully functional. <mobile>You are seeing a mobile version of the platform which has limited functionality, please use the desktop version to see the complete version.</mobile>"
+          id="8XtmJS"
           values={{
-            n: (chunk: string) => <span className="font-semibold">{chunk}</span>,
+            mobile: (chunk: string) => <span className="md:hidden">{chunk}</span>,
           }}
         />
       </p>

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -527,6 +527,9 @@
   "8XJceA": {
     "string": "Have you previously invested in impact?"
   },
+  "8XtmJS": {
+    "string": "HeCo Invest is currently on Beta version. We are still testing and making improvements and for that reason some features may not be fully functional. <mobile>You are seeing a mobile version of the platform which has limited functionality, please use the desktop version to see the complete version.</mobile>"
+  },
   "8dGhWP": {
     "string": "Browse or drag and drop"
   },
@@ -1006,9 +1009,6 @@
   },
   "HtMY9H": {
     "string": "Type your message"
-  },
-  "HvSsTa": {
-    "string": "HeCo Invest is currently on Beta version. We are still testing and making improvements and for that reason some features may not be fully functional."
   },
   "HyAD0J": {
     "string": "{numItems} of {totalItems} entries"
@@ -1961,6 +1961,9 @@
   },
   "b8sVDI": {
     "string": "Privacy notice"
+  },
+  "bALo1R": {
+    "string": "Account security"
   },
   "bNpbHr": {
     "string": "Find other people with similar interests. Join forces, secure more investment and create a greater impact."


### PR DESCRIPTION
This PR updates the content of the beta disclaimer to recommend the use of a desktop computer when the platform is seen on a device with a screen narrower than 768px.

## Testing instructions

Empty you local storage or open the platform in a private tab/window to see the disclaimer.

## Tracking

[LET-1167](https://vizzuality.atlassian.net/browse/LET-1167)
