### PR TITLE
Display the creation and edition date of projects and open calls

### DIFF
--- a/frontend/containers/multi-page-layout/component.tsx
+++ b/frontend/containers/multi-page-layout/component.tsx
@@ -35,6 +35,8 @@ export const MultiPageLayout: FC<MultiPageLayoutProps> = ({
   children,
   autoNavigation = true,
   footerElements,
+  createdAt,
+  updatedAt,
   onPreviousClick = noop,
   onNextClick = noop,
   onPageClick = noop,
@@ -114,6 +116,8 @@ export const MultiPageLayout: FC<MultiPageLayoutProps> = ({
         locale={locale}
         siteHeader={siteHeader}
         leaveButtonText={leaveButtonText}
+        createdAt={createdAt}
+        updatedAt={updatedAt}
         onCloseClick={onCloseClick}
       />
       <LayoutContainer layout={layout}>

--- a/frontend/containers/multi-page-layout/header/component.tsx
+++ b/frontend/containers/multi-page-layout/header/component.tsx
@@ -5,6 +5,7 @@ import { useIntl, FormattedMessage } from 'react-intl';
 
 import cx from 'classnames';
 
+import dayjs from 'dayjs';
 import { noop } from 'lodash-es';
 
 import Button from 'components/button';
@@ -19,6 +20,8 @@ export const MultiPageLayoutHeader: React.FC<MultiPageLayoutHeaderProps> = ({
   siteHeader = false,
   locale,
   leaveButtonText,
+  createdAt,
+  updatedAt,
   onCloseClick = noop,
 }: MultiPageLayoutHeaderProps) => {
   const intl = useIntl();
@@ -33,15 +36,29 @@ export const MultiPageLayoutHeader: React.FC<MultiPageLayoutHeaderProps> = ({
       })}
     >
       <LayoutContainer>
-        <div className="flex items-center justify-between h-20 gap-x-8 md:gap-x-16">
-          <div className="flex justify-start flex-1">
+        <div className="flex items-center justify-between h-20 gap-x-8 xl:gap-x-16">
+          <div className="flex justify-start flex-shrink-0">
             <span className="font-semibold">HeCo Invest</span>
           </div>
           <LayoutContainer
             layout="narrow"
-            className="flex flex-col items-center justify-between lg:flex-row"
+            className="flex flex-row items-center justify-between gap-x-4"
           >
-            <span>{title}</span>
+            <div className="flex flex-wrap gap-x-4">
+              <span>{title}</span>
+              {!!createdAt && !!updatedAt && (
+                <span className="flex-grow text-gray-700">
+                  <FormattedMessage
+                    defaultMessage="created on {createdDate} updated on {updatedDate}"
+                    id="0b0kmZ"
+                    values={{
+                      createdDate: dayjs(createdAt).format('MMM DD, YYYY'),
+                      updatedDate: dayjs(updatedAt).format('MMM DD, YYYY'),
+                    }}
+                  />
+                </span>
+              )}
+            </div>
             {locale && (
               <span className="px-2 py-1 text-sm text-black rounded-lg lg:py-2 bg-background-dark">
                 <FormattedMessage defaultMessage="Content language" id="zetZX8" />

--- a/frontend/containers/multi-page-layout/header/types.ts
+++ b/frontend/containers/multi-page-layout/header/types.ts
@@ -11,6 +11,10 @@ export interface MultiPageLayoutHeaderProps {
   locale?: LanguageType;
   /** Text to display on top right "Leave" button. Defaults to +Leave` */
   leaveButtonText?: string;
+  /** Date at which the entity was created */
+  createdAt?: string;
+  /** Date of last modification of the entity */
+  updatedAt?: string;
   /** Callback when the close button is pressed */
   onCloseClick?: () => void;
 }

--- a/frontend/containers/multi-page-layout/types.ts
+++ b/frontend/containers/multi-page-layout/types.ts
@@ -33,7 +33,10 @@ export type MultiPageLayoutProps = PropsWithChildren<
     /** Returns the total number of pages */
     getTotalPages?: (totalPages: number) => void;
   } & Pick<LayoutContainerProps, 'layout'> &
-    Pick<MultiPageLayoutHeaderProps, 'title' | 'onCloseClick' | 'leaveButtonText'> &
+    Pick<
+      MultiPageLayoutHeaderProps,
+      'title' | 'onCloseClick' | 'leaveButtonText' | 'createdAt' | 'updatedAt'
+    > &
     Pick<
       MultiPageLayoutFooterProps,
       | 'footerElements'

--- a/frontend/containers/open-call-card/component.tsx
+++ b/frontend/containers/open-call-card/component.tsx
@@ -151,11 +151,22 @@ export const OpenCallCard: FC<OpenCallCardProps> = ({ className, openCall }: Ope
           </div>
         </div>
         <div
-          className="flex items-start flex-grow mt-4"
+          className="flex items-start mt-4"
           aria-label={intl.formatMessage({ defaultMessage: 'Description', id: 'Q8Qw5B' })}
         >
           {truncatedDescription}
         </div>
+        <p className="flex-grow text-xs text-gray-700">
+          <FormattedMessage
+            defaultMessage="Created on <b>{createdDate}</b> and updated on <b>{updatedDate}</b>"
+            id="hwBx6v"
+            values={{
+              b: (chunks: string) => <span className="font-semibold">{chunks}</span>,
+              createdDate: dayjs(openCall.created_at).format('MMM DD, YYYY'),
+              updatedDate: dayjs(openCall.updated_at).format('MMM DD, YYYY'),
+            }}
+          />
+        </p>
         <div
           className="flex items-center justify-between gap-2 mt-2"
           aria-label={intl.formatMessage({

--- a/frontend/containers/open-call-form/component.tsx
+++ b/frontend/containers/open-call-form/component.tsx
@@ -150,6 +150,8 @@ export const OpenCallForm = <MutationType extends BasicMutationType>({
         onNextClick={handleNextClick}
         onPreviousClick={() => setCurrentPage(currentPage - 1)}
         showProgressBar
+        createdAt={openCall?.created_at}
+        updatedAt={openCall?.updated_at}
         onCloseClick={() => setShowLeave(true)}
         onSubmitClick={handleSubmitPublish}
         isLoading={isLoading}

--- a/frontend/containers/open-call-page/header/component.tsx
+++ b/frontend/containers/open-call-page/header/component.tsx
@@ -112,6 +112,17 @@ export const OpenCallHeader: FC<OpenCallHeaderProps> = ({ openCall, instrumentTy
               <p>{openCall.description}</p>
             </div>
             <div className="order-1 md:order-2 w-full flex flex-col justify-start md:mr-4 p-6 bg-white drop-shadow-xl -mb-12 h-full md:w-[395px] -translate-y-32 md:max-w-2/3 rounded-2xl">
+              <p className="mb-4 text-xs text-gray-700">
+                <FormattedMessage
+                  defaultMessage="Created on <b>{createdDate}</b> and updated on <b>{updatedDate}</b>"
+                  id="hwBx6v"
+                  values={{
+                    b: (chunks: string) => <span className="font-semibold">{chunks}</span>,
+                    createdDate: dayjs(openCall.created_at).format('MMM DD, YYYY'),
+                    updatedDate: dayjs(openCall.updated_at).format('MMM DD, YYYY'),
+                  }}
+                />
+              </p>
               <div className="px-2">
                 <div className="flex flex-wrap justify-between gap-8 md:gap-11">
                   <div className="flex flex-col justify-end gap-2 md:items-start">

--- a/frontend/containers/project-details/component.tsx
+++ b/frontend/containers/project-details/component.tsx
@@ -6,6 +6,7 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import Image from 'next/image';
 import Link from 'next/link';
 
+import dayjs from 'dayjs';
 import { noop } from 'lodash-es';
 
 import { projectImpact } from 'helpers/project';
@@ -183,6 +184,17 @@ export const ProjectDetails: FC<ProjectDetailsProps> = ({
         >
           {project.description}
         </div>
+        <p className="mt-2 text-xs text-gray-700">
+          <FormattedMessage
+            defaultMessage="Created on <b>{createdDate}</b> and updated on <b>{updatedDate}</b>"
+            id="hwBx6v"
+            values={{
+              b: (chunks: string) => <span className="font-semibold">{chunks}</span>,
+              createdDate: dayjs(project.created_at).format('MMM DD, YYYY'),
+              updatedDate: dayjs(project.updated_at).format('MMM DD, YYYY'),
+            }}
+          />
+        </p>
         <div
           className="flex items-center mt-4 text-sm text-gray-900"
           aria-label={intl.formatMessage({ defaultMessage: 'Project developer', id: 'yF82he' })}

--- a/frontend/containers/project-form/component.tsx
+++ b/frontend/containers/project-form/component.tsx
@@ -244,6 +244,8 @@ export const ProjectForm: FC<ProjectFormProps> = ({
         onNextClick={handleNextClick}
         onPreviousClick={() => setCurrentPage(currentPage - 1)}
         showProgressBar
+        createdAt={project?.created_at}
+        updatedAt={project?.updated_at}
         onSubmitClick={handleSubmitPublish}
         isLoading={isLoading}
         footerElements={

--- a/frontend/containers/project-page/header/component.tsx
+++ b/frontend/containers/project-page/header/component.tsx
@@ -5,6 +5,8 @@ import { FormattedMessage, useIntl } from 'react-intl';
 
 import cx from 'classnames';
 
+import dayjs from 'dayjs';
+
 import { translatedLanguageNameForLocale } from 'helpers/intl';
 import { useProjectContacts } from 'helpers/project';
 
@@ -146,6 +148,17 @@ export const Header: FC<HeaderProps> = ({ className, project }: HeaderProps) => 
           <p>{project.description}</p>
         </div>
         <div className="lg:mr-4 p-6 bg-white drop-shadow-xl mb-16 lg:mb-[-70%] h-full lg:w-[395px] lg:translate-y-[-70%] lg:max-w-4/12 rounded-2xl mt-8 lg:mt-0 flex flex-col">
+          <p className="mb-4 text-xs text-gray-700">
+            <FormattedMessage
+              defaultMessage="Created on <b>{createdDate}</b> and updated on <b>{updatedDate}</b>"
+              id="hwBx6v"
+              values={{
+                b: (chunks: string) => <span className="font-semibold">{chunks}</span>,
+                createdDate: dayjs(project.created_at).format('MMM DD, YYYY'),
+                updatedDate: dayjs(project.updated_at).format('MMM DD, YYYY'),
+              }}
+            />
+          </p>
           {project.looking_for_funding ? (
             <div className="flex flex-col gap-8 mb-8 md:flex-row">
               <div className="flex flex-col items-start justify-end w-full gap-2 text-center sm:text-left md:min-w-1/2">

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -2472,6 +2472,9 @@
   "huqKGl": {
     "string": "Create account"
   },
+  "hwBx6v": {
+    "string": "Created on <b>{createdDate}</b> and updated on <b>{updatedDate}</b>"
+  },
   "hwNIf9": {
     "string": "Use the ‘Resend email’ button below to resend the verification email in case you don’t receive it. Note that you must wait 30 seconds before resending."
   },

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -134,6 +134,9 @@
   "0ZkvWW": {
     "string": "Amazonian Piedmont - Massif"
   },
+  "0b0kmZ": {
+    "string": "created on {createdDate} updated on {updatedDate}"
+  },
   "0cWjQP": {
     "string": "{title} - page {currentPage} out of {numPages}"
   },

--- a/frontend/types/open-calls.ts
+++ b/frontend/types/open-calls.ts
@@ -22,6 +22,7 @@ export type OpenCall = {
   account_language: Languages;
   trusted: boolean;
   created_at: string;
+  updated_at: string;
   picture: Picture;
   investor: Investor;
   country: Locations;

--- a/frontend/types/project.ts
+++ b/frontend/types/project.ts
@@ -98,6 +98,8 @@ export type Project = ProjectBase &
     trusted?: boolean;
     type: 'project';
     priority_landscape: Locations;
+    created_at: string;
+    updated_at: string;
   };
 
 /** Project Form inputs */


### PR DESCRIPTION
This PR adds changes to display the creation and last edition date of:

- Projects on…
  - … the project public page
  - … the project details card
  - … the project edition form
- Open calls on…
  - … the open call public page
  - … the open call card
  - … the open call edition form

## Testing instructions

- Check that you can see the creation and last edition dates on the places described above
- Check you can still create new projects and open calls

## Tracking

- [LET-1258](https://vizzuality.atlassian.net/browse/LET-1258)
- [LET-1259](https://vizzuality.atlassian.net/browse/LET-1259)
