### PR TITLE
Allow the users to input incomplete URLs in the social media and website inputs

### DIFF
--- a/frontend/helpers/pages.ts
+++ b/frontend/helpers/pages.ts
@@ -217,7 +217,11 @@ export const useQueryReturnPath = () => {
 };
 
 export const getSocialMediaLinksRegex = () => {
-  const getRegex = (media: string) => new RegExp(`^https?:\/\/(www.)?${media}.com\/.*$`);
+  const getRegex = (media: string) => {
+    const subdomain = media === 'linkedin' ? '([a-z]{2}\\.)?' : '';
+    return new RegExp(`^https?:\/\/${subdomain}(www.)?${media}.com\/.*$`);
+  };
+
   return {
     twitter: getRegex('twitter'),
     facebook: getRegex('facebook'),

--- a/frontend/helpers/pages.ts
+++ b/frontend/helpers/pages.ts
@@ -226,6 +226,19 @@ export const getSocialMediaLinksRegex = () => {
   };
 };
 
+/**
+ * Yup transform that completes URLs with “https://” at the beginning
+ * @param url Incomplete Url starting with “www” or directly the domain name
+ * @returns URL starting with “https://”
+ */
+export const getPartialUrlTransform = (url: string) => {
+  if (url === null || url === undefined || url.length === 0) {
+    return url;
+  }
+
+  return /^https?:\/\//.test(url) ? url : `https://${url}`;
+};
+
 export const getPageErrors = (formPageInputs: string[], errors: FormState<any>['errors']) => {
   return formPageInputs.some((input) => errors.hasOwnProperty(input));
 };


### PR DESCRIPTION
This PR allows the users to input incomplete URLs such as “twitter.com/Vizzuality/” or “www.twitter.com/Vizzuality/” in the social media and website inputs.

In addition, the LinkedIn input now accepts more formats such as “https://se.linkedin.com/in/cl%C3%A9ment-prod-homme-158a815b”.

## Testing instructions

- PD account
  - You can create a new account with incomplete URLs [^1]
  - You can edit an existing account to add incomplete URLs
- Investor account
  - You can create a new account with incomplete URLs [^1]
  - You can edit an existing account to add incomplete URLs

[^1]: You may not be able to create a new account due to the email verification. Use [Swagger](https://staging.heco.vizzuality.com/backend/api-docs/index.html) to verify your email address.

## Tracking

[LET-1213](https://vizzuality.atlassian.net/browse/LET-1213)
