### PR TITLE
Fix full screen layout issues on Chrome (Android)

### DIFF
--- a/frontend/layouts/discover-page/component.tsx
+++ b/frontend/layouts/discover-page/component.tsx
@@ -119,8 +119,8 @@ export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
   });
 
   return (
-    <div className="fixed top-0 bottom-0 left-0 right-0 h-screen bg-background-dark">
-      <div className="flex flex-col h-screen sm:overflow-auto bg-gradient-to-t from-background-green-dark to-background-green-dark bg-[length:100%_164px] bg-no-repeat sm:bg-none">
+    <div className="fixed top-0 bottom-0 left-0 right-0 h-full bg-background-dark">
+      <div className="flex flex-col h-full sm:overflow-auto bg-gradient-to-t from-background-green-dark to-background-green-dark bg-[length:100%_164px] bg-no-repeat sm:bg-none">
         <div className="z-10 h-min">
           <Header />
           <LayoutContainer className="z-10 flex justify-center mt-1 pointer-events-none sm:pt-1 sm:mb-2 xl:pb-0 xl:mb-0 xl:-mt-10 xl:left-0 xl:right-0 xl:relative">

--- a/frontend/pages/discover/projects.tsx
+++ b/frontend/pages/discover/projects.tsx
@@ -184,7 +184,7 @@ const ProjectsPage: PageComponent<ProjectsPageProps, DiscoverPageLayoutProps> = 
               })}
               open={!!selectedProject}
               onDismiss={handleProjectDetailsClose}
-              className="w-screen h-screen !max-h-screen rounded-none sm:rounded-lg left-0"
+              className="w-screen h-screen !max-h-full rounded-none sm:rounded-lg left-0"
             >
               <ProjectDetails project={selectedProject} onClose={handleProjectDetailsClose} />
             </Modal>


### PR DESCRIPTION
This PR fixes two issues affecting mobile layout on Chrome and Android:

1. The project preview card (on Discover) was cut at the top and bottom of the screen
2. The pagination component (also on Discover) was cut at the bottom of the screen

## Testing instructions

The test must be done on an Android device and not Chrome's simulator. You can follow the steps here: https://developer.chrome.com/docs/devtools/remote-debugging/

1. Open Chrome on your Android device
2. Go to Discover
3. Click on a project

The preview card must not be cut at the top nor bottom.

4. Close the preview card
5. Scroll at the bottom of the page

The pagination component must be fully visible.

## Tracking

[LET-1292](https://vizzuality.atlassian.net/browse/LET-1292)
