### PR TITLE
Fix a deployment failure due to the Transifex CLI installation

### DIFF
--- a/.github/workflows/backend-push-translations.yml
+++ b/.github/workflows/backend-push-translations.yml
@@ -18,12 +18,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Install Transifex CLI
+        run: |
+          echo 'Installing the Transifex CLI…'
+          mkdir tx-cli
+          cd tx-cli
+          curl -o- https://raw.githubusercontent.com/transifex/cli/v1.0.3/install.sh | bash
+          cd ..
+
       - name: Push source strings to Transifex
         env:
           TRANSIFEX_TOKEN: ${{ secrets.TRANSIFEX_TOKEN }}
           ENV: ${{ inputs.env }}
-        run: |
-          echo 'Installing the Transifex CLI…'
-          curl -o- https://raw.githubusercontent.com/transifex/cli/v1.0.3/install.sh | bash
-          echo 'Pushing the source strings…'
-          TX_TOKEN=${{ env.TRANSIFEX_TOKEN }} ./tx push -s
+        run: TX_TOKEN=${{ env.TRANSIFEX_TOKEN }} ./tx-cli/tx push -s

--- a/.github/workflows/frontend-deployment.yml
+++ b/.github/workflows/frontend-deployment.yml
@@ -64,6 +64,14 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       run: yarn install --immutable
 
+    - name: Install Transifex CLI
+      run: |
+        echo 'Installing the Transifex CLI…'
+        mkdir tx-cli
+        cd tx-cli
+        curl -o- https://raw.githubusercontent.com/transifex/cli/v1.0.3/install.sh | bash
+        cd ..
+
     - name: Push source strings to and pull translated strings from Transifex
       env:
         TRANSIFEX_TOKEN: ${{ secrets.transifex-token }}
@@ -72,14 +80,12 @@ jobs:
       # pushed on staging. This should give enough time for translators before the content appears
       # on production. On production and development, we should only pull translations.
       run: |
-        echo 'Installing the Transifex CLI…'
-        curl -o- https://raw.githubusercontent.com/transifex/cli/v1.0.3/install.sh | bash
         if [[ "${{ env.ENV }}" == "staging" ]]; then
           echo 'Pushing the source strings…'
-          TX_TOKEN=${{ env.TRANSIFEX_TOKEN }} ./tx push -s
+          TX_TOKEN=${{ env.TRANSIFEX_TOKEN }} ./tx-cli/tx push -s
         fi
         echo 'Pulling the translations…'
-        TX_TOKEN=${{ env.TRANSIFEX_TOKEN }} ./tx pull -f
+        TX_TOKEN=${{ env.TRANSIFEX_TOKEN }} ./tx-cli/tx pull -f
 
     - name: Run tests
       run: yarn test

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -40,7 +40,11 @@ RUN yarn install
 
 COPY . /usr/src/app
 
+# Install Transifex CLI
+WORKDIR /usr/tx-cli
 RUN curl -o- https://raw.githubusercontent.com/transifex/cli/v1.0.3/install.sh | bash
+WORKDIR /usr/src/app
+
 ENV PATH "$PATH:/usr/src/app"
 
 EXPOSE 3000

--- a/backend/lib/tasks/transifex.rake
+++ b/backend/lib/tasks/transifex.rake
@@ -2,7 +2,7 @@ namespace :transifex do
   desc "Pulling transifex translations and post processing"
   task :pull do
     puts "transifex_pull: Running TX client to pull translations"
-    IO.popen("tx pull -f -a") { |p| p.each { |line| puts line } }
+    IO.popen("/usr/tx-cli/tx pull -f -a") { |p| p.each { |line| puts line } }
     puts "transifex_pull: Post-processing"
     Dir[Rails.root.join("config/locales/{en,es,pt}.yml")].each do |file|
       puts "transifex_pull: Cleaning up #{file} from empty strings"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -49,8 +49,14 @@ COPY --chown=nextjs:nextjs . .
 
 RUN yarn install --immutable
 
+# Install Transifex CLI
+RUN mkdir tx-cli
+WORKDIR /tx-cli
 RUN curl -o- https://raw.githubusercontent.com/transifex/cli/v1.0.3/install.sh | bash
-RUN ./tx pull -f
+WORKDIR /app
+
+# Pull translations from Transifex
+RUN /tx-cli/tx pull -f
 
 RUN yarn build
 


### PR DESCRIPTION
Since #635 has been merged, all the deployments to staging have been failing ([example](https://console.cloud.google.com/cloud-build/builds;region=global/1c795806-2a2a-47b6-b8ed-11d0847559d6;step=0?project=heco-342801)).

At the present, when deployed, the Transifex CLI is downloaded from GitHub and decompressed at the root of the repository. [The archive](https://github.com/transifex/cli/releases/latest/download/tx-linux-amd64.tar.gz) contains a few files that may overwrite inconsequential files in our source code (such as `README.md`).

Nevertheless, it seems that a change introduced in the CLI installation script between v1.0.3 and v1.3.1 has also changed the behaviour of how the archive is decompressed: https://github.com/transifex/cli/commit/e86c5ede66b4f1069c876729f75ba37fc882ae30. This change prevents the CLI from being installed and thus prevents the deployment from proceeding.

This PR aims to download and decompress the CLI archive in a different folder.

## Testing instructions

When merged, the GitHub Actions run smoothly and the build on Google Cloud as well.

## Tracking

[LET-1195](https://vizzuality.atlassian.net/browse/LET-1195) (reopened for this issue).
