### PR TITLE
Rescue exception in after_commit and explicitly report error

### DIFF
--- a/backend/app/models/concerns/translatable.rb
+++ b/backend/app/models/concerns/translatable.rb
@@ -19,11 +19,17 @@ module Translatable
     end
   end
 
+  # From the Rails docs: The after_commit and after_rollback callbacks are called for all models created, updated,
+  # or destroyed within a transaction block. - in our case we have Investor / Account or PD / Account
+  # However, if an exception is raised within one of these callbacks, the exception will bubble up and any remaining
+  # after_commit or after_rollback methods will not be executed. As such, if your callback code could raise an exception,
+  # you'll need to rescue it and handle it within the callback in order to allow other callbacks to run.
   def translate_attributes
     changed_attrs = translatable_attributes.each_with_object([]) do |attr, res|
       res << attr if public_send "saved_change_to_#{attr}_#{language}?"
     end
-
     TranslateJob.perform_later id, self.class.name, changed_attrs: changed_attrs if changed_attrs.present?
+  rescue Exception => e # rubocop:disable Lint/RescueException
+    Google::Cloud::ErrorReporting.report e
   end
 end


### PR DESCRIPTION
Some entities are still not being translated, despite the fix in https://github.com/Vizzuality/heco-invest/pull/634.

From the log it looks like translations are not enqueued at all, I saw this happen for project developers and investors (it seems to work for projects though). 

The only things that comes to my mind at this point that is that after changing the callback from `after_save` to `after_commit` we might have somehow lost visibility of exceptions thrown in callbacks, and in case of `after_commit` with multiple objects, as we have in the accounts scenario, if one fails the rest are skipped.

I would like to merge this change and see if I can get anywhere closer to an explanation, but more and more I'm coming to the conclusion that we should just have a periodic job looking at untranslated content and starting translation jobs as needed. If this ends up not helping, I'll revert.

## Testing instructions

Needs to be tested on staging, I haven't seen this issue on localhost.

## Tracking

https://vizzuality.atlassian.net/browse/LET-1172?atlOrigin=eyJpIjoiYWE5ODUzNWIzZTQyNDcxN2JhOWZjYTczOWM0MmU2MDYiLCJwIjoiaiJ9
