### PR TITLE
Improve the responsiveness of the public pages and Discover

### DIFF
--- a/frontend/containers/breadcrumbs/component.tsx
+++ b/frontend/containers/breadcrumbs/component.tsx
@@ -104,7 +104,7 @@ export const Breadcrumbs: FC<BreadcrumbsProps> = ({
     >
       <ol
         className={cx({
-          'text-sm ': true,
+          'text-sm flex': true,
           'text-gray-400': theme === 'dark',
           'text-white': theme === 'light',
         })}
@@ -113,11 +113,14 @@ export const Breadcrumbs: FC<BreadcrumbsProps> = ({
           const isLastBreadcrumb = index === breadcrumbs.length - 1;
 
           return (
-            <li key={name} className="inline ml-3 first-of-type:ml-0">
+            <li
+              key={name}
+              className="ml-3 first-of-type:ml-0 last-of-type:flex-shrink last-of-type:overflow-hidden last-of-type:text-ellipsis"
+            >
               <Link key={link} href={link}>
                 <a
                   className={cx({
-                    'transition-all rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-dark':
+                    'transition-all rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-dark whitespace-nowrap':
                       true,
                     'cursor-pointer': isLastBreadcrumb,
                     'text-black': isLastBreadcrumb && theme === 'dark',

--- a/frontend/containers/sdgs/component.tsx
+++ b/frontend/containers/sdgs/component.tsx
@@ -4,42 +4,48 @@ import cx from 'classnames';
 
 import Image from 'next/image';
 
+import { useBreakpoint } from 'hooks/use-breakpoint';
+
 import Tooltip from 'components/tooltip';
 
 import { SDGS_SIZES, SDGS_IMAGES } from './constants';
 import { SDGsProps } from './types';
 
-export const SDGs: FC<SDGsProps> = ({ className, size = 'small', sdgs = [] }: SDGsProps) => (
-  <div className={cx('flex flex-wrap items-center gap-2', className)}>
-    {sdgs.map((sdg) => (
-      <Fragment key={sdg.id}>
-        <Tooltip
-          arrow
-          arrowClassName="bg-black"
-          content={
-            <div className="max-w-xs p-2 font-sans text-sm font-normal text-white bg-black rounded-sm">
-              {sdg.name}
-            </div>
-          }
-        >
-          <div
-            // This removes an extra space displayed below the image when the container wraps
-            className="flex"
+export const SDGs: FC<SDGsProps> = ({ className, size = 'small', sdgs = [] }: SDGsProps) => {
+  const screenLargerThanSm = useBreakpoint()('sm');
+
+  return (
+    <div className={cx('grid grid-cols-3 sm:flex sm:flex-wrap sm:items-center gap-2', className)}>
+      {sdgs.map((sdg) => (
+        <Fragment key={sdg.id}>
+          <Tooltip
+            arrow
+            arrowClassName="bg-black"
+            content={
+              <div className="max-w-xs p-2 font-sans text-sm font-normal text-white bg-black rounded-sm">
+                {sdg.name}
+              </div>
+            }
           >
-            <Image
-              className="rounded"
-              src={SDGS_IMAGES[sdg.id]}
-              alt={sdg.name}
-              width={SDGS_SIZES[size]}
-              height={SDGS_SIZES[size]}
-              layout="intrinsic"
-              quality={100}
-            />
-          </div>
-        </Tooltip>
-      </Fragment>
-    ))}
-  </div>
-);
+            <div
+              // This removes an extra space displayed below the image when the container wraps
+              className="sm:flex"
+            >
+              <Image
+                className="rounded"
+                src={SDGS_IMAGES[sdg.id]}
+                alt={sdg.name}
+                width={SDGS_SIZES[size]}
+                height={SDGS_SIZES[size]}
+                layout={screenLargerThanSm ? 'intrinsic' : 'responsive'}
+                quality={100}
+              />
+            </div>
+          </Tooltip>
+        </Fragment>
+      ))}
+    </div>
+  );
+};
 
 export default SDGs;

--- a/frontend/pages/discover/investors.tsx
+++ b/frontend/pages/discover/investors.tsx
@@ -51,18 +51,25 @@ const InvestorsPage: PageComponent<InvestorsPageProps, DiscoverPageLayoutProps> 
   return (
     <>
       <Head title={intl.formatMessage({ defaultMessage: 'Discover Investors', id: 'nWf75J' })} />
-      <div className="flex flex-col w-full h-full pb-2 lg:p-1 lg:-m-1 lg:gap-0 lg:overflow-hidden lg:flex-row">
-        <div className="relative flex flex-col w-full lg:overflow-hidden ">
+      <div className="flex h-full">
+        <div className="relative flex flex-col w-full lg:overflow-hidden">
           <div
             ref={investorsContainerRef}
             className={cx({
-              'relative flex-grow lg:pr-2.5': true,
+              'relative flex-grow': true,
               'lg:overflow-y-auto': !loading,
               'lg:pointer-events-none lg:overflow-hidden': loading,
             })}
           >
             {loading && (
-              <span className="absolute bottom-0 z-20 flex items-center justify-center bg-gray-600 bg-opacity-20 top-1 left-1 right-3 rounded-2xl">
+              <span
+                className={cx({
+                  'flex items-center justify-center bg-gray-600 bg-opacity-20': true,
+                  'absolute bottom-0.5 md:bottom-0 z-20 top-0.5 left-0.5 right-0.5 border':
+                    hasInvestors,
+                  'my-40': !hasInvestors,
+                })}
+              >
                 <Loading visible={loading} iconClassName="w-10 h-10" />
               </span>
             )}

--- a/frontend/pages/discover/open-calls.tsx
+++ b/frontend/pages/discover/open-calls.tsx
@@ -62,7 +62,7 @@ const OpenCallsPage: PageComponent<OpenCallsPageProps, DiscoverPageLayoutProps> 
   return (
     <>
       <Head title={intl.formatMessage({ defaultMessage: 'Discover Open Calls', id: 'Y9+L0O' })} />
-      <div className="flex flex-col w-full h-full pb-2 lg:p-1 lg:-m-1 lg:gap-0 lg:overflow-hidden lg:flex-row">
+      <div className="flex h-full">
         <div className="relative flex flex-col w-full lg:overflow-hidden ">
           <DiscoverNotice className="mb-1" isVisible={showNotice} onClose={handleCloseNoticeClick}>
             <FormattedMessage
@@ -73,13 +73,20 @@ const OpenCallsPage: PageComponent<OpenCallsPageProps, DiscoverPageLayoutProps> 
           <div
             ref={openCallsContainerRef}
             className={cx({
-              'relative flex-grow lg:pr-2.5': true,
+              'relative flex-grow': true,
               'lg:overflow-y-auto': !loading,
               'lg:pointer-events-none lg:overflow-hidden': loading,
             })}
           >
             {loading && (
-              <span className="absolute bottom-0 z-20 flex items-center justify-center bg-gray-600 bg-opacity-20 top-1 left-1 right-3 rounded-2xl">
+              <span
+                className={cx({
+                  'flex items-center justify-center bg-gray-600 bg-opacity-20': true,
+                  'absolute bottom-0.5 md:bottom-0 z-20 top-0.5 left-0.5 right-0.5 border':
+                    hasOpenCalls,
+                  'my-40': !hasOpenCalls,
+                })}
+              >
                 <Loading visible={loading} iconClassName="w-10 h-10" />
               </span>
             )}

--- a/frontend/pages/discover/project-developers.tsx
+++ b/frontend/pages/discover/project-developers.tsx
@@ -53,18 +53,25 @@ const ProjectDevelopersPage: PageComponent<ProjectDevelopersPageProps, DiscoverP
       <Head
         title={intl.formatMessage({ defaultMessage: 'Discover Project Developers', id: '2qzivP' })}
       />
-      <div className="flex flex-col w-full h-full pb-2 lg:p-1 lg:-m-1 lg:gap-0 lg:overflow-hidden lg:flex-row">
+      <div className="flex h-full">
         <div className="relative flex flex-col w-full lg:overflow-hidden ">
           <div
             ref={projectDevelopersContainerRef}
             className={cx({
-              'relative flex-grow lg:pr-2.5': true,
+              'relative flex-grow': true,
               'lg:overflow-y-auto': !loading,
               'lg:pointer-events-none lg:overflow-hidden': loading,
             })}
           >
             {loading && (
-              <span className="absolute bottom-0 z-20 flex items-center justify-center bg-gray-600 bg-opacity-20 top-1 left-1 right-3 rounded-2xl">
+              <span
+                className={cx({
+                  'flex items-center justify-center bg-gray-600 bg-opacity-20': true,
+                  'absolute bottom-0.5 md:bottom-0 z-20 top-0.5 left-0.5 right-0.5 border':
+                    hasProjectDevelopers,
+                  'my-40': !hasProjectDevelopers,
+                })}
+              >
                 <Loading visible={loading} iconClassName="w-10 h-10" />
               </span>
             )}

--- a/frontend/pages/discover/projects.tsx
+++ b/frontend/pages/discover/projects.tsx
@@ -123,7 +123,7 @@ const ProjectsPage: PageComponent<ProjectsPageProps, DiscoverPageLayoutProps> = 
                 <span
                   className={cx({
                     ' flex items-center justify-center bg-gray-600 bg-opacity-20': true,
-                    'absolute bottom-0.5 md:bottom-0 z-20 top-0.5 left-0.5 right-0.5 md:right-3 border':
+                    'absolute bottom-0.5 md:bottom-0 z-20 top-0.5 left-0.5 right-0.5 border':
                       hasProjects,
                     'my-40': !hasProjects,
                   })}

--- a/frontend/pages/discover/projects.tsx
+++ b/frontend/pages/discover/projects.tsx
@@ -105,22 +105,29 @@ const ProjectsPage: PageComponent<ProjectsPageProps, DiscoverPageLayoutProps> = 
   return (
     <>
       <Head title={intl.formatMessage({ defaultMessage: 'Discover Projects', id: 'Qt/+mk' })} />
-      <div className="relative flex flex-col w-full h-full md:gap-0 md:overflow-hidden md:flex-row">
+      <div className="relative flex flex-col w-full h-full md:gap-4 md:overflow-hidden md:flex-row">
         <div
           ref={projectsListAndDetailsContainerRef}
-          className="flex flex-col md:top-1 md:bottom-1 md:absolute md:w-full"
+          className="relative flex flex-col flex-shrink-0 md:w-5/12"
         >
-          <div className="relative flex flex-col md:overflow-hidden md:w-5/12">
+          <div className="relative flex flex-col md:overflow-hidden">
             <div
               ref={projectsListContainerRef}
               className={cx({
-                'relative flex-grow md:pr-2.5': true,
+                'relative flex-grow': true,
                 'md:overflow-y-auto': !loading,
                 'md:pointer-events-none md:overflow-hidden': loading,
               })}
             >
               {loading && (
-                <span className="absolute bottom-0 z-20 flex items-center justify-center bg-gray-600 bg-opacity-20 top-1 left-1 right-3 rounded-2xl">
+                <span
+                  className={cx({
+                    ' flex items-center justify-center bg-gray-600 bg-opacity-20': true,
+                    'absolute bottom-0.5 md:bottom-0 z-20 top-0.5 left-0.5 right-0.5 md:right-3 border':
+                      hasProjects,
+                    'my-40': !hasProjects,
+                  })}
+                >
                   <Loading visible={loading} iconClassName="w-10 h-10" />
                 </span>
               )}
@@ -152,19 +159,17 @@ const ProjectsPage: PageComponent<ProjectsPageProps, DiscoverPageLayoutProps> = 
                   autoFocus
                 >
                   <motion.div
-                    className="z-20"
+                    className="z-20 absolute top-0.5 left-full w-[53vw] lg:w-[45vw] xl:w-full bottom-3 "
                     transition={{ duration: 0.15 }}
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: 1 }}
+                    initial={{ opacity: 0, x: -20 }}
+                    animate={{ opacity: 1, x: 0 }}
                     exit={{ opacity: 0 }}
                   >
-                    <aside className="absolute top-0 z-10 w-7/12 xl:w-5/12 mt-1 mb-0 -ml-2.5 left-5/12 bottom-1 rounded-2xl">
-                      <div className="max-h-full overflow-y-auto bg-white border rounded-2xl">
-                        <ProjectDetails
-                          project={selectedProject}
-                          onClose={handleProjectDetailsClose}
-                        />
-                      </div>
+                    <aside className="max-h-full overflow-y-auto translate-x-1 bg-white border rounded-2xl">
+                      <ProjectDetails
+                        project={selectedProject}
+                        onClose={handleProjectDetailsClose}
+                      />
                     </aside>
                   </motion.div>
                 </FocusScope>
@@ -185,7 +190,7 @@ const ProjectsPage: PageComponent<ProjectsPageProps, DiscoverPageLayoutProps> = 
             </Modal>
           )}
         </div>
-        <aside className="flex-grow hidden min-h-full m-1 overflow-hidden bg-white sm:block rounded-2xl md:min-h-0 md:absolute md:right-0 md:w-7/12 md:bottom-1 md:top-1">
+        <aside className="flex-grow hidden overflow-hidden bg-white sm:block rounded-2xl md:mt-0.5 md:mb-3">
           <DiscoverMap onSelectProjectPin={handleProjectCardClick} />
         </aside>
       </div>


### PR DESCRIPTION
This PR improves the responsiveness of:

- **Breadcrumbs**: on mobile, they are always displayed on one line only and with an ellipsis if the text is too long
- **SDGs**: on mobile, they are always displayed in a 3-column layout
- **Discover**:
	- the spinning loader is now fully visible on mobile and its background is aligned with the cards
	- the general layouts have been updated to fix alignment issues

## Testing instructions

Check the responsiveness of the public pages and Discover. Make sure the scrollbars do not break the layout on Discover.

## Tracking

[LET-1287](https://vizzuality.atlassian.net/browse/LET-1287)

This PR makes changes to the Discover page that were not tracked by the task. 
