### PR TITLE
Fire Google Analytics events for specific actions

### DIFF
--- a/frontend/components/badge-navigation/component.tsx
+++ b/frontend/components/badge-navigation/component.tsx
@@ -18,6 +18,7 @@ export const BadgeNavigation: FC<BadgeNavigationProps> = ({
   badgePosition = 'right',
   activeId,
   items,
+  onClick,
 }: BadgeNavigationProps) => {
   const isMobile = !useBreakpoint()('sm');
 
@@ -105,6 +106,7 @@ export const BadgeNavigation: FC<BadgeNavigationProps> = ({
                 })}
               >
                 <Link href={link}>
+                  {/* eslint-disable-next-line jsx-a11y/anchor-is-valid, jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
                   <a
                     className={cx({
                       'relative inline-flex focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2':
@@ -116,6 +118,7 @@ export const BadgeNavigation: FC<BadgeNavigationProps> = ({
                       'rounded-full': type === 'pill',
                     })}
                     aria-current={isActive ? 'location' : false}
+                    onClick={() => onClick(id)}
                   >
                     <Tag
                       border={false}

--- a/frontend/components/badge-navigation/types.ts
+++ b/frontend/components/badge-navigation/types.ts
@@ -20,4 +20,6 @@ export type BadgeNavigationProps = {
   activeId?: string;
   /** Navigation items array */
   items: BadgeNavigationType[];
+  /** Callback executed when the user clicks on an item */
+  onClick?: (id: BadgeNavigationType['id']) => void;
 };

--- a/frontend/containers/discover-map/component.tsx
+++ b/frontend/containers/discover-map/component.tsx
@@ -19,6 +19,7 @@ import ZoomControl from 'components/map/controls/zoom';
 import ClusterLayer from 'components/map/layers/cluster';
 import { Legend, LegendType } from 'components/map/legend/types';
 import ProjectMapPin from 'components/project-map-pin';
+import { logEvent } from 'lib/analytics/ga';
 import { ProjectMapParams } from 'types/project';
 
 import { useProjectsMap } from 'services/projects/projectService';
@@ -106,11 +107,14 @@ export const DiscoverMap: FC<DiscoverMapProps> = ({ onSelectProjectPin }) => {
   }, [layerLegends]);
 
   const handleChangeVisibleLayer = (e: ChangeEvent<HTMLInputElement>) => {
-    // The layer inputs are groups of checkboxes. To limit one value per group, the value is always updated to an array of one item with the last selected value. If the checkbox is already selected (the user unchecked the checkbox), the field is reseted.
+    // The layer inputs are groups of checkboxes. To limit one value per group, the value is always
+    // updated to an array of one item with the last selected value. If the checkbox is already
+    // selected (the user unchecked the checkbox), the field is reseted.
     const { name, value } = e.currentTarget;
     if (visibleLayers.includes(value)) {
       resetField(name as keyof MapLayersSelectorForm);
     } else {
+      logEvent('layer_toggled', { layer_name: value });
       setValue(name as keyof MapLayersSelectorForm, [value]);
     }
   };

--- a/frontend/containers/discover-map/location-searcher/component.tsx
+++ b/frontend/containers/discover-map/location-searcher/component.tsx
@@ -12,6 +12,7 @@ import { useOutsideClick } from 'rooks';
 import Button from 'components/button';
 import Icon from 'components/icon';
 import Loading from 'components/loading';
+import { logEvent } from 'lib/analytics/ga';
 
 import SearchIcon from 'svgs/search.svg';
 import CloseIcon from 'svgs/ui/close.svg';
@@ -49,12 +50,22 @@ export const LocationSearcher: FC<LocationSearcherProps> = ({ className, onLocat
   };
 
   const handleSelectAddress = (newAddress: string) => {
+    console.log('address', address);
+    console.log('newAddress', newAddress);
     setIsFocused(false);
     setAddress(newAddress);
     setAddressSetted(true);
 
     geocodeByAddress(newAddress)
       .then((results) => {
+        logEvent('map_search', {
+          // `user_input` is either what the user has typed (if they pressed the enter key to
+          // trigger the search) or the suggestion they selected (if they used the arrow keys or
+          // clicked a suggestion)
+          user_input: newAddress,
+          final_location: results[0].formatted_address,
+        });
+
         getLatLng(results[0]);
         const { bounds } = results[0].geometry;
         const NELat = bounds.getNorthEast().lat();

--- a/frontend/containers/for-public-pages/public-page-card/component.tsx
+++ b/frontend/containers/for-public-pages/public-page-card/component.tsx
@@ -25,6 +25,7 @@ export const PublicPageCard: FC<PublicPageCardProps> = ({
   filterName,
   onMouseEnter,
   onMouseLeave,
+  onClick,
 }) => {
   return (
     <div
@@ -60,9 +61,18 @@ export const PublicPageCard: FC<PublicPageCardProps> = ({
           )}
         </p>
         {!!filterName && (
-          <Button theme="naked" to={`${Paths.Discover}/${cardType}/?filter[${filterName}]=${id}`}>
+          <Button
+            theme="naked"
+            to={`${Paths.Discover}/${cardType}/?filter[${filterName}]=${id}`}
+            onClick={onClick}
+          >
             <span className="sr-only">
-              <FormattedMessage defaultMessage="See projects" id="q6rG+e" />
+              {cardType === 'projects' && (
+                <FormattedMessage defaultMessage="See projects" id="q6rG+e" />
+              )}
+              {cardType === 'investors' && (
+                <FormattedMessage defaultMessage="See investors" id="ctc1sP" />
+              )}
             </span>
             <Icon
               icon={ArrowIcon}

--- a/frontend/containers/for-public-pages/public-page-card/types.ts
+++ b/frontend/containers/for-public-pages/public-page-card/types.ts
@@ -17,4 +17,6 @@ export type PublicPageCardProps = {
   onMouseEnter?: () => void;
   /** Callback executed when the cursor leaves the card */
   onMouseLeave?: () => void;
+  /** Callback executed when the user clicks on the card's button */
+  onClick?: () => void;
 };

--- a/frontend/containers/forms/filters/types.ts
+++ b/frontend/containers/forms/filters/types.ts
@@ -22,6 +22,7 @@ export type FilterParams = {
 // - `T` if there's only one checkbox with a specific `name` and it is checkcked
 // - `false` if there's only one checkbox with a specific `name` and it is not checked
 // - `T[]` if there are multiple checkboxes with the same `name` (checked or not)
+// The filter suggestions list may render only one checkbox
 type FilterFormValue<T> = T | T[] | false;
 
 export type FilterForm = {
@@ -31,4 +32,5 @@ export type FilterForm = {
   // only_verified: boolean; VERIFICATION FILTERS: HIDDEN
   sdg: FilterFormValue<string>;
   impact: FilterFormValue<string>;
+  priority_landscape: FilterFormValue<string>;
 };

--- a/frontend/containers/investor-form/component.tsx
+++ b/frontend/containers/investor-form/component.tsx
@@ -22,6 +22,7 @@ import LeaveFormModal from 'containers/leave-form-modal';
 import MultiPageLayout, { Page, OutroPage } from 'containers/multi-page-layout';
 
 import Head from 'components/head';
+import { logEvent } from 'lib/analytics/ga';
 import { InvestorForm as InvestorFormType } from 'types/investor';
 import useValidation, { formPageInputs } from 'validations/investor';
 
@@ -84,7 +85,12 @@ const InvestorForm: FC<InvestorFormProps> = ({
       mutation.mutate(values, {
         onError: handleServiceErrors,
         onSuccess: () => {
-          !isCreateForm ? onComplete() : setCurrentPage(currentPage + 1);
+          if (!isCreateForm) {
+            onComplete();
+          } else {
+            logEvent('account_creation', { account_type: 'investor' });
+            setCurrentPage(currentPage + 1);
+          }
         },
       });
     } else {

--- a/frontend/containers/layouts/discover-search/component.tsx
+++ b/frontend/containers/layouts/discover-search/component.tsx
@@ -25,6 +25,7 @@ import SearchAutoSuggestion from 'containers/search-auto-suggestion';
 import Button from 'components/button';
 import Icon from 'components/icon';
 import { Paths } from 'enums';
+import { logEvent } from 'lib/analytics/ga';
 
 import FilterIcon from 'svgs/discover/filters.svg';
 
@@ -56,6 +57,11 @@ export const DiscoverSearch: FC<DiscoverSearchProps> = ({ className }) => {
 
   const handleSubmitSearch = (e: SyntheticEvent) => {
     e.preventDefault();
+
+    logEvent(pathname !== Paths.Home ? 'discover_type_search' : 'homepage_type_search', {
+      search_term: searchInputValue,
+    });
+
     doSearch(searchInputValue, filters);
     setShowSuggestions(false);
     setOpenFilters(false);

--- a/frontend/containers/open-call-page/header/component.tsx
+++ b/frontend/containers/open-call-page/header/component.tsx
@@ -19,6 +19,7 @@ import Button from 'components/button';
 import Icon from 'components/icon';
 import LayoutContainer from 'components/layout-container';
 import { Languages, OpenCallStatus, UserRoles } from 'enums';
+import { logEvent } from 'lib/analytics/ga';
 import languages from 'locales.config.json';
 
 import { useAccount } from 'services/account';
@@ -38,6 +39,7 @@ export const OpenCallHeader: FC<OpenCallHeaderProps> = ({ openCall, instrumentTy
 
   const {
     id,
+    slug,
     name,
     instrument_types,
     maximum_funding_per_project,
@@ -69,7 +71,12 @@ export const OpenCallHeader: FC<OpenCallHeaderProps> = ({ openCall, instrumentTy
   }, [closing_at, created_at, locale]);
 
   const handleFavoriteClick = () => {
-    // This mutation uses a 'DELETE' request when the isFavorite is true, and a 'POST' request when is false.
+    if (!favourite) {
+      logEvent('click_favorite', { category_name: 'open-call', slug: slug });
+    }
+
+    // This mutation uses a 'DELETE' request when the isFavorite is true, and a 'POST' request when
+    // is false.
     favoriteOpenCall.mutate({ id, isFavourite: favourite });
   };
 

--- a/frontend/containers/open-call-page/investor/component.tsx
+++ b/frontend/containers/open-call-page/investor/component.tsx
@@ -12,6 +12,7 @@ import Button from 'components/button';
 import Icon from 'components/icon';
 import LayoutContainer from 'components/layout-container';
 import { OpenCallStatus, Paths, UserRoles } from 'enums';
+import { logEvent } from 'lib/analytics/ga';
 
 import { useAccount } from 'services/account';
 import { useFavoriteOpenCall } from 'services/open-call/open-call-service';
@@ -26,7 +27,12 @@ export const OpenCallInvestorAndFooter: FC<OpenCallInvestorProps> = ({ openCall 
   const { investor } = openCall;
 
   const handleFavoriteClick = () => {
-    // This mutation uses a 'DELETE' request when the isFavorite is true, and a 'POST' request when is false.
+    if (!openCall.favourite) {
+      logEvent('click_favorite', { category_name: 'open-call', slug: openCall.slug });
+    }
+
+    // This mutation uses a 'DELETE' request when the isFavorite is true, and a 'POST' request when
+    // is false.
     favoriteOpenCall.mutate({ id: openCall.id, isFavourite: openCall.favourite });
   };
 

--- a/frontend/containers/profile-header/component.tsx
+++ b/frontend/containers/profile-header/component.tsx
@@ -18,6 +18,7 @@ import WebsiteSocial from 'containers/social-contact/website-social';
 import Button from 'components/button';
 import Icon from 'components/icon';
 import LayoutContainer from 'components/layout-container';
+import { logEvent } from 'lib/analytics/ga';
 
 import { useAccount } from 'services/account';
 
@@ -25,6 +26,8 @@ import type { ProfileHeaderProps } from './types';
 
 export const ProfileHeader: FC<ProfileHeaderProps> = ({
   className,
+  type,
+  slug,
   logo: logoProp,
   title,
   subtitle,
@@ -137,7 +140,10 @@ export const ProfileHeader: FC<ProfileHeaderProps> = ({
               className="flex-grow-[3] md:flex-grow-[10] md:max-w-[200px] justify-center px-6"
               theme="primary-green"
               disabled={!contact?.phone && !contact?.email}
-              onClick={() => setIsContactInfoModalOpen(true)}
+              onClick={() => {
+                logEvent('click_contact', { category_name: type, slug });
+                setIsContactInfoModalOpen(true);
+              }}
             >
               <FormattedMessage defaultMessage="Contact" id="zFegDD" />
             </Button>

--- a/frontend/containers/profile-header/types.ts
+++ b/frontend/containers/profile-header/types.ts
@@ -6,6 +6,10 @@ import { LanguageType } from 'types';
 export type ProfileHeaderProps = {
   /** Classnames to apply to the container */
   className?: string;
+  /** Type of profile */
+  type: 'project-developer' | 'investor';
+  /** Slug of the project developer/investor */
+  slug: string;
   /** Logo to display */
   logo?: string;
   /** Title to display */
@@ -22,7 +26,7 @@ export type ProfileHeaderProps = {
   projectsWaitingFunding?: number;
   /** Number of projects */
   totalProjects?: number;
-  /** Contact information for the project developer */
+  /** Contact information for the project developer/investor */
   contact?: ContactItemType;
   /** Callback for when the favorite button is clicked */
   onFavoriteClick?: () => void;

--- a/frontend/containers/project-details/component.tsx
+++ b/frontend/containers/project-details/component.tsx
@@ -20,6 +20,7 @@ import Button from 'components/button';
 import Tag from 'components/tag';
 import { Paths } from 'enums';
 import { ImpactAreas } from 'enums';
+import { logEvent } from 'lib/analytics/ga';
 import { CategoryType } from 'types/category';
 import { Enum } from 'types/enums';
 
@@ -82,7 +83,12 @@ export const ProjectDetails: FC<ProjectDetailsProps> = ({
   const favoriteProject = useFavoriteProject();
 
   const handleFavoriteClick = () => {
-    // This mutation uses a 'DELETE' request when the isFavorite is true, and a 'POST' request when is false.
+    if (!project.favourite) {
+      logEvent('click_favorite', { category_name: 'project', slug: project.slug });
+    }
+
+    // This mutation uses a 'DELETE' request when the isFavorite is true, and a 'POST' request when
+    // is false.
     favoriteProject.mutate(
       { id: project.id, isFavourite: project.favourite },
       {

--- a/frontend/containers/project-details/favorite-contact/component.tsx
+++ b/frontend/containers/project-details/favorite-contact/component.tsx
@@ -18,6 +18,7 @@ import ContactInformationModal from 'containers/social-contact/contact-informati
 import Button from 'components/button';
 import Icon from 'components/icon';
 import { Paths } from 'enums';
+import { logEvent } from 'lib/analytics/ga';
 
 import { FavoriteContactProps } from './types';
 
@@ -39,7 +40,10 @@ export const FavoriteContact: FC<FavoriteContactProps> = ({
             disabled={!user || !contacts.length}
             className="px-4 py-2 text-sm sm:px-6 sm:py-2"
             theme="primary-green"
-            onClick={() => setIsContactInfoModalOpen(true)}
+            onClick={() => {
+              logEvent('click_contact', { category_name: 'project', slug: project.slug });
+              setIsContactInfoModalOpen(true);
+            }}
           >
             <FormattedMessage defaultMessage="Contact" id="zFegDD" />
           </Button>

--- a/frontend/containers/project-developer-form/component.tsx
+++ b/frontend/containers/project-developer-form/component.tsx
@@ -19,6 +19,7 @@ import MultiPageLayout, { Page, OutroPage } from 'containers/multi-page-layout';
 
 import Head from 'components/head';
 import { LocationsTypes } from 'enums';
+import { logEvent } from 'lib/analytics/ga';
 import { ProjectDeveloperSetupForm } from 'types/projectDeveloper';
 import useProjectDeveloperValidation, { formPageInputs } from 'validations/project-developer';
 
@@ -95,7 +96,12 @@ export const ProjectDeveloperForm: FC<ProjectDeveloperFormProps> = ({
       mutation.mutate(values, {
         onError: handleServiceErrors,
         onSuccess: () => {
-          !isCreateForm ? onComplete() : setCurrentPage(currentPage + 1);
+          if (!isCreateForm) {
+            onComplete();
+          } else {
+            logEvent('account_creation', { account_type: 'project-developer' });
+            setCurrentPage(currentPage + 1);
+          }
         },
       });
     } else {

--- a/frontend/containers/project-page/contact/component.tsx
+++ b/frontend/containers/project-page/contact/component.tsx
@@ -9,6 +9,7 @@ import ContactInformationModal from 'containers/social-contact/contact-informati
 
 import Button from 'components/button';
 import LayoutContainer from 'components/layout-container';
+import { logEvent } from 'lib/analytics/ga';
 
 export const Contact: React.FC<ContactProps> = ({ project }: ContactProps) => {
   const [isContactInfoModalOpen, setIsContactInfoModalOpen] = useState<boolean>(false);
@@ -35,7 +36,10 @@ export const Contact: React.FC<ContactProps> = ({ project }: ContactProps) => {
           theme="primary-white"
           size="base"
           className="flex justify-center w-full py-3 sm:w-auto"
-          onClick={() => setIsContactInfoModalOpen(true)}
+          onClick={() => {
+            logEvent('click_contact', { category_name: 'project', slug: project.slug });
+            setIsContactInfoModalOpen(true);
+          }}
         >
           <FormattedMessage defaultMessage="Contact" id="zFegDD" />
         </Button>

--- a/frontend/containers/project-page/header/component.tsx
+++ b/frontend/containers/project-page/header/component.tsx
@@ -215,7 +215,10 @@ export const Header: FC<HeaderProps> = ({ className, project }: HeaderProps) => 
               className="flex-grow-[3] md:flex-grow-[10] md:max-w-[200px] justify-center px-6"
               disabled={!contacts?.length}
               theme="primary-green"
-              onClick={() => setIsContactInfoModalOpen(true)}
+              onClick={() => {
+                logEvent('click_contact', { category_name: 'project', slug: project.slug });
+                setIsContactInfoModalOpen(true);
+              }}
             >
               <FormattedMessage defaultMessage="Contact" id="zFegDD" />
             </Button>

--- a/frontend/containers/project-page/header/component.tsx
+++ b/frontend/containers/project-page/header/component.tsx
@@ -18,6 +18,7 @@ import ContactInformationModal from 'containers/social-contact/contact-informati
 import Button from 'components/button';
 import Icon from 'components/icon';
 import LayoutContainer from 'components/layout-container';
+import { logEvent } from 'lib/analytics/ga';
 import { CategoryType } from 'types/category';
 
 import { useAccount } from 'services/account';
@@ -75,7 +76,12 @@ export const Header: FC<HeaderProps> = ({ className, project }: HeaderProps) => 
   const contacts = useProjectContacts(project);
 
   const handleFavoriteClick = () => {
-    // This mutation uses a 'DELETE' request when the isFavorite is true, and a 'POST' request when is false.
+    if (!project.favourite) {
+      logEvent('click_favorite', { category_name: 'project', slug: project.slug });
+    }
+
+    // This mutation uses a 'DELETE' request when the isFavorite is true, and a 'POST' request when
+    // is false.
     favoriteProject.mutate({ id: project.id, isFavourite: project.favourite });
   };
 

--- a/frontend/containers/search-auto-suggestion/component.tsx
+++ b/frontend/containers/search-auto-suggestion/component.tsx
@@ -5,6 +5,8 @@ import { FormattedMessage } from 'react-intl';
 
 import cx from 'classnames';
 
+import { useRouter } from 'next/router';
+
 import {
   transformFilterInputsToParams,
   transformFilterParamsToInputs,
@@ -15,7 +17,8 @@ import { FilterForm } from 'containers/forms/filters/types';
 
 import Button from 'components/button';
 import Tag from 'components/forms/tag';
-import { EnumTypes } from 'enums';
+import { EnumTypes, Paths } from 'enums';
+import { logEvent } from 'lib/analytics/ga';
 
 import { SeachAutoSuggestionProps } from './types';
 
@@ -25,6 +28,8 @@ export const SearchAutoSuggestion: FC<SeachAutoSuggestionProps> = ({
   filtersData,
   closeSuggestions,
 }) => {
+  const { pathname } = useRouter();
+
   const selectedFilters = useMemo(() => Object.values(filters), [filters]);
   const doSearch = useSearch();
 
@@ -43,6 +48,10 @@ export const SearchAutoSuggestion: FC<SeachAutoSuggestionProps> = ({
   };
 
   const handleSearchSuggestion = () => {
+    logEvent(pathname !== Paths.Home ? 'discover_type_search' : 'homepage_type_search', {
+      search_term: searchText,
+    });
+
     doSearch(searchText, filters);
     closeSuggestions();
   };

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -2154,6 +2154,9 @@
   "cdeA3/": {
     "string": "Investor email"
   },
+  "ctc1sP": {
+    "string": "See investors"
+  },
   "ctfKNN": {
     "string": "Set your priorities and HeCo Invest will connect you with the best opportunities."
   },

--- a/frontend/layouts/discover-page/navigation/component.tsx
+++ b/frontend/layouts/discover-page/navigation/component.tsx
@@ -8,6 +8,7 @@ import { useQueryString } from 'helpers/pages';
 
 import BadgeNavigation from 'components/badge-navigation';
 import { Paths } from 'enums';
+import { logEvent } from 'lib/analytics/ga';
 
 import { defaultSorting } from '../helpers';
 
@@ -17,7 +18,8 @@ export const Navigation: FC<NavigationProps> = ({ stats }: NavigationProps) => {
   const intl = useIntl();
   const { asPath } = useRouter();
 
-  // Pick the the query params we want to preserve in the navigation links (search, filters). The page and sorting will always change to default when changing tabs.
+  // Pick the the query params we want to preserve in the navigation links (search, filters). The
+  // page and sorting will always change to default when changing tabs.
   const queryString = useQueryString({
     page: null,
     sorting: `${defaultSorting.sortBy} ${defaultSorting.sortOrder}`,
@@ -68,6 +70,7 @@ export const Navigation: FC<NavigationProps> = ({ stats }: NavigationProps) => {
         // The `before:*` and `after:*` classes are used to fade out the navigation items on the
         // sides on mobile
         className="px-4 sm:px-0 before:absolute before:left-0 before:top-0 before:w-4 before:h-[calc(100%_-_theme(spacing.2))] before:bg-gradient-to-r before:via-background-green-dark/70 before:from-background-green-dark before:to-transparent before:z-10 after:absolute after:right-0 after:top-0 after:w-4 after:h-[calc(100%_-_theme(spacing.2))] after:bg-gradient-to-l after:via-background-green-dark/70 after:from-background-green-dark after:to-transparent after:z-10 sm:before:hidden sm:after:hidden"
+        onClick={(id) => logEvent('click_tab_in_catalogue', { tab_name: id })}
       />
     </div>
   );

--- a/frontend/lib/analytics/ga.ts
+++ b/frontend/lib/analytics/ga.ts
@@ -1,13 +1,11 @@
-export const GA_TRACKING_ID = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS;
-
-// log the pageview with their URL
-export const GAPage = (url: string): void => {
-  window.gtag('config', GA_TRACKING_ID, {
-    page_path: url,
-  });
-};
-
-// log specific events happening.
-export const GAEvent = ({ action, params }): void => {
-  window.gtag('event', action, params);
+/**
+ * Log an event in Google Analytics
+ */
+export const logEvent = (
+  name: string,
+  params?: Record<string, string | number | boolean>
+): void => {
+  if (typeof window !== 'undefined' && window.gtag) {
+    window.gtag('event', name, params);
+  }
 };

--- a/frontend/pages/_document.tsx
+++ b/frontend/pages/_document.tsx
@@ -2,8 +2,6 @@
 import type { DocumentContext, DocumentInitialProps } from 'next/document';
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 
-import { GA_TRACKING_ID } from 'lib/analytics/ga';
-
 class MyDocument extends Document {
   static async getInitialProps(ctx: DocumentContext): Promise<DocumentInitialProps> {
     const initialProps = await Document.getInitialProps(ctx);
@@ -14,22 +12,6 @@ class MyDocument extends Document {
     return (
       <Html>
         <Head>
-          {/* Global site tag (gtag.js) - Google Analytics */}
-          {/* When re-enabling Google Analytics, please make it GDPR complient i.e. it can't be
-          loaded until the user has approved the use of cookies for that purpose. */}
-          {/* <script async src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`} /> */}
-          <script
-            dangerouslySetInnerHTML={{
-              __html: `
-                window.dataLayer = window.dataLayer || [];
-                function gtag(){dataLayer.push(arguments);}
-                gtag('js', new Date());
-                gtag('config', '${GA_TRACKING_ID}', {
-                  page_path: window.location.pathname,
-                });
-              `,
-            }}
-          />
           <link rel="icon" type="image/png" href="/favicon-512x512.png" sizes="512x512" />
           <link rel="icon" type="image/png" href="/favicon-192x192.png" sizes="192x192" />
           <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32" />

--- a/frontend/pages/for-investors.tsx
+++ b/frontend/pages/for-investors.tsx
@@ -23,6 +23,7 @@ import ImpactModal from 'containers/modals/impact';
 import Head from 'components/head';
 import LayoutContainer from 'components/layout-container';
 import { StaticPageLayoutProps } from 'layouts/static-page';
+import { logEvent } from 'lib/analytics/ga';
 import { PageComponent } from 'types';
 import { Enum } from 'types/enums';
 import { Locations } from 'types/locations';
@@ -256,6 +257,7 @@ const ForInvestorsPage: PageComponent<ForInvestorsPageProps, StaticPageLayoutPro
                   cardType="projects"
                   enumType="category"
                   filterName="category"
+                  onClick={() => logEvent('for_investors_card', { card_name: id })}
                 />
               </div>
             );
@@ -331,6 +333,7 @@ const ForInvestorsPage: PageComponent<ForInvestorsPageProps, StaticPageLayoutPro
                   filterName="priority_landscape"
                   onMouseEnter={() => setHoveredPriorityLandscapeCode(code)}
                   onMouseLeave={() => setHoveredPriorityLandscapeCode(null)}
+                  onClick={() => logEvent('for_investors_card', { card_name: code })}
                 />
               );
             })}

--- a/frontend/pages/for-project-developers.tsx
+++ b/frontend/pages/for-project-developers.tsx
@@ -23,6 +23,7 @@ import ImpactModal from 'containers/modals/impact';
 import Head from 'components/head';
 import LayoutContainer from 'components/layout-container';
 import { StaticPageLayoutProps } from 'layouts/static-page';
+import { logEvent } from 'lib/analytics/ga';
 import { PageComponent } from 'types';
 import { Enum } from 'types/enums';
 import { Investor } from 'types/investor';
@@ -234,6 +235,7 @@ const ForProjectDevelopers: PageComponent<ForProjectDevelopersProps, StaticPageL
                   filterName="ticket_size"
                   enumType="ticket_size"
                   cardType="investors"
+                  onClick={() => logEvent('for_PD_card', { card_name: id })}
                 />
               </div>
             );
@@ -283,6 +285,7 @@ const ForProjectDevelopers: PageComponent<ForProjectDevelopersProps, StaticPageL
                   cardType="investors"
                   filterName="category"
                   enumType="category"
+                  onClick={() => logEvent('for_PD_card', { card_name: id })}
                 />
               </div>
             );

--- a/frontend/pages/investor/[id]/index.tsx
+++ b/frontend/pages/investor/[id]/index.tsx
@@ -18,6 +18,7 @@ import TagsGrid, { TagsGridRowType } from 'containers/tags-grid';
 import Head from 'components/head';
 import LayoutContainer from 'components/layout-container';
 import { StaticPageLayoutProps } from 'layouts/static-page';
+import { logEvent } from 'lib/analytics/ga';
 import { PageComponent } from 'types';
 import { GroupedEnums } from 'types/enums';
 import { Investor } from 'types/investor';
@@ -142,7 +143,12 @@ const InvestorPage: PageComponent<InvestorPageProps, StaticPageLayoutProps> = ({
   const favoriteInvestor = useFavoriteInvestor();
 
   const handleFavoriteClick = () => {
-    // This mutation uses a 'DELETE' request when the isFavorite is true, and a 'POST' request when is false.
+    if (!investor.favourite) {
+      logEvent('click_favorite', { category_name: 'investor', slug: investor.slug });
+    }
+
+    // This mutation uses a 'DELETE' request when the isFavorite is true, and a 'POST' request when
+    // is false.
     favoriteInvestor.mutate({ id: investor.id, isFavourite: investor.favourite });
   };
 

--- a/frontend/pages/investor/[id]/index.tsx
+++ b/frontend/pages/investor/[id]/index.tsx
@@ -62,6 +62,7 @@ const InvestorPage: PageComponent<InvestorPageProps, StaticPageLayoutProps> = ({
   const { data: investor } = useInvestor(router.query.id as string, investorProp);
 
   const {
+    slug,
     name,
     twitter,
     facebook,
@@ -167,6 +168,8 @@ const InvestorPage: PageComponent<InvestorPageProps, StaticPageLayoutProps> = ({
 
         <ProfileHeader
           className="mt-3 sm:mt-6"
+          type="investor"
+          slug={slug}
           logo={logo}
           title={name}
           subtitle={investorTypeName}

--- a/frontend/pages/project-developer/[id]/index.tsx
+++ b/frontend/pages/project-developer/[id]/index.tsx
@@ -179,6 +179,8 @@ const ProjectDeveloperPage: PageComponent<ProjectDeveloperPageProps, StaticPageL
         </LayoutContainer>
         <ProfileHeader
           className="mt-3 sm:mt-6"
+          type="project-developer"
+          slug={projectDeveloper.slug}
           logo={projectDeveloper.picture?.medium}
           title={projectDeveloper.name}
           subtitle={projectDeveloperTypeName}

--- a/frontend/pages/project-developer/[id]/index.tsx
+++ b/frontend/pages/project-developer/[id]/index.tsx
@@ -20,6 +20,7 @@ import Head from 'components/head';
 import LayoutContainer from 'components/layout-container';
 import { EnumTypes } from 'enums';
 import { StaticPageLayoutProps } from 'layouts/static-page';
+import { logEvent } from 'lib/analytics/ga';
 import { PageComponent } from 'types';
 import { CategoryType } from 'types/category';
 import { GroupedEnums as GroupedEnumsType } from 'types/enums';
@@ -146,7 +147,15 @@ const ProjectDeveloperPage: PageComponent<ProjectDeveloperPageProps, StaticPageL
   const favoriteProjectDeveloper = useFavoriteProjectDeveloper();
 
   const handleFavoriteClick = () => {
-    // This mutation uses a 'DELETE' request when the isFavorite is true, and a 'POST' request when is false.
+    if (!projectDeveloper.favourite) {
+      logEvent('click_favorite', {
+        category_name: 'project-developer',
+        slug: projectDeveloper.slug,
+      });
+    }
+
+    // This mutation uses a 'DELETE' request when the isFavorite is true, and a 'POST' request when
+    // is false.
     favoriteProjectDeveloper.mutate({
       id: projectDeveloper.id,
       isFavourite: projectDeveloper.favourite,

--- a/frontend/pages/sign-in/code.tsx
+++ b/frontend/pages/sign-in/code.tsx
@@ -20,6 +20,7 @@ import Input from 'components/forms/input';
 import Loading from 'components/loading';
 import { Paths, UserRoles } from 'enums';
 import NakedLayout, { NakedLayoutProps } from 'layouts/naked';
+import { logEvent } from 'lib/analytics/ga';
 import { PageComponent } from 'types';
 import { SignIn, SignInCodeForm } from 'types/sign-in';
 
@@ -98,6 +99,8 @@ const SignInCode: PageComponent<ProjectDeveloperProps, NakedLayoutProps> = () =>
     (data: SignIn) => {
       signIn.mutate(data, {
         onSuccess: () => {
+          logEvent('login', { method: 'credentials' });
+
           if (!!invitedUser) {
             acceptInvitation.mutate(query.invitation_token as string, {
               onSuccess: () => replace(Paths.Dashboard),

--- a/frontend/pages/sign-in/index.tsx
+++ b/frontend/pages/sign-in/index.tsx
@@ -23,6 +23,7 @@ import Label from 'components/forms/label';
 import Loading from 'components/loading';
 import { Paths, UserRoles } from 'enums';
 import AuthPageLayout, { AuthPageLayoutProps } from 'layouts/auth-page';
+import { logEvent } from 'lib/analytics/ga';
 import { PageComponent } from 'types';
 import { SignIn } from 'types/sign-in';
 import { useSignInResolver } from 'validations/sign-in';
@@ -105,6 +106,8 @@ const SignIn: PageComponent<ProjectDeveloperProps, AuthPageLayoutProps> = () => 
           } else {
             signIn.mutate(data, {
               onSuccess: () => {
+                logEvent('login', { method: 'credentials' });
+
                 if (!!invitedUser) {
                   acceptInvitation.mutate(query.invitation_token as string, {
                     onSuccess: () => replace(Paths.Dashboard),

--- a/frontend/pages/sign-up/index.tsx
+++ b/frontend/pages/sign-up/index.tsx
@@ -23,6 +23,7 @@ import Input from 'components/forms/input';
 import Loading from 'components/loading';
 import { Paths, Queries, UserRoles } from 'enums';
 import AuthPageLayout, { AuthPageLayoutProps } from 'layouts/auth-page';
+import { logEvent } from 'lib/analytics/ga';
 import { PageComponent } from 'types';
 import { SignupDto, SignupFormI } from 'types/user';
 import { useSignupResolver } from 'validations/signup';
@@ -68,7 +69,14 @@ const SignUp: PageComponent<SignUpPageProps, AuthPageLayoutProps> = () => {
     isError: confirmedUserIsError,
     error: confirmedUserError,
     isLoading: confirmedUserIsLoading,
+    isSuccess: confirmedUserIsSuccess,
   } = useConfirmEmail(query.confirmation_token as string);
+
+  useEffect(() => {
+    if (confirmedUserIsSuccess) {
+      logEvent('sign_up', { method: 'credentials' });
+    }
+  }, [confirmedUserIsSuccess]);
 
   useEffect(() => {
     // Wait until user and invited user are loaded to be able to compare them


### PR DESCRIPTION
This PR adds code to fire some Google Analytics events when specific actions are completed by the user.

The complete list of events can be found on [this spreadsheet](https://docs.google.com/spreadsheets/d/1S7XJbK3FKtmGZNaKVuCcLE2KFY6iJdAhl1_apRdXgeY/edit#gid=0).

## Testing instructions

1. Set this key in your `.env` file:
```
NEXT_PUBLIC_GOOGLE_ANALYTICS=G-33LN47S3NZ
```
2. Install this extension on Chrome: https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna
3. While on localhost:3000, activate the Google Analytics Debugging
![Google Analytics Debugging in on in the extension's menu](https://user-images.githubusercontent.com/6073968/202414322-ffad7c4b-7fdb-4e0d-b03a-810175288ffd.png)
4. Fire each event based on the list of triggers in the [spreadsheet](https://docs.google.com/spreadsheets/d/1S7XJbK3FKtmGZNaKVuCcLE2KFY6iJdAhl1_apRdXgeY/edit#gid=0)

Make sure the events are fired by looking at the console.

## Tracking

[LET-1294](https://vizzuality.atlassian.net/browse/LET-1294).
