### PR TITLE
Fix for "missing interpolation argument :email"

### DIFF
--- a/backend/app/views/users/mailer/confirmation_instructions.html.erb
+++ b/backend/app/views/users/mailer/confirmation_instructions.html.erb
@@ -1,4 +1,4 @@
-<p><%= t("devise.mailer.confirmation_instructions.greeting", recipient: @email) %></p>
+<p><%= t("devise.mailer.confirmation_instructions.greeting", recipient: @email, email: @email) %></p>
 
 <p><%= t("devise.mailer.confirmation_instructions.instruction") %></p>
 


### PR DESCRIPTION
The confirmation email doesn't get sent and the error reads:

```
ERROR -- : [9a5764ac-55f6-426d-baf6-0cc5064813d4] [ActiveJob] [ActionMailer::MailDeliveryJob] [88326f38-06a9-41f4-8d79-2c7966b3b4f7] Error performing ActionMailer::MailDeliveryJob (Job ID: 88326f38-06a9-41f4-8d79-2c7966b3b4f7) from Cloudtasker(heco-default-queue) in 87.07ms: ActionView::Template::Error (missing interpolation argument :email in "Bienvenido(a) %{email}" ({:recipient=>"xxx@..."} given)):
```

The interpolation argument in the zulu locale is called `email`. However, the default interpolation argument name in devise is called `recipient`. I'm guessing that is why the specs were passing, using default devise translations, whereas it doesn't work with the translations from transifex, which require `email`.

I figured this is an easier fix than touching the localised message and its translations.
