### PR TITLE
Fix missing visual clue when navigating to Discover and the Account information page on the client

### DIFF
--- a/frontend/layouts/discover-page/navigation/component.tsx
+++ b/frontend/layouts/discover-page/navigation/component.tsx
@@ -15,7 +15,7 @@ import { NavigationProps } from './types';
 
 export const Navigation: FC<NavigationProps> = ({ stats }: NavigationProps) => {
   const intl = useIntl();
-  const { asPath } = useRouter();
+  const { pathname } = useRouter();
 
   // Pick the the query params we want to preserve in the navigation links (search, filters). The page and sorting will always change to default when changing tabs.
   const queryString = useQueryString({
@@ -54,7 +54,7 @@ export const Navigation: FC<NavigationProps> = ({ stats }: NavigationProps) => {
     },
   ];
 
-  const activeId = navigationItems.find(({ path }) => asPath.startsWith(path))?.id;
+  const activeId = navigationItems.find(({ path }) => pathname.startsWith(path))?.id;
 
   return (
     <div className="flex overflow-x-auto">

--- a/frontend/layouts/settings/navigation/component.tsx
+++ b/frontend/layouts/settings/navigation/component.tsx
@@ -13,7 +13,7 @@ import { NavigationProps } from './types';
 
 export const Navigation: FC<NavigationProps> = ({ className, userRole }: NavigationProps) => {
   const intl = useIntl();
-  const { asPath } = useRouter();
+  const { pathname } = useRouter();
 
   const links = useMemo(
     () => [
@@ -32,8 +32,8 @@ export const Navigation: FC<NavigationProps> = ({ className, userRole }: Navigat
   );
 
   const activeLinkId = useMemo(
-    () => links.find(({ id }) => asPath.startsWith(id))?.id,
-    [asPath, links]
+    () => links.find(({ id }) => pathname.startsWith(id))?.id,
+    [pathname, links]
   );
 
   return (


### PR DESCRIPTION
This PR fixes the following two issues:

- When navigating client-side to the Discover page, the “Projects” tab wouldn't be highlighted
- When navigating client-side to the Account information page, the “Information” tab wouldn't be highlighted

The issue was introduced in #678 and stems either from the Next.js upgrade or the addition of the middleware. Either way, [Next.js' documentation](https://nextjs.org/docs/api-reference/next.config.js/redirects) now states that the client-side redirection will not occur unless there is a middleware with a matching path:
 
>Redirects are not applied to client-side routing (Link, router.push), unless [Middleware](https://nextjs.org/docs/advanced-features/middleware) is present and matches the path.

In order to avoid further potential issues, I'm not modifying the middleware itself but changed how we detect the active tab instead. The only drawback is that when navigating on the client, the URL is not updated to `/discover/projects` (from `/discover`) and `/settings/information` (from `/settings`) automatically.

## Testing instructions

1. Go to the homepage
2. Click the magnifying glass icon (or “Search”) menu item in the main navigation

The Discover page must load and the “Projects” tab be active.

3. Log in
4. Click on the account profile menu item (the circle with the initials)
5. Click on “My preferences”

You must be brought to the Account information page and the “Information” tab must be highlighted.

## Tracking

[LET-1300](https://vizzuality.atlassian.net/browse/LET-1300)
