### PR TITLE
Add validations folder to i18n:extract script

### DIFF
--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -20,6 +20,9 @@
   "+USuwC": {
     "string": "Funding available per project"
   },
+  "+UvbBR": {
+    "string": "You need to confirm the password."
+  },
   "+hdaRx": {
     "string": "Financial information about your project and what are the needs. This information will be <n>public</n> except the one marked as <n>private</n> which will only be visible for admins."
   },
@@ -95,6 +98,9 @@
   "03HUos": {
     "string": "View public page"
   },
+  "05q+7T": {
+    "string": "Invalid email format."
+  },
   "06VF+w": {
     "string": "Share on Facebook"
   },
@@ -121,6 +127,9 @@
   },
   "0WuJfZ": {
     "string": "Enter the estimated implementation duration for the project."
+  },
+  "0ZgDo2": {
+    "string": "The message can have a maximum of 600 characters"
   },
   "0ZkvWW": {
     "string": "Amazonian Piedmont - Massif"
@@ -398,6 +407,9 @@
   "62pTkz": {
     "string": "Save your favorites"
   },
+  "64TO4B": {
+    "string": "You need to confirm the new password."
+  },
   "68i9X8": {
     "string": "Investor information"
   },
@@ -646,6 +658,9 @@
   },
   "APjPYs": {
     "string": "I want to write my content in"
+  },
+  "AXCPbS": {
+    "string": "You need to enter your current password."
   },
   "AdAi3x": {
     "string": "Emails"
@@ -1016,6 +1031,9 @@
   "HnG9/3": {
     "string": "Insert password"
   },
+  "HrWuWv": {
+    "string": "You need to enter a new password."
+  },
   "HtMY9H": {
     "string": "Type your message"
   },
@@ -1169,6 +1187,9 @@
   },
   "KxPY7j": {
     "string": "Date of creation"
+  },
+  "L/i942": {
+    "string": "You need to select a project."
   },
   "L2CvBU": {
     "string": "Expect to have impact"
@@ -1418,6 +1439,9 @@
   },
   "PheCRL": {
     "string": "Estimated Impact"
+  },
+  "Pl5xI4": {
+    "string": "You need to enter a name."
   },
   "Py+eVV": {
     "string": "Basic info"
@@ -1821,6 +1845,9 @@
   "Y2zB+b": {
     "string": "No project developers"
   },
+  "Y4hw30": {
+    "string": "The password must contain at least one uppercase letter, one lowercase letter and one number."
+  },
   "Y9+L0O": {
     "string": "Discover Open Calls"
   },
@@ -1946,6 +1973,9 @@
   },
   "aT5Ajq": {
     "string": "Start drawing"
+  },
+  "aVk9a9": {
+    "string": "The new password must contain at least 12 characters, with at least one uppercase letter, one lowercase letter and a number."
   },
   "adPUXO": {
     "string": "Until approval you can continue exploring our database."
@@ -2124,6 +2154,9 @@
   "eItis6": {
     "string": "Discover investors by budget/ticket size"
   },
+  "eKEHsg": {
+    "string": "The password must have at least 12 characters."
+  },
   "eM7TKf": {
     "string": "About the platform"
   },
@@ -2204,6 +2237,9 @@
   },
   "fnihsY": {
     "string": "Leave"
+  },
+  "fo1tCY": {
+    "string": "You need to enter your password."
   },
   "fqJtkV": {
     "string": "Others"
@@ -2318,6 +2354,9 @@
   },
   "i7V7mZ": {
     "string": "Search icon"
+  },
+  "i8NU3I": {
+    "string": "You need to enter a message."
   },
   "i9cSUD": {
     "string": "Invests in"
@@ -2793,6 +2832,9 @@
   "rE2fon": {
     "string": "Are you sure you want to withdraw from the “<strong>{openCallName}</strong>“ open call?"
   },
+  "rJnXTe": {
+    "string": "The password must contain at least 12 characters, with at least one uppercase letter, one lowercase letter and a number."
+  },
   "rLzWx9": {
     "string": "{name} picture"
   },
@@ -2919,6 +2961,9 @@
   "tAug9g": {
     "string": "Groups with disabilities"
   },
+  "tCfD2Y": {
+    "string": "You need to enter your email."
+  },
   "tDM2u5": {
     "string": "Can I add colleagues from my organization to the account?"
   },
@@ -2948,6 +2993,9 @@
   },
   "tjunxL": {
     "string": "Active filters"
+  },
+  "tkP6dd": {
+    "string": "You need to accept the Terms and Privacy Policy."
   },
   "twK/jv": {
     "string": "Project developer profile"
@@ -3096,6 +3144,9 @@
   "we4Lby": {
     "string": "Info"
   },
+  "weOT3A": {
+    "string": "The passwords don't match."
+  },
   "wghPR3": {
     "string": "Group of projects"
   },
@@ -3240,6 +3291,9 @@
   "zLCDho": {
     "string": "Farmers"
   },
+  "zPMPr9": {
+    "string": "You need to enter a last name."
+  },
   "zSOvI0": {
     "string": "Filters"
   },
@@ -3248,6 +3302,9 @@
   },
   "zdIaHp": {
     "string": "Investors"
+  },
+  "zeCjLr": {
+    "string": "You need to enter a password."
   },
   "zetZX8": {
     "string": "Content language"

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -26,6 +26,9 @@
   "+hdaRx": {
     "string": "Financial information about your project and what are the needs. This information will be <n>public</n> except the one marked as <n>private</n> which will only be visible for admins."
   },
+  "+m/R6q": {
+    "string": "You need to select a municipality"
+  },
   "+mzZak": {
     "string": "About {name}"
   },
@@ -82,6 +85,9 @@
   },
   "/cMb5f": {
     "string": "Zoom out icon"
+  },
+  "/i6bRr": {
+    "string": "The received amount must be greater than 0"
   },
   "/oLNw7": {
     "string": "The impact score of this project is 0."
@@ -140,6 +146,9 @@
   "0ch6f/": {
     "string": "Scaling - up"
   },
+  "0dbfpr": {
+    "string": "You need to enter a text for the progress and impact tracking"
+  },
   "0hzVw6": {
     "string": "How accounts work?"
   },
@@ -169,6 +178,9 @@
   },
   "0zLVGQ": {
     "string": "Instrument types"
+  },
+  "1+wwRC": {
+    "string": "Upload a geometry or draw on the map"
   },
   "11hyS6": {
     "string": "Add your legal registration number so we can verify your legal entity . This information will not be publicaly available."
@@ -220,6 +232,9 @@
   },
   "2O2sfp": {
     "string": "Finish"
+  },
+  "2RaCKb": {
+    "string": "Select if there are other project developers involved on the project"
   },
   "2ffyX7": {
     "string": "This page is coming soon"
@@ -310,6 +325,9 @@
   },
   "4EYbNW": {
     "string": "Create open calls"
+  },
+  "4EYr7Q": {
+    "string": "You need to select the closing date"
   },
   "4HIQfn": {
     "string": "Landscapes location"
@@ -575,6 +593,9 @@
   "9+Ddtu": {
     "string": "Next"
   },
+  "9+IpyL": {
+    "string": "You need to enter the estimated duration of the project"
+  },
   "94Fg25": {
     "string": "Select all"
   },
@@ -598,6 +619,9 @@
   },
   "9WcWke": {
     "string": "{name} investor"
+  },
+  "9a4/mT": {
+    "string": "You need to select a state"
   },
   "9a9+ww": {
     "string": "Title"
@@ -752,6 +776,9 @@
   "CiYFzk": {
     "string": "SME and MSME"
   },
+  "Cise0r": {
+    "string": "You need to select a language"
+  },
   "CqohYm": {
     "string": "All content associated with the account will be deleted. If you have created Open Calls to which some Projects have applied, the owners of these Projects will be automatically notified that the Open Call no longer exists."
   },
@@ -815,11 +842,17 @@
   "DeOyLr": {
     "string": "Want to know more about this project?"
   },
+  "DffEkP": {
+    "string": "You need enter an \"about\" text"
+  },
   "DkjIbR": {
     "string": "insert email"
   },
   "Dm1lEK": {
     "string": "A score of expected impact along the four sustainability dimensions is assigned to every project. These scores are calculated using a combination of landscape-level variables (<b>Demand</b>) and self-reported project data (<b>Supply</b>)."
+  },
+  "Dm4fJl": {
+    "string": "Website must be a valid URL"
   },
   "DqD1yK": {
     "string": "Applications"
@@ -965,6 +998,9 @@
   "G9iCfx": {
     "string": "Reach them in"
   },
+  "GC4Ve3": {
+    "string": "You need to enter a text with a short description of your project"
+  },
   "GDPNty": {
     "string": "insert value"
   },
@@ -991,6 +1027,9 @@
   },
   "GhrkT+": {
     "string": "confirm password"
+  },
+  "GkDTfx": {
+    "string": "You need to enter an email"
   },
   "Gpyrow": {
     "string": "IDB Lab is the innovation laboratory of the Inter-American Development Back Group, the leading source of financing for improving lives in Latin America and the Caribbean. The IDB Lab promotes development through the private sector by identifying, supporting, testing, and piloting new solutions to development challenges. It seeks to create opportunities for poor and vulnerable populations affected by economic, social, or environmental factors in Latin America and the Caribbean."
@@ -1024,6 +1063,9 @@
   },
   "HcakU9": {
     "string": "What is the open call about?"
+  },
+  "HhjmvS": {
+    "string": "Invalid phone number"
   },
   "HlDhAh": {
     "string": "10%"
@@ -1143,6 +1185,9 @@
   "JnwEP6": {
     "string": "Edit investor profile"
   },
+  "JpLZrZ": {
+    "string": "You need to select the development of the project"
+  },
   "Jwjqn/": {
     "string": "focused"
   },
@@ -1172,6 +1217,9 @@
   },
   "KlHNih": {
     "string": "option {optionName} is disabled. Select another option."
+  },
+  "Km6ekR": {
+    "string": "You need enter a description of the open call"
   },
   "Knhvmr": {
     "string": "Who is financing this open call"
@@ -1244,6 +1292,9 @@
   },
   "LxYOKo": {
     "string": "With a known <b>Demand</b> and <b>Supply</b>, a <b>Net value</b> is generated as <b>Supply</b> - <b>Demand</b>. This value ranges from -1 to 1. The closest the net value to 0 the better because it means that supply meets demand and vice versa. The Net value is then transformed into an <b>impact score</b>, using the formula y = - (x^​2) + 1. The results range from 0 to 1, where 0 is the low positive impact and 1 is a high positive impact, in relation to the context demand. Finally, this value is multiplied by 10 to rescale it from 0 to 10."
+  },
+  "M+H+u+": {
+    "string": "Select at least one project developer involved on the project"
   },
   "M1xKEI": {
     "string": "Language: {language}"
@@ -1329,6 +1380,9 @@
   "NdyMBg": {
     "string": "In the {area} the highest impact of the project is on <b>{impactDimension}</b> with a <b>score</b> of {score}."
   },
+  "NeZ5aL": {
+    "string": "You need to enter a text for the solution proposed"
+  },
   "NjKSap": {
     "string": "Online presence"
   },
@@ -1389,6 +1443,9 @@
   "Oc8Fmg": {
     "string": "Estimated duration of the project"
   },
+  "Oh6Jeq": {
+    "string": "Select at least one SDG"
+  },
   "OkH5va": {
     "string": "Loan"
   },
@@ -1442,6 +1499,9 @@
   },
   "Pl5xI4": {
     "string": "You need to enter a name."
+  },
+  "PsOtRA": {
+    "string": "The max development durations is 36 months"
   },
   "Py+eVV": {
     "string": "Basic info"
@@ -1593,8 +1653,14 @@
   "T7Ry38": {
     "string": "Message"
   },
+  "TCb/DD": {
+    "string": "You need to enter a text for the sustainability of the project"
+  },
   "TDaF6J": {
     "string": "Dismiss"
+  },
+  "TJSbSS": {
+    "string": "You need enter the entity legal registration number"
   },
   "TJo5E6": {
     "string": "Preview"
@@ -1614,6 +1680,9 @@
   "TdTXXf": {
     "string": "Learn more"
   },
+  "TfAnzZ": {
+    "string": "The pictures must have a maximum size of 5 MB"
+  },
   "TfXhCr": {
     "string": "No projects"
   },
@@ -1631,6 +1700,9 @@
   },
   "U1OBY8": {
     "string": "options {options}, selected."
+  },
+  "U6/vVg": {
+    "string": "Upload a maximum of six images"
   },
   "U98Mu/": {
     "string": "This layer shows the permanent and temporal wetlands of Colombia at a 1:100.000 reoslution"
@@ -1710,6 +1782,9 @@
   "VavuU5": {
     "string": "Project Developer type"
   },
+  "Vddg/J": {
+    "string": "You need to enter a text for the expected impact"
+  },
   "Vge+RX": {
     "string": "Footer"
   },
@@ -1785,6 +1860,9 @@
   "X2YMUl": {
     "string": "Contact the project developers to know more about the project."
   },
+  "X9irAo": {
+    "string": "You need to enter a profile name"
+  },
   "XDC7Vp": {
     "string": "Select the intrument type(s) you provide"
   },
@@ -1832,6 +1910,9 @@
   },
   "Xms+aE": {
     "string": "Currently you don’t have any <b>Projects</b> in your favorites."
+  },
+  "XvwE2r": {
+    "string": "You need to insert a name"
   },
   "XwmxKZ": {
     "string": "A project is an enterprise or initiative carefully planned and run by project developers in a given region with the objective of contributing to its environmental conservation. Projects are set up whenever a project developer is seeking visibility or needing investment."
@@ -2007,6 +2088,9 @@
   "bALo1R": {
     "string": "Account security"
   },
+  "bE1H34": {
+    "string": "You need to select one or more impact areas that you prioritixe"
+  },
   "bNpbHr": {
     "string": "Find other people with similar interests. Join forces, secure more investment and create a greater impact."
   },
@@ -2018,6 +2102,9 @@
   },
   "bhxvPM": {
     "string": "Setup project developer’s account"
+  },
+  "biZCxW": {
+    "string": "You need to select if you have previously invested in impact"
   },
   "bjubNC": {
     "string": "Add your logo or a picture that indentifies the account."
@@ -2052,6 +2139,9 @@
   "cE4Hfw": {
     "string": "Discover"
   },
+  "cFytiP": {
+    "string": "You need to select the types of financing are you can provide"
+  },
   "cIQfgu": {
     "string": "Restoration"
   },
@@ -2069,6 +2159,9 @@
   },
   "caaGgO": {
     "string": "How can I invest/fund a project?"
+  },
+  "cappSj": {
+    "string": "You need to select a country"
   },
   "ccXLVi": {
     "string": "Category"
@@ -2102,6 +2195,9 @@
   },
   "dKiARI": {
     "string": "To produce this population density and distribution data set, researchers mapped global built-up areas, which are defined as all above ground constructions intended for human or animal sheltering or to produce economic goods. The locations of these built up areas was established using Landsat imagery analysis. An additional source used to compile this data set was the Gridded Population of the World (GPW) data set assembled by the Center for International Earth Science Information Network (CIESIN). The GPW data set consists of census population data and bolstered the built-up areas data by enabling researchers to estimate residential population. To present this data as grid cells, GPW data was disaggregated from census or administrative units."
+  },
+  "dOO/qA": {
+    "string": "You need to enter a text for the funding plan"
   },
   "dPuc1g": {
     "string": "Slide {slideNumber}"
@@ -2150,6 +2246,9 @@
   },
   "eFJIPT": {
     "string": "{numInstrumentTypes, plural, one {Instrument type} other {Instrument types}}"
+  },
+  "eG1BWC": {
+    "string": "You need to write other relevant information"
   },
   "eItis6": {
     "string": "Discover investors by budget/ticket size"
@@ -2244,6 +2343,9 @@
   "fqJtkV": {
     "string": "Others"
   },
+  "frm1UB": {
+    "string": "It must have a maximum of 600 characters"
+  },
   "fvFVbs": {
     "string": "Shows above ground live woody biomass density."
   },
@@ -2264,6 +2366,12 @@
   },
   "gF/kn9": {
     "string": "Contribute to protecting areas of greatest ecosystems diversity, conservation and restoration potential, degree of threat or protection for flora and fauna, landscape connectivity and degree of endemism."
+  },
+  "gFz7AV": {
+    "string": "Select at least one impact area"
+  },
+  "gLT/Md": {
+    "string": "You need to upload a profile picture"
   },
   "gQ16Mj": {
     "string": "Funding exclusions"
@@ -2306,6 +2414,9 @@
   },
   "hPsrc0": {
     "string": "insert your answer (max 600 characters)"
+  },
+  "hRZo+X": {
+    "string": "You need to select the type of financing are you can provide"
   },
   "hRcpAt": {
     "string": "max 1 layer"
@@ -2379,6 +2490,9 @@
   "iSPvEQ": {
     "string": "To create an open call you will need the following information."
   },
+  "iTkO2x": {
+    "string": "You need to select the investor/funder type"
+  },
   "iUt7so": {
     "string": "of the planet’s known biodiversity lives in the Amazon, the largest tropical rainforest on the planet."
   },
@@ -2405,6 +2519,9 @@
   },
   "ipYSrV": {
     "string": "The email where you want to receive contacts from Investors or other Project Developers"
+  },
+  "ir/b1N": {
+    "string": "You need to enter impact that the project is expected to generate."
   },
   "itfsqC": {
     "string": "Currently you don’t have any <b>Projects</b>."
@@ -2481,6 +2598,9 @@
   "k5DITM": {
     "string": "Users will receive an email to sign up into the platform and join <strong>{name}</strong> account."
   },
+  "k5J7dK": {
+    "string": "You need to enter the max funding value"
+  },
   "k62/kN": {
     "string": "Fit bounds"
   },
@@ -2489,6 +2609,9 @@
   },
   "kEXoaQ": {
     "string": "About your work"
+  },
+  "kGJlX6": {
+    "string": "You need to select the target groups"
   },
   "kHpaMt": {
     "string": "Edit Open Call"
@@ -2529,11 +2652,17 @@
   "keWpuD": {
     "string": "In this data set, “tree cover” is defined as all vegetation greater than 5 meters in height, and may take the form of natural forests or plantations across a range of canopy densities. Tree cover loss is defined as “stand replacement disturbance,” or the complete removal of tree cover canopy at the Landsat pixel scale. Tree cover loss may be the result of human activities, including forestry practices such as timber harvesting or deforestation (the conversion of natural forest to other land uses), as well as natural causes such as disease or storm damage. Fire is another widespread cause of tree cover loss, and can be either natural or human-induced."
   },
+  "khRkg/": {
+    "string": "You need to select the amount of money you can provide"
+  },
   "ku+mDU": {
     "string": "State"
   },
   "l+2DwB": {
     "string": "Reach out {title} on HeCo Invest through the link"
+  },
+  "l2C1SN": {
+    "string": "You need to select a project developer type"
   },
   "l2HvdU": {
     "string": "Estimated duration for project in months"
@@ -2546,6 +2675,9 @@
   },
   "lYS3vO": {
     "string": "Project developers provide the impact information during the project registration phase by selecting one or more indicators from each dimension."
+  },
+  "laO/jL": {
+    "string": "You need to enter a \"mission\" text"
   },
   "lda5xz": {
     "string": "My users"
@@ -2571,11 +2703,17 @@
   "lpyO42": {
     "string": "Impact of projects on ensuring and improving equal and inclusive physical, mental, economic, and spiritual health."
   },
+  "lr5x1P": {
+    "string": "You need to enter a text for the replicability of the project"
+  },
   "ltUH9L": {
     "string": "Note that all of this information will be visible in the open call public page."
   },
   "lviFjb": {
     "string": "The Herencia Colombia program contains 9 priority landscapes or conservation mosaics. These are: Amazon Heart, Amazonian Piedmont - Massif, Orinoquía, Orinoquía Transition, Central Mountain Range, Eastern Mountain range, Caribbean, Pacific - Caribbean Transition, Pacific - Coastal Marine. The HeCo Invest platform centers its attention on areas directly connected to the Amazon. These are: Amazon Heart, Amazonian Piedmont - Massif, Orinoquía, Orinoquía Transition. More information about these regions <link>here</link>."
+  },
+  "lwv2DP": {
+    "string": "You need to select one or more expected impact"
   },
   "m1w8ew": {
     "string": "30 million"
@@ -2586,11 +2724,17 @@
   "m3Dnav": {
     "string": "Investment info"
   },
+  "m4AGCI": {
+    "string": "You need to select an option"
+  },
   "mEYG82": {
     "string": "Funding information"
   },
   "mMReor": {
     "string": "Go to project page"
+  },
+  "mOUwuv": {
+    "string": "It should be a valid account"
   },
   "mQk71L": {
     "string": "Why invest in the Amazon"
@@ -2624,6 +2768,9 @@
   },
   "nEvNJb": {
     "string": "Investor"
+  },
+  "nGC2oX": {
+    "string": "Invalid entity legal registration number format. It must be a 10 digit number."
   },
   "nIbokM": {
     "string": "Contact access"
@@ -2694,6 +2841,9 @@
   "ojuv8F": {
     "string": "Investor contacts"
   },
+  "ora/x9": {
+    "string": "You need to select one or more categories"
+  },
   "orirkU": {
     "string": "What information do I need to create a Project Developer account?"
   },
@@ -2709,6 +2859,9 @@
   "p+Qmws": {
     "string": "Which of these topic/sector categories better describe your project?"
   },
+  "p8jXrR": {
+    "string": "You need to enter the funding exclusions"
+  },
   "pHaFj5": {
     "string": "To create an Investor account you will need the following information."
   },
@@ -2717,6 +2870,9 @@
   },
   "pONqz8": {
     "string": "First name"
+  },
+  "pQMwQ7": {
+    "string": "The min development duration is 1 month"
   },
   "pWwsxm": {
     "string": "Delete image"
@@ -2868,8 +3024,14 @@
   "roJe5R": {
     "string": "Investor/ Funder type"
   },
+  "rsKPyl": {
+    "string": "You need to select the project category"
+  },
   "rsWAqe": {
     "string": "select multiple"
+  },
+  "rtG8sS": {
+    "string": "You need to select the amount of money you need for the project"
   },
   "rtcoCk": {
     "string": "Carbon emission reduction"
@@ -3009,6 +3171,9 @@
   "tzMNF3": {
     "string": "Status"
   },
+  "tzSubd": {
+    "string": "You need enter a \"about\" text"
+  },
   "u+TnMw": {
     "string": "To estimate the project’s impact, 0 (non-selected) and 1 (selected) are assigned for each indicator. However, if all the indicators of a given dimension are selected, then the <b>score goes automatically to 0</b>. This is to ensure that the project developers only report the direct impacts of their projects and avoid exaggerating the project’s scope."
   },
@@ -3138,6 +3303,9 @@
   "wSZR47": {
     "string": "Submit"
   },
+  "wasfcn": {
+    "string": "You need to enter a text for the problems you are solving"
+  },
   "wduJme": {
     "string": "Instrument"
   },
@@ -3146,6 +3314,9 @@
   },
   "weOT3A": {
     "string": "The passwords don't match."
+  },
+  "wf8svn": {
+    "string": "You need to enter the funding priorities"
   },
   "wghPR3": {
     "string": "Group of projects"
@@ -3278,6 +3449,9 @@
   },
   "z3yOZn": {
     "string": "This .kml/.kmz file does not have a valid XML syntax. Please try to validate it and resolve the issues."
+  },
+  "zBO3fW": {
+    "string": "You need to select what type of financing are you looking for"
   },
   "zFegDD": {
     "string": "Contact"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "test": "yarn check-types && jest --ci --passWithNoTests",
     "storybook:dev": "start-storybook -p 6006 -c .storybook",
     "storybook:build": "build-storybook -c .storybook",
-    "i18n:extract": "formatjs extract \"{components,containers,helpers,hoc,hooks,layouts,lib,pages,services,store,validations}/**/*.{js,jsx,ts,tsx}\" --ignore \"**/*.d.ts\" --out-file lang/transifex/zu.json --format transifex",
+    "i18n:extract": "formatjs extract \"{components,containers,helpers,hoc,hooks,layouts,lib,pages,services,store,validations,schemas}/**/*.{js,jsx,ts,tsx}\" --ignore \"**/*.d.ts\" --out-file lang/transifex/zu.json --format transifex",
     "i18n:compile": "formatjs compile-folder lang/transifex lang/compiled --format transifex"
   },
   "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "test": "yarn check-types && jest --ci --passWithNoTests",
     "storybook:dev": "start-storybook -p 6006 -c .storybook",
     "storybook:build": "build-storybook -c .storybook",
-    "i18n:extract": "formatjs extract \"{components,containers,helpers,hoc,hooks,layouts,lib,pages,services,store}/**/*.{js,jsx,ts,tsx}\" --ignore \"**/*.d.ts\" --out-file lang/transifex/zu.json --format transifex",
+    "i18n:extract": "formatjs extract \"{components,containers,helpers,hoc,hooks,layouts,lib,pages,services,store,validations}/**/*.{js,jsx,ts,tsx}\" --ignore \"**/*.d.ts\" --out-file lang/transifex/zu.json --format transifex",
     "i18n:compile": "formatjs compile-folder lang/transifex lang/compiled --format transifex"
   },
   "engines": {


### PR DESCRIPTION
This PR adds the 'validations' folder to the 'i18n:extract' script

## Testing instructions

The validation texts on files inside the validations folder should be included on the 'lang/transifex/zu.json' file

## Tracking

[1194](https://vizzuality.atlassian.net/browse/LET-1194)
