### PR TITLE
Display the ticket sizes in currency on the investor public page and Discover

### DIFF
--- a/frontend/containers/forms/active-filters/component.tsx
+++ b/frontend/containers/forms/active-filters/component.tsx
@@ -11,6 +11,7 @@ import {
 
 import Tag from 'components/forms/tag';
 import TagGroup from 'components/forms/tag-group';
+import { EnumTypes } from 'enums';
 import { Enum } from 'types/enums';
 
 import { ActiveFilterProps } from '.';
@@ -75,7 +76,7 @@ export const ActiveFilters: FC<ActiveFilterProps> = ({ filters = {}, filtersData
               checked
               showDeleteIcon
             >
-              {filter.name}
+              {filter.type === EnumTypes.TicketSize ? filter.description : filter.name}
             </Tag>
           ))}
         </TagGroup>

--- a/frontend/pages/investor/[id]/index.tsx
+++ b/frontend/pages/investor/[id]/index.tsx
@@ -121,7 +121,9 @@ const InvestorPage: PageComponent<InvestorPageProps, StaticPageLayoutProps> = ({
     {
       id: 'ticket-size',
       title: intl.formatMessage({ defaultMessage: 'Ticket size', id: 'lfx6Nc' }),
-      tags: allTicketSizes.filter(({ id }) => ticket_sizes?.includes(id)),
+      tags: allTicketSizes
+        .filter(({ id }) => ticket_sizes?.includes(id))
+        .map((ticket) => ({ ...ticket, name: ticket.description })),
     },
     {
       id: 'instrument-size',


### PR DESCRIPTION
This PR displays the ticket sizes as currencies on the:
- investor public page
- “Active filters” section of Discover

## Testing instructions

Check that we're displaying the currency and not the name of the ticket size on both pages.

## Tracking

[LET-1249](https://vizzuality.atlassian.net/browse/LET-1249)
