### PR TITLE
Update the Transifex CLI to fix some deployment failures

### DIFF
--- a/.github/workflows/backend-push-translations.yml
+++ b/.github/workflows/backend-push-translations.yml
@@ -24,6 +24,6 @@ jobs:
           ENV: ${{ inputs.env }}
         run: |
           echo 'Installing the Transifex CLI…'
-          curl -o- https://raw.githubusercontent.com/transifex/cli/v1.0.3/install.sh | bash
+          curl -o- https://raw.githubusercontent.com/transifex/cli/v1.3.1/install.sh | bash
           echo 'Pushing the source strings…'
           TX_TOKEN=${{ env.TRANSIFEX_TOKEN }} ./tx push -s

--- a/.github/workflows/frontend-deployment.yml
+++ b/.github/workflows/frontend-deployment.yml
@@ -73,7 +73,7 @@ jobs:
       # on production. On production and development, we should only pull translations.
       run: |
         echo 'Installing the Transifex CLI…'
-        curl -o- https://raw.githubusercontent.com/transifex/cli/v1.0.3/install.sh | bash
+        curl -o- https://raw.githubusercontent.com/transifex/cli/v1.3.1/install.sh | bash
         if [[ "${{ env.ENV }}" == "staging" ]]; then
           echo 'Pushing the source strings…'
           TX_TOKEN=${{ env.TRANSIFEX_TOKEN }} ./tx push -s

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -40,7 +40,7 @@ RUN yarn install
 
 COPY . /usr/src/app
 
-RUN curl -o- https://raw.githubusercontent.com/transifex/cli/v1.0.3/install.sh | bash
+RUN curl -o- https://raw.githubusercontent.com/transifex/cli/v1.3.1/install.sh | bash
 ENV PATH "$PATH:/usr/src/app"
 
 EXPOSE 3000

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -43,7 +43,7 @@ COPY --chown=nextjs:nextjs . .
 
 RUN yarn install --immutable
 
-RUN curl -o- https://raw.githubusercontent.com/transifex/cli/v1.0.3/install.sh | bash
+RUN curl -o- https://raw.githubusercontent.com/transifex/cli/v1.3.1/install.sh | bash
 RUN ./tx pull -f
 
 RUN yarn build


### PR DESCRIPTION
The Transifex CLI is used to push source strings to and pull translations from Transifex when deploying to staging and production. v1.0.3 of the CLI installation script would rely on the GitHub API to fetch the latest version of the CLI. The requests could exceed the rate limit and provoke a deployment failure. v1.3.1 [addresses this issue](https://github.com/transifex/cli/releases/tag/v1.3.1) by not relying on GitHub's API anymore.

This PR updates our deployment pipeline to use v1.3.1 of the Transifex CLI installation script.

## Testing instructions

Make sure the GitHub Actions have executed correctly.

## Tracking

[LET-1195](https://vizzuality.atlassian.net/browse/LET-1195)
