### PR TITLE
fix select priority landscape impact bug

### DIFF
--- a/frontend/containers/impact-chart/component.tsx
+++ b/frontend/containers/impact-chart/component.tsx
@@ -270,7 +270,7 @@ export const ImpactChart: FC<ImpactChartProps> = ({
           <FieldInfo content={impactData[impactType].description} />
         </div>
         <span className="text-lg leading-tight text-gray-600">
-          {impactData[impactType].value.toFixed(1)}
+          {impactData[impactType].value?.toFixed(1)}
         </span>
       </div>
     );

--- a/frontend/containers/impact-chart/component.tsx
+++ b/frontend/containers/impact-chart/component.tsx
@@ -270,7 +270,7 @@ export const ImpactChart: FC<ImpactChartProps> = ({
           <FieldInfo content={impactData[impactType].description} />
         </div>
         <span className="text-lg leading-tight text-gray-600">
-          {impactData[impactType].value?.toFixed(1) || 0}
+          {impactData[impactType].value?.toFixed(1) || '0.0'}
         </span>
       </div>
     );

--- a/frontend/containers/impact-chart/component.tsx
+++ b/frontend/containers/impact-chart/component.tsx
@@ -270,7 +270,7 @@ export const ImpactChart: FC<ImpactChartProps> = ({
           <FieldInfo content={impactData[impactType].description} />
         </div>
         <span className="text-lg leading-tight text-gray-600">
-          {impactData[impactType].value?.toFixed(1)}
+          {impactData[impactType].value?.toFixed(1) || 0}
         </span>
       </div>
     );


### PR DESCRIPTION
This PR fixes the bug on project page generated when selecting the impact chart - priority landscape

## Testing instructions

Bug reproduction steps

1. Open https://staging.hecoinvest.org/en/project/clement-vizzuality-test-project-clement-2809221

2. In the “Estimated Impact” section, select “HeCo priority landscape” in the dropdown 

Bug:
The application crashes and display a 500 error.

Expected result

The impact graph is updated with the values of the impact on the priority landscape.

## Tracking

[1307](https://vizzuality.atlassian.net/browse/LET-1307)
