### PR TITLE
Update the button's wording of the error pages

### DIFF
--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -2673,6 +2673,9 @@
   "khRkg/": {
     "string": "You need to select the amount of money you can provide"
   },
+  "kk1RMl": {
+    "string": "Go to homepage"
+  },
   "ku+mDU": {
     "string": "State"
   },
@@ -2864,9 +2867,6 @@
   },
   "orirkU": {
     "string": "What information do I need to create a Project Developer account?"
-  },
-  "orvpWh": {
-    "string": "Go back"
   },
   "osBdnp": {
     "string": "IPLC organization"

--- a/frontend/pages/404.tsx
+++ b/frontend/pages/404.tsx
@@ -53,7 +53,7 @@ const InternalError: PageComponent<InternalErrorProps, NakedLayoutProps> = () =>
           </p>
         </div>
         <Button to={Paths.Home}>
-          <FormattedMessage defaultMessage="Go back" id="orvpWh" />
+          <FormattedMessage defaultMessage="Go to homepage" id="kk1RMl" />
         </Button>
       </LayoutContainer>
     </div>

--- a/frontend/pages/500.tsx
+++ b/frontend/pages/500.tsx
@@ -53,7 +53,7 @@ const InternalError: PageComponent<InternalErrorProps, NakedLayoutProps> = () =>
           </p>
         </div>
         <Button to={Paths.Home}>
-          <FormattedMessage defaultMessage="Go back" id="orvpWh" />
+          <FormattedMessage defaultMessage="Go to homepage" id="kk1RMl" />
         </Button>
       </LayoutContainer>
     </div>

--- a/frontend/pages/_error.tsx
+++ b/frontend/pages/_error.tsx
@@ -53,7 +53,7 @@ const InternalError: PageComponent<InternalErrorProps, NakedLayoutProps> = () =>
           </p>
         </div>
         <Button to={Paths.Home}>
-          <FormattedMessage defaultMessage="Go back" id="orvpWh" />
+          <FormattedMessage defaultMessage="Go to homepage" id="kk1RMl" />
         </Button>
       </LayoutContainer>
     </div>


### PR DESCRIPTION
This PR updates the wording of the main button located on the error pages to indicate it leads to the homepage.

## Testing instructions

You can access `/404` or `/500` to see the change. Note that the 500 page may crash because Next.js actually simulates sending a 500 error code for some requests.

To test the change made to the `/pages/_error.tsx` file, you need to insert some code that will crash the app. You can follow these steps:

1. Add this to the `pages/index.tsx` file
```ts
const router = useRouter();
if (router.query?.crash) throw new Error();
```
  2. Run the application in production mode: `yarn build && yarn start`
  3. Check on `/?crash=hello`

Please note that there is an issue with the visibility of the logo in that last case: [LET-1362](https://vizzuality.atlassian.net/browse/LET-1362).

## Tracking

[LET-1308](https://vizzuality.atlassian.net/browse/LET-1308)


[LET-1362]: https://vizzuality.atlassian.net/browse/LET-1362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LET-1308]: https://vizzuality.atlassian.net/browse/LET-1308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ