### PR TITLE
Let 1214 fe add scroll to top button to most pages

### DIFF
--- a/frontend/components/scroll-to-top-button/component.tsx
+++ b/frontend/components/scroll-to-top-button/component.tsx
@@ -1,0 +1,41 @@
+import { FC } from 'react';
+
+import { ArrowUp } from 'react-feather';
+
+import cx from 'classnames';
+
+import { useScrollY } from 'hooks/use-scroll-y';
+
+import Button from 'components/button';
+
+import { ScrollToTopProps } from './types';
+
+export const ScrollToTop: FC<ScrollToTopProps> = ({ className }) => {
+  const { scrollY } = useScrollY();
+
+  const scrollToTop = () =>
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+
+  console.log(scrollY);
+
+  return (
+    <Button
+      theme="primary-white"
+      size="smallest"
+      className={cx(
+        'scroll-top z-50 fixed justify-center w-10 h-10 !shadow-xl bottom-4  transition-opacity duration-700',
+        {
+          // 'opacity-0 w-0 h-0': scrollY < 56,
+          [className]: !!className,
+        }
+      )}
+      icon={() => <ArrowUp className="mr-0" />}
+      onClick={scrollToTop}
+    />
+  );
+};
+
+export default ScrollToTop;

--- a/frontend/components/scroll-to-top-button/component.tsx
+++ b/frontend/components/scroll-to-top-button/component.tsx
@@ -1,6 +1,7 @@
-import { FC } from 'react';
+import { FC, useEffect, useMemo, useState } from 'react';
 
 import { ArrowUp } from 'react-feather';
+import { useIntl } from 'react-intl';
 
 import cx from 'classnames';
 
@@ -10,30 +11,51 @@ import Button from 'components/button';
 
 import { ScrollToTopProps } from './types';
 
-export const ScrollToTop: FC<ScrollToTopProps> = ({ className }) => {
+export const ScrollToTop: FC<ScrollToTopProps> = ({ containerRef, className }) => {
+  const { formatMessage } = useIntl();
   const { scrollY } = useScrollY();
+  const [containerScrollY, setContainerScrollY] = useState(0);
 
-  const scrollToTop = () =>
-    window.scrollTo({
+  const scrollToTop = () => {
+    (containerRef?.current || window).scrollTo({
       top: 0,
       behavior: 'smooth',
     });
+  };
 
-  console.log(scrollY);
+  useEffect(() => {
+    if (containerRef) {
+      const container = containerRef?.current;
+      const containerScrollListener = () => {
+        setContainerScrollY(container?.scrollTop);
+      };
+      container?.addEventListener('scroll', containerScrollListener);
+      return () => {
+        container?.removeEventListener('scroll', containerScrollListener);
+      };
+    }
+  }, [containerRef]);
+
+  const notScrolled = useMemo(() => {
+    // MIN_SCROLL is the height of the scroll button (40px) + the button bottom position (16px)
+    const MIN_SCROLL = 56;
+    return !!containerRef ? containerScrollY < MIN_SCROLL : scrollY < MIN_SCROLL;
+  }, [containerRef, containerScrollY, scrollY]);
 
   return (
     <Button
       theme="primary-white"
       size="smallest"
       className={cx(
-        'scroll-top z-50 fixed justify-center w-10 h-10 !shadow-xl bottom-4  transition-opacity duration-700',
+        'z-50 fixed justify-center w-10 h-10 px-2 !shadow-xl bottom-4 transition-opacity duration-500',
         {
-          // 'opacity-0 w-0 h-0': scrollY < 56,
+          'opacity-0 w-0 h-0 !px-0 py-0 border-none': notScrolled,
           [className]: !!className,
         }
       )}
       icon={() => <ArrowUp className="mr-0" />}
       onClick={scrollToTop}
+      aria-label={formatMessage({ defaultMessage: 'Scroll to top', id: 'lIJKZh' })}
     />
   );
 };

--- a/frontend/components/scroll-to-top-button/component.tsx
+++ b/frontend/components/scroll-to-top-button/component.tsx
@@ -56,6 +56,7 @@ export const ScrollToTop: FC<ScrollToTopProps> = ({ containerRef, className }) =
       icon={() => <ArrowUp className="mr-0" />}
       onClick={scrollToTop}
       aria-label={formatMessage({ defaultMessage: 'Scroll to top', id: 'lIJKZh' })}
+      disabled={notScrolled}
     />
   );
 };

--- a/frontend/components/scroll-to-top-button/index.ts
+++ b/frontend/components/scroll-to-top-button/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { ScrollToTopProps } from './types';

--- a/frontend/components/scroll-to-top-button/types.ts
+++ b/frontend/components/scroll-to-top-button/types.ts
@@ -1,4 +1,8 @@
+import { MutableRefObject } from 'react';
+
 export type ScrollToTopProps = {
   /** button class name */
   className?: string;
+  /** Container element reference */
+  containerRef?: MutableRefObject<HTMLDivElement>;
 };

--- a/frontend/components/scroll-to-top-button/types.ts
+++ b/frontend/components/scroll-to-top-button/types.ts
@@ -1,0 +1,4 @@
+export type ScrollToTopProps = {
+  /** button class name */
+  className?: string;
+};

--- a/frontend/hooks/use-scroll-y.ts
+++ b/frontend/hooks/use-scroll-y.ts
@@ -1,4 +1,4 @@
-import { useWindowScrollPosition } from 'rooks';
+import { useWindowScrollPosition, useOnWindowScroll } from 'rooks';
 
 export const useScrollY = () => {
   const { scrollY }: ReturnType<typeof useWindowScrollPosition> =

--- a/frontend/hooks/use-scroll-y.ts
+++ b/frontend/hooks/use-scroll-y.ts
@@ -1,4 +1,4 @@
-import { useWindowScrollPosition, useOnWindowScroll } from 'rooks';
+import { useWindowScrollPosition } from 'rooks';
 
 export const useScrollY = () => {
   const { scrollY }: ReturnType<typeof useWindowScrollPosition> =

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -2664,6 +2664,9 @@
   "l2HvdU": {
     "string": "Estimated duration for project in months"
   },
+  "lIJKZh": {
+    "string": "Scroll to top"
+  },
   "lJfJXg": {
     "string": "About the project developer"
   },

--- a/frontend/layouts/discover-page/component.tsx
+++ b/frontend/layouts/discover-page/component.tsx
@@ -11,6 +11,7 @@ import { cleanQueryParams, useQueryParams } from 'helpers/pages';
 import DiscoverSearch from 'containers/layouts/discover-search';
 
 import LayoutContainer from 'components/layout-container';
+import ScrollToTopButton from 'components/scroll-to-top-button';
 import SortingButtons, { SortingOrderType } from 'components/sorting-buttons';
 import { SortingOptionKey } from 'components/sorting-buttons/types';
 import { Paths, Queries } from 'enums';
@@ -142,6 +143,9 @@ export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
           </LayoutContainer>
         </main>
       </div>
+      <LayoutContainer className="flex justify-end">
+        <ScrollToTopButton />
+      </LayoutContainer>
     </div>
   );
 };

--- a/frontend/layouts/discover-page/component.tsx
+++ b/frontend/layouts/discover-page/component.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useMemo, useState } from 'react';
+import React, { FC, useEffect, useMemo, useRef, useState } from 'react';
 
 import { UseQueryResult } from 'react-query';
 
@@ -32,6 +32,8 @@ export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
   children,
 }: DiscoverPageLayoutProps) => {
   const { push, pathname } = useRouter();
+
+  const mainRef = useRef<HTMLDivElement>();
 
   const [sorting, setSorting] =
     useState<{ sortBy: SortingOptionKey; sortOrder: SortingOrderType }>(defaultSorting);
@@ -125,7 +127,7 @@ export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
             <DiscoverSearch className="w-full max-w-3xl pointer-events-auto -z-10" />
           </LayoutContainer>
         </div>
-        <main className="z-0 flex flex-col flex-grow h-screen overflow-y-auto">
+        <main ref={mainRef} className="z-0 flex flex-col flex-grow h-screen overflow-y-auto">
           <LayoutContainer className="">
             <div className="relative flex flex-col items-center gap-2 pb-2 mx-2 mt-4 mb-6 -ml-1 -mr-1 after:left-2 after:right-2 after:h-px after:bg-[#D3CDC4] after:bg-opacity-40 after:absolute after:-bottom-2 after:lg:bottom-2 lg:mb-1 lg:mt-2 lg:gap-6 lg:flex-row space-between lg:pb-0">
               <Navigation stats={stats} />
@@ -144,7 +146,7 @@ export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
         </main>
       </div>
       <LayoutContainer className="flex justify-end">
-        <ScrollToTopButton />
+        <ScrollToTopButton containerRef={mainRef} />
       </LayoutContainer>
     </div>
   );

--- a/frontend/layouts/static-page/component.tsx
+++ b/frontend/layouts/static-page/component.tsx
@@ -4,6 +4,9 @@ import cx from 'classnames';
 
 import { omit } from 'lodash-es';
 
+import LayoutContainer from 'components/layout-container';
+import ScrollToTopButton from 'components/scroll-to-top-button';
+
 import Footer from './footer';
 import Header from './header';
 import { StaticPageLayoutProps } from './types';
@@ -26,6 +29,9 @@ export const StaticPageLayout: React.FC<StaticPageLayoutProps> = ({
     >
       {children}
     </main>
+    <LayoutContainer className="flex justify-end">
+      <ScrollToTopButton />
+    </LayoutContainer>
     <Footer props={footerProps} />
   </div>
 );


### PR DESCRIPTION
This PR adds the scroll to top button

There will be a way to scroll up to the top of the page

Design: [mobile][HeCo - Work in progress](https://www.figma.com/file/KC49uMR9t1YARmFR0Sr6aN/HeCo---Work-in-progress?node-id=8576%3A121116) [desktop][HeCo - Work in progress](https://www.figma.com/file/KC49uMR9t1YARmFR0Sr6aN/HeCo---Work-in-progress?node-id=8782%3A114858) - it’s the same button, the design just show the position on the page

Applies to:

- Homepage
- For investors
- For project developers
- About
- FAQ
- Discover (mobile only)
- Project public page
- Open call public page
- Project developer public page
- Investor public page

Unless stated otherwise, applies to mobile and desktop

The option will only appear after the user has started scrolling


## Tracking

[1214](https://vizzuality.atlassian.net/browse/LET-1214)
