### PR TITLE
Allow the users to select multiple values for each filter on Discover

### DIFF
--- a/frontend/containers/forms/active-filters/component.tsx
+++ b/frontend/containers/forms/active-filters/component.tsx
@@ -5,7 +5,11 @@ import { FormattedMessage } from 'react-intl';
 
 import { omitBy } from 'lodash-es';
 
-import { transformFilterInputsToParams, useSearch } from 'helpers/pages';
+import {
+  transformFilterInputsToParams,
+  transformFilterParamsToInputs,
+  useSearch,
+} from 'helpers/pages';
 
 import Tag from 'components/forms/tag';
 import TagGroup from 'components/forms/tag-group';
@@ -18,10 +22,13 @@ export const ActiveFilters: FC<ActiveFilterProps> = ({ filters = {}, filtersData
 
   const activeFilters: Enum[] = useMemo(
     () =>
-      Object.entries(filters).reduce((prev, [key, value]) => {
-        const data = !!value && filtersData?.find((data) => data.id === value);
-        if (data) return [...prev, data];
-        return prev;
+      Object.entries(transformFilterParamsToInputs(filters)).reduce((prev, [key, value]) => {
+        const filters =
+          value?.length > 0
+            ? filtersData.filter((data) => data.type === key && value.includes(data.id))
+            : [];
+
+        return [...prev, ...filters];
       }, []),
     [filters, filtersData]
   );

--- a/frontend/containers/forms/active-filters/component.tsx
+++ b/frontend/containers/forms/active-filters/component.tsx
@@ -3,8 +3,6 @@ import { FC, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 
-import { omitBy } from 'lodash-es';
-
 import {
   transformFilterInputsToParams,
   transformFilterParamsToInputs,
@@ -42,10 +40,12 @@ export const ActiveFilters: FC<ActiveFilterProps> = ({ filters = {}, filtersData
     defaultValues: { activeFilters: activeFilters.map(({ id }) => id) },
   });
 
-  const handleDeleteActiveFilter = (filterId: string) => {
-    const newFilters = omitBy(filters, (value, key) => value === filterId);
-    const newFilterParams = transformFilterInputsToParams(newFilters);
-    doSearch(undefined, newFilterParams);
+  const handleDeleteActiveFilter = (activeFilter: Enum) => {
+    const newFilters = transformFilterParamsToInputs(filters);
+    newFilters[activeFilter.type] = newFilters[activeFilter.type].filter(
+      (value) => value !== activeFilter.id
+    );
+    doSearch(undefined, transformFilterInputsToParams(newFilters));
   };
 
   return (
@@ -61,21 +61,21 @@ export const ActiveFilters: FC<ActiveFilterProps> = ({ filters = {}, filtersData
           errors={errors}
           thresholdToShowSelectAll={Infinity}
         >
-          {activeFilters?.map(({ name, id }) => (
+          {activeFilters?.map((filter) => (
             <Tag
+              key={`${filter.type}-${filter.id}`}
               type="checkbox"
-              name="appliedFilters"
-              id={id}
+              name="active-filters"
+              id={`${filter.type}-${filter.id}`}
               register={register}
               registerOptions={{
-                onChange: () => handleDeleteActiveFilter(id),
+                onChange: () => handleDeleteActiveFilter(filter),
               }}
-              key={id}
               isfilterTag
               checked
               showDeleteIcon
             >
-              {name}
+              {filter.name}
             </Tag>
           ))}
         </TagGroup>

--- a/frontend/containers/forms/filters/component.tsx
+++ b/frontend/containers/forms/filters/component.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC, useCallback, useEffect, useState } from 'react';
 
 import { ChevronDown, ChevronUp, X as CloseIcon } from 'react-feather';
 import { useForm } from 'react-hook-form';
@@ -15,7 +15,6 @@ import {
 } from 'helpers/pages';
 
 import Button from 'components/button';
-import Checkbox from 'components/forms/checkbox';
 import FieldInfo from 'components/forms/field-info';
 import Tag from 'components/forms/tag';
 import TagGroup from 'components/forms/tag-group';
@@ -30,7 +29,6 @@ export const Filters: FC<FiltersProps> = ({ closeFilters, filtersData, filters }
   const { formatMessage } = useIntl();
   const { pathname } = useRouter();
 
-  const [filtersInputValue, setFiltersInputValue] = useState<Partial<FilterForm>>({});
   const doSearch = useSearch();
 
   const [showMoreFilters, setShowMoreFilters] = useState(false);
@@ -40,9 +38,18 @@ export const Filters: FC<FiltersProps> = ({ closeFilters, filtersData, filters }
     reset,
     handleSubmit,
     setValue,
+    getValues,
     clearErrors,
     formState: { errors },
-  } = useForm<FilterForm>();
+  } = useForm<FilterForm>({
+    defaultValues: {
+      category: [],
+      impact: [],
+      instrument_type: [],
+      sdg: [],
+      ticket_size: [],
+    },
+  });
 
   const { category, impact, ticket_size, instrument_type, priority_landscape, sdg } = groupBy<Enum>(
     filtersData,
@@ -78,41 +85,20 @@ export const Filters: FC<FiltersProps> = ({ closeFilters, filtersData, filters }
     },
   ];
 
-  const handleClear = () => {
+  const onClearFilters = useCallback(() => {
     if (!isEmpty(filters)) {
       // Perform new search to remove filters only if are filters applied
       doSearch(undefined, {});
     }
     reset();
     closeFilters();
-  };
+  }, [closeFilters, doSearch, filters, reset]);
 
-  useEffect(() => {
-    const filterInputs = transformFilterParamsToInputs(filters);
-    Object.entries(filterInputs).forEach(([key, value]) => {
-      setValue(key as keyof FilterForm, value);
-    });
-    setFiltersInputValue(filterInputs);
-  }, [filters, setValue]);
-
-  const onChange = (ev: any) => {
-    const { value, name } = ev.target;
-    // Remove check when clicking on a checked tag
-    if (filtersInputValue[name] === value) {
-      setValue(name, undefined);
-      setFiltersInputValue({ ...filtersInputValue, [name]: undefined });
-      return;
-    }
-
-    setValue(name, value);
-    setFiltersInputValue({ ...filtersInputValue, [name]: value });
-  };
-
-  const onSubmitFilters = () => {
-    const newFilterParams = transformFilterInputsToParams(filtersInputValue);
+  const onSubmitFilters = useCallback(() => {
+    const newFilterParams = transformFilterInputsToParams(getValues());
     doSearch(undefined, newFilterParams);
     closeFilters();
-  };
+  }, [closeFilters, doSearch, getValues]);
 
   /* VERIFICATION FILTERS: HIDDEN
   const onCheckboxChange = (ev: any) => {
@@ -121,6 +107,13 @@ export const Filters: FC<FiltersProps> = ({ closeFilters, filtersData, filters }
     setFiltersInputValue({ ...filtersInputValue, [name]: checked });
   };
   */
+
+  useEffect(() => {
+    const filterInputs = transformFilterParamsToInputs(filters);
+    Object.entries(filterInputs).forEach(([key, value]) => {
+      setValue(key as keyof FilterForm, value);
+    });
+  }, [filters, setValue]);
 
   return (
     <div
@@ -189,7 +182,7 @@ export const Filters: FC<FiltersProps> = ({ closeFilters, filtersData, filters }
                       {!!filter.values?.length && (
                         <TagGroup
                           name={filter.values?.[0].type}
-                          type="radio"
+                          type="checkbox"
                           clearErrors={clearErrors}
                           setValue={setValue}
                           errors={errors}
@@ -206,11 +199,9 @@ export const Filters: FC<FiltersProps> = ({ closeFilters, filtersData, filters }
                               register={register}
                               registerOptions={{
                                 disabled: false,
-                                onChange,
                               }}
                               type="radio"
                               isfilterTag
-                              onClick={onChange}
                             >
                               <span className="block">
                                 {type === EnumTypes.TicketSize ? description : name}
@@ -256,7 +247,7 @@ export const Filters: FC<FiltersProps> = ({ closeFilters, filtersData, filters }
                   <div className="flex flex-wrap gap-4">
                     <TagGroup
                       name="sdg"
-                      type="radio"
+                      type="checkbox"
                       clearErrors={clearErrors}
                       setValue={setValue}
                       errors={errors}
@@ -272,11 +263,9 @@ export const Filters: FC<FiltersProps> = ({ closeFilters, filtersData, filters }
                           register={register}
                           registerOptions={{
                             disabled: false,
-                            onChange,
                           }}
                           type="radio"
                           isfilterTag
-                          onClick={onChange}
                         >
                           <span className="block">{name}</span>
                         </Tag>
@@ -300,7 +289,7 @@ export const Filters: FC<FiltersProps> = ({ closeFilters, filtersData, filters }
                 <Button
                   theme="secondary-green"
                   className="justify-center sm:justify-between"
-                  onClick={handleClear}
+                  onClick={onClearFilters}
                 >
                   <FormattedMessage defaultMessage="Clear filters" id="F4gyn3" />
                 </Button>

--- a/frontend/containers/forms/filters/types.ts
+++ b/frontend/containers/forms/filters/types.ts
@@ -19,10 +19,10 @@ export type FilterParams = {
 };
 
 export type FilterForm = {
-  category: string;
-  instrument_type: string;
-  ticket_size: string;
+  category: string[];
+  instrument_type: string[];
+  ticket_size: string[];
   // only_verified: boolean; VERIFICATION FILTERS: HIDDEN
-  sdg: string;
-  impact: string;
+  sdg: string[];
+  impact: string[];
 };

--- a/frontend/helpers/pages.ts
+++ b/frontend/helpers/pages.ts
@@ -169,7 +169,7 @@ export const transformFilterInputsToParams = (filterInputs: Partial<FilterForm>)
   Object.entries(filterInputs).forEach(([key, value]) => {
     // Just send the used filters
     if (value) {
-      filterParams[`filter[${key}]`] = `${value}`;
+      filterParams[`filter[${key}]`] = `${value.join(',')}`;
     }
   });
   return filterParams;
@@ -181,7 +181,7 @@ export const transformFilterParamsToInputs = (filters: Partial<FilterParams>) =>
     // Just send the used filters
     const inputKey = key.replace(/filter\[|\]/gi, '');
     if (value) {
-      filterInputs[inputKey] = `${value}`;
+      filterInputs[inputKey] = value.split(',').map((value) => `${value}`);
     }
   });
   return filterInputs;


### PR DESCRIPTION
This PR allows the users to select multiple values for each filter on Discover and the homepage.

## Testing instructions

- You can select multiple values for each filter
- You can deselect each value
- Once applied, the filters are working and correctly displayed in the “Active filters” list
- If you reload the page, the filters are still applied

## Tracking

[LET-1205](https://vizzuality.atlassian.net/browse/LET-1205)
