### PR TITLE
Let 1157 fe tweak the project and open call public page layout

### DIFF
--- a/frontend/containers/open-call-page/funding-impact/component.tsx
+++ b/frontend/containers/open-call-page/funding-impact/component.tsx
@@ -39,7 +39,7 @@ export const OpenCallFundingImpact: FC<OpenCallFundingImpactProps> = ({ openCall
         </LayoutContainer>
       </LayoutContainer>
 
-      <LayoutContainer className="my-18 sm:mt-28 sm:mb-24">
+      <LayoutContainer className="my-18 sm:mt-20 sm:mb-24">
         {!!openCallSdgs.length ? (
           <LayoutContainer>
             <h2 className="mb-4 font-serif text-4xl font-bold sm:mb-10">

--- a/frontend/containers/open-call-page/funding-impact/component.tsx
+++ b/frontend/containers/open-call-page/funding-impact/component.tsx
@@ -2,79 +2,27 @@ import { FC, Fragment } from 'react';
 
 import { FormattedMessage } from 'react-intl';
 
-import { useRouter } from 'next/router';
-
 import SDGs from 'containers/sdgs/component';
 
 import LayoutContainer from 'components/layout-container';
 
 import { OpenCallFundingImpactProps } from '.';
 
-export const OpenCallFundingImpact: FC<OpenCallFundingImpactProps> = ({
-  openCall,
-  allSdgs,
-  instrumentTypes,
-}) => {
-  const { locale } = useRouter();
-
-  const {
-    impact_description,
-    sdgs,
-    maximum_funding_per_project,
-    funding_priorities,
-    funding_exclusions,
-  } = openCall;
+export const OpenCallFundingImpact: FC<OpenCallFundingImpactProps> = ({ openCall, allSdgs }) => {
+  const { impact_description, sdgs, funding_priorities, funding_exclusions } = openCall;
 
   const openCallSdgs = allSdgs.filter((sdg) => sdgs.includes(Number(sdg.id)));
 
   return (
     <>
-      <LayoutContainer>
+      <LayoutContainer className="mt-18 sm:mt-28">
         <LayoutContainer>
-          <h2 className="mb-10 font-serif text-4xl font-bold">
+          <h2 className="mb-4 font-serif text-4xl font-bold sm:mb-10">
             <FormattedMessage defaultMessage="Funding information" id="mEYG82" />
           </h2>
         </LayoutContainer>
-        <LayoutContainer className="p-6 text-white lg:p-16 bg-green-dark rounded-2xl">
-          <div>
-            <h3 className="font-serif text-3xl font-semibold sm:w-1/2">
-              <FormattedMessage defaultMessage="Funding available per project" id="+USuwC" />
-            </h3>
-            <div className="flex flex-col gap-6 mt-10 lg:gap-56 sm:flex-row">
-              <div>
-                <p className="mb-2 text-2xl font-semibold">
-                  ${maximum_funding_per_project?.toLocaleString(locale)}
-                </p>
-                <p className="text-base">
-                  <FormattedMessage defaultMessage="Maximum value" id="sfFhiy" />
-                </p>
-              </div>
-              <div>
-                <div className="flex-wrap gap-x-4 sm:flex">
-                  {instrumentTypes?.map((instrumentType, index) => (
-                    <Fragment key={instrumentType}>
-                      <p key={instrumentType} className="mb-2 text-2xl font-semibold">
-                        {instrumentType}
-                      </p>
-                      {index !== instrumentTypes.length - 1 && (
-                        <span className="hidden text-2xl sm:inline">&#183;</span>
-                      )}
-                    </Fragment>
-                  ))}
-                </div>
-                <p className="text-base">
-                  <FormattedMessage
-                    defaultMessage="{numInstrumentTypes, plural, one {Instrument type} other {Instrument types}}"
-                    id="eFJIPT"
-                    values={{
-                      numInstrumentTypes: instrumentTypes?.length || 0,
-                    }}
-                  />
-                </p>
-              </div>
-            </div>
-          </div>
-          <div className="flex flex-col mt-20 gap-14 sm:flex-row">
+        <LayoutContainer className="p-6 text-white lg:py-14 lg:px-15 bg-green-dark rounded-2xl">
+          <div className="flex flex-col gap-14 sm:flex-row">
             <div className="sm:w-1/2">
               <h3 className="mb-2 font-serif text-3xl font-semibold">
                 <FormattedMessage defaultMessage="Funding priorities" id="P1f6hp" />
@@ -91,14 +39,12 @@ export const OpenCallFundingImpact: FC<OpenCallFundingImpactProps> = ({
         </LayoutContainer>
       </LayoutContainer>
 
-      <LayoutContainer className="my-20 sm:my-36">
+      <LayoutContainer className="my-18 sm:mt-28 sm:mb-24">
         {!!openCallSdgs.length ? (
           <LayoutContainer>
-            <div>
-              <h2 className="mb-10 font-serif text-4xl font-bold">
-                <FormattedMessage defaultMessage="Impact" id="W2JBdp" />
-              </h2>
-            </div>
+            <h2 className="mb-4 font-serif text-4xl font-bold sm:mb-10">
+              <FormattedMessage defaultMessage="Impact" id="W2JBdp" />
+            </h2>
             <div className="flex flex-col gap-12 lg:flex-row lg:gap-28">
               <div className="flex-1">
                 <h3 className="text-xl font-semibold">

--- a/frontend/containers/open-call-page/header/component.tsx
+++ b/frontend/containers/open-call-page/header/component.tsx
@@ -110,8 +110,8 @@ export const OpenCallHeader: FC<OpenCallHeaderProps> = ({ openCall, instrumentTy
               <p>{openCall.description}</p>
             </div>
             <div className="mb-10 flex flex-col justify-start sm:mr-4 p-6 bg-white drop-shadow-xl sm:mb-[-70%] h-full sm:w-[395px] sm:translate-y-[-70%] sm:max-w-1/3 rounded-2xl mt-8 sm:mt-0">
-              <>
-                <div className="flex flex-col gap-8 pl-2 sm:gap-11 sm:flex-row sm:justify-between">
+              <div className="px-2">
+                <div className="flex flex-col gap-8 sm:gap-11 sm:flex-row sm:justify-between">
                   <div className="flex flex-col items-center justify-end gap-2 sm:items-start">
                     <span
                       aria-labelledby="open-call-value"
@@ -148,9 +148,9 @@ export const OpenCallHeader: FC<OpenCallHeaderProps> = ({ openCall, instrumentTy
                     </span>
                   </div>
                 </div>
-                <hr className="mt-6 mb-8" />
-                <div className="flex flex-col justify-between gap-8 pl-2 sm:flex-row sm:gap-11">
-                  <div className="flex flex-col items-center justify-end gap-2 sm:items-start">
+                <hr className="my-4" />
+                <div className="flex flex-col justify-between gap-8 sm:flex-row sm:gap-11">
+                  <div className="flex flex-col items-center justify-center gap-2 mb-6 sm:items-start">
                     <span
                       id="total-of-projects"
                       className={cx('text-xl font-semibold leading-6', {
@@ -165,7 +165,7 @@ export const OpenCallHeader: FC<OpenCallHeaderProps> = ({ openCall, instrumentTy
                     </span>
                   </div>
                   {openCallRange.remaining <= 8 && (
-                    <div className="flex flex-col items-center justify-end gap-2 text-center">
+                    <div className="flex flex-col items-center justify-end gap-2 mb-4 text-center">
                       <div className="w-[82px] h-[82px] rounded-full flex justify-center items-center">
                         <OpenCallChart openCallRange={openCallRange} />
                         <p className="absolute max-w-[62px] text-xs font-semibold text-green-dark">
@@ -179,9 +179,9 @@ export const OpenCallHeader: FC<OpenCallHeaderProps> = ({ openCall, instrumentTy
                     </div>
                   )}
                 </div>
-              </>
+              </div>
 
-              <div className="flex flex-col justify-center gap-4 sm:gap-2 sm:flex-row mt-7">
+              <div className="flex flex-col justify-center gap-4 sm:gap-2 sm:flex-row">
                 <Button
                   className="justify-center"
                   theme="secondary-green"

--- a/frontend/containers/open-call-page/header/component.tsx
+++ b/frontend/containers/open-call-page/header/component.tsx
@@ -73,28 +73,28 @@ export const OpenCallHeader: FC<OpenCallHeaderProps> = ({ openCall, instrumentTy
 
   return (
     <>
-      <LayoutContainer className="-mt-10 md:mt-0 lg:-mt-16">
+      <LayoutContainer className="-mt-10 md:mt-0 sm:-mt-16">
         <Breadcrumbs
-          className="sm:px-6 lg:px-8"
+          className="sm:px-6"
           substitutions={{
             id: { name },
           }}
         />
         <div className="mt-4">
           <div
-            className="flex items-end sm:mx-4 bg-center bg-cover lg:mx-0 rounded-2xl bg-radial-green-dark bg-green-dark min-h-[250px] lg:min-h-[372px]"
+            className="flex items-end bg-center bg-cover sm:mx-0 rounded-2xl bg-radial-green-dark bg-green-dark min-h-[250px] sm:min-h-[372px]"
             style={{
               ...(coverImage && { backgroundImage: `url(${coverImage})` }),
             }}
           >
             <LayoutContainer>
-              <div className="mb-8 text-center lg:w-1/2 lg:text-left">
-                <h1 className="font-serif text-2xl text-white lg:text-4xl">{name}</h1>
+              <div className="mb-8 text-center sm:w-1/2 sm:text-left">
+                <h1 className="font-serif text-2xl text-white sm:text-4xl">{name}</h1>
               </div>
             </LayoutContainer>
           </div>
-          <LayoutContainer className="flex flex-col justify-between mt-8 lg:flex-row">
-            <div className="w-full lg:w-6/12">
+          <LayoutContainer className="flex flex-col justify-between mt-8 sm:flex-row">
+            <div className="w-full sm:w-6/12 sm:pr-2">
               {originalLanguage && (
                 <span className="block mb-4 text-sm text-gray-400">
                   <FormattedMessage
@@ -109,14 +109,17 @@ export const OpenCallHeader: FC<OpenCallHeaderProps> = ({ openCall, instrumentTy
               )}
               <p>{openCall.description}</p>
             </div>
-            <div className="mb-10 flex flex-col justify-start lg:mr-4 p-6 bg-white drop-shadow-xl lg:mb-[-70%] h-full lg:translate-y-[-70%] lg:max-w-1/3 rounded-2xl mt-8 lg:mt-0">
+            <div className="mb-10 flex flex-col justify-start sm:mr-4 p-6 bg-white drop-shadow-xl sm:mb-[-70%] h-full sm:w-[395px] sm:translate-y-[-70%] sm:max-w-1/3 rounded-2xl mt-8 sm:mt-0">
               <>
                 <div className="flex flex-col gap-8 pl-2 sm:gap-11 sm:flex-row sm:justify-between">
                   <div className="flex flex-col items-center justify-end gap-2 sm:items-start">
-                    <span aria-labelledby="open-call-value" className="text-2xl font-semibold">
+                    <span
+                      aria-labelledby="open-call-value"
+                      className="text-xl font-semibold leading-6"
+                    >
                       ${maximum_funding_per_project.toLocaleString(locale)}
                     </span>
-                    <span id="open-call-value" className="text-gray-400">
+                    <span id="open-call-value" className="leading-4 text-gray-400">
                       <FormattedMessage defaultMessage="Value" id="GufXy5" />
                     </span>
                   </div>
@@ -127,17 +130,14 @@ export const OpenCallHeader: FC<OpenCallHeaderProps> = ({ openCall, instrumentTy
                           <p
                             aria-labelledby="block open-call-instrument-types"
                             key={type}
-                            className={cx('font-semibold whitespace-nowrap', {
-                              'text-2xl': instrument_types.length === 1,
-                              'text-xl': instrument_types.length > 1,
-                            })}
+                            className="text-xl font-semibold leading-6 whitespace-nowrap"
                           >
                             {type}
                           </p>
                         );
                       })}
                     </div>
-                    <span id="open-call-instrument-types" className="text-gray-400">
+                    <span id="open-call-instrument-types" className="leading-4 text-gray-400">
                       <FormattedMessage
                         defaultMessage="{numInstrumentTypes, plural, one {Instrument type} other {Instrument types}}"
                         id="eFJIPT"
@@ -151,10 +151,16 @@ export const OpenCallHeader: FC<OpenCallHeaderProps> = ({ openCall, instrumentTy
                 <hr className="mt-6 mb-8" />
                 <div className="flex flex-col justify-between gap-8 pl-2 sm:flex-row sm:gap-11">
                   <div className="flex flex-col items-center justify-end gap-2 sm:items-start">
-                    <span id="total-of-projects" className="text-2xl font-semibold text-gray-700">
+                    <span
+                      id="total-of-projects"
+                      className={cx('text-xl font-semibold leading-6', {
+                        'text-black': status !== OpenCallStatus.Closed,
+                        'text-gray-600': status === OpenCallStatus.Closed,
+                      })}
+                    >
                       {openCallRange.deadline}
                     </span>
-                    <span aria-labelledby="total-of-projects" className="text-gray-400">
+                    <span aria-labelledby="total-of-projects" className="leading-4 text-gray-400">
                       <FormattedMessage defaultMessage="Deadline" id="8/Da7A" />
                     </span>
                   </div>
@@ -175,7 +181,7 @@ export const OpenCallHeader: FC<OpenCallHeaderProps> = ({ openCall, instrumentTy
                 </div>
               </>
 
-              <div className="flex flex-col justify-between gap-4 lg:flex-row mt-7">
+              <div className="flex flex-col justify-center gap-4 sm:gap-2 sm:flex-row mt-7">
                 <Button
                   className="justify-center"
                   theme="secondary-green"
@@ -187,7 +193,7 @@ export const OpenCallHeader: FC<OpenCallHeaderProps> = ({ openCall, instrumentTy
                   <FormattedMessage defaultMessage="Favorite" id="5Hzwqs" />
                 </Button>
                 <Button
-                  className="w-full lg:max-w-[200px] justify-center"
+                  className="justify-center flex-grow"
                   disabled={
                     !userAccount ||
                     userAccount.type !== UserRoles.ProjectDeveloper ||

--- a/frontend/containers/open-call-page/overview/component.tsx
+++ b/frontend/containers/open-call-page/overview/component.tsx
@@ -7,41 +7,26 @@ import LayoutContainer from 'components/layout-container';
 import { OpenCallOverviewTypes } from './types';
 
 export const Overview: FC<OpenCallOverviewTypes> = ({ openCall }) => {
-  const { country, municipality, department } = openCall;
+  const { country, department } = openCall;
 
   return (
-    <LayoutContainer id="overview" className="mt-10 mb-20 lg:mb-28">
-      <LayoutContainer className="font-serif lg:flex">
-        <div className="flex flex-col gap-10 lg:justify-between lg:flex-row">
-          <div className="flex flex-col space-y-4 lg:mb-12 lg:w-1/2">
-            <h2 className="text-2xl lg:text-3xl">
-              <FormattedMessage defaultMessage="Location" id="rvirM2" />
-            </h2>
-            <div className="flex flex-col space-y-1">
-              <div className="flex space-x-2 font-sans text-base">
-                <h3 className="font-semibold min-w-[130px]">
-                  <FormattedMessage defaultMessage="Country" id="vONi+O" />
-                </h3>
-                <p>{country?.name}</p>
-              </div>
-              {!!department && (
-                <div className="flex space-x-2 font-sans text-base">
-                  <h3 className="font-semibold min-w-[130px]">
-                    <FormattedMessage defaultMessage="State" id="ku+mDU" />
-                  </h3>
-                  <p>{department?.name}</p>
-                </div>
-              )}{' '}
-              {!!municipality && (
-                <div className="flex space-x-2 font-sans text-base">
-                  <h3 className="font-semibold min-w-[130px]">
-                    <FormattedMessage defaultMessage="Municipality" id="9I1zvK" />
-                  </h3>
-                  <p>{municipality?.name}</p>
-                </div>
-              )}
-            </div>
+    <LayoutContainer id="overview" className="mt-8">
+      <LayoutContainer>
+        <div className="flex flex-col sm:flex-row gap-x-8 gap-y-2">
+          <div className="flex gap-2 font-sans text-base">
+            <h3 className="font-semibold">
+              <FormattedMessage defaultMessage="Country" id="vONi+O" />
+            </h3>
+            <p>{country?.name}</p>
           </div>
+          {!!department && (
+            <div className="flex gap-2 font-sans text-base">
+              <h3 className="font-semibold">
+                <FormattedMessage defaultMessage="State" id="ku+mDU" />
+              </h3>
+              <p>{department?.name}</p>
+            </div>
+          )}
         </div>
       </LayoutContainer>
     </LayoutContainer>

--- a/frontend/containers/project-page/funding/component.tsx
+++ b/frontend/containers/project-page/funding/component.tsx
@@ -82,8 +82,8 @@ export const Funding: React.FC<FundingProps> = ({ project, enums }: FundingProps
         <h2 className="pl-6 mb-6 font-serif text-2xl text-black lg:text-4xl lg:pl-16 lg:mb-16">
           <FormattedMessage defaultMessage="Funding & development" id="psXhQO" />
         </h2>
-        <div className="flex flex-col p-6 text-white lg:px-16 lg:py-12 lg:space-x-10 lg:flex-row bg-green-dark rounded-t-2xl">
-          <div className="flex flex-col pb-12 pr-10 space-y-8 border-b-2 border-white lg:pb-6 pb:10 lg:border-b-0 lg:w-1/3 lg:border-r-2">
+        <div className="flex flex-col p-6 text-white lg:px-12 lg:py-12 lg:space-x-10 lg:flex-row bg-green-dark rounded-t-2xl">
+          <div className="flex flex-col pb-12 pr-8 space-y-8 border-b border-white lg:pb-6 pb:10 lg:border-b-0 lg:w-2/5 lg:border-r">
             <h3 className="font-serif text-2xl lg:text-3xl">
               {project.looking_for_funding ? (
                 <FormattedMessage defaultMessage="Currently looking for" id="sV+3z0" />
@@ -108,7 +108,7 @@ export const Funding: React.FC<FundingProps> = ({ project, enums }: FundingProps
               </div>
             )}
           </div>
-          <div className="flex flex-col mt-12 space-y-4 lg:mt-0 lg:w-2/3">
+          <div className="flex flex-col mt-12 space-y-4 lg:mt-0 lg:w-3/5">
             {project.looking_for_funding ? (
               <>
                 <h3 className="font-serif text-2xl lg:text-3xl">

--- a/frontend/containers/project-page/funding/component.tsx
+++ b/frontend/containers/project-page/funding/component.tsx
@@ -83,7 +83,7 @@ export const Funding: React.FC<FundingProps> = ({ project, enums }: FundingProps
           <FormattedMessage defaultMessage="Funding & development" id="psXhQO" />
         </h2>
         <div className="flex flex-col p-6 text-white lg:px-12 lg:py-12 lg:space-x-10 lg:flex-row bg-green-dark rounded-t-2xl">
-          <div className="flex flex-col pb-12 pr-8 space-y-8 border-b border-white lg:pb-6 pb:10 lg:border-b-0 lg:w-2/5 lg:border-r">
+          <div className="flex flex-col pb-12 space-y-8 border-b border-white lg:pr-10 lg:pb-6 pb:10 lg:border-b-0 lg:w-2/5 lg:border-r">
             <h3 className="font-serif text-2xl lg:text-3xl">
               {project.looking_for_funding ? (
                 <FormattedMessage defaultMessage="Currently looking for" id="sV+3z0" />
@@ -92,7 +92,7 @@ export const Funding: React.FC<FundingProps> = ({ project, enums }: FundingProps
               )}
             </h3>
             {project.looking_for_funding && (
-              <div className="flex flex-col gap-4 font-sans 2xl:gap-02xl:space-x-20 2xl:flex-row">
+              <div className="flex flex-col gap-4 font-sans 2xl:gap-0 2xl:space-x-20 2xl:flex-row">
                 <div className="flex flex-col justify-end space-y-1">
                   <p className="text-xl font-semibold lg:text-2xl">{ticketSizeStr}</p>
                   <p className="text-base whitespace-nowrap">

--- a/frontend/containers/project-page/header/component.tsx
+++ b/frontend/containers/project-page/header/component.tsx
@@ -145,9 +145,9 @@ export const Header: FC<HeaderProps> = ({ className, project }: HeaderProps) => 
           )}
           <p>{project.description}</p>
         </div>
-        <div className="lg:mr-4 p-6 bg-white drop-shadow-xl mb-16 lg:pb-8 lg:mb-[-70%] h-full lg:w-[395px] lg:translate-y-[-70%] lg:max-w-4/12 rounded-2xl mt-8 lg:mt-0 flex flex-col">
+        <div className="lg:mr-4 p-6 bg-white drop-shadow-xl mb-16 lg:mb-[-70%] h-full lg:w-[395px] lg:translate-y-[-70%] lg:max-w-4/12 rounded-2xl mt-8 lg:mt-0 flex flex-col">
           {project.looking_for_funding ? (
-            <div className="flex flex-col gap-8 md:flex-row">
+            <div className="flex flex-col gap-8 mb-8 md:flex-row">
               <div className="flex flex-col items-start justify-end w-full gap-2 text-center sm:text-left md:min-w-1/2">
                 <span id="ticket-size" className="text-xl font-semibold">
                   {ticketSizeStr}
@@ -169,7 +169,7 @@ export const Header: FC<HeaderProps> = ({ className, project }: HeaderProps) => 
               </div>
             </div>
           ) : (
-            <div className="max-w-sm text-gray-800">
+            <div className="max-w-sm mb-4 text-gray-800">
               <p className="text-lg font-semibold">
                 <FormattedMessage
                   defaultMessage="This project isn’t currently looking for funding."
@@ -185,7 +185,7 @@ export const Header: FC<HeaderProps> = ({ className, project }: HeaderProps) => 
             </div>
           )}
 
-          <div className="flex flex-col justify-between mt-5 gap-x-2 gap-y-4 lg:flex-row">
+          <div className="flex flex-col justify-between gap-x-2 gap-y-4 lg:flex-row">
             <Button
               className="justify-center"
               theme="secondary-green"

--- a/frontend/containers/project-page/header/component.tsx
+++ b/frontend/containers/project-page/header/component.tsx
@@ -16,7 +16,6 @@ import ContactInformationModal from 'containers/social-contact/contact-informati
 import Button from 'components/button';
 import Icon from 'components/icon';
 import LayoutContainer from 'components/layout-container';
-import Tag from 'components/tag';
 import { CategoryType } from 'types/category';
 
 import { useAccount } from 'services/account';
@@ -110,7 +109,7 @@ export const Header: FC<HeaderProps> = ({ className, project }: HeaderProps) => 
               */}
               {category && (
                 <CategoryTag
-                  className="bg-white text-green-dark"
+                  className="text-sm bg-white text-green-dark"
                   category={category.id as CategoryType}
                 >
                   {category.name}
@@ -131,7 +130,7 @@ export const Header: FC<HeaderProps> = ({ className, project }: HeaderProps) => 
         </LayoutContainer>
       </div>
       <LayoutContainer className="flex flex-col justify-between mt-8 lg:flex-row">
-        <div className="w-full lg:w-6/12">
+        <div className="w-full lg:w-6/12 min-h-[160px] pr-2">
           {project.language && (
             <span className="block mb-4 text-sm text-gray-400">
               <FormattedMessage
@@ -149,28 +148,21 @@ export const Header: FC<HeaderProps> = ({ className, project }: HeaderProps) => 
         <div className="lg:mr-4 p-6 bg-white drop-shadow-xl mb-16 lg:pb-8 lg:mb-[-70%] h-full lg:translate-y-[-70%] lg:max-w-4/12 rounded-2xl mt-8 lg:mt-0 flex flex-col">
           {project.looking_for_funding ? (
             <div className="flex flex-col gap-8 md:flex-row">
-              <div className="flex flex-col items-start justify-end w-full gap-2 text-center md:min-w-1/2">
-                <span id="ticket-size" className="text-2xl font-semibold">
+              <div className="flex flex-col items-start justify-end w-full gap-2 text-center sm:text-left md:min-w-1/2">
+                <span id="ticket-size" className="text-xl font-semibold">
                   {ticketSizeStr}
                 </span>
-                <span aria-labelledby="ticket-size" className="text-gray-400">
+                <span aria-labelledby="ticket-size" className="leading-4 text-gray-400">
                   <FormattedMessage defaultMessage="Ticket size" id="lfx6Nc" />
                 </span>
               </div>
               <div className="flex flex-col items-start justify-end w-full gap-2 text-left md:min-w-1/2">
-                <span
-                  id="instrument-types"
-                  className={cx({
-                    'font-semibold': true,
-                    'text-2xl': project.instrument_types.length <= 1,
-                    'text-xl': project.instrument_types.length > 1,
-                  })}
-                >
+                <span id="instrument-types" className="text-xl font-semibold">
                   {instrumentTypesStr}
                 </span>
                 <span
                   aria-labelledby="instrument-types"
-                  className="text-gray-400 whitespace-nowrap"
+                  className="leading-4 text-gray-400 whitespace-nowrap"
                 >
                   <FormattedMessage defaultMessage="Instrument type" id="fDd10o" />
                 </span>
@@ -193,7 +185,7 @@ export const Header: FC<HeaderProps> = ({ className, project }: HeaderProps) => 
             </div>
           )}
 
-          <div className="flex flex-col justify-between gap-4 mt-5 lg:flex-row">
+          <div className="flex flex-col justify-between mt-5 gap-x-2 gap-y-4 lg:flex-row">
             <Button
               className="justify-center"
               theme="secondary-green"

--- a/frontend/containers/project-page/header/component.tsx
+++ b/frontend/containers/project-page/header/component.tsx
@@ -145,7 +145,7 @@ export const Header: FC<HeaderProps> = ({ className, project }: HeaderProps) => 
           )}
           <p>{project.description}</p>
         </div>
-        <div className="lg:mr-4 p-6 bg-white drop-shadow-xl mb-16 lg:pb-8 lg:mb-[-70%] h-full lg:translate-y-[-70%] lg:max-w-4/12 rounded-2xl mt-8 lg:mt-0 flex flex-col">
+        <div className="lg:mr-4 p-6 bg-white drop-shadow-xl mb-16 lg:pb-8 lg:mb-[-70%] h-full lg:w-[395px] lg:translate-y-[-70%] lg:max-w-4/12 rounded-2xl mt-8 lg:mt-0 flex flex-col">
           {project.looking_for_funding ? (
             <div className="flex flex-col gap-8 md:flex-row">
               <div className="flex flex-col items-start justify-end w-full gap-2 text-center sm:text-left md:min-w-1/2">
@@ -201,7 +201,7 @@ export const Header: FC<HeaderProps> = ({ className, project }: HeaderProps) => 
               <FormattedMessage defaultMessage="Favorite" id="5Hzwqs" />
             </Button>
             <Button
-              className="w-full lg:max-w-[200px] justify-center"
+              className="justify-center w-full"
               disabled={!contacts.length}
               theme="primary-green"
               onClick={() => setIsContactInfoModalOpen(true)}

--- a/frontend/containers/project-page/overview/component.tsx
+++ b/frontend/containers/project-page/overview/component.tsx
@@ -53,8 +53,8 @@ export const Overview: React.FC<OverviewProps> = ({
   );
 
   return (
-    <LayoutContainer className="mb-14 lg:mb-20 mt-18 space-y-36">
-      <section className="p-4 mt-32 font-serif text-white sm:p-6 lg:mt-48 lg:p-16 bg-green-dark rounded-2xl">
+    <LayoutContainer className="mb-14 lg:mb-20 pt-18 space-y-36">
+      <section className="p-4 font-serif text-white mt-28 sm:p-6 lg:mt-28 lg:p-16 bg-green-dark rounded-2xl">
         <div className="relative grid w-full grid-cols-1 gap-12 lg:grid-cols-2">
           <div className="relative z-10 -mb-32 border-8 border-white drop-shadow-xl h-96 -top-28 lg:-top-44 lg:overflow-hidden rounded-xl">
             <Map

--- a/frontend/containers/project-page/overview/component.tsx
+++ b/frontend/containers/project-page/overview/component.tsx
@@ -55,8 +55,8 @@ export const Overview: React.FC<OverviewProps> = ({
   return (
     <LayoutContainer className="mb-14 lg:mb-20 pt-18 space-y-36">
       <section className="p-4 font-serif text-white mt-28 sm:p-6 lg:mt-28 lg:p-16 bg-green-dark rounded-2xl">
-        <div className="relative grid w-full grid-cols-1 gap-12 lg:grid-cols-2">
-          <div className="relative z-10 -mb-32 border-8 border-white drop-shadow-xl h-96 -top-28 lg:-top-44 lg:overflow-hidden rounded-xl">
+        <div className="relative grid w-full grid-cols-1 gap-x-10 gap-y-20 lg:grid-cols-2">
+          <div className="relative z-10 -mb-32 border-8 border-white drop-shadow-xl h-96 -top-28 lg:-top-44 lg:-mb-44 lg:overflow-hidden rounded-xl">
             <Map
               onMapViewportChange={onViewportChange}
               viewport={viewport}

--- a/frontend/containers/share-icons/component.tsx
+++ b/frontend/containers/share-icons/component.tsx
@@ -12,6 +12,8 @@ import Tooltip from 'components/tooltip';
 
 import { ShareIconsProps } from '.';
 
+import { theme } from 'tailwind.config';
+
 export const ShareIcons: FC<ShareIconsProps> = ({ title }) => {
   const [copied, setCopied] = useState(false);
   const { formatMessage } = useIntl();
@@ -59,6 +61,8 @@ export const ShareIcons: FC<ShareIconsProps> = ({ title }) => {
     });
   };
 
+  const iconFillColor = theme.colors.green.dark;
+
   return (
     <div className="absolute self-center translate-y-full -bottom-4">
       <div className="flex items-center gap-2">
@@ -76,13 +80,13 @@ export const ShareIcons: FC<ShareIconsProps> = ({ title }) => {
             to={shareLinks.twitter}
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center justify-center w-8 h-8 px-0 py-0 transition-all rounded-full bg-beige text-beige hover:opacity-60 hover:text-beige focus-visible:outline-green-dark "
+            className="flex items-center justify-center w-8 h-8 px-2 py-2 transition-all rounded-full bg-beige text-beige hover:opacity-60 hover:text-beige focus-visible:outline-green-dark "
             theme="naked"
           >
             <span className="sr-only">
               <FormattedMessage defaultMessage="Share on Twitter" id="80Vefc" />
             </span>
-            <Icon fill="white" icon={Twitter} />
+            <Icon className="fill-green-dark" icon={Twitter} />
           </Button>
         </Tooltip>
         <Tooltip
@@ -96,13 +100,13 @@ export const ShareIcons: FC<ShareIconsProps> = ({ title }) => {
             to={shareLinks.facebook}
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center justify-center w-8 h-8 px-0 py-0 text-transparent transition-all rounded-full bg-beige hover:opacity-60 hover:text-transparent focus-visible:outline-green-dark"
+            className="flex items-center justify-center w-8 h-8 px-2 py-2 text-transparent transition-all rounded-full bg-beige hover:opacity-60 hover:text-transparent focus-visible:outline-green-dark"
             theme="naked"
           >
             <span className="sr-only">
               <FormattedMessage defaultMessage="Share on Facebook" id="06VF+w" />
             </span>
-            <Icon fill="white" icon={Facebook} />
+            <Icon className="fill-green-dark" icon={Facebook} />
           </Button>
         </Tooltip>
         <Tooltip
@@ -114,25 +118,25 @@ export const ShareIcons: FC<ShareIconsProps> = ({ title }) => {
         >
           <Button
             to={shareLinks.email}
-            className="flex items-center justify-center w-8 h-8 px-0 py-0 transition-all rounded-full bg-beige text-beige hover:opacity-60 hover:text-beige focus-visible:outline-green-dark"
+            className="flex items-center justify-center w-8 h-8 px-2 py-2 transition-all rounded-full bg-beige text-beige fill-green-dark hover:opacity-60 focus-visible:outline-green-dark"
             theme="naked"
           >
             <span className="sr-only">
               <FormattedMessage defaultMessage="Share by email" id="O29TSs" />
             </span>
-            <Icon icon={Mail} fill="white" />
+            <Icon icon={Mail} className="fill-green-dark text-beige" />
           </Button>
         </Tooltip>
         <Tooltip
           content={
             <div className="max-w-xs p-2 font-sans text-sm font-normal text-white bg-black rounded-sm sm:max-w-md">
-              <FormattedMessage defaultMessage="Copy link to clipboard" id="EsZlwZ" />{' '}
+              <FormattedMessage defaultMessage="Copy link to clipboard" id="EsZlwZ" />
             </div>
           }
         >
           <Button
             onClick={copyToClipboard}
-            className="flex items-center justify-center w-8 h-8 px-0 py-0 text-white transition-all rounded-full bg-beige hover:opacity-60 hover:text-white focus-visible:outline-green-dark"
+            className="flex items-center justify-center w-8 h-8 px-2 py-2 transition-all rounded-full text-green-dark bg-beige hover:opacity-60 focus-visible:outline-green-dark"
             theme="naked"
           >
             <span className="sr-only">


### PR DESCRIPTION
This PR updates the open call and project public pages design


### Open calls public page

- Reduce the space between sections
- Remove “Location" title and just keep the country and state and align them horizontally
- Remove the “Funding available per project” since we have this info before there’s no need to repeat it here

Header’s white card
-  Reduce the size of text so it fits properly all labels (ticket size and instrument values) to text-xl instead of text-2xl. The -    white box should always stay with fixed width, otherwise it will hide text.
- Fix also space between the buttons, these should be fixed

**Designs:** 

[Open call with few content](https://www.figma.com/file/KC49uMR9t1YARmFR0Sr6aN/HeCo---Work-in-progress?node-id=8517%3A107785)
[Open call default](https://www.figma.com/file/KC49uMR9t1YARmFR0Sr6aN/HeCo---Work-in-progress?node-id=8517%3A107457)
Design: [here](https://www.figma.com/file/3epSYh4KQZBCyh4Y5OzmHw/HeCo---Design-System?node-id=2864%3A3446)

### Projects public page

- Reduce the size of category label to text-sm
- Add space between these two sections
- Increase the size of the left column

Header’s white card

- Reduce the size of text so it fits properly all labels (ticket size and instrument values) to text-xl instead of text-2xl. The white box should always stay with fixed width, otherwise it will hide text.
- Fix also space between the buttons, these should be fixed

Design: [here](https://www.figma.com/file/3epSYh4KQZBCyh4Y5OzmHw/HeCo---Design-System?node-id=2864%3A3446)


## Tracking

[LET-1157](https://vizzuality.atlassian.net/browse/LET-1157)
[LET-1162](https://vizzuality.atlassian.net/browse/LET-1162)
