### PR TITLE
LET-1195 - Install transifex CLI outside of project folder

### DIFF
--- a/.github/workflows/backend-push-translations.yml
+++ b/.github/workflows/backend-push-translations.yml
@@ -24,6 +24,6 @@ jobs:
           ENV: ${{ inputs.env }}
         run: |
           echo 'Installing the Transifex CLI…'
-          curl -o- https://raw.githubusercontent.com/transifex/cli/v1.0.3/install.sh | bash
+          curl -o- https://raw.githubusercontent.com/transifex/cli/v1.4.1/install.sh | bash
           echo 'Pushing the source strings…'
           TX_TOKEN=${{ env.TRANSIFEX_TOKEN }} ./tx push -s

--- a/.github/workflows/frontend-deployment.yml
+++ b/.github/workflows/frontend-deployment.yml
@@ -73,7 +73,7 @@ jobs:
       # on production. On production and development, we should only pull translations.
       run: |
         echo 'Installing the Transifex CLI…'
-        curl -o- https://raw.githubusercontent.com/transifex/cli/v1.0.3/install.sh | bash
+        curl -o- https://raw.githubusercontent.com/transifex/cli/v1.4.1/install.sh | bash
         if [[ "${{ env.ENV }}" == "staging" ]]; then
           echo 'Pushing the source strings…'
           TX_TOKEN=${{ env.TRANSIFEX_TOKEN }} ./tx push -s

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -40,7 +40,7 @@ RUN yarn install
 
 COPY . /usr/src/app
 
-RUN curl -o- https://raw.githubusercontent.com/transifex/cli/v1.0.3/install.sh | bash
+RUN curl -o- https://raw.githubusercontent.com/transifex/cli/v1.4.1/install.sh | bash
 ENV PATH "$PATH:/usr/src/app"
 
 EXPOSE 3000

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -38,6 +38,9 @@ RUN adduser --system --uid 1001 nextjs
 
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat curl bash
+
+RUN curl -o- https://raw.githubusercontent.com/transifex/cli/v1.4.1/install.sh | bash
+
 WORKDIR /app
 RUN chown nextjs:nextjs /app
 
@@ -49,8 +52,7 @@ COPY --chown=nextjs:nextjs . .
 
 RUN yarn install --immutable
 
-RUN curl -o- https://raw.githubusercontent.com/transifex/cli/v1.0.3/install.sh | bash
-RUN ./tx pull -f
+RUN /tx pull -f
 
 RUN yarn build
 


### PR DESCRIPTION
This superseeds https://github.com/Vizzuality/heco-invest/pull/644

The issue here happens only if the transifex CLI is installed under a non-GNU environment - as our Docker images are. GH Actions is not affected.

It happens because the transifex installer for non-GNU envs does not properly handle decompression file collisions (FE's README vs the tx CLI README) so it fails at that stage. The BE docker env is not affected because the BE does not copy its README into the docker image.

The fix here is to install the transifex CLI to the root of the FE image, and run it from there. On the BE it would be ideal to do the same, for consistency, but the tx CLI is called from within the ruby code (rake task), so we would need to modify that for compatibility, which would cause problems when running said rake task locally. So the lesser evil, IMO, is to have said inconsistency.

Parallel to the above, I update the transifex CLI version, because bigger is always better.