### PR TITLE
Change action from arrow icon to the whole card

### DIFF
--- a/frontend/containers/for-public-pages/public-page-card/component.tsx
+++ b/frontend/containers/for-public-pages/public-page-card/component.tsx
@@ -1,12 +1,12 @@
-import { FC } from 'react';
+import { FC, useRef } from 'react';
 
-import { FormattedMessage } from 'react-intl';
+import { useButton } from 'react-aria';
+import { FormattedMessage, useIntl } from 'react-intl';
 
-import cx from 'classnames';
+import Link from 'next/link';
 
 import { CategoryTagDot } from 'containers/category-tag';
 
-import Button from 'components/button';
 import Icon from 'components/icon';
 import { Paths } from 'enums';
 import { CategoryType } from 'types/category';
@@ -27,61 +27,71 @@ export const PublicPageCard: FC<PublicPageCardProps> = ({
   onMouseLeave,
   onClick,
 }) => {
+  const { formatMessage } = useIntl();
+  const triggerRef = useRef<HTMLAnchorElement>(null);
+
+  const { buttonProps } = useButton(
+    {
+      onPress: onClick,
+      elementType: 'a',
+    },
+    triggerRef
+  );
+
   return (
-    <div
-      className="w-[75vw] sm:w-[60vw] md:w-auto flex flex-col justify-between p-4 transition-all duration-500 bg-white rounded-lg shadow-sm group drop-shadow-none hover:drop-shadow-lg ease min-h-[290px]"
-      key={id}
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
-    >
-      <div className="flex justify-between mb-2">
-        <h3 className="font-serif text-2xl font-bold xl:text-2xl max-w-[80%]">{name}</h3>
-        {enumType === 'category' && <CategoryTagDot category={id as CategoryType} size="large" />}
-      </div>
-      <div>
-        <p className="mb-4 text-sm text-gray-800 transition-all duration-500 md:opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 ease">
-          {description}
-        </p>
-      </div>
-      <div className="flex items-center justify-between">
-        <p className="text-base text-gray-600">
-          <span className="font-bold text-black">{quantity}</span>{' '}
-          {cardType === 'projects' ? (
-            <FormattedMessage
-              defaultMessage="{quantity, plural, one {project} other {projects}}"
-              id="KYymTZ"
-              values={{ quantity }}
-            />
-          ) : (
-            <FormattedMessage
-              defaultMessage="{quantity, plural, one {investor} other {investors}}"
-              id="q7I+Bg"
-              values={{ quantity }}
-            />
-          )}
-        </p>
-        {!!filterName && (
-          <Button
-            theme="naked"
-            to={`${Paths.Discover}/${cardType}/?filter[${filterName}]=${id}`}
-            onClick={onClick}
-          >
-            <span className="sr-only">
-              {cardType === 'projects' && (
-                <FormattedMessage defaultMessage="See projects" id="q6rG+e" />
+    <Link href={`${Paths.Discover}/${cardType}/?filter[${filterName}]=${id}`} passHref>
+      <a
+        {...buttonProps}
+        ref={triggerRef}
+        className="focus-visible:outline-green-dark"
+        aria-label={
+          cardType === 'projects'
+            ? formatMessage({ defaultMessage: 'See projects', id: 'q6rG+e' })
+            : formatMessage({ defaultMessage: 'See investors', id: 'ctc1sP' })
+        }
+      >
+        <div
+          className="w-[75vw] sm:w-[60vw] md:w-auto flex flex-col justify-between p-4 transition-all duration-500 bg-white rounded-lg shadow-sm group drop-shadow-none hover:drop-shadow-lg ease h-full min-h-[290px] cursor-pointer"
+          key={id}
+          onMouseEnter={onMouseEnter}
+          onMouseLeave={onMouseLeave}
+        >
+          <div className="flex justify-between mb-2">
+            <h3 className="font-serif text-2xl font-bold xl:text-2xl max-w-[80%]">{name}</h3>
+            {enumType === 'category' && (
+              <CategoryTagDot category={id as CategoryType} size="large" />
+            )}
+          </div>
+          <div>
+            <p className="mb-4 text-sm text-gray-800 transition-all duration-500 md:opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 ease">
+              {description}
+            </p>
+          </div>
+          <div className="flex items-center justify-between">
+            <p className="text-base text-gray-600">
+              <span className="font-bold text-black">{quantity} </span>
+              {cardType === 'projects' ? (
+                <FormattedMessage
+                  defaultMessage="{quantity, plural, one {project} other {projects}}"
+                  id="KYymTZ"
+                  values={{ quantity }}
+                />
+              ) : (
+                <FormattedMessage
+                  defaultMessage="{quantity, plural, one {investor} other {investors}}"
+                  id="q7I+Bg"
+                  values={{ quantity }}
+                />
               )}
-              {cardType === 'investors' && (
-                <FormattedMessage defaultMessage="See investors" id="ctc1sP" />
-              )}
-            </span>
+            </p>
             <Icon
               icon={ArrowIcon}
               className="transition-all duration-500 md:opacity-0 w-15 group-hover:opacity-100 group-focus-within:opacity-100 ease"
             />
-          </Button>
-        )}
-      </div>
-    </div>
+          </div>
+        </div>
+      </a>
+    </Link>
   );
 };
 


### PR DESCRIPTION
This PR changes the 'For investors' and 'For Project Developers' filter cards to be fully clickable.

- For investors The "category" and "Priority landscape" cards will be fully clickable 
- For Project Developers The "ticket size" and "category" cards will be fully clickable 

Note: the functionality to access the search results with the corresponding filter applied remains the same

## Testing instructions

The filters cards should be fully clickable:

1. for-project-developers:

- Discover investors by budget/ticket size
- Discover investors by category

2. for-investors:

- Discover projects by category
- By priority landscapes

## Tracking

[LET-1311](https://vizzuality.atlassian.net/browse/LET-1311)