### PR TITLE
LET-1234 Back Office - Improvements to the account approval/rejection process for accounts with invalid pictures uploaded

### DIFF
--- a/backend/app/controllers/backoffice/accounts_controller.rb
+++ b/backend/app/controllers/backoffice/accounts_controller.rb
@@ -3,9 +3,12 @@ module Backoffice
     before_action :fetch_account, only: [:approve, :reject]
 
     def approve
-      @account.approved!
-      UserMailer.approved(@account.owner).deliver_later
-      redirect_back(fallback_location: admin_root_path)
+      if @account.update(review_status: :approved)
+        UserMailer.approved(@account.owner).deliver_later
+        redirect_back(fallback_location: admin_root_path)
+      else
+        redirect_back(fallback_location: admin_root_path, alert: @account.errors.first.full_message)
+      end
     end
 
     def reject

--- a/backend/app/models/account.rb
+++ b/backend/app/models/account.rb
@@ -20,17 +20,20 @@ class Account < ApplicationRecord
   ransacker :review_status, formatter: proc { |v| review_statuses[v] }
 
   validates :name, presence: true, uniqueness: {case_sensitive: false}
-  validates :about, presence: true
-  validates :website, url: true
-  validates :linkedin, url: true
-  validates :twitter, url: true
-  validates :facebook, url: true
-  validates :instagram, url: true
   validates :language, inclusion: {in: Language::TYPES, allow_blank: true}, presence: true
-  validates :picture, attached: true, content_type: /\Aimage\/.*\z/
-  validates :contact_email, presence: true
-  validates :contact_email, format: {with: Devise.email_regexp}, unless: -> { contact_email.blank? }
-  validate :owner_is_part_of_account, if: :owner_id_changed?
+
+  with_options(unless: :rejected?) do |account|
+    account.validates :about, presence: true
+    account.validates :website, url: true
+    account.validates :linkedin, url: true
+    account.validates :twitter, url: true
+    account.validates :facebook, url: true
+    account.validates :instagram, url: true
+    account.validates :picture, attached: true, content_type: /\Aimage\/.*\z/
+    account.validates :contact_email, presence: true
+    account.validates :contact_email, format: {with: Devise.email_regexp}, unless: -> { contact_email.blank? }
+    account.validate :owner_is_part_of_account, if: :owner_id_changed?
+  end
 
   before_update :set_reviewed_at, if: :review_status_changed?
   before_update :change_invitations_ownership, if: :owner_id_changed?

--- a/backend/app/views/backoffice/accounts/_status_form.html.erb
+++ b/backend/app/views/backoffice/accounts/_status_form.html.erb
@@ -1,5 +1,8 @@
 <%= simple_form_for [:backoffice, form_object] do |f| %>
   <%= f.error_notification %>
+  <% f.object.errors.each do |error| %>
+    <%= f.error_notification message: error.full_message %>
+  <% end %>
   <%= hidden_field_tag :section, params[:section] %>
 
   <h2 class="mb-2 text-gray-900 font-semibold">

--- a/backend/app/views/backoffice/base/_image_with_thumbnail.html.erb
+++ b/backend/app/views/backoffice/base/_image_with_thumbnail.html.erb
@@ -5,4 +5,4 @@
     <%= image_tag blob_object.variant(resize: "200x200"), class: "inline" %>
   <% end %>
 <% end %>
-<%= f.input blob, as: :file, input_html: { accept: "image/*" } %>
+<%= f.input blob, as: :file, input_html: { accept: "image/*" }, required: required %>

--- a/backend/app/views/backoffice/investors/_form.html.erb
+++ b/backend/app/views/backoffice/investors/_form.html.erb
@@ -8,7 +8,7 @@
   </h2>
 
   <%= f.simple_fields_for :account do |ff|  %>
-    <%= render "image_with_thumbnail", f: ff, blob: :picture %>
+    <%= render "image_with_thumbnail", f: ff, blob: :picture, required: true %>
   <% end %>
   <div class="grid grid-cols-2 gap-4">
     <%= f.simple_fields_for :account do |ff|  %>

--- a/backend/app/views/backoffice/open_calls/_form.html.erb
+++ b/backend/app/views/backoffice/open_calls/_form.html.erb
@@ -8,7 +8,7 @@
   </h2>
 
   <%= localized_input f, :name, content_language, as: :string %>
-  <%= render "image_with_thumbnail", f: f, blob: :picture %>
+  <%= render "image_with_thumbnail", f: f, blob: :picture, required: false %>
   <div class="grid grid-cols-3 gap-4">
     <%= f.input :country_id, collection: Location.country.order(["name", content_language].join("_")), include_blank: false %>
     <%= f.input :department_id, collection: Location.department.order(["name", content_language].join("_")) %>

--- a/backend/app/views/backoffice/project_developers/_form.html.erb
+++ b/backend/app/views/backoffice/project_developers/_form.html.erb
@@ -8,7 +8,7 @@
   </h2>
 
   <%= f.simple_fields_for :account do |ff|  %>
-    <%= render "image_with_thumbnail", f: ff, blob: :picture %>
+    <%= render "image_with_thumbnail", f: ff, blob: :picture, required: true %>
   <% end %>
   <div class="grid grid-cols-2 gap-4">
     <%= f.simple_fields_for :account do |ff|  %>

--- a/backend/app/views/backoffice/users/_form.html.erb
+++ b/backend/app/views/backoffice/users/_form.html.erb
@@ -6,7 +6,7 @@
     <%= t(".information") %>
   </h2>
 
-  <%= render "image_with_thumbnail", f: f, blob: :avatar %>
+  <%= render "image_with_thumbnail", f: f, blob: :avatar, required: false %>
   <%= f.input :first_name %>
   <%= f.input :last_name %>
   <%= f.input :otp_required_for_login, collection: [[t("true"), true], [t("false"), false]], as: :radio_buttons %>

--- a/backend/spec/models/account_spec.rb
+++ b/backend/spec/models/account_spec.rb
@@ -81,6 +81,51 @@ RSpec.describe Account, type: :model do
     end
   end
 
+  describe "approve!" do
+    subject { create(:account, :unapproved) }
+    context "when no validation errors" do
+      it "should change status to approved" do
+        subject.approved!
+        expect(subject.review_status).to eq("approved")
+      end
+    end
+
+    context "when validation errors" do
+      before(:each) do
+        subject.assign_attributes about_en: nil, about_es: nil, about_pt: nil
+        subject.save(validate: false)
+      end
+
+      it "should not change status to approved" do
+        expect {
+          subject.approved!
+        }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+  end
+
+  describe "reject!" do
+    subject { create(:account, :unapproved) }
+    context "when no validation errors" do
+      it "should change status to rejected" do
+        subject.rejected!
+        expect(subject.review_status).to eq("rejected")
+      end
+    end
+
+    context "when validation errors" do
+      before(:each) do
+        subject.assign_attributes about_en: nil, about_es: nil, about_pt: nil
+        subject.save(validate: false)
+      end
+
+      it "should change status to rejected" do
+        subject.rejected!
+        expect(subject.review_status).to eq("rejected")
+      end
+    end
+  end
+
   context "when changing ownership" do
     subject { create(:account) }
 

--- a/backend/spec/system/backoffice/project_developers_spec.rb
+++ b/backend/spec/system/backoffice/project_developers_spec.rb
@@ -79,6 +79,19 @@ RSpec.describe "Backoffice: Project Developers", type: :system do
           expect(page).to have_text(ReviewStatus.find("approved").name)
         end
       end
+
+      context "when validation errors" do
+        before { unapproved_pd.account.update_attribute(:picture, nil) }
+
+        it "doesn't change the status to approved" do
+          within_row("Unapproved PD Enterprise") do
+            expect(page).to have_text(ReviewStatus.find("unapproved").name)
+            click_on t("backoffice.common.approve")
+            expect(page).not_to have_text(ReviewStatus.find("approved").name)
+          end
+          expect(page).to have_text("Picture can't be blank")
+        end
+      end
     end
 
     context "when rejecting project developer" do
@@ -90,6 +103,18 @@ RSpec.describe "Backoffice: Project Developers", type: :system do
             click_on t("backoffice.common.reject")
           }.to have_enqueued_mail(UserMailer, :rejected).with(approved_pd_owner).once
           expect(page).to have_text(ReviewStatus.find("rejected").name)
+        end
+      end
+
+      context "when validation errors" do
+        before { approved_pd.account.update_attribute(:picture, nil) }
+
+        it "still flips the status to rejected" do
+          within_row(approved_pd.name) do
+            expect(page).to have_text(ReviewStatus.find("approved").name)
+            click_on t("backoffice.common.reject")
+            expect(page).to have_text(ReviewStatus.find("rejected").name)
+          end
         end
       end
     end
@@ -175,6 +200,30 @@ RSpec.describe "Backoffice: Project Developers", type: :system do
         click_on t("backoffice.common.save")
         expect(page).to have_text(t("backoffice.messages.success_update", model: t("backoffice.common.project_developer")))
         expect(approved_pd.account.reload.review_status).to eq("unapproved")
+      end
+
+      context "when validation errors" do
+        before(:each) do
+          approved_pd.account.unapproved!
+          approved_pd.account.update_attribute(:picture, nil)
+        end
+
+        it "doesn't change the status to approved" do
+          expect(page).to have_text(ReviewStatus.find("unapproved").name)
+          select "Approved", from: t("simple_form.labels.account.review_status")
+          click_on t("backoffice.common.save")
+          expect(page).to have_text(t("simple_form.error_notification.default_message"))
+          expect(page).to have_text("Account picture can't be blank")
+          expect(approved_pd.account.reload.review_status).to eq("unapproved")
+        end
+
+        it "still flips the status to rejected" do
+          expect(page).to have_text(ReviewStatus.find("unapproved").name)
+          select "Rejected", from: t("simple_form.labels.account.review_status")
+          click_on t("backoffice.common.save")
+          expect(page).not_to have_text(t("simple_form.error_notification.default_message"))
+          expect(approved_pd.account.reload.review_status).to eq("rejected")
+        end
       end
     end
 


### PR DESCRIPTION
Some changes to the logic of rejecting / approving accounts in the backoffice, most importantly introduces conditional validations to the account object when rejecting. Not all validations can be made conditional, since some match constraints on the db; the rest of them should not be checked when rejecting an account either from the list or the form in the backoffice.

Validation errors should be displayed when approving an invalid object, i.e. they should be visible on the status tab.

## Testing instructions
Requires to manufacture an invalid object, e.g. directly in db.

In the list (investors / pd's):
- it should be possible to reject an invalid object
- it should not be possible to approve and an error message should be shown

In the form: (investor / pd):
- it should be indicated that picture is mandatory (asterisk)
- on the status tab, it should be possible to reject an invalid object
- on the status tab, it should not be possible to approve an invalid object and validation messaged should be shows

## Tracking

https://vizzuality.atlassian.net/browse/LET-1265
https://vizzuality.atlassian.net/browse/LET-1266
https://vizzuality.atlassian.net/browse/LET-1265
