### PR TITLE
Change labels of location inputs of project create/edit project form

### DIFF
--- a/frontend/containers/project-form/pages/general-information.tsx
+++ b/frontend/containers/project-form/pages/general-information.tsx
@@ -212,7 +212,10 @@ const GeneralInformation = ({
         </div>
         <div className="mb-8">
           <h2 className="mb-2.5 text-gray-600">
-            <FormattedMessage defaultMessage="Location" id="rvirM2" />
+            <FormattedMessage
+              defaultMessage="Specify the administrative division your project is located at"
+              id="wsffCL"
+            />
           </h2>
           <LocationSelectors
             control={control}
@@ -229,15 +232,18 @@ const GeneralInformation = ({
         <div className="mb-6.5">
           <Label htmlFor="geometry">
             <span className="mr-2.5">
-              <FormattedMessage defaultMessage="Draw or upload your location" id="MHwpc4" />
+              <FormattedMessage
+                defaultMessage="Draw or upload the area of the region your project will have an impact on"
+                id="pnBOKb"
+              />
             </span>
             <FieldInfo
               content={
                 <>
                   <p>
                     <FormattedMessage
-                      defaultMessage="Draw on the map or upload a file with the geographical area your project will have an impact on."
-                      id="YEYmEz"
+                      defaultMessage="Draw or upload the area of the region your project will have an impact on (i.e. your production zone and/or the location of your target audiences)"
+                      id="4wNuFe"
                     />
                   </p>
                   <p className="mt-2">

--- a/frontend/containers/project-form/pages/general-information.tsx
+++ b/frontend/containers/project-form/pages/general-information.tsx
@@ -211,23 +211,35 @@ const GeneralInformation = ({
           />
         </div>
         <div className="mb-8">
-          <h2 className="mb-2.5 text-gray-600">
-            <FormattedMessage
-              defaultMessage="Specify the administrative division your project is located at"
-              id="wsffCL"
-            />
+          <h2 className="mb-4.5 text-gray-600">
+            <FormattedMessage defaultMessage="Location" id="rvirM2" />
           </h2>
-          <LocationSelectors
-            control={control}
-            resetField={resetField}
-            getValues={getValues}
-            errors={errors}
-            fields={{
-              country: { fieldName: 'country_id', required: true },
-              state: { fieldName: 'department_id', required: true },
-              municipality: { fieldName: 'municipality_id', required: true },
-            }}
-          />
+          <fieldset>
+            <legend>
+              <span className="mr-2.5 font-sans font-semibold text-sm text-gray-800 mb-4.5">
+                <FormattedMessage defaultMessage="Administrative division" id="2owSZn" />
+              </span>
+              <FieldInfo
+                content={
+                  <FormattedMessage
+                    defaultMessage="Specify the administrative division your project is located at."
+                    id="VQsDFV"
+                  />
+                }
+              />
+            </legend>
+            <LocationSelectors
+              control={control}
+              resetField={resetField}
+              getValues={getValues}
+              errors={errors}
+              fields={{
+                country: { fieldName: 'country_id', required: true },
+                state: { fieldName: 'department_id', required: true },
+                municipality: { fieldName: 'municipality_id', required: true },
+              }}
+            />
+          </fieldset>
         </div>
         <div className="mb-6.5">
           <Label htmlFor="geometry">

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -233,6 +233,9 @@
   "2inebt": {
     "string": "The opportunities are located in geographies that are are unique due to of their biodiversity, cultural heritages, and regulation of water systems. As such, these projects will have the greatest impact for people and nature."
   },
+  "2owSZn": {
+    "string": "Administrative division"
+  },
   "2qzivP": {
     "string": "Discover Project Developers"
   },
@@ -343,6 +346,9 @@
   },
   "4vn+6A": {
     "string": "{inputName} is focused, type to refine list, press down to open the menu, press left to focus selected values"
+  },
+  "4wNuFe": {
+    "string": "Draw or upload the area of the region your project will have an impact on (i.e. your production zone and/or the location of your target audiences)"
   },
   "4zK41e": {
     "string": "Investing in the Amazon means contributing to improving the quality of life of more than 30 million people. It is also contributing to the development and conservation of a vital region for South America and the world."
@@ -1314,9 +1320,6 @@
   "MH3koz": {
     "string": "Previous slide"
   },
-  "MHwpc4": {
-    "string": "Draw or upload your location"
-  },
   "MJuP2l": {
     "string": "Displays the impacts of forest change on local biodiversity intactness."
   },
@@ -1778,6 +1781,9 @@
   },
   "VNrnq9": {
     "string": "Non-VC Investment vehicle"
+  },
+  "VQsDFV": {
+    "string": "Specify the administrative division your project is located at."
   },
   "VR21hO": {
     "string": "The climate crisis is where short-term thinking and long-term consequences collide. How to think long-term in a short-term world?"
@@ -2906,6 +2912,9 @@
   },
   "pkBu4q": {
     "string": "insert number (max 36)"
+  },
+  "pnBOKb": {
+    "string": "Draw or upload the area of the region your project will have an impact on"
   },
   "psPbog": {
     "string": "Corporation"


### PR DESCRIPTION
This PR changes the labels of location inputs of project create/edit project form

## Testing instructions

project/conta-teste-2-projeto-teste/edit

As a Project developer creating/editing a project, I need to know the purpose of drawing or uploading the area of the project, so that I have clarity about what I have to do

Acceptance criteria

The location section will have the following explanation:

Dropdown: “Specify the administrative division your project is located at”

Map: “Draw or upload the area of the region your project will have an impact on (i.e. your production zone and/or the location of your target **audiences)**

## Tracking

[LET-1342](https://vizzuality.atlassian.net/browse/LET-1342)
