### PR TITLE
Basic http auth for Rails app - backoffice only

### DIFF
--- a/backend/app/controllers/backoffice/admins/passwords_controller.rb
+++ b/backend/app/controllers/backoffice/admins/passwords_controller.rb
@@ -1,3 +1,4 @@
 class Backoffice::Admins::PasswordsController < Devise::PasswordsController
+  include Backoffice::HttpAuth
   include Backoffice::Localization
 end

--- a/backend/app/controllers/backoffice/admins/sessions_controller.rb
+++ b/backend/app/controllers/backoffice/admins/sessions_controller.rb
@@ -1,4 +1,5 @@
 class Backoffice::Admins::SessionsController < Devise::SessionsController
+  include Backoffice::HttpAuth
   include Backoffice::Localization
 
   # GET

--- a/backend/app/controllers/backoffice/base_controller.rb
+++ b/backend/app/controllers/backoffice/base_controller.rb
@@ -1,5 +1,6 @@
 module Backoffice
   class BaseController < ApplicationController
+    include Backoffice::HttpAuth
     include Pagy::Backend
     include Breadcrumbs
     include Localization

--- a/backend/app/controllers/concerns/backoffice/http_auth.rb
+++ b/backend/app/controllers/concerns/backoffice/http_auth.rb
@@ -1,0 +1,17 @@
+module Backoffice
+  module HttpAuth
+    extend ActiveSupport::Concern
+
+    included do
+      before_action :http_auth
+    end
+
+    def http_auth
+      return unless ENV["HTTP_AUTH_USERNAME"].present? && ENV["HTTP_AUTH_PASSWORD"].present?
+
+      authenticate_or_request_with_http_basic do |username, password|
+        username == ENV["HTTP_AUTH_USERNAME"] && password == ENV["HTTP_AUTH_PASSWORD"]
+      end
+    end
+  end
+end

--- a/backend/spec/requests/backoffice_http_auth_spec.rb
+++ b/backend/spec/requests/backoffice_http_auth_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe "Backoffice http auth", type: :request do
+  describe "GET #backoffice" do
+    context "when no http auth credentials set" do
+      it "returns correct html code" do
+        with_environment("HTTP_AUTH_USERNAME" => "", "HTTP_AUTH_PASSWORD" => "") do
+          get "/backoffice/sign_in"
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+
+    context "when http auth credentials set" do
+      let(:username) { "TEST" }
+      let(:password) { "TEST" }
+
+      it "returns error when credentials not provided" do
+        with_environment("HTTP_AUTH_USERNAME" => username, "HTTP_AUTH_PASSWORD" => password) do
+          get "/backoffice/sign_in", headers: {}
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+
+      it "returns correct html code when credentials provided" do
+        with_environment("HTTP_AUTH_USERNAME" => username, "HTTP_AUTH_PASSWORD" => password) do
+          headers = {"HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic.encode_credentials(username, password)}
+          get "/backoffice/sign_in", headers: headers
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+  end
+end

--- a/backend/spec/support/request_helpers.rb
+++ b/backend/spec/support/request_helpers.rb
@@ -8,4 +8,13 @@ module RequestHelpers
     get "/api/v1/user", headers: headers
     cookies["csrf_token"]
   end
+
+  def with_environment(replacement_env)
+    original_env = ENV.to_hash
+    ENV.update(replacement_env)
+
+    yield
+  ensure
+    ENV.replace(original_env)
+  end
 end


### PR DESCRIPTION
## Testing instructions

If the env vars HTTP_AUTH_PASSWORD and HTTP_AUTH_USERNAME are set, you should be prompted for a login on any backoffice page, but not API, as that will be secured by http auth on the FE.

Note: the reason why I used a `before_action` rather than `http_basic_authenticate_with` is because of the usage of env vars I found it impossible to test otherwise, i.e. regardless if I used stubbing on ENV or the approach of updating ENV for the duration of the test, the ENV vars would not always be reloaded in the context of the controller class action and I gave up.

## Tracking

https://vizzuality.atlassian.net/browse/LET-1277?atlOrigin=eyJpIjoiN2E0MTdhOTg4MmJkNDI3Mjk1YTA3NTM3YTIzZGQ2ODUiLCJwIjoiaiJ9
