### PR TITLE
Let 1338 fe change magnifying glass for a text on menu

### DIFF
--- a/frontend/containers/layouts/navigation-menu-button/component.tsx
+++ b/frontend/containers/layouts/navigation-menu-button/component.tsx
@@ -79,7 +79,7 @@ export const NavigationMenuButton: FC<NavigationMenuButtonProps> = ({
           <MenuSection>
             {!isSearchPage && (
               <MenuItem key={Paths.Projects}>
-                <FormattedMessage defaultMessage="Search" id="xmcVZ0" />
+                <FormattedMessage defaultMessage="Catalog" id="GOdq5V" />
               </MenuItem>
             )}
             <MenuItem key={Paths.ForInvestors}>

--- a/frontend/containers/layouts/navigation/component.tsx
+++ b/frontend/containers/layouts/navigation/component.tsx
@@ -3,10 +3,7 @@ import { FC } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import ActiveLink from 'components/active-link';
-import Icon from 'components/icon';
 import { Paths } from 'enums';
-
-import SearchIcon from 'svgs/search.svg';
 
 import { NavigationProps } from './types';
 
@@ -17,8 +14,8 @@ export const Navigation: FC<NavigationProps> = ({ className }: NavigationProps) 
     <div className={className}>
       <nav className="flex space-x-8 text-sm xl:text-base">
         <ActiveLink href={Paths.Discover} activeClassName="font-semibold">
-          <a title={intl.formatMessage({ defaultMessage: 'Search', id: 'xmcVZ0' })}>
-            <Icon icon={SearchIcon} />
+          <a title={intl.formatMessage({ defaultMessage: 'Full catalogue', id: '0h5kbM' })}>
+            <FormattedMessage defaultMessage="Catalogue" id="U2napd" />
           </a>
         </ActiveLink>
         <ActiveLink href={Paths.ForInvestors} activeClassName="font-semibold">

--- a/frontend/containers/layouts/navigation/component.tsx
+++ b/frontend/containers/layouts/navigation/component.tsx
@@ -15,7 +15,7 @@ export const Navigation: FC<NavigationProps> = ({ className }: NavigationProps) 
       <nav className="flex space-x-8 text-sm xl:text-base">
         <ActiveLink href={Paths.Discover} activeClassName="font-semibold">
           <a title={intl.formatMessage({ defaultMessage: 'Full catalogue', id: '0h5kbM' })}>
-            <FormattedMessage defaultMessage="Catalogue" id="U2napd" />
+            <FormattedMessage defaultMessage="Catalog" id="GOdq5V" />
           </a>
         </ActiveLink>
         <ActiveLink href={Paths.ForInvestors} activeClassName="font-semibold">

--- a/frontend/layouts/static-page/footer/component.tsx
+++ b/frontend/layouts/static-page/footer/component.tsx
@@ -205,7 +205,7 @@ export const Footer: React.FC<FooterProps> = ({
             <div className="md:grid md:grid-cols-2 md:gap-8">
               <div>
                 <h3 className="text-gray-600">
-                  <FormattedMessage defaultMessage="Discover" id="cE4Hfw" />
+                  <FormattedMessage defaultMessage="Catalog" id="GOdq5V" />
                 </h3>
                 <ul className="mt-2 space-y-2">
                   <li>


### PR DESCRIPTION
This PR changes the magnifying glass in desktop version for "Catalog" (American spelling)

## Testing instructions

It must be consistent in desktop and responsive

NOTE

Make sure to rename all the references to “Discover” as “Catalog” (American spelling)

## Tracking

[LET-1338](https://vizzuality.atlassian.net/browse/LET-1338)


[LET-1338]: https://vizzuality.atlassian.net/browse/LET-1338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ