### PR TITLE
Show search location box always open on project forms 

### DIFF
--- a/frontend/containers/discover-map/location-searcher/component.tsx
+++ b/frontend/containers/discover-map/location-searcher/component.tsx
@@ -19,7 +19,11 @@ import CloseIcon from 'svgs/ui/close.svg';
 
 import { LocationSearcherProps } from './types';
 
-export const LocationSearcher: FC<LocationSearcherProps> = ({ className, onLocationSelected }) => {
+export const LocationSearcher: FC<LocationSearcherProps> = ({
+  className,
+  onLocationSelected,
+  isAlwaysOpen = false,
+}) => {
   const intl = useIntl();
   const placesRef = useRef();
   const containerRef = useRef();
@@ -27,7 +31,7 @@ export const LocationSearcher: FC<LocationSearcherProps> = ({ className, onLocat
 
   const [address, setAddress] = useState('');
   const [addressSetted, setAddressSetted] = useState(false);
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(isAlwaysOpen);
   const [isFocused, setIsFocused] = useState(false);
   const [isError, setIsError] = useState(false);
 
@@ -38,7 +42,7 @@ export const LocationSearcher: FC<LocationSearcherProps> = ({ className, onLocat
   };
 
   useOutsideClick(containerRef, () => {
-    if (!isOpen || addressSetted) return;
+    if (isAlwaysOpen || !isOpen || addressSetted) return;
     setIsOpen(false);
     handleClearSearch();
   });
@@ -50,8 +54,6 @@ export const LocationSearcher: FC<LocationSearcherProps> = ({ className, onLocat
   };
 
   const handleSelectAddress = (newAddress: string) => {
-    console.log('address', address);
-    console.log('newAddress', newAddress);
     setIsFocused(false);
     setAddress(newAddress);
     setAddressSetted(true);
@@ -125,7 +127,7 @@ export const LocationSearcher: FC<LocationSearcherProps> = ({ className, onLocat
                   })}
                   onMouseEnter={() => setIsOpen(true)}
                   onMouseLeave={() => {
-                    if (!isFocused && !addressSetted) {
+                    if (!isAlwaysOpen && !isFocused && !addressSetted) {
                       setIsOpen(false);
                     }
                   }}

--- a/frontend/containers/discover-map/location-searcher/types.ts
+++ b/frontend/containers/discover-map/location-searcher/types.ts
@@ -3,4 +3,6 @@ export interface LocationSearcherProps {
   className?: string;
   /** Callback to pass the bbox of a selected location */
   onLocationSelected: ({ bbox }: { bbox: number[] }) => void;
+  /** Whether the search box should always be open. Defaults to 'false' */
+  isAlwaysOpen?: boolean;
 }

--- a/frontend/containers/forms/geometry/component.tsx
+++ b/frontend/containers/forms/geometry/component.tsx
@@ -319,7 +319,7 @@ export const GeometryInput = <FormValues extends FieldValues>({
               )}
             </Map>
             <div className="absolute flex gap-2 top-3.5 left-3.5 text-gray-800 text-sm">
-              <LocationSearcher onLocationSelected={handleLocationSelected} />
+              <LocationSearcher onLocationSelected={handleLocationSelected} isAlwaysOpen />
             </div>
             <Controls className="absolute bottom-2 left-2">
               <ZoomControl viewport={{ ...viewport }} onZoomChange={onZoomChange} />


### PR DESCRIPTION
This PR adds the possibility to the search box on maps be always open and set it to true on the project form map

## Testing instructions

Signin as a project developer and go to a project form
On the first page of the form,  the location search box should be always expanded

## Tracking

[1339](https://vizzuality.atlassian.net/browse/LET-1339)
