### PR TITLE
Update the impact sentence when the impact of a project is 0

### DIFF
--- a/frontend/containers/impact-text/component.tsx
+++ b/frontend/containers/impact-text/component.tsx
@@ -18,7 +18,6 @@ export const ImpactText: FC<ImpactTextProps> = ({
   impact,
   impactCalculated,
   linkToFAQ = false,
-  shortText = false,
 }) => {
   const intl = useIntl();
 
@@ -78,11 +77,14 @@ export const ImpactText: FC<ImpactTextProps> = ({
     }
 
     if (highestImpactValue === 0) {
-      if (shortText) {
-        return <FormattedMessage defaultMessage="The impact of this project is 0." id="VJPvoR" />;
-      }
       return (
-        <FormattedMessage defaultMessage="The impact score of this project is 0." id="/oLNw7" />
+        <FormattedMessage
+          defaultMessage="In the {impactArea}, the impact of this project is 0."
+          id="x3IdR3"
+          values={{
+            impactArea: impactAreaStr.toLowerCase(),
+          }}
+        />
       );
     }
 

--- a/frontend/containers/impact-text/component.tsx
+++ b/frontend/containers/impact-text/component.tsx
@@ -108,6 +108,7 @@ export const ImpactText: FC<ImpactTextProps> = ({
         {getImpactText()}
         {linkToFAQ && (
           <>
+            {' '}
             <Link href={FaqPaths['how-is-the-impact-calculated']}>
               <a className="underline text-green-dark" target="_blank">
                 <FormattedMessage defaultMessage="Learn more" id="TdTXXf" />

--- a/frontend/containers/impact-text/types.ts
+++ b/frontend/containers/impact-text/types.ts
@@ -11,6 +11,4 @@ export type ImpactTextProps = {
   impact: Record<Impacts | 'total', number>;
   /** Whether to display a link to the FAQ. Defaults to `false`. */
   linkToFAQ?: boolean;
-  /** Whether to display a shorter version of the text. Defaults to `false`. */
-  shortText?: boolean;
 };

--- a/frontend/containers/project-details/component.tsx
+++ b/frontend/containers/project-details/component.tsx
@@ -208,7 +208,6 @@ export const ProjectDetails: FC<ProjectDetailsProps> = ({
             area={impactArea}
             impactCalculated={project.impact_calculated}
             impact={impact}
-            shortText
             linkToFAQ
           />
           <ImpactChart className="my-4" category={category.id} impact={impact} />

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -89,9 +89,6 @@
   "/i6bRr": {
     "string": "The received amount must be greater than 0"
   },
-  "/oLNw7": {
-    "string": "The impact score of this project is 0."
-  },
   "/plMvw": {
     "string": "Project category"
   },
@@ -1758,9 +1755,6 @@
   "VG3saq": {
     "string": "<span>Water:</span> water cycling, quality, and risk management."
   },
-  "VJPvoR": {
-    "string": "The impact of this project is 0."
-  },
   "VKb1MS": {
     "string": "Categories"
   },
@@ -3365,6 +3359,9 @@
   },
   "x/AykP": {
     "string": "Project ticket size"
+  },
+  "x3IdR3": {
+    "string": "In the {impactArea}, the impact of this project is 0."
   },
   "x6wKw3": {
     "string": "All selected options have been cleared."


### PR DESCRIPTION
This PR makes the impact sentence clearer when a project's impact is 0 in a specific area.

## Testing instructions

The impact of a project is never communicated as being 0 without saying in which area.

## Tracking

[LET-1210](https://vizzuality.atlassian.net/browse/LET-1210)
