### PR TITLE
Fix not translating error

### DIFF
--- a/frontend/pages/dashboard/index.tsx
+++ b/frontend/pages/dashboard/index.tsx
@@ -2,13 +2,30 @@ import { useEffect } from 'react';
 
 import { useRouter } from 'next/router';
 
+import { withLocalizedRequests } from 'hoc/locale';
+
+import { InferGetStaticPropsType } from 'next';
+
+import { loadI18nMessages } from 'helpers/i18n';
+
 import { Paths, ReviewStatus, UserRoles } from 'enums';
 import DashboardLayout from 'layouts/dashboard';
-import NakedLayout from 'layouts/naked';
+import NakedLayout, { NakedLayoutProps } from 'layouts/naked';
+import { PageComponent } from 'types';
 
 import { useAccount } from 'services/account';
 
-export const DashboardPage = () => {
+export const getStaticProps = withLocalizedRequests(async ({ locale }) => {
+  return {
+    props: {
+      intlMessages: await loadI18nMessages({ locale }),
+    },
+  };
+});
+
+type ProjectsPageProps = InferGetStaticPropsType<typeof getStaticProps>;
+
+const DashboardPage: PageComponent<ProjectsPageProps, NakedLayoutProps> = () => {
   const router = useRouter();
   const { user, userIsLoading, userAccount, userAccountLoading } = useAccount();
 


### PR DESCRIPTION
This PR fixes the 'Pending approval' page not being translated when in dashboard

## Testing instructions

With a not approved user, go to dashboard
The page should be translated when changed to 'ES' or 'PT' languages

## Tracking

[LET-1193](https://vizzuality.atlassian.net/browse/LET-1193)
