### PR TITLE
FE - Improve search results page performance

### DIFF
--- a/frontend/containers/discover-map/component.tsx
+++ b/frontend/containers/discover-map/component.tsx
@@ -3,15 +3,13 @@ import { ChangeEvent, FC, useCallback, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 
-import omit from 'lodash-es/omit';
-
-import { useRouter } from 'next/router';
-
 import MapboxGLPlugin from '@vizzuality/layer-manager-plugin-mapboxgl';
 import CartoProvider from '@vizzuality/layer-manager-provider-carto';
 import { LayerManager, Layer } from '@vizzuality/layer-manager-react';
 
 import { useLayers } from 'hooks/useLayers';
+
+import { useQueryParams } from 'helpers/pages';
 
 import Map from 'components/map';
 import Controls from 'components/map/controls';
@@ -36,11 +34,11 @@ const cartoProvider = new CartoProvider();
 
 export const DiscoverMap: FC<DiscoverMapProps> = ({ onSelectProjectPin }) => {
   const { layers } = useLayers();
-  const { query } = useRouter();
+  const { page, sorting, search, ...filters } = useQueryParams();
 
   const { projectsMap } = useProjectsMap({
-    ...(omit(query, 'search') as ProjectMapParams),
-    'filter[full_text]': query.search as string,
+    ...filters,
+    'filter[full_text]': search as string,
   });
 
   const [viewport, setViewport] = useState({});
@@ -122,7 +120,12 @@ export const DiscoverMap: FC<DiscoverMapProps> = ({ onSelectProjectPin }) => {
   return (
     <>
       <div className="relative w-full h-full">
-        <Map bounds={bounds} viewport={viewport} onMapViewportChange={handleViewportChange}>
+        <Map
+          bounds={bounds}
+          viewport={viewport}
+          onMapViewportChange={handleViewportChange}
+          reuseMaps
+        >
           {(map) => (
             <>
               <LayerManager

--- a/frontend/containers/open-call-card/component.tsx
+++ b/frontend/containers/open-call-card/component.tsx
@@ -39,7 +39,7 @@ export const OpenCallCard: FC<OpenCallCardProps> = ({ className, openCall }: Ope
     data: { instrument_type: allInstrumentTypes, impact: allImpacts },
   } = useEnums();
 
-  const [picture, setPicture] = useState<string>(investor.picture?.small || placeholderPicture);
+  const [picture, setPicture] = useState<string>(investor?.picture?.small || placeholderPicture);
   const [isFocusWithin, setIsFocusWithin] = useState<boolean>(false);
 
   const link = `${Paths.OpenCall}/${slug}`;
@@ -172,13 +172,13 @@ export const OpenCallCard: FC<OpenCallCardProps> = ({ className, openCall }: Ope
           })}
         >
           <span className="flex flex-row-reverse items-center gap-2">
-            <span className="text-sm">{investor.name}</span>
+            <span className="text-sm">{investor?.name}</span>
             <span className="relative flex-shrink-0 w-8 overflow-hidden rounded-full aspect-square">
               <Image
                 src={picture}
                 alt={intl.formatMessage(
                   { defaultMessage: '{name} picture', id: 'rLzWx9' },
-                  { name: investor.name }
+                  { name: investor?.name }
                 )}
                 layout="fill"
                 objectFit="contain"

--- a/frontend/layouts/discover-page/helpers.ts
+++ b/frontend/layouts/discover-page/helpers.ts
@@ -1,10 +1,21 @@
+import { useMemo } from 'react';
+
 import { useIntl } from 'react-intl';
 
-import { compact } from 'lodash-es';
+import { useRouter } from 'next/router';
+
+import { compact, pickBy } from 'lodash-es';
+
+import { useQueryParams } from 'helpers/pages';
 
 import { SortingOptionType } from 'components/sorting-buttons';
 import { SortingOptionKey, SortingOrderType } from 'components/sorting-buttons/types';
-import { Queries } from 'enums';
+import { Paths, Queries } from 'enums';
+
+import { useInvestorsList } from 'services/investors/investorsService';
+import { useOpenCallsList } from 'services/open-call/open-call-service';
+import { useProjectDevelopersList } from 'services/project-developers/projectDevelopersService';
+import { useProjectsList } from 'services/projects/projectService';
 
 export type SortingByTargetType = Queries.Project;
 
@@ -46,4 +57,124 @@ export const useSortingByOptions = (target?: SortingByTargetType): SortingOption
     ...sortingOptions['general'],
     ...(sortingOptions[target] || []),
   ]) as SortingOptionType[];
+};
+
+const pathFilters = {
+  [Paths.Projects]: [
+    'filter[category]',
+    'filter[sdg]',
+    'filter[instrument_type]',
+    'filter[ticket_size]',
+    'filter[impact]',
+    'filter[only_verified]',
+    'filter[full_text]',
+    'filter[priority_landscape]',
+  ],
+  [Paths.ProjectDevelopers]: [
+    'filter[category]',
+    'filter[impact]',
+    'filter[full_text]',
+    'filter[priority_landscape]',
+  ],
+  [Paths.Investors]: [
+    'filter[category]',
+    'filter[sdg]',
+    'filter[instrument_type]',
+    'filter[ticket_size]',
+    'filter[impact]',
+    'filter[full_text]',
+  ],
+  [Paths.OpenCalls]: [
+    'filter[sdg]',
+    'filter[instrument_type]',
+    'filter[ticket_size]',
+    'filter[only_verified]',
+    'filter[full_text]',
+  ],
+};
+
+const getPathParams = (
+  path: string,
+  pathname: string,
+  queryParams: { [key: string]: string | string[] }
+) => {
+  const { page, sorting, search, ...filters } = queryParams;
+
+  // Get only applicable filters for each path to avoid unnecessary fetches
+  const pathFilter = pickBy(filters, (_, key) => pathFilters[path].includes(key));
+
+  const params: { [key: string]: string | string[] } = { page, search, ...pathFilter };
+
+  if (pathname !== path) {
+    return {
+      ...params,
+      fields: ['name'],
+      perPage: 1,
+      'page[size]': 1,
+    };
+  }
+
+  // Use sorting value only when applies to path to avoid unnecessary fetches
+  if (path === Paths.Projects || sorting?.includes('name') || sorting?.includes('created_at')) {
+    params.sorting = sorting;
+  }
+
+  if (pathname === Paths.Projects) {
+    return {
+      ...params,
+      includes: ['project_developer', 'involved_project_developers'],
+      'fields[project_developer]': 'picture,name,contact_phone,contact_email',
+      'fields[involved_project_developers]': 'picture,name,contact_phone,contact_email',
+    };
+  }
+  if (pathname === Paths.Investors || pathname === Paths.ProjectDevelopers) {
+    return { ...params, perPage: 9 };
+  }
+  if (pathname === Paths.OpenCalls) {
+    return { ...params, includes: ['investor'] };
+  }
+};
+
+/** Hook to use the stats and the search results on Discover pages */
+export const useDiscoverData = () => {
+  const queryParams = useQueryParams();
+  const { pathname } = useRouter();
+  const getParams = (path: string) => getPathParams(path, pathname, queryParams);
+  const queryOptions = { keepPreviousData: true };
+
+  const projects = useProjectsList(getParams(Paths.Projects), queryOptions);
+  const projectDevelopers = useProjectDevelopersList(
+    getParams(Paths.ProjectDevelopers),
+    queryOptions
+  );
+  const investors = useInvestorsList(getParams(Paths.Investors), queryOptions);
+  const openCalls = useOpenCallsList(getParams(Paths.OpenCalls), queryOptions);
+
+  const stats = useMemo(
+    () => ({
+      projects: projects?.data?.meta?.total,
+      projectDevelopers: projectDevelopers?.data?.meta?.total,
+      investors: investors?.data?.meta?.total,
+      openCalls: openCalls?.data?.meta?.total,
+    }),
+    [investors?.data, openCalls?.data, projectDevelopers?.data, projects?.data]
+  );
+
+  const data = useMemo(() => {
+    const allPathsData = {
+      [Paths.Projects]: projects,
+      [Paths.ProjectDevelopers]: projectDevelopers,
+      [Paths.Investors]: investors,
+      [Paths.OpenCalls]: openCalls,
+    };
+    const currData = allPathsData[pathname];
+
+    return {
+      data: currData.data?.data,
+      meta: currData.data?.meta,
+      loading: currData?.isLoading || currData?.isFetching || currData?.isRefetching,
+    };
+  }, [investors, openCalls, pathname, projectDevelopers, projects]);
+
+  return { stats, data };
 };

--- a/frontend/layouts/discover-page/helpers.ts
+++ b/frontend/layouts/discover-page/helpers.ts
@@ -59,40 +59,6 @@ export const useSortingByOptions = (target?: SortingByTargetType): SortingOption
   ]) as SortingOptionType[];
 };
 
-const pathFilters = {
-  [Paths.Projects]: [
-    'filter[category]',
-    'filter[sdg]',
-    'filter[instrument_type]',
-    'filter[ticket_size]',
-    'filter[impact]',
-    'filter[only_verified]',
-    'filter[full_text]',
-    'filter[priority_landscape]',
-  ],
-  [Paths.ProjectDevelopers]: [
-    'filter[category]',
-    'filter[impact]',
-    'filter[full_text]',
-    'filter[priority_landscape]',
-  ],
-  [Paths.Investors]: [
-    'filter[category]',
-    'filter[sdg]',
-    'filter[instrument_type]',
-    'filter[ticket_size]',
-    'filter[impact]',
-    'filter[full_text]',
-  ],
-  [Paths.OpenCalls]: [
-    'filter[sdg]',
-    'filter[instrument_type]',
-    'filter[ticket_size]',
-    'filter[only_verified]',
-    'filter[full_text]',
-  ],
-};
-
 const getPathParams = (
   path: string,
   pathname: string,
@@ -100,17 +66,13 @@ const getPathParams = (
 ) => {
   const { page, sorting, search, ...filters } = queryParams;
 
-  // Get only applicable filters for each path to avoid unnecessary fetches
-  const pathFilter = pickBy(filters, (_, key) => pathFilters[path].includes(key));
-
-  const params: { [key: string]: string | string[] } = { page, search, ...pathFilter };
+  const params: { [key: string]: string | string[] } = { page, search, ...filters };
 
   if (pathname !== path) {
     return {
       ...params,
       fields: ['name'],
       perPage: 1,
-      'page[size]': 1,
     };
   }
 
@@ -131,7 +93,7 @@ const getPathParams = (
     return { ...params, perPage: 9 };
   }
   if (pathname === Paths.OpenCalls) {
-    return { ...params, includes: ['investor'] };
+    return { ...params, includes: ['investor'], 'fields[investor]': 'picture,name,impacts' };
   }
 };
 

--- a/frontend/layouts/discover-page/helpers.ts
+++ b/frontend/layouts/discover-page/helpers.ts
@@ -76,10 +76,7 @@ const getPathParams = (
     };
   }
 
-  // Use sorting value only when applies to path to avoid unnecessary fetches
-  if (path === Paths.Projects || sorting?.includes('name') || sorting?.includes('created_at')) {
-    params.sorting = sorting;
-  }
+  params.sorting = sorting;
 
   if (pathname === Paths.Projects) {
     return {

--- a/frontend/pages/discover/projects.tsx
+++ b/frontend/pages/discover/projects.tsx
@@ -32,7 +32,7 @@ import { Project as ProjectType } from 'types/project';
 
 import { getProject } from 'services/projects/projectService';
 
-export const getStaticProps = withLocalizedRequests(async ({ locale }) => {
+export const getServerSideProps = withLocalizedRequests(async ({ locale }) => {
   return {
     props: {
       intlMessages: await loadI18nMessages({ locale }),

--- a/frontend/pages/discover/projects.tsx
+++ b/frontend/pages/discover/projects.tsx
@@ -32,7 +32,7 @@ import { Project as ProjectType } from 'types/project';
 
 import { getProject } from 'services/projects/projectService';
 
-export const getServerSideProps = withLocalizedRequests(async ({ locale }) => {
+export const getStaticProps = withLocalizedRequests(async ({ locale }) => {
   return {
     props: {
       intlMessages: await loadI18nMessages({ locale }),

--- a/frontend/services/open-call/open-call-service.ts
+++ b/frontend/services/open-call/open-call-service.ts
@@ -52,7 +52,7 @@ export function useOpenCallsList(
   params?: PagedRequest,
   options?: UseQueryOptions<PagedResponse<OpenCall>>
 ): UseQueryResult<PagedResponse<OpenCall>> & { openCalls: OpenCall[] } {
-  const query = useLocalizedQuery([Queries.ProjectList, params], () => getOpenCalls(params), {
+  const query = useLocalizedQuery([Queries.OpenCallList, params], () => getOpenCalls(params), {
     ...staticDataQueryOptions,
     ...options,
   });

--- a/frontend/services/open-call/open-call-service.ts
+++ b/frontend/services/open-call/open-call-service.ts
@@ -28,7 +28,7 @@ import { ErrorResponse, PagedRequest, PagedResponse, ResponseData } from 'servic
 
 /** Get a paged list of openCalls */
 export const getOpenCalls = async (params?: PagedRequest): Promise<PagedResponse<OpenCall>> => {
-  const { search, page, includes, fields, ...rest } = params || {};
+  const { search, page, includes, fields, perPage, ...rest } = params || {};
 
   const config: AxiosRequestConfig = {
     url: '/api/v1/open_calls',
@@ -39,6 +39,7 @@ export const getOpenCalls = async (params?: PagedRequest): Promise<PagedResponse
       'filter[full_text]': search,
       'page[number]': page,
       'fields[open_call]': fields?.join(','),
+      'page[size]': perPage,
     },
   };
 

--- a/frontend/services/projects/projectService.ts
+++ b/frontend/services/projects/projectService.ts
@@ -118,6 +118,9 @@ export const useProjectsMap = (
     placeholderData: {
       data: [],
     },
+    keepPreviousData: true,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
   });
 
   return useMemo(() => {

--- a/frontend/services/projects/projectService.ts
+++ b/frontend/services/projects/projectService.ts
@@ -21,7 +21,7 @@ const Point: 'Point' = 'Point';
 
 /** Get a paged list of projects */
 export const getProjects = async (params?: PagedRequest): Promise<PagedResponse<Project>> => {
-  const { search, page, includes, fields, ...rest } = params || {};
+  const { search, page, includes, fields, perPage, ...rest } = params || {};
 
   const config: AxiosRequestConfig = {
     url: '/api/v1/projects',
@@ -32,6 +32,7 @@ export const getProjects = async (params?: PagedRequest): Promise<PagedResponse<
       'filter[full_text]': search,
       'page[number]': page,
       'fields[project]': fields?.join(','),
+      'page[size]': perPage,
     },
   };
 


### PR DESCRIPTION
This PR minimises the number of fetches and the size of fetched data on discover pages

- The first load fetches the complete data from just the current page and just one item from the other pages;
- Projects included entities fields minimised to just the used fields;
- Sorting value just change when the page can use the value;
- Filter values just change when the page can use the value;


## Tracking

https://vizzuality.atlassian.net/browse/LET-1314
