### PR TITLE
Change subtitle and labels of Other Information page of project create/edit project form

### DIFF
--- a/frontend/containers/project-form/pages/other-information.tsx
+++ b/frontend/containers/project-form/pages/other-information.tsx
@@ -19,8 +19,8 @@ const OtherInformation = ({ register, errors }: ProjectFormPagesProps<ProjectFor
       </h1>
       <p className="mb-10 text-gray-900">
         <FormattedMessage
-          defaultMessage="This description should sumarize your project in a few words. This information will be <n>public</n>."
-          id="8SBW1H"
+          defaultMessage="This description should sumarize your project in a few words. This might include relevant financial information that you want potential investors to know about. This information will be <n>public</n>."
+          id="aXPVkO"
           values={{
             n: (chunk: string) => <span className="font-semibold">{chunk}</span>,
           }}
@@ -60,8 +60,8 @@ const OtherInformation = ({ register, errors }: ProjectFormPagesProps<ProjectFor
             <FieldInfo
               content={formatMessage({
                 defaultMessage:
-                  'Use this space to share links to documents, videos and websites that support your pitch.',
-                id: 'efZTBX',
+                  'Use this space to share links to documents, videos and websites that support your pitch. This might include relevant financial information that you want potential investors to know about.',
+                id: 'DsldZ2',
               })}
             />
           </Label>


### PR DESCRIPTION
This PR changes the subtitle and labels of Other Information page of project create/edit project form

As a Project developers creating or editing a project, I can see instructions on how to add more financial information, so that I can add all the information I need to make my project more appealing

In the project creation step 6, explain that the user can put a link to their pitch deck or other resources where more financial information is available

Add to the subtitle of the section


Text: “This description should sumarize your project in a few words. This might include relevant financial information that you want potential investors to know about. This information will be public.”

Info button

Text: “Use this space to share links to documents, videos and websites that support your pitch. This might include relevant financial information that you want potential investors to know about”


## Testing instructions

project/[project-url]/edit

## Tracking

[LET-1343](https://vizzuality.atlassian.net/browse/LET-1343)
