### PR TITLE
Fix priority landscapes filter options

### DIFF
--- a/frontend/containers/forms/filters/component.tsx
+++ b/frontend/containers/forms/filters/component.tsx
@@ -44,7 +44,7 @@ export const Filters: FC<FiltersProps> = ({ closeFilters, filtersData, filters }
     formState: { errors },
   } = useForm<FilterForm>();
 
-  const { category, impact, ticket_size, instrument_type, priorityLandscapes, sdg } = groupBy<Enum>(
+  const { category, impact, ticket_size, instrument_type, priority_landscape, sdg } = groupBy<Enum>(
     filtersData,
     'type'
   );
@@ -70,7 +70,7 @@ export const Filters: FC<FiltersProps> = ({ closeFilters, filtersData, filters }
         }
       ),
       values:
-        priorityLandscapes?.map(({ id, name }) => ({
+        priority_landscape?.map(({ id, name }) => ({
           id,
           type: LocationsTypes.PriorityLandscapes,
           name,


### PR DESCRIPTION
This PR fixes the priority landscape filters not showing

## Testing instructions

1. Go to discover/projects
2. Open the filter options
3. The priority landscapes filter options should be displayed

## Tracking

[1220](https://vizzuality.atlassian.net/browse/LET-1220)
