### PR TITLE
LET-1241 Explicit error reporting from jobs instance

### DIFF
--- a/backend/app/jobs/application_job.rb
+++ b/backend/app/jobs/application_job.rb
@@ -13,6 +13,7 @@ class ApplicationJob < ActiveJob::Base
     yield
   rescue Exception => e # rubocop:disable Lint/RescueException
     upsert_event self, status: :crashed, message: e.backtrace
+    Google::Cloud::ErrorReporting.report e
     raise e
   end
 

--- a/backend/config/initializers/google_cloud_error_reporting.rb
+++ b/backend/config/initializers/google_cloud_error_reporting.rb
@@ -2,4 +2,5 @@ require "google/cloud/error_reporting"
 
 Google::Cloud.configure do |config|
   config.project_id = ENV["GCP_PROJECT_ID"]
+  config.service_name = [ENV["INSTANCE_ROLE"], ENV["IS_JOBS_INSTANCE"].to_s == "true" ? "JOBS" : ""].join("-")
 end


### PR DESCRIPTION
According to Tiago's findings, when using reporting directly from the jobs instance, exceptions get captured in the error reporting interface. So I'm adding this directly to ApplicationJob, even if it seems that it should not be necessary.

## Tracking

https://vizzuality.atlassian.net/browse/LET-1241?atlOrigin=eyJpIjoiN2FmZTU1ZTRhZWFhNDFhZGIwODgyZDhlMjMxNmQ1NjQiLCJwIjoiaiJ9
