### PR TITLE
Fix bugs related to the search on Discover

### DIFF
--- a/frontend/containers/forms/active-filters/component.tsx
+++ b/frontend/containers/forms/active-filters/component.tsx
@@ -23,7 +23,7 @@ export const ActiveFilters: FC<ActiveFilterProps> = ({ filters = {}, filtersData
     () =>
       Object.entries(transformFilterParamsToInputs(filters)).reduce((prev, [key, value]) => {
         const filters =
-          value?.length > 0
+          (Array.isArray(value) && value?.length > 0) || (!Array.isArray(value) && !!value)
             ? filtersData.filter((data) => data.type === key && value.includes(data.id))
             : [];
 

--- a/frontend/containers/forms/filters/types.ts
+++ b/frontend/containers/forms/filters/types.ts
@@ -18,11 +18,17 @@ export type FilterParams = {
   'filter[impact]': string;
 };
 
+// These filters are represented by checkboxes. React Hook Form sends their values as follows:
+// - `T` if there's only one checkbox with a specific `name` and it is checkcked
+// - `false` if there's only one checkbox with a specific `name` and it is not checked
+// - `T[]` if there are multiple checkboxes with the same `name` (checked or not)
+type FilterFormValue<T> = T | T[] | false;
+
 export type FilterForm = {
-  category: string[];
-  instrument_type: string[];
-  ticket_size: string[];
+  category: FilterFormValue<string>;
+  instrument_type: FilterFormValue<string>;
+  ticket_size: FilterFormValue<string>;
   // only_verified: boolean; VERIFICATION FILTERS: HIDDEN
-  sdg: string[];
-  impact: string[];
+  sdg: FilterFormValue<string>;
+  impact: FilterFormValue<string>;
 };

--- a/frontend/containers/layouts/discover-search/component.tsx
+++ b/frontend/containers/layouts/discover-search/component.tsx
@@ -232,6 +232,7 @@ export const DiscoverSearch: FC<DiscoverSearchProps> = ({ className }) => {
             filters={filters}
             searchText={searchInputValue}
             closeSuggestions={() => {
+              setSearchInputValue('');
               setShowSuggestions(false);
             }}
           />

--- a/frontend/containers/search-auto-suggestion/component.tsx
+++ b/frontend/containers/search-auto-suggestion/component.tsx
@@ -39,6 +39,7 @@ export const SearchAutoSuggestion: FC<SeachAutoSuggestionProps> = ({
   const handleFilterSuggestion = () => {
     const newFilterParams = transformFilterInputsToParams(getValues());
     doSearch(undefined, newFilterParams);
+    closeSuggestions();
   };
 
   const handleSearchSuggestion = () => {

--- a/frontend/helpers/pages.ts
+++ b/frontend/helpers/pages.ts
@@ -169,7 +169,7 @@ export const transformFilterInputsToParams = (filterInputs: Partial<FilterForm>)
   Object.entries(filterInputs).forEach(([key, value]) => {
     // Just send the used filters
     if (value) {
-      filterParams[`filter[${key}]`] = `${value.join(',')}`;
+      filterParams[`filter[${key}]`] = Array.isArray(value) ? `${value.join(',')}` : value;
     }
   });
   return filterParams;

--- a/frontend/helpers/pages.ts
+++ b/frontend/helpers/pages.ts
@@ -121,13 +121,13 @@ export const useFiltersEnums = () => {
     if (isLoading) {
       return [];
     }
+
     const { category, ticket_size, instrument_type, impact, sdg } = data;
+
     return [
-      category,
-      ticket_size,
-      instrument_type,
-      impact,
-      sdg,
+      ...[category, ticket_size, instrument_type, impact, sdg].map((item) =>
+        Array.isArray(item) ? item : []
+      ),
       priorityLandscapes?.map(({ id, name }) => ({
         id,
         // A bit hacky but the priority landscapes are not enums. It was assumed that filters


### PR DESCRIPTION
This PR fixes 3 issues related to the search on Discover:

- If the user would search a term that would suggest only one filter, then nothing would happen if they clicked on it
- The suggestion box would not close after selecting a suggested filter
- The application would crash when navigating or opening a link to Discover that would include a filter

## Testing instructions

1. Go to Discover
2. Type “bio” in the search box
3. Click the “Biodiversity” filter suggestion

The suggestions list must close and the “Active filters” panel must show the filter you just selected.

4. Reload the page

The filter must still be selected.

## Tracking

- [LET-1289](https://vizzuality.atlassian.net/browse/LET-1289)
- [LET-1290](https://vizzuality.atlassian.net/browse/LET-1290)
