### PR TITLE
Attempted fix for "Discarded TranslateJob due to a ActiveJob::DeserializationError"

### DIFF
--- a/backend/app/jobs/translate_job.rb
+++ b/backend/app/jobs/translate_job.rb
@@ -1,7 +1,9 @@
 class TranslateJob < ApplicationJob
   queue_as ENV["CLOUD_TASKS_TEST_QUEUE_NAME"].to_sym
+  discard_on ActiveRecord::RecordNotFound
 
-  def perform(resource, changed_attrs: nil)
+  def perform(resource_id, resource_class, changed_attrs: nil)
+    resource = resource_class.constantize.find(resource_id)
     Translations::Translate.new(resource, changed_attrs: changed_attrs).call
   end
 end

--- a/backend/app/models/concerns/translatable.rb
+++ b/backend/app/models/concerns/translatable.rb
@@ -24,6 +24,6 @@ module Translatable
       res << attr if public_send "saved_change_to_#{attr}_#{language}?"
     end
 
-    TranslateJob.perform_later self, changed_attrs: changed_attrs if changed_attrs.present?
+    TranslateJob.perform_later id, self.class.name, changed_attrs: changed_attrs if changed_attrs.present?
   end
 end

--- a/backend/app/models/concerns/translatable.rb
+++ b/backend/app/models/concerns/translatable.rb
@@ -4,7 +4,7 @@ module Translatable
   included do
     attr_accessor :skip_translation
 
-    after_save :translate_attributes, unless: :skip_translation
+    after_commit :translate_attributes, on: [:create, :update], unless: :skip_translation
   end
 
   class_methods do

--- a/backend/spec/support/shared_examples/models/translatable.rb
+++ b/backend/spec/support/shared_examples/models/translatable.rb
@@ -31,7 +31,7 @@ RSpec.shared_examples :translatable do
       end
 
       it "queues translation job" do
-        assert_enqueued_with job: TranslateJob, args: [resource, changed_attrs: [attribute]] do
+        assert_enqueued_with job: TranslateJob, args: [resource.id, resource.class.name, changed_attrs: [attribute]] do
           resource.save!
         end
       end


### PR DESCRIPTION
I checked the logs for the project mentioned in the task description, which ended up not being translated. The error I found in the log was `Discarded TranslateJob due to a ActiveJob::DeserializationError`, which I think might have to do with passing an AR object as argument to the background job. While in principle that should work, I am not really sure how CloudTasks interacts with those arguments, and so to be on the safe side I think it is worth passing objects to translate by id and see if this error goes away (there are multiple instances in the logs, related to different types of translated objects, so there's nothing specifically wrong about projects I think).

## Testing instructions

I tested that translation jobs still run locally, so at least this is not worse than it was, but really it needs to be vetted on staging, as I never came across this error locally previously.

## Tracking

https://vizzuality.atlassian.net/browse/LET-1172?atlOrigin=eyJpIjoiNzBkNmRiN2QyZDkzNDE4YTllZTYxZGVkYjhhNmNjMjMiLCJwIjoiaiJ9
