### PR TITLE
Fix the visibility of the Discover's filters panel on Chrome (Android)

### DIFF
--- a/frontend/containers/forms/filters/component.tsx
+++ b/frontend/containers/forms/filters/component.tsx
@@ -122,13 +122,13 @@ export const Filters: FC<FiltersProps> = ({ closeFilters, filtersData, filters }
       id="filters"
       role="region"
       aria-labelledby="filters-button"
-      className="w-full bg-white border-t-2 border-t-gray-200 sm:rounded-b-3xl h-[calc(100vh-56px)] sm:h-auto"
+      className="flex-grow w-full overflow-hidden bg-white border-t-2 sm:absolute border-t-gray-200 sm:rounded-b-3xl"
     >
       {!filters ? (
         <Loading />
       ) : (
         <form
-          className="relative flex flex-col justify-between h-full p-6"
+          className="relative flex flex-col justify-between h-full overflow-hidden"
           onSubmit={handleSubmit(onSubmitFilters)}
         >
           <Button
@@ -142,7 +142,7 @@ export const Filters: FC<FiltersProps> = ({ closeFilters, filtersData, filters }
             </span>
             <CloseIcon className="w-4 h-4 transition-transform rotate-0 hover:rotate-180" />
           </Button>
-          <div className="overflow-y-auto">
+          <div className="p-6 pb-0 overflow-y-auto">
             {/* VERIFICATION FILTERS: HIDDEN
             <div className="flex justify-between">
               <div className="flex items-center mb-4">
@@ -287,7 +287,7 @@ export const Filters: FC<FiltersProps> = ({ closeFilters, filtersData, filters }
               />
             </p>
           </div>
-          <div className="flex-shrink-0 w-screen p-4 -mb-6 -ml-6 bg-white sm:items-center sm:justify-between sm:flex sm:gap-2 sm:mb-0 sm:ml-0 sm:w-auto shadow-lg-top sm:shadow-none sm: sm:p-0 sm:relative sm:pt-4">
+          <div className="flex-shrink-0 p-4 sm:items-center sm:justify-between sm:flex sm:gap-2 sm:mb-0 sm:ml-0 sm:w-auto shadow-lg-top sm:shadow-none sm: sm:p-6 sm:relative sm:pt-4">
             <p className="hidden mb-4 text-sm text-gray-600 sm:block sm:mb-0">
               <FormattedMessage
                 defaultMessage="Note: Some filters not apply to all tabs"

--- a/frontend/containers/layouts/discover-search/component.tsx
+++ b/frontend/containers/layouts/discover-search/component.tsx
@@ -105,19 +105,21 @@ export const DiscoverSearch: FC<DiscoverSearchProps> = ({ className }) => {
     >
       <div
         className={cx(
-          'sm:relative sm:z-10 sm:w-full sm:overflow-visible text-black bg-white drop-shadow-xl',
+          'sm:relative sm:z-10 sm:w-full sm:overflow-visible text-black drop-shadow-xl',
           {
-            'rounded-full': !openFilters || !showSuggestion,
-            'sm:rounded-3xl': showActiveFilters,
-            'sm:rounded-t-3xl sm:rounded-b-none mb-0 h-14 sm:h-16 fixed left-0 top-0 w-screen rounded-none':
+            'mb-0 fixed left-0 top-0 w-screen h-full sm:h-auto flex flex-col sm:block':
               showSuggestion || openFilters,
           }
         )}
       >
         <div
-          className={cx(
-            'flex h-full min-h-[56px] sm:min-h-[64px] items-center justify-between pl-4 pr-2 sm:px-6 py-2 sm:gap-4'
-          )}
+          className={cx({
+            'flex-shrink-0 flex h-14 sm:h-16 items-center justify-between pl-4 pr-2 sm:px-6 py-2 sm:gap-4 bg-white':
+              true,
+            'rounded-full': !openFilters && !showSuggestion,
+            'sm:rounded-t-3xl sm:rounded-b-none':
+              showSuggestion || openFilters || showActiveFilters,
+          })}
         >
           <form
             role="search"

--- a/frontend/layouts/discover-page/component.tsx
+++ b/frontend/layouts/discover-page/component.tsx
@@ -124,7 +124,7 @@ export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
         <div className="z-10 h-min">
           <Header />
           <LayoutContainer className="z-10 flex justify-center mt-1 pointer-events-none sm:pt-1 sm:mb-2 xl:pb-0 xl:mb-0 xl:-mt-10 xl:left-0 xl:right-0 xl:relative">
-            <DiscoverSearch className="w-full max-w-3xl pointer-events-auto -z-10" />
+            <DiscoverSearch className="w-full max-w-3xl pointer-events-auto" />
           </LayoutContainer>
         </div>
         <main


### PR DESCRIPTION
This PR fixes an issue where the action buttons of the filters panel (Discover) wouldn't be fully visible on Chrome on Android.

## Testing instructions

- Make sure that the search bar, filters panel and active filters panel look good on all screen sizes.
- Make sure that the filters panel is not cut off at the bottom on Chrome on Android.

## Tracking

[LET-1288](https://vizzuality.atlassian.net/browse/LET-1288)
