### PR TITLE
Rename the Privacy Policy page and add a link to it in the Sign up page

### DIFF
--- a/frontend/components/privacy-notice/notice-content/component.tsx
+++ b/frontend/components/privacy-notice/notice-content/component.tsx
@@ -54,7 +54,7 @@ const NoticeContent: FC<NoticeContentProps> = ({}: NoticeContentProps) => {
                   id="RrcFtD"
                   values={{
                     a: (chunks) => (
-                      <Link href={Paths.PrivacyPolicy}>
+                      <Link href={Paths.TermsConditions}>
                         <a
                           className="underline focus-visible:outline focus-visible:outline-green-dark focus-visible:outline-2 focus-visible:outline-offset-2"
                           target="_blank"

--- a/frontend/enums/index.ts
+++ b/frontend/enums/index.ts
@@ -44,7 +44,7 @@ export enum Paths {
   Invitation = '/invitation',
   ForInvestors = '/for-investors',
   ForProjectDevelopers = '/for-project-developers',
-  PrivacyPolicy = '/privacy-policy',
+  TermsConditions = '/terms-conditions',
   UserInformation = '/settings/information',
   UserSecurity = '/settings/security',
   /** HIDDEN PAGES */

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -2082,6 +2082,9 @@
   "apgkuO": {
     "string": "More about ARIES"
   },
+  "arPp4e": {
+    "string": "Terms & Conditions"
+  },
   "azx2BO": {
     "string": "Discover open calls"
   },
@@ -2156,9 +2159,6 @@
   },
   "cKaiI0": {
     "string": "File {fileName} has an invalid format"
-  },
-  "cPwv2c": {
-    "string": "Privacy policy"
   },
   "cT6b2H": {
     "string": "WWF"
@@ -2243,9 +2243,6 @@
   },
   "e0c9xF": {
     "string": "insert the name of the investor/funder"
-  },
-  "e61Jf3": {
-    "string": "Coming soon"
   },
   "eCiudu": {
     "string": "Open call cover image"

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -602,6 +602,9 @@
   "9CDBQg": {
     "string": "The solution proposed"
   },
+  "9EgeeX": {
+    "string": "I agree with the <a>Terms and Privacy Policy</a>."
+  },
   "9Er2U2": {
     "string": "Investments in HeCo will contribute to climate change mitigation and adaptation. Investments will conserve the natural capital and associated environmental services of some of the most biodiverse landscapes on the planet."
   },
@@ -1859,9 +1862,6 @@
   },
   "X+46wB": {
     "string": "HeCo priority landscapes"
-  },
-  "X0E3iC": {
-    "string": "I agree with the Terms and Privacy Policy."
   },
   "X2YMUl": {
     "string": "Contact the project developers to know more about the project."

--- a/frontend/layouts/static-page/footer/component.tsx
+++ b/frontend/layouts/static-page/footer/component.tsx
@@ -274,9 +274,9 @@ export const Footer: React.FC<FooterProps> = ({
                     </Link>
                   </li>
                   <li>
-                    <Link href={Paths.PrivacyPolicy} passHref>
+                    <Link href={Paths.TermsConditions} passHref>
                       <a className="hover:underline">
-                        <FormattedMessage defaultMessage="Privacy policy" id="cPwv2c" />
+                        <FormattedMessage defaultMessage="Terms & Conditions" id="arPp4e" />
                       </a>
                     </Link>
                   </li>

--- a/frontend/pages/sign-up/index.tsx
+++ b/frontend/pages/sign-up/index.tsx
@@ -4,6 +4,7 @@ import { SubmitHandler, useForm } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useQueryClient } from 'react-query';
 
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 
 import { withLocalizedRequests } from 'hoc/locale';
@@ -303,8 +304,20 @@ const SignUp: PageComponent<SignUpPageProps, AuthPageLayoutProps> = () => {
             />
             <span className="ml-2 font-sans text-sm text-gray-800 font-regular">
               <FormattedMessage
-                defaultMessage="I agree with the Terms and Privacy Policy."
-                id="X0E3iC"
+                defaultMessage="I agree with the <a>Terms and Privacy Policy</a>."
+                id="9EgeeX"
+                values={{
+                  a: (chunks) => (
+                    <Link href={Paths.TermsConditions}>
+                      <a
+                        className="underline focus-visible:outline focus-visible:outline-green-dark focus-visible:outline-2 focus-visible:outline-offset-2"
+                        target="_blank"
+                      >
+                        {chunks}
+                      </a>
+                    </Link>
+                  ),
+                }}
               />
             </span>
           </label>

--- a/frontend/pages/terms-conditions.tsx
+++ b/frontend/pages/terms-conditions.tsx
@@ -19,13 +19,13 @@ export const getStaticProps = withLocalizedRequests(async ({ locale }) => {
   };
 });
 
-type PrivacyPolicyProps = InferGetStaticPropsType<typeof getStaticProps>;
+type TermsConditionsProps = InferGetStaticPropsType<typeof getStaticProps>;
 
-const PrivacyPolicy: PageComponent<PrivacyPolicyProps, StaticPageLayoutProps> = () => {
+const TermsConditions: PageComponent<TermsConditionsProps, StaticPageLayoutProps> = () => {
   const { formatMessage } = useIntl();
   return (
     <div>
-      <Head title={formatMessage({ defaultMessage: 'Coming soon', id: 'e61Jf3' })} />
+      <Head title={formatMessage({ defaultMessage: 'Terms & Conditions', id: 'arPp4e' })} />
       <LayoutContainer className="bg-background-light">
         <div>
           <h1 className="mb-6 font-serif text-4xl text-center md:text-6xl text-green-dark sm:mb-0">
@@ -37,7 +37,7 @@ const PrivacyPolicy: PageComponent<PrivacyPolicyProps, StaticPageLayoutProps> = 
   );
 };
 
-PrivacyPolicy.layout = {
+TermsConditions.layout = {
   props: {
     footerProps: {
       className: 'mt-0 sm:absolute bottom-0 left-0 right-0',
@@ -45,4 +45,4 @@ PrivacyPolicy.layout = {
   },
 };
 
-export default PrivacyPolicy;
+export default TermsConditions;


### PR DESCRIPTION
This PR makes two changes related to the Privacy Policy page:
- It renames it to “Terms & Conditions”
- It adds a link to it from the Sign up page

## Testing instructions

- The footer link goes to the new Terms & Conditions page
- The privacy notice's link goes to the new Terms & Conditions page
- On the Sign up page, “I agree with the Terms and Privacy Policy.” contains a link that goes to the new Terms & Conditions page

## Tracking

- [LET-1202](https://vizzuality.atlassian.net/browse/LET-1202)
- [LET-1201](https://vizzuality.atlassian.net/browse/LET-1201)
