### PR TITLE
Let 1206 fe remove notice from basic info in account information dashboard

### DIFF
--- a/frontend/containers/dashboard/account-information/basic-info/component.tsx
+++ b/frontend/containers/dashboard/account-information/basic-info/component.tsx
@@ -47,14 +47,6 @@ export const AccountBasicInfo: FC<AccountBasicInfoProps> = ({}: AccountBasicInfo
               {userAccount?.owner.first_name} {userAccount?.owner.last_name}
             </span>
           </div>
-          <div className="flex flex-col items-center gap-4 p-4 mt-6 text-sm md:flex-row rounded-xl bg-background-middle">
-            <div className="flex flex-grow">
-              <FormattedMessage
-                defaultMessage="To update any of this information, please contact the platform administrator. To delete the account, please contact the account owner."
-                id="9lOzos"
-              />
-            </div>
-          </div>
         </>
       )}
     </div>

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -245,9 +245,6 @@
   "3BlzQw": {
     "string": "Select project to apply"
   },
-  "3T3umg": {
-    "string": "If you are the owner of the account, please transfer the ownership before continuing."
-  },
   "3WLO/M": {
     "string": "Tell the investor why your project should receive the funding."
   },
@@ -596,9 +593,6 @@
   "9dtx+L": {
     "string": "Something went wrong while sending an invitation to the email {email}."
   },
-  "9lOzos": {
-    "string": "To update any of this information, please contact the platform administrator. To delete the account, please contact the account owner."
-  },
   "9nYuln": {
     "string": "Base Layers"
   },
@@ -622,9 +616,6 @@
   },
   "A4UTjl": {
     "string": "Portuguese"
-  },
-  "A775MJ": {
-    "string": "You are currently the account owner. Please transfer the ownership before continuing."
   },
   "A8VNfu": {
     "string": "Map Layers"
@@ -1344,6 +1335,9 @@
   "OChccW": {
     "string": "Investor / Funder"
   },
+  "OEYYbj": {
+    "string": "You are the owner of the account <accountName></accountName>, please <a>transfer the ownership</a> before continuing."
+  },
   "OJfOvp": {
     "string": "The account owner can invite other colleagues to the account. These will receive an invitation by email to join the account. Each email can only be associated with one account. Once you are set as an account user, you can manage the account. However, adding or removing other account users can only be managed by account owners."
   },
@@ -1415,6 +1409,9 @@
   },
   "PexDlg": {
     "string": "Show legend"
+  },
+  "PfIj8p": {
+    "string": "By deleting your user, you will be removed from the account <accountName></accountName> and you no longer will have access to HeCo Invest Platform."
   },
   "PheCRL": {
     "string": "Estimated Impact"
@@ -2798,9 +2795,6 @@
   },
   "rPEEqE": {
     "string": "Afro-descendant peoples"
-  },
-  "rPwLb7": {
-    "string": "By deleting your user, you will be removed from the account <n>accountName</n> and you no longer will have access to HeCo Invest Platform."
   },
   "rPwaWt": {
     "string": "A great name is short, crisp, and easily understood."

--- a/frontend/pages/settings/information.tsx
+++ b/frontend/pages/settings/information.tsx
@@ -5,6 +5,7 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import { useQueryClient } from 'react-query';
 
 // import dynamic from 'next/dynamic';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 
 import { withLocalizedRequests } from 'hoc/locale';
@@ -58,21 +59,12 @@ const Information: PageComponent<InformationPageProps, SettingsLayoutProps> = ()
   const deleteUser = useDeleteUser();
   const [showConfirmDelete, setShowConfirmDelete] = useState(false);
 
-  const {
-    control,
-    clearErrors,
-    setError,
-    setValue,
-    register,
-    reset,
-    handleSubmit,
-    formState,
-    watch,
-  } = useForm<UpdateUserDto>({
-    shouldUseNativeValidation: true,
-    shouldFocusError: true,
-    reValidateMode: 'onChange',
-  });
+  const { setError, setValue, register, reset, handleSubmit, formState, watch } =
+    useForm<UpdateUserDto>({
+      shouldUseNativeValidation: true,
+      shouldFocusError: true,
+      reValidateMode: 'onChange',
+    });
 
   const userInfo = watch();
 
@@ -269,23 +261,39 @@ const Information: PageComponent<InformationPageProps, SettingsLayoutProps> = ()
               <div className="p-4 mt-6 rounded-lg bg-red-50">
                 <p>
                   <FormattedMessage
-                    defaultMessage="By deleting your user, you will be removed from the account <n>accountName</n> and you no longer will have access to HeCo Invest Platform."
-                    id="rPwLb7"
+                    defaultMessage="By deleting your user, you will be removed from the account <accountName></accountName> and you no longer will have access to HeCo Invest Platform."
+                    id="PfIj8p"
                     values={{
-                      n: () => <span className="font-semibold">{userAccount?.name}</span>,
+                      accountName: () => <span className="font-semibold">{userAccount?.name}</span>,
                     }}
                   />
                 </p>
-                <p className="mt-4 font-semibold">
-                  <FormattedMessage
-                    defaultMessage="If you are the owner of the account, please transfer the ownership before continuing."
-                    id="3T3umg"
-                  />
-                </p>
+                {user?.owner && (
+                  <p className="mt-4 font-semibold">
+                    <FormattedMessage
+                      defaultMessage="You are the owner of the account <accountName></accountName>, please <a>transfer the ownership</a> before continuing."
+                      id="OEYYbj"
+                      values={{
+                        accountName: () => (
+                          <span className="font-semibold">{userAccount?.name}</span>
+                        ),
+                        a: (chunk: string) => (
+                          <Link href={Paths.DashboardUsers} passHref>
+                            <a className="underline">{chunk}</a>
+                          </Link>
+                        ),
+                      }}
+                    />
+                  </p>
+                )}
               </div>
               <div className="flex justify-end mt-6">
-                <Button theme="primary-red" onClick={() => setShowConfirmDelete(true)}>
-                  <FormattedMessage defaultMessage="Delete" id="K3r6DQ" />
+                <Button
+                  disabled={user?.owner}
+                  theme="primary-red"
+                  onClick={() => setShowConfirmDelete(true)}
+                >
+                  <FormattedMessage defaultMessage="Delete my user" id="fZpvTQ" />
                 </Button>
               </div>
             </div>
@@ -298,19 +306,11 @@ const Information: PageComponent<InformationPageProps, SettingsLayoutProps> = ()
           open={showConfirmDelete}
           onConfirmDisabled={!user || user.owner}
           title={formatMessage({ defaultMessage: 'Delete my user', id: 'fZpvTQ' })}
-          description={
-            user?.owner
-              ? formatMessage({
-                  defaultMessage:
-                    'You are currently the account owner. Please transfer the ownership before continuing.',
-                  id: 'A775MJ',
-                })
-              : formatMessage({
-                  defaultMessage:
-                    "Are you sure you want to delete your user? You can't undo this action and you will lose your access to the platform.",
-                  id: 's63oNj',
-                })
-          }
+          description={formatMessage({
+            defaultMessage:
+              "Are you sure you want to delete your user? You can't undo this action and you will lose your access to the platform.",
+            id: 's63oNj',
+          })}
         />
       </SettingsLayout>
     </ProtectedPage>


### PR DESCRIPTION
This PR removes the disclaimer in the “Basic info“ section and changes the delete user instructions

## Testing instructions

- 1206

1.  Go to  dashboard/account-information. There shouldn’t be any 'change information' disclaimer

<img width="1183" alt="Screenshot 2022-10-06 at 16 19 32" src="https://user-images.githubusercontent.com/48164343/194337545-db1f1bb2-6f65-4944-b291-5e37844e0497.png">

-  1207

1.  Sign-in as an account owner
2. Go to /settings/information
3. On Delete account, the text should be:
 (https://www.figma.com/file/KC49uMR9t1YARmFR0Sr6aN/HeCo---Work-in-progress?node-id=8373%3A108156)
“By deleting your user, you will be removed from the account <Account Name> and you no longer will have access to HeCo Invest Platform.   You are the owner of the account Account name, please transfer the ownership before continuing.” with a link to the users table
4. The 'Delete account' button should be disabled

5. Sign-in as an account user
6. On Delete account, the text should be: By deleting your user, you will be removed from the account <Account Name> and you no longer will have access to HeCo Invest Platform.  "


## Tracking

[1206](https://vizzuality.atlassian.net/browse/LET-1206)
[1207](https://vizzuality.atlassian.net/browse/LET-1207)
