### PR TITLE
Remove link to see the public profile in the Account information section of the Dashboard

### DIFF
--- a/frontend/containers/dashboard/account-information/public-profile/component.tsx
+++ b/frontend/containers/dashboard/account-information/public-profile/component.tsx
@@ -1,9 +1,6 @@
 import { FC } from 'react';
 
-import { ExternalLink as ExternalLinkIcon } from 'react-feather';
 import { FormattedMessage } from 'react-intl';
-
-import Link from 'next/link';
 
 import Button from 'components/button';
 import Loading from 'components/loading';
@@ -16,33 +13,18 @@ import { AccountPublicProfileProps } from './types';
 export const AccountPublicProfile: FC<
   AccountPublicProfileProps
 > = ({}: AccountPublicProfileProps) => {
-  const { user, userAccount } = useAccount();
+  const { user } = useAccount();
 
   const isProjectDeveloper = user?.role === UserRoles.ProjectDeveloper;
-
-  const publicProfileLink = `${isProjectDeveloper ? Paths.ProjectDeveloper : Paths.Investor}/${
-    userAccount?.slug
-  }`;
 
   const editProfileLink = isProjectDeveloper ? Paths.EditProjectDeveloper : Paths.EditInvestor;
 
   return (
     <div className="p-6 bg-white rounded-lg">
-      <div className="flex text-sm">
-        <div className="flex-grow font-semibold">
+      <div className="text-sm">
+        <div className="font-semibold">
           <FormattedMessage defaultMessage="Public profile" id="G6hIMy" />
         </div>
-        {userAccount && (
-          <Link href={publicProfileLink}>
-            <a
-              className="flex gap-2 px-2 transition-all rounded-full text-green-light focus-visible:outline focus-visible:outline-green-dark focus-visible:outline-2 focus-visible:outline-offset-2"
-              target="_blank"
-            >
-              <ExternalLinkIcon className="w-4 h-4 translate-y-px" />
-              <FormattedMessage defaultMessage="View public profile" id="0PnfDn" />
-            </a>
-          </Link>
-        )}
       </div>
       {!user ? (
         <div className="flex items-center justify-center w-full h-10">


### PR DESCRIPTION
This PR removes the link to see the user's public profile in the Account information section of the Dashboard.

## Testing instructions

1. Go to the Dashboard
2. Click the “Account information” tab

Inside the “Public profile” section, there should not be any link to see the public profile.

## Tracking

[LET-1204](https://vizzuality.atlassian.net/browse/LET-1204)
