### PR TITLE
Adds error reporting & cloud tasks permissions to jobs instance service account

### DIFF
--- a/infrastructure/base/modules/cloud-tasks/main.tf
+++ b/infrastructure/base/modules/cloud-tasks/main.tf
@@ -3,13 +3,19 @@ resource "google_project_service" "cloud_tasks_api" {
   disable_on_destroy = false
 }
 
-resource "google_cloud_tasks_queue" "cloud_task" {
+resource "google_cloud_tasks_queue" "cloud_tasks" {
   name     = "${var.prefix}-${var.name}"
   location = var.region
 }
 
-resource "google_project_iam_member" "cloud_tasks_admin" {
+resource "google_project_iam_member" "cloud_tasks_backend_admin" {
   project = var.project_id
   role    = "roles/cloudtasks.admin"
-  member = "serviceAccount:${var.service_account_email}"
+  member = "serviceAccount:${var.backend_service_account_email}"
+}
+
+resource "google_project_iam_member" "cloud_tasks_jobs_enqueuer" {
+  project = var.project_id
+  role    = "roles/cloudtasks.enqueuer"
+  member = "serviceAccount:${var.jobs_service_account_email}"
 }

--- a/infrastructure/base/modules/cloud-tasks/variables.tf
+++ b/infrastructure/base/modules/cloud-tasks/variables.tf
@@ -16,7 +16,12 @@ variable "project_id" {
   description = "GCP project id"
 }
 
-variable "service_account_email" {
+variable "backend_service_account_email" {
   type        = string
-  description = "Email address of the service account to grant cloud tasks access to"
+  description = "Email address of the backend service account to grant access to cloud tasks"
+}
+
+variable "jobs_service_account_email" {
+  type        = string
+  description = "Email address of the jobs service account to grant access to cloud tasks"
 }

--- a/infrastructure/base/modules/env/main.tf
+++ b/infrastructure/base/modules/env/main.tf
@@ -232,7 +232,7 @@ module "backend_cloudrun" {
     },
     {
       name  = "CLOUD_TASKS_TEST_QUEUE_NAME"
-      value = "email-test"
+      value = "heco-default-queue"
     },
     {
       name  = "IS_JOBS_INSTANCE"
@@ -343,7 +343,7 @@ module "jobs_cloudrun" {
     },
     {
       name  = "CLOUD_TASKS_TEST_QUEUE_NAME"
-      value = "email-test"
+      value = "heco-default-queue"
     },
     {
       name  = "IS_JOBS_INSTANCE"
@@ -413,13 +413,14 @@ module "bastion" {
   subnetwork_name = module.network.subnetwork_name
 }
 
-module "test_cloud_tasks" {
+module "cloud_tasks" {
   source                = "../cloud-tasks"
-  name                  = "email-test"
+  name                  = "heco-default-queue"
   prefix                = var.project_name
   project_id            = var.gcp_project_id
   region                = var.gcp_region
-  service_account_email = module.backend_cloudrun.service_account_email
+  backend_service_account_email = module.backend_cloudrun.service_account_email
+  jobs_service_account_email = module.jobs_cloudrun.service_account_email
 }
 
 module "purge_users_cron" {

--- a/infrastructure/base/modules/env/main.tf
+++ b/infrastructure/base/modules/env/main.tf
@@ -477,5 +477,6 @@ module "translation" {
 module "error_reporting" {
   source                = "../error-reporting"
   project_id            = var.gcp_project_id
-  service_account_email = module.backend_cloudrun.service_account_email
+  backend_service_account_email = module.backend_cloudrun.service_account_email
+  jobs_service_account_email = module.jobs_cloudrun.service_account_email
 }

--- a/infrastructure/base/modules/error-reporting/main.tf
+++ b/infrastructure/base/modules/error-reporting/main.tf
@@ -3,8 +3,14 @@ resource "google_project_service" "error_reporting_api" {
   disable_on_destroy = false
 }
 
-resource "google_project_iam_member" "error_reporting_writer" {
+resource "google_project_iam_member" "error_reporting_backend_writer" {
   project = var.project_id
   role    = "roles/errorreporting.writer"
-  member = "serviceAccount:${var.service_account_email}"
+  member = "serviceAccount:${var.backend_service_account_email}"
+}
+
+resource "google_project_iam_member" "error_reporting_jobs_writer" {
+  project = var.project_id
+  role    = "roles/errorreporting.writer"
+  member = "serviceAccount:${var.jobs_service_account_email}"
 }

--- a/infrastructure/base/modules/error-reporting/variables.tf
+++ b/infrastructure/base/modules/error-reporting/variables.tf
@@ -3,7 +3,12 @@ variable "project_id" {
   description = "GCP project id"
 }
 
-variable "service_account_email" {
+variable "backend_service_account_email" {
   type        = string
-  description = "Email address of the service account to grant cloud tasks access to"
+  description = "Email address of the backend service account to grant access to error reporting"
+}
+
+variable "jobs_service_account_email" {
+  type        = string
+  description = "Email address of the jobs service account to grant access to error reporting"
 }


### PR DESCRIPTION
Found an error when testing https://vizzuality.atlassian.net/browse/LET-1152 which was probably due to insufficient permissions to queue a job from the jobs instance. A similar issue might have been the reason why exceptions from the jobs instance were not surfaced in error reporting.
