### PR TITLE
Fix a bug preventing the user from using the homepage's search bar

### DIFF
--- a/frontend/helpers/pages.ts
+++ b/frontend/helpers/pages.ts
@@ -143,8 +143,8 @@ export const useFiltersEnums = () => {
 
 /** Hook to change the page's query */
 export const useSearch = () => {
-  const { push } = useRouter();
-  const pathname = useDiscoverPath();
+  const { pathname, push } = useRouter();
+  const discoverPathname = useDiscoverPath();
   const { page, sorting, search, ...filters } = useQueryParams();
 
   return (newSearch?: string, newFilters?: Partial<FilterParams>) =>
@@ -156,10 +156,10 @@ export const useSearch = () => {
           sorting: sorting || null,
           ...(newFilters || filters),
         }),
-        pathname,
+        pathname: discoverPathname,
       },
       undefined,
-      { shallow: true }
+      { shallow: pathname === discoverPathname }
     );
 };
 


### PR DESCRIPTION
This PR fixes an issue that prevents the user from accessing the Discover page after performing a search on the homepage. The issue is a regression from #678.

The homepage's search bar has also some layout issues which will be fixed as part of [LET-1297](https://vizzuality.atlassian.net/browse/LET-1297)

## Testing instructions

1. Go to the homepage
2. Type something into the search bar
3. Press enter

You must be brought to the Discover page and the search must be applied as expected.

## Tracking

[LET-1291](https://vizzuality.atlassian.net/browse/LET-1291)
