### PR TITLE
Use a new tileset for sub-basin boundaries layer

### DIFF
--- a/frontend/hooks/useLayers.ts
+++ b/frontend/hooks/useLayers.ts
@@ -165,21 +165,15 @@ export const useLayers = () => {
           specification: {
             type: 'vector',
             source: {
-              url: 'mapbox://leticiaheco.7r96572i',
+              url: 'mapbox://leticiaheco.77lko5p2',
             },
             render: {
               layers: [
                 {
                   paint: {
                     'line-color': 'hsl(202, 68%, 44%)',
-                    'line-width': ['interpolate', ['linear'], ['zoom'], 4, 0.5, 8, 1],
                   },
-                  layout: {
-                    'line-cap': 'round',
-                    'line-join': 'round',
-                    'line-round-limit': 1,
-                  },
-                  'source-layer': 'Zonificacion_Hidrografica_201-4s7eff',
+                  'source-layer': 'Basins',
                   type: 'line',
                 },
               ],


### PR DESCRIPTION
This PR updates the tileset of the sub-basin boundaries layer so that it can be displayed at all zoom levels.

## Testing instructions

1. Go to Discover
2. Toggle on the layer
3. Zoom out

The layer should always be visible.

## Tracking

[LET-1264](https://vizzuality.atlassian.net/browse/LET-1264)
