### PR TITLE
Allow investors to mark favourited projects as projects they fund

### DIFF
--- a/frontend/components/forms/switch/types.ts
+++ b/frontend/components/forms/switch/types.ts
@@ -9,8 +9,6 @@ export type SwitchProps<FormValues> = {
   'aria-label'?: string;
   /** Name of the switch */
   name: Path<FormValues>;
-  /** Value of the switch */
-  value: any;
   /** React Hook Form's `register` function */
   register: UseFormRegister<FormValues>;
   /** Options for React Hook Form's `register` function */

--- a/frontend/containers/dashboard/open-call-details/funding-switch/component.tsx
+++ b/frontend/containers/dashboard/open-call-details/funding-switch/component.tsx
@@ -65,7 +65,6 @@ export const FundingSwitch: FC<FundingSwitchProps> = ({
           name="funding"
           switchSize="smallest"
           register={register}
-          value={true}
           checked={funding}
           {...pressProps}
         />

--- a/frontend/containers/discover-map/map-layers-selector/component.tsx
+++ b/frontend/containers/discover-map/map-layers-selector/component.tsx
@@ -126,8 +126,8 @@ export const MapLayersSelector: FC<MapLayersSelectorProps> = ({
                                 <Switch
                                   id={id}
                                   name={group}
+                                  defaultValue={id}
                                   switchSize="smallest"
-                                  value={id}
                                   register={register}
                                   registerOptions={registerOptions}
                                 />

--- a/frontend/containers/project-card/types.ts
+++ b/frontend/containers/project-card/types.ts
@@ -7,6 +7,8 @@ export type ProjectCardProps = {
   active?: boolean;
   /** Projects list */
   project: ProjectType;
+  /** Whether the card should have a “funding” option. Default to `false`. */
+  canFund?: boolean;
   /** onClick callback */
   onClick?: (projectId: string) => void;
 };

--- a/frontend/containers/settings-security/2fa/component.tsx
+++ b/frontend/containers/settings-security/2fa/component.tsx
@@ -45,7 +45,6 @@ const Settings2FA: FC<Settings2FAProps> = () => {
           <Switch
             id="otp-required-for-login"
             name="otp_required_for_login"
-            value=""
             register={register}
             registerOptions={{
               onChange: () => {

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -1962,6 +1962,9 @@
   "b8sVDI": {
     "string": "Privacy notice"
   },
+  "bALo1R": {
+    "string": "Account security"
+  },
   "bNpbHr": {
     "string": "Find other people with similar interests. Join forces, secure more investment and create a greater impact."
   },

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -2331,6 +2331,9 @@
   "iiVhlC": {
     "string": "insert phone number"
   },
+  "ijVzNu": {
+    "string": "I’m financing this project"
+  },
   "ikyoJL": {
     "string": "HeCo will support the improved management of ecosystems in the Amazon, Andes, Orinoco, Pacific, and Caribbean regions. This aims to ensure the <n>long-term sustainability</n> of natural capital, through creating and channeling new and additional financial flows from the public and private sectors into specific projects and initiatives."
   },

--- a/frontend/layouts/dashboard-favorites/component.tsx
+++ b/frontend/layouts/dashboard-favorites/component.tsx
@@ -32,7 +32,7 @@ export const DashboardFavoritesLayout: FC<DashboardFavoritesLayoutProps> = ({
 
   const defaultQueryOptions = {
     refetchOnMount: true, // Fix issues with react-query not refetching stale data
-    keepPreviousData: false,
+    keepPreviousData: true,
   };
 
   const projects = useFavoriteProjectsList(defaultQueryParams, defaultQueryOptions);
@@ -60,7 +60,7 @@ export const DashboardFavoritesLayout: FC<DashboardFavoritesLayoutProps> = ({
     return {
       data: data.data?.data,
       meta: data.data?.meta,
-      loading: data.isLoading || data?.isFetching,
+      loading: data.isLoading,
     };
   };
 

--- a/frontend/pages/dashboard/favorites/projects.tsx
+++ b/frontend/pages/dashboard/favorites/projects.tsx
@@ -3,6 +3,8 @@ import { FormattedMessage } from 'react-intl';
 
 import { withLocalizedRequests } from 'hoc/locale';
 
+import useMe from 'hooks/me';
+
 import { loadI18nMessages } from 'helpers/i18n';
 
 import CardHoverToDelete from 'containers/dashboard/favorites/card-hover-to-delete';
@@ -10,7 +12,7 @@ import ProjectCard from 'containers/project-card';
 
 import Button from 'components/button';
 import Icon from 'components/icon';
-import { Paths } from 'enums';
+import { Paths, UserRoles } from 'enums';
 import DashboardFavoritesLayout, {
   DashboardFavoritesLayoutProps,
 } from 'layouts/dashboard-favorites';
@@ -39,6 +41,7 @@ export const FavoritesProjectsPage: PageComponent<
   const hasProjects = projects?.length > 0;
 
   const favoriteProject = useFavoriteProject();
+  const { user } = useMe();
 
   const handleRemoveClick = (slug: string) => {
     favoriteProject.mutate({ id: slug, isFavourite: true });
@@ -58,7 +61,7 @@ export const FavoritesProjectsPage: PageComponent<
           <>
             {projects.map((project) => (
               <CardHoverToDelete key={project.id} onClick={() => handleRemoveClick(project.id)}>
-                <ProjectCard className="" project={project} />
+                <ProjectCard project={project} canFund={user?.role === UserRoles.Investor} />
               </CardHoverToDelete>
             ))}
           </>

--- a/frontend/services/account/index.ts
+++ b/frontend/services/account/index.ts
@@ -386,6 +386,28 @@ export function useAccountProjectsList(
   );
 }
 
+const fundProject = async (projectId: Project['id'], fund: boolean): Promise<Project> => {
+  const config: AxiosRequestConfig = {
+    url: `/api/v1/account/projects/${projectId}/${fund ? 'funding' : 'not_funding'}`,
+    method: 'POST',
+    data: {},
+  };
+
+  return await API.request(config).then((result) => result.data.data);
+};
+
+export const useFundProject = (projectId: Project['id']) => {
+  const queryClient = useQueryClient();
+
+  return useMutation((fund: boolean) => fundProject(projectId, fund), {
+    onSuccess: (dete) => {
+      queryClient.invalidateQueries(Queries.FavoriteProjectsList);
+      queryClient.invalidateQueries(Queries.Project);
+      queryClient.invalidateQueries(Queries.ProjectList);
+    },
+  });
+};
+
 /** Hook to use the the Users Invited to User Account */
 const getAccountUsers = async (params?: PagedRequest): Promise<PagedResponse<AccountUser>> => {
   const { search, includes, ...rest } = params || {};
@@ -441,7 +463,6 @@ export const transferOwnership = async (userId: string) => {
 /** Hook with mutation to delete an account */
 export const useDeleteAccount = (): UseMutationResult<AxiosResponse, AxiosError> => {
   const queryClient = useQueryClient();
-  const router = useRouter();
 
   const deleteAccount = async (): Promise<AxiosResponse> => {
     const config: AxiosRequestConfig = {

--- a/frontend/types/project.ts
+++ b/frontend/types/project.ts
@@ -59,6 +59,11 @@ export type ProjectBase = {
   status?: ProjectStatus;
   project_developer?: any; // Cannot use ProjectDeveloperType because linting will complain about circular references
   involved_project_developers?: any[]; // Cannot use ProjectDeveloperType because linting will complain about circular references
+  /**
+   * Whether the logged in investor has marked the project as funded. `null` if the user is not
+   * logged in or not an investor.
+   **/
+  funded?: boolean;
 };
 
 /** Project impact properties  */


### PR DESCRIPTION
This PR allows investors to mark projects they've favourited as projects they are funding.

## Testing instructions

1. Log in as an investor
2. Favourite some projects
3. Go to the “Projects” tab of your favourites in the Dashboard

Make sure you can mark a project as funded and undo it. Make sure you can click on the project's title to see its public page.

4. Reload the page

Make sure the project is still funded/unfunded.

5. Log in as a PD
6. Favourite some projects
7. Go to the “Projects” tab of your favourites in the Dashboard

Make sure you don't see any option to fund the projects. Make sure you can click any part of the cards to see their public page.

8. Go to Discover

Make sure you don't see any funding option and that you can click on any part of the project cards to open the preview.

## Tracking

[LET-1124](https://vizzuality.atlassian.net/browse/LET-1124)
