### PR TITLE
LET-1302 fix issue with concurent executions of migrations on api dep…

### DIFF
--- a/infrastructure/base/modules/env/main.tf
+++ b/infrastructure/base/modules/env/main.tf
@@ -157,9 +157,17 @@ module "backend_build" {
       entrypoint = "gcloud"
       args       = [
         "run", "deploy", "${var.project_name}-jobs", "--image", "gcr.io/${var.gcp_project_id}/backend:${var.tag}",
-        "--region", var.gcp_region
+        "--region", var.gcp_region, "--max-instances", "1", "--no-traffic"
       ]
-    }
+    },
+    {
+      name       = "gcr.io/google.com/cloudsdktool/cloud-sdk"
+      entrypoint = "gcloud"
+      args       = [
+        "run", "deploy", "${var.project_name}-jobs", "--image", "gcr.io/${var.gcp_project_id}/backend:${var.tag}",
+        "--region", var.gcp_region, "--max-instances", var.backend_max_scale
+      ]
+    },
   ]
 }
 


### PR DESCRIPTION
This adds an extra step to the api deployment. It first deploys a version with a single instance and not traffic. Once that's done, it deploys the "standard" number of instances while accepting traffic. hopefully it will work, because I can't think of alternatives