### PR TITLE
Reduced the timeout when resending confirmation email

### DIFF
--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   include PgSearch::Model
 
-  EMAIL_CONFIRMATION_LIMIT_PERIOD = 10.minutes
+  EMAIL_CONFIRMATION_LIMIT_PERIOD = 30.seconds
 
   belongs_to :account, optional: true, counter_cache: true
 

--- a/backend/spec/models/user_spec.rb
+++ b/backend/spec/models/user_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe User, type: :model do
         user.send_confirmation_instructions # first send
       }.to have_enqueued_mail(DeviseMailer, :confirmation_instructions)
       expect {
-        travel_to((limit_period - 3.minutes).from_now) { user.send_confirmation_instructions }
-        travel_to((limit_period - 2.minutes).from_now) { user.send_confirmation_instructions }
+        travel_to((limit_period - 30.seconds).from_now) { user.send_confirmation_instructions }
+        travel_to((limit_period - 20.seconds).from_now) { user.send_confirmation_instructions }
       }.not_to have_enqueued_mail(DeviseMailer, :confirmation_instructions)
     end
 
@@ -69,7 +69,7 @@ RSpec.describe User, type: :model do
         travel_to(third_send_time) { user.send_confirmation_instructions } # send
       }.to have_enqueued_mail(DeviseMailer, :confirmation_instructions)
       expect {
-        travel_to(third_send_time + 2.minutes) { user.send_confirmation_instructions } # do not send
+        travel_to(third_send_time + 20.seconds) { user.send_confirmation_instructions } # do not send
       }.not_to have_enqueued_mail(DeviseMailer, :confirmation_instructions)
     end
 


### PR DESCRIPTION
We have a 10 min timeout before the confirmation email can be resent, but we'd need more changes for the FE to disable the resend button accordingly. So the temporary solution to avoid user confusion is to reduce the timeout to 30s & display a message on FE to give it a few.

## Tracking

https://vizzuality.atlassian.net/browse/LET-1269
