### PR TITLE
Improve Discover's content tabs on mobile

### DIFF
--- a/frontend/layouts/discover-page/navigation/component.tsx
+++ b/frontend/layouts/discover-page/navigation/component.tsx
@@ -57,8 +57,18 @@ export const Navigation: FC<NavigationProps> = ({ stats }: NavigationProps) => {
   const activeId = navigationItems.find(({ path }) => asPath.startsWith(path))?.id;
 
   return (
-    <div className="flex overflow-x-auto">
-      <BadgeNavigation activeId={activeId} items={navigationItems} />
+    <div
+      // The `relative`, `-mx-4` and `sm:mx-0` classes are used by the before and after
+      // pseudo-elements of the `<BadgeNavigation />` component below
+      className="relative flex -mx-4 overflow-x-auto sm:mx-0"
+    >
+      <BadgeNavigation
+        activeId={activeId}
+        items={navigationItems}
+        // The `before:*` and `after:*` classes are used to fade out the navigation items on the
+        // sides on mobile
+        className="px-4 sm:px-0 before:absolute before:left-0 before:top-0 before:w-4 before:h-[calc(100%_-_theme(spacing.2))] before:bg-gradient-to-r before:via-background-green-dark/70 before:from-background-green-dark before:to-transparent before:z-10 after:absolute after:right-0 after:top-0 after:w-4 after:h-[calc(100%_-_theme(spacing.2))] after:bg-gradient-to-l after:via-background-green-dark/70 after:from-background-green-dark after:to-transparent after:z-10 sm:before:hidden sm:after:hidden"
+      />
     </div>
   );
 };

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,4 +1,5 @@
 const colors = require('tailwindcss/colors');
+const plugin = require('tailwindcss/plugin');
 
 module.exports = {
   content: ['./**/*.ts', './**/*.tsx'],
@@ -109,5 +110,18 @@ module.exports = {
   plugins: [
     // Use the overflow-elispis with more lines
     require('@tailwindcss/line-clamp'),
+    // Borrowed from https://github.com/tailwindlabs/tailwindcss/pull/5732
+    plugin(function ({ addUtilities }) {
+      addUtilities({
+        '.scrollbar-auto': { 'scrollbar-width': 'auto' },
+        '.scrollbar-thin': { 'scrollbar-width': 'thin' },
+        '.scrollbar-none': {
+          'scrollbar-width': 'none',
+          '&::-webkit-scrollbar': {
+            display: 'none',
+          },
+        },
+      });
+    }),
   ],
 };


### PR DESCRIPTION
This PR makes some changes to the tabs on Discover on mobile so that:

- The scrollbar is hidden
- The tabs are auto scrolled when active (towards the left mostly)
- The tabs are faded out on the sides of the screen

## Testing instructions

1. Open Discover
2. Reduce the viewport size to less than 640px wide
3. Click on any tab

Make sure that:

- the tab you clicked on is moved (as much as possible) towards the left edge of the screen
- there is no scrollbar for the tabs
- the tabs are faded on the sides of the screen

## Tracking

[LET-1293](https://vizzuality.atlassian.net/browse/LET-1293)
