### PR TITLE
Manually keep track of changed attributes, which get wiped out in aft…

### DIFF
--- a/backend/app/models/concerns/translatable.rb
+++ b/backend/app/models/concerns/translatable.rb
@@ -4,6 +4,8 @@ module Translatable
   included do
     attr_accessor :skip_translation
 
+    after_save :store_changed_attributes
+    after_commit :clear_changed_attributes # this will execute last
     after_commit :translate_attributes, on: [:create, :update], unless: :skip_translation
   end
 
@@ -19,16 +21,24 @@ module Translatable
     end
   end
 
+  def store_changed_attributes
+    @stored_changed_attrs ||= []
+    @stored_changed_attrs += translatable_attributes.each_with_object([]) do |attr, res|
+      res << attr if previous_changes.key?("#{attr}_#{language}")
+    end
+  end
+
+  def clear_changed_attributes
+    @stored_changed_attrs = nil
+  end
+
   # From the Rails docs: The after_commit and after_rollback callbacks are called for all models created, updated,
   # or destroyed within a transaction block. - in our case we have Investor / Account or PD / Account
   # However, if an exception is raised within one of these callbacks, the exception will bubble up and any remaining
   # after_commit or after_rollback methods will not be executed. As such, if your callback code could raise an exception,
   # you'll need to rescue it and handle it within the callback in order to allow other callbacks to run.
   def translate_attributes
-    changed_attrs = translatable_attributes.each_with_object([]) do |attr, res|
-      res << attr if public_send "saved_change_to_#{attr}_#{language}?"
-    end
-    TranslateJob.perform_later id, self.class.name, changed_attrs: changed_attrs if changed_attrs.present?
+    TranslateJob.perform_later(id, self.class.name, changed_attrs: @stored_changed_attrs) if @stored_changed_attrs.present?
   rescue Exception => e # rubocop:disable Lint/RescueException
     Google::Cloud::ErrorReporting.report e
   end

--- a/backend/spec/requests/api/v1/accounts/project_developers_spec.rb
+++ b/backend/spec/requests/api/v1/accounts/project_developers_spec.rb
@@ -111,17 +111,23 @@ RSpec.describe "API V1 Account Project Developers", type: :request do
 
         before(:each) { sign_in user }
 
-        run_test!
-
-        it "matches snapshot", generate_swagger_example: true do
+        it "matches snapshot", generate_swagger_example: true do |example|
+          submit_request example.metadata
           expect(response.body).to match_snapshot("api/v1/accounts-project-developer-create")
         end
 
-        it "saves data to correct language" do
+        it "saves data to correct language" do |example|
+          submit_request example.metadata
           project_developer = ProjectDeveloper.find response_json["data"]["id"]
           ProjectDeveloper.translatable_attributes.each do |attr|
             expect(project_developer.public_send("#{attr}_#{project_developer_params[:language]}")).to eq(project_developer_params[attr])
           end
+        end
+
+        it "queues translation job" do |example|
+          expect {
+            submit_request example.metadata
+          }.to have_enqueued_job(TranslateJob).at_least(:once)
         end
       end
 


### PR DESCRIPTION
It's the "content not translated" bug again 🐛 , except it morphed 🐉 .

After we switched "after_save" to "after_commit", projects content gets translated OK, but account / project developer content - not at all. I finally managed to reproduce this locally and now my new working hypothesis is that our method for checking if there's anything that needs translating is not effective in an `after_commit`, because dirty state gets overwritten by multiple saves (e.g. there's a timestamp touch on account after saving project developer) and it ends up not enqueuing the job because "nothing changed".

This solution uses an instance variable to keep track of changed attributes. By the way this happens when creating / updating via controller, so model / service level specs didn't catch this - I added a request spec.

## Tracking

https://vizzuality.atlassian.net/browse/LET-1172?atlOrigin=eyJpIjoiN2JkNzUzZDQ3NDQ4NGMxMWI1NWEyODQ5MDhkOGQ4YTYiLCJwIjoiaiJ9
