### PR TITLE
Added status column and renamed old status column to Verification

### DIFF
--- a/backend/app/helpers/application_helper.rb
+++ b/backend/app/helpers/application_helper.rb
@@ -7,7 +7,11 @@ module ApplicationHelper
     "approved" => "text-green-dark bg-green-light/20",
     "rejected" => "text-red-dark bg-red-dark/20",
     "unverified" => "text-gray-800 bg-gray-800/20",
-    "verified" => "text-green-dark bg-green-light/20"
+    "verified" => "text-green-dark bg-green-light/20",
+    "draft" => "text-gray-800 bg-gray-800/20",
+    "published" => "text-green-dark bg-green-light/20",
+    "launched" => "text-green-dark bg-green-light/20",
+    "closed" => "text-red-dark bg-red-dark/20"
   }
 
   FLASH_CLASSES = {

--- a/backend/app/services/backoffice/csv/open_call_exporter.rb
+++ b/backend/app/services/backoffice/csv/open_call_exporter.rb
@@ -8,6 +8,15 @@ module Backoffice
           column(I18n.t("backoffice.open_calls.index.location")) { |r| [r.municipality&.name, r.department&.name, r.country&.name].compact.join(", ") }
           column(I18n.t("backoffice.open_calls.index.applications")) { |r| r.open_call_applications_count }
           column(I18n.t("backoffice.common.status")) { |r|
+            if r.launched?
+              I18n.t("enum.open_call_status.launched")
+            elsif r.closed?
+              I18n.t("enum.open_call_status.closed")
+            else
+              I18n.t("enum.open_call_status.draft")
+            end
+          }
+          column(I18n.t("backoffice.common.verification")) { |r|
             r.verified? ? I18n.t("backoffice.common.verified") : I18n.t("backoffice.common.unverified")
           }
         end

--- a/backend/app/services/backoffice/csv/project_exporter.rb
+++ b/backend/app/services/backoffice/csv/project_exporter.rb
@@ -8,6 +8,9 @@ module Backoffice
           column(I18n.t("backoffice.common.category")) { |r| Category.find(r.category).name }
           column(I18n.t("backoffice.projects.index.priority_landscape")) { |r| r.priority_landscape&.name }
           column(I18n.t("backoffice.common.status")) { |r|
+            r.published? ? I18n.t("enum.project_status.published") : I18n.t("enum.project_status.draft")
+          }
+          column(I18n.t("backoffice.common.verification")) { |r|
             r.verified? ? I18n.t("backoffice.common.verified") : I18n.t("backoffice.common.unverified")
           }
         end

--- a/backend/app/views/backoffice/open_calls/index.html.erb
+++ b/backend/app/views/backoffice/open_calls/index.html.erb
@@ -19,7 +19,10 @@
       <%= sort_link @q, :open_call_applications_count, t("backoffice.open_calls.index.applications") %>
     </th>
     <th class="min-w-[10rem]">
-      <%= sort_link @q, :verified, t("backoffice.common.status") %>
+      <%= sort_link @q, :status, t("backoffice.common.status") %>
+    </th>
+    <th class="min-w-[10rem]">
+      <%= sort_link @q, :verified, t("backoffice.common.verification") %>
     </th>
     <th>
     </th>
@@ -35,6 +38,12 @@
       <td><%= open_call.investor.name %></td>
       <td><%= [open_call.municipality&.name, open_call.department&.name, open_call.country&.name].compact.join(", ") %></td>
       <td><%= open_call.open_call_applications_count %></td>
+      <td>
+        <%= status_tag :launched, t('enum.open_call_status.launched') if open_call.launched? %>
+        <%= status_tag :closed, t('enum.open_call_status.closed') if open_call.closed? %>
+        <%= status_tag :draft, t('enum.open_call_status.draft') unless open_call.launched? || open_call.closed? %>
+      </td>
+      </td>
       <td>
         <%= status_tag :verified, t('backoffice.common.verified') if open_call.verified?  %>
         <%= status_tag :unverified, t('backoffice.common.unverified') unless open_call.verified?  %>

--- a/backend/app/views/backoffice/projects/index.html.erb
+++ b/backend/app/views/backoffice/projects/index.html.erb
@@ -19,7 +19,10 @@
         <%= sort_link @q, :priority_landscape_name, t("backoffice.projects.index.priority_landscape") %>
       </th>
       <th class="min-w-[10rem]">
-        <%= sort_link @q, :verified, t("backoffice.common.status") %>
+        <%= sort_link @q, :status, t("backoffice.common.status") %>
+      </th>
+      <th class="min-w-[10rem]">
+        <%= sort_link @q, :verified, t("backoffice.common.verification") %>
       </th>
       <th>
       </th>
@@ -36,8 +39,12 @@
         <td><%= Category.find(p.category).name %></td>
         <td><%= p.priority_landscape&.name %></td>
         <td>
-          <%= status_tag :verified, t('backoffice.common.verified') if p.verified?  %>
-          <%= status_tag :unverified, t('backoffice.common.unverified') unless p.verified?  %>
+          <%= status_tag :published, t('enum.project_status.published') if p.published? %>
+          <%= status_tag :draft, t('enum.project_status.draft') unless p.published? %>
+        </td>
+        <td>
+          <%= status_tag :verified, t('backoffice.common.verified') if p.verified? %>
+          <%= status_tag :unverified, t('backoffice.common.unverified') unless p.verified? %>
         </td>
         <td><%= link_to t("backoffice.common.edit"), edit_backoffice_project_path(p.id), class: "link-button" %></td>
         <td>

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -159,6 +159,7 @@ zu:
       language: Language
       name: Name
       status: Status
+      verification: Verification
       approve: Approve
       reject: Reject
       email: Email

--- a/backend/spec/services/backoffice/csv/open_call_exporter_spec.rb
+++ b/backend/spec/services/backoffice/csv/open_call_exporter_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Backoffice::CSV::OpenCallExporter do
   subject { described_class.new(query) }
 
-  let(:query) { create_list :open_call, 4, verified: true }
+  let(:query) { create_list :open_call, 4, verified: true, status: :launched }
   let(:parsed_csv) { CSV.parse(subject.call) }
 
   describe "#call" do
@@ -13,7 +13,8 @@ RSpec.describe Backoffice::CSV::OpenCallExporter do
         I18n.t("backoffice.common.investor"),
         I18n.t("backoffice.open_calls.index.location"),
         I18n.t("backoffice.open_calls.index.applications"),
-        I18n.t("backoffice.common.status")
+        I18n.t("backoffice.common.status"),
+        I18n.t("backoffice.common.verification")
       ])
     end
 
@@ -24,6 +25,7 @@ RSpec.describe Backoffice::CSV::OpenCallExporter do
         query.first.investor.name,
         [query.first.municipality&.name, query.first.department&.name, query.first.country&.name].compact.join(", "),
         query.first.open_call_applications_count.to_s,
+        I18n.t("enum.open_call_status.launched"),
         I18n.t("backoffice.common.verified")
       ])
     end

--- a/backend/spec/services/backoffice/csv/project_exporter_spec.rb
+++ b/backend/spec/services/backoffice/csv/project_exporter_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Backoffice::CSV::ProjectExporter do
   subject { described_class.new(query) }
 
-  let(:query) { create_list :project, 4, verified: true }
+  let(:query) { create_list :project, 4, verified: true, status: :published }
   let(:parsed_csv) { CSV.parse(subject.call) }
 
   describe "#call" do
@@ -13,7 +13,8 @@ RSpec.describe Backoffice::CSV::ProjectExporter do
         I18n.t("backoffice.common.project_developer"),
         I18n.t("backoffice.common.category"),
         I18n.t("backoffice.projects.index.priority_landscape"),
-        I18n.t("backoffice.common.status")
+        I18n.t("backoffice.common.status"),
+        I18n.t("backoffice.common.verification")
       ])
     end
 
@@ -24,6 +25,7 @@ RSpec.describe Backoffice::CSV::ProjectExporter do
         query.first.project_developer.name,
         Category.find(query.first.category).name,
         query.first.priority_landscape&.name,
+        I18n.t("enum.project_status.published"),
         I18n.t("backoffice.common.verified")
       ])
     end


### PR DESCRIPTION
On both projects and open calls lists, the current "Status" column was renamed to "Verification" to reflect verification status, and a new "Status" column was added to reflect publishing status.

## Testing instructions

projects and open call lists in the backoffice + csv downloads

## Tracking

https://vizzuality.atlassian.net/browse/LET-1218?atlOrigin=eyJpIjoiYjMyZjdiY2Y2M2VmNGNjN2EzZjkxNWE1ZjhlMzE1OTYiLCJwIjoiaiJ9
https://vizzuality.atlassian.net/browse/LET-1219?atlOrigin=eyJpIjoiZGExYmEyOTY4OTdlNGNiZjlhZGQ3YzY5YzcxZTk5NzYiLCJwIjoiaiJ9
