### PR TITLE
Fix Discover's main navigation items not fully clickable

### DIFF
--- a/frontend/layouts/discover-page/component.tsx
+++ b/frontend/layouts/discover-page/component.tsx
@@ -123,7 +123,7 @@ export const DiscoverPageLayout: FC<DiscoverPageLayoutProps> = ({
       <div className="flex flex-col h-full sm:overflow-auto bg-gradient-to-t from-background-green-dark to-background-green-dark bg-[length:100%_164px] bg-no-repeat sm:bg-none">
         <div className="z-10 h-min">
           <Header />
-          <LayoutContainer className="z-10 flex justify-center mt-1 sm:pt-1 sm:mb-2 xl:pb-0 xl:mb-0 xl:-mt-10 xl:left-0 xl:right-0 xl:relative">
+          <LayoutContainer className="z-10 flex justify-center mt-1 sm:pt-1 sm:mb-2 xl:pb-0 xl:mb-0 xl:-mt-10">
             <DiscoverSearch className="w-full max-w-3xl" />
           </LayoutContainer>
         </div>


### PR DESCRIPTION
This PR fixes an issue on Desktop where the user would not be able to click on any part of Discover's main navigation items to trigger their action.

## Testing instructions

1. Go to Discover
2. Try to click on the bottom part of the logo, language menu, account menu (if logged in) and hamburger menu

You should be able to perform the action of each of the items listed above by clicking their bottom part.

## Tracking

[LET-1298](https://vizzuality.atlassian.net/browse/LET-1298)
