### PR TITLE
Update the copyright holder

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Vizzuality
+Copyright (c) 2022 World Wildlife Fund, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/data/LICENSE
+++ b/data/LICENSE
@@ -1,6 +1,6 @@
 
 The MIT License (MIT)
-Copyright (c) 2022, vizzuality
+Copyright (c) 2022, World Wildlife Fund, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
This PR updates the copyright holder to replace Vizzuality by WWF.

## Testing instructions

All the license files mention “World Wildlife Fund, Inc.”.

## Tracking

[LET-1347](https://vizzuality.atlassian.net/browse/LET-1347)


[LET-1347]: https://vizzuality.atlassian.net/browse/LET-1347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ