### PR TITLE
Tag docker containers based on branch

### DIFF
--- a/infrastructure/base/main.tf
+++ b/infrastructure/base/main.tf
@@ -32,6 +32,10 @@ module "staging" {
   sendgrid_api_key       = var.sendgrid_api_key
   mapbox_api_key         = var.mapbox_api_key
   hotjar_site_id         = ""
+  frontend_min_scale     = 0
+  backend_min_scale      = 0
+  frontend_max_scale     = 1
+  backend_max_scale      = 1
   redirect_domain        = var.redirect_domain
   dns_zone_name          = module.dns.dns_zone_name
   redirect_dns_zone_name = module.redirect_dns.dns_zone_name
@@ -39,6 +43,7 @@ module "staging" {
   uptime_alert_email     = var.uptime_alert_email
   from_email_address     = var.from_email_address
   instance_role          = "staging"
+  tag                    = "staging"
 }
 
 module "production" {
@@ -65,6 +70,7 @@ module "production" {
   uptime_alert_email     = var.uptime_alert_email
   from_email_address     = var.from_email_address
   instance_role          = "production"
+  tag                    = "production"
 }
 
 module "dns" {

--- a/infrastructure/base/modules/cloudbuild-webhook/main.tf
+++ b/infrastructure/base/modules/cloudbuild-webhook/main.tf
@@ -79,7 +79,7 @@ resource "google_cloudbuild_trigger" "build_trigger" {
       name = "gcr.io/cloud-builders/docker"
       args = [
         "build", "-t", "gcr.io/${var.project_id}/${var.github_project}", "-t",
-        "gcr.io/${var.project_id}/${var.image_name}:latest", "."
+        "gcr.io/${var.project_id}/${var.image_name}:${var.tag}", "."
       ]
     }
   }

--- a/infrastructure/base/modules/cloudbuild/main.tf
+++ b/infrastructure/base/modules/cloudbuild/main.tf
@@ -52,7 +52,7 @@ locals {
           "build",
           "-f", var.dockerfile_path,
           "-t", "gcr.io/${var.project_id}/${var.image_name}",
-          "-t", "gcr.io/${var.project_id}/${var.image_name}:latest",
+          "-t", "gcr.io/${var.project_id}/${var.image_name}:${var.tag}",
         ],
         [for key, value in var.docker_build_args : "--build-arg=${key}=$_${key}"],
         [
@@ -61,12 +61,12 @@ locals {
       )
     }, {
       name = "gcr.io/cloud-builders/docker"
-      args = ["push", "gcr.io/${var.project_id}/${var.image_name}:latest"]
+      args = ["push", "gcr.io/${var.project_id}/${var.image_name}:${var.tag}"]
     }, {
       name       = "gcr.io/google.com/cloudsdktool/cloud-sdk"
       entrypoint = "gcloud"
       args       = [
-        "run", "deploy", var.cloud_run_service_name, "--image", "gcr.io/${var.project_id}/${var.image_name}:latest",
+        "run", "deploy", var.cloud_run_service_name, "--image", "gcr.io/${var.project_id}/${var.image_name}:${var.tag}",
         "--region", var.region
       ]
     }
@@ -99,7 +99,7 @@ resource "google_cloudbuild_trigger" "build_trigger" {
       }
     }
 
-    images = ["gcr.io/${var.project_id}/${var.image_name}", "gcr.io/${var.project_id}/${var.image_name}:latest"]
+    images = ["gcr.io/${var.project_id}/${var.image_name}", "gcr.io/${var.project_id}/${var.image_name}:${var.tag}"]
 
     options {
       machine_type = "E2_HIGHCPU_8"

--- a/infrastructure/base/modules/cloudbuild/variables.tf
+++ b/infrastructure/base/modules/cloudbuild/variables.tf
@@ -66,3 +66,8 @@ variable "test_container_name" {
   description = "The name of the test container to run"
   type = string
 }
+
+variable "tag" {
+  type = string
+  description = "Tag name to use for docker image tagging and deployment"
+}

--- a/infrastructure/base/modules/cloudrun/main.tf
+++ b/infrastructure/base/modules/cloudrun/main.tf
@@ -30,7 +30,7 @@ resource "google_cloud_run_service" "cloud_run" {
       service_account_name = google_service_account.service_account.email
 
       containers {
-        image = "gcr.io/${var.project_id}/${var.image_name}:latest"
+        image = "gcr.io/${var.project_id}/${var.image_name}:${var.tag}"
         args  = [var.start_command]
         ports {
           container_port = var.container_port
@@ -44,7 +44,6 @@ resource "google_cloud_run_service" "cloud_run" {
               for_each = lookup(env.value, "secret_name", null) != null ? [1] : []
               content {
                 secret_key_ref {
-
                   key  = "latest"
                   name = env.value["secret_name"]
                 }
@@ -65,7 +64,7 @@ resource "google_cloud_run_service" "cloud_run" {
         # Use the VPC Connector
         "run.googleapis.com/vpc-access-connector" = var.vpc_connector_name
         # all egress from the service should go through the VPC Connector
-        "run.googleapis.com/vpc-access-egress"    = "all"
+        "run.googleapis.com/vpc-access-egress"    = "all-traffic"
       }
     }
   }

--- a/infrastructure/base/modules/cloudrun/variables.tf
+++ b/infrastructure/base/modules/cloudrun/variables.tf
@@ -65,3 +65,8 @@ variable "max_scale" {
   description = "Maximum number of app instances to deploy"
   default = 5
 }
+
+variable "tag" {
+  type = string
+  description = "Tag name to use for docker image tagging and deployment"
+}

--- a/infrastructure/base/modules/env/variables.tf
+++ b/infrastructure/base/modules/env/variables.tf
@@ -138,3 +138,8 @@ variable "instance_role" {
   default = "production"
   description = "staging|production, NOT the same as RAILS_ENV as that is 'production' in staging as well"
 }
+
+variable "tag" {
+  type = string
+  description = "Tag name to use for docker image tagging and deployment"
+}


### PR DESCRIPTION
Previously, for whatever reason, I had all images being tagged as "latest", which works fine as long as we don't have to manually deploy staging/production. This should address that, and create separate tags on the docker container registry, so we can deploy staging or production manually, at any time.