### PR TITLE
Fix issues with the search bar on the homepage and Discover

### DIFF
--- a/frontend/containers/home/hero/component.tsx
+++ b/frontend/containers/home/hero/component.tsx
@@ -21,13 +21,11 @@ export const Hero = () => {
           />
         </p>
       </div>
-      <LayoutContainer className="sm:mt-5 md:mt-9">
-        <div className="relative z-10 sm:mx-auto sm:max-w-2xl md:max-w-4xl h-[4.5rem] translate-y-1/2 flex justify-center items-center w-full">
-          <DiscoverSearch
-            className="w-full"
-            searchButtonText={<FormattedMessage id="oG/A0q" defaultMessage="See full catalogue" />}
-          />
-        </div>
+      <LayoutContainer className="flex items-center justify-center h-0 sm:mt-5 md:mt-9 xl:relative sm:mx-auto pt-14">
+        <DiscoverSearch
+          className="w-full sm:max-w-2xl md:max-w-4xl"
+          searchButtonText={<FormattedMessage id="oG/A0q" defaultMessage="See full catalogue" />}
+        />
       </LayoutContainer>
     </div>
   );

--- a/frontend/containers/layouts/discover-search/component.tsx
+++ b/frontend/containers/layouts/discover-search/component.tsx
@@ -99,7 +99,8 @@ export const DiscoverSearch: FC<DiscoverSearchProps> = ({ className }) => {
 
   return (
     <div
-      className={cx('z-50', {
+      className={cx({
+        'z-50 sm:z-auto': showSuggestion || openFilters,
         [className]: !!className,
       })}
     >

--- a/frontend/containers/search-auto-suggestion/component.tsx
+++ b/frontend/containers/search-auto-suggestion/component.tsx
@@ -68,10 +68,7 @@ export const SearchAutoSuggestion: FC<SeachAutoSuggestionProps> = ({
       id="filters"
       role="region"
       aria-labelledby="filters-button"
-      className={cx('w-full bg-white border-t-2 border-t-gray-200 h-[calc(100vh-56px)] sm:h-auto', {
-        'rounded-b-3xl': !selectedFilters?.length,
-        'sm:rounded-b-none': !!selectedFilters?.length,
-      })}
+      className="w-full bg-white border-t-2 border-t-gray-200 h-[calc(100vh-56px)] sm:h-auto sm:absolute sm:rounded-b-3xl"
     >
       {searchText?.length >= 1 && (
         <div className="h-full px-4 py-2 sm:py-5 sm:px-9">

--- a/frontend/layouts/discover-page/component.tsx
+++ b/frontend/layouts/discover-page/component.tsx
@@ -123,8 +123,8 @@ export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
       <div className="flex flex-col h-screen sm:overflow-auto bg-gradient-to-t from-background-green-dark to-background-green-dark bg-[length:100%_164px] bg-no-repeat sm:bg-none">
         <div className="z-10 h-min">
           <Header />
-          <LayoutContainer className="z-10 flex justify-center mt-1 pointer-events-none sm:pt-1 sm:mb-2 xl:pb-0 xl:mb-0 xl:-mt-10 xl:left-0 xl:right-0 xl:relative">
-            <DiscoverSearch className="w-full max-w-3xl pointer-events-auto" />
+          <LayoutContainer className="z-10 flex justify-center mt-1 sm:pt-1 sm:mb-2 xl:pb-0 xl:mb-0 xl:-mt-10 xl:left-0 xl:right-0 xl:relative">
+            <DiscoverSearch className="w-full max-w-3xl" />
           </LayoutContainer>
         </div>
         <main


### PR DESCRIPTION
This PR fixes two main issues with the search bar:

- On the homepage and Discover, the search suggestions list would break the layout of the page.
- On the homepage, the search suggestions list and filters list wouldn't be displayed correctly on mobile.

## Testing instructions

1. Go to the homepage
2. Type in the search bar

Make sure the bar is not moved from its original place.

3. Go to Discover
4. Type in the search bar

Make sure the list of projects and map are not moved downward.

5. Open the homepage on Chrome on Android **(*)**
6. Type in the search bar or open the list of filters

Make sure the suggestions list or filters list is displayed full screen.

**(*)** The application will crash locally because of CORS errors. Reload the page when that happens.

## Tracking

- [LET-1297](https://vizzuality.atlassian.net/browse/LET-1297)
- First point of [LET-1292](https://vizzuality.atlassian.net/browse/LET-1292)
