### PR TITLE
change useBreakPoint function

### DIFF
--- a/frontend/containers/layouts/beta-version-disclaimer/component.tsx
+++ b/frontend/containers/layouts/beta-version-disclaimer/component.tsx
@@ -24,7 +24,7 @@ const BetaVersionDisclaimer: FC<BetaVersionDisclaimerProps> = ({ className }) =>
     localStorage.setItem('beta-version-disclaimer-closed', 'true');
   };
 
-  const isNotMobile = useBreakpoint(true)('md');
+  const isMobile = !useBreakpoint(true)('md');
 
   return (
     <div
@@ -42,7 +42,7 @@ const BetaVersionDisclaimer: FC<BetaVersionDisclaimerProps> = ({ className }) =>
           defaultMessage="HeCo Invest is currently on Beta version. We are still testing and making improvements and for that reason some features may not be fully functional. <mobile>You are seeing a mobile version of the platform which has limited functionality, please use the desktop version to see the complete version.</mobile>"
           id="8XtmJS"
           values={{
-            mobile: (chunk: string) => !isNotMobile && <span>{chunk}</span>,
+            mobile: (chunk: string) => isMobile && <span>{chunk}</span>,
           }}
         />
       </p>

--- a/frontend/containers/layouts/beta-version-disclaimer/component.tsx
+++ b/frontend/containers/layouts/beta-version-disclaimer/component.tsx
@@ -5,6 +5,8 @@ import { FormattedMessage } from 'react-intl';
 
 import cx from 'classnames';
 
+import { useBreakpoint } from 'hooks/use-breakpoint';
+
 import Button from 'components/button';
 
 import { BetaVersionDisclaimerProps } from './types';
@@ -22,6 +24,8 @@ const BetaVersionDisclaimer: FC<BetaVersionDisclaimerProps> = ({ className }) =>
     localStorage.setItem('beta-version-disclaimer-closed', 'true');
   };
 
+  const isNotMobile = useBreakpoint(true)('md');
+
   return (
     <div
       className={cx(
@@ -38,7 +42,7 @@ const BetaVersionDisclaimer: FC<BetaVersionDisclaimerProps> = ({ className }) =>
           defaultMessage="HeCo Invest is currently on Beta version. We are still testing and making improvements and for that reason some features may not be fully functional. <mobile>You are seeing a mobile version of the platform which has limited functionality, please use the desktop version to see the complete version.</mobile>"
           id="8XtmJS"
           values={{
-            mobile: (chunk: string) => <span className="md:hidden">{chunk}</span>,
+            mobile: (chunk: string) => !isNotMobile && <span>{chunk}</span>,
           }}
         />
       </p>

--- a/frontend/hooks/use-breakpoint.ts
+++ b/frontend/hooks/use-breakpoint.ts
@@ -7,7 +7,7 @@ import tailwindConfig from 'tailwind.config.js';
 
 const config = resolveConfig(tailwindConfig);
 
-export const useBreakpoint = () => {
+export const useBreakpoint = (useOuterWidth: boolean = false) => {
   const [currentBreakpoint, setCurrentBreakpoint] = useState<string | null>(null);
   const { screens } = config?.theme;
 
@@ -41,7 +41,9 @@ export const useBreakpoint = () => {
       // one, this will return `undefined`. That's why the default is set as the last one.
       const matchingBreakpoint = breakpointsObjArr.find((item) => {
         const [_key, value] = Object.entries(item)[0];
-        return window.innerWidth < value;
+
+        const width = useOuterWidth ? window.outerWidth : window.innerWidth;
+        return width < value;
       });
 
       // If we have a match we'll use it, if not the screen must be larger than the last breakpoint;
@@ -51,7 +53,7 @@ export const useBreakpoint = () => {
         : Object.keys(defaultBreakpoint)[0];
 
       setCurrentBreakpoint(breakpoint);
-    }, [breakpointsObjArr, defaultBreakpoint]),
+    }, [breakpointsObjArr, defaultBreakpoint, useOuterWidth]),
     250
   );
 

--- a/frontend/hooks/use-breakpoint.ts
+++ b/frontend/hooks/use-breakpoint.ts
@@ -8,7 +8,6 @@ import tailwindConfig from 'tailwind.config.js';
 const config = resolveConfig(tailwindConfig);
 
 export const useBreakpoint = (useOuterWidth: boolean = false) => {
-  const [currentBreakpoint, setCurrentBreakpoint] = useState<string | null>(null);
   const { screens } = config?.theme;
 
   const breakpoints = Object.keys(screens);
@@ -29,13 +28,18 @@ export const useBreakpoint = (useOuterWidth: boolean = false) => {
   );
 
   // Use the last breakpoint (largest screen) as the default one.
-  const defaultBreakpoint = breakpointsObjArr[breakpointsObjArr.length - 1];
+  const defaultBreakpointKey = Object.keys(breakpointsObjArr[breakpointsObjArr.length - 1])[0];
+
+  const [currentBreakpoint, setCurrentBreakpoint] = useState<string>(defaultBreakpointKey);
 
   // Here we compute the current breakpoint based on the window width.
   const computeBreakpoint = debounce(
     useCallback(() => {
-      // If no window object we can't get the window width. Return the default breakpoint.
-      if (typeof window !== 'object') return defaultBreakpoint;
+      // If no window object we can't get the window width. Set the the default breakpoint as the current one.
+      if (typeof window === undefined) {
+        setCurrentBreakpoint(defaultBreakpointKey);
+        return;
+      }
 
       // We try to find the current matching endpoint. Note that if the window matches the largest
       // one, this will return `undefined`. That's why the default is set as the last one.
@@ -50,10 +54,10 @@ export const useBreakpoint = (useOuterWidth: boolean = false) => {
       // We set the default one then.
       const breakpoint = matchingBreakpoint
         ? Object.keys(matchingBreakpoint)[0]
-        : Object.keys(defaultBreakpoint)[0];
+        : defaultBreakpointKey;
 
       setCurrentBreakpoint(breakpoint);
-    }, [breakpointsObjArr, defaultBreakpoint, useOuterWidth]),
+    }, [breakpointsObjArr, defaultBreakpointKey, useOuterWidth]),
     250
   );
 


### PR DESCRIPTION
This PR adds the **mobile** text to the beta version disclaimer

## Testing instructions

On mobile (< 768px wide), on the Dashboard, the beta disclaimer should say:
«HeCo Invest is currently on Beta version. We are still testing and making improvements and for that reason some features may not be fully functional. You are seeing a mobile version of the platform which has limited functionality, please use the desktop version to see the complete version»

## Tracking

[LET-1222](https://vizzuality.atlassian.net/browse/LET-1222)