### PR TITLE
LET-1209 created / updated timestamps in project and open call form

### DIFF
--- a/backend/app/views/backoffice/open_calls/edit.html.erb
+++ b/backend/app/views/backoffice/open_calls/edit.html.erb
@@ -20,6 +20,10 @@
     <% end %>
   </aside>
   <div class="w-full h-full bg-white rounded-xl p-6">
+    <div class="mb-3 flex justify-end gap-3 text-s text-gray-600">
+      <span><%= t("backoffice.common.created") %>: <%= I18n.l @open_call.created_at.to_date %></span>
+      <span><%= t("backoffice.common.updated") %>: <%= I18n.l @open_call.updated_at.to_date %></span>
+    </div>
     <%= render section_partial %>
   </div>
 </div>

--- a/backend/app/views/backoffice/projects/edit.html.erb
+++ b/backend/app/views/backoffice/projects/edit.html.erb
@@ -20,6 +20,10 @@
     <% end %>
   </aside>
   <div class="w-full h-full bg-white rounded-xl p-6">
+    <div class="mb-3 flex justify-end gap-3 text-s text-gray-600">
+      <span><%= t("backoffice.common.created") %>: <%= I18n.l @project.created_at.to_date %></span>
+      <span><%= t("backoffice.common.updated") %>: <%= I18n.l @project.updated_at.to_date %></span>
+    </div>
     <%= render section_partial %>
   </div>
 </div>

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -194,6 +194,8 @@ zu:
         prev: "←"
         next: "→"
         gap: "..."
+      created: Created
+      updated: Updated
     account:
       account_language: Account language
       account_language_description: This is the default language in which all the content is created by the account users.


### PR DESCRIPTION
Timestamps were added in the project and open call forms in backoffice.

<img width="1094" alt="Screenshot 2022-10-26 at 08 53 25" src="https://user-images.githubusercontent.com/134055/197955465-1e3ed0c2-9cd8-44aa-b1ca-4953ca50174c.png">


## Tracking

https://vizzuality.atlassian.net/browse/LET-1209
