### PR TITLE
Fix the visibility of the HeCo Invest logo on the crash error page

### DIFF
--- a/frontend/containers/layouts/logo/component.tsx
+++ b/frontend/containers/layouts/logo/component.tsx
@@ -12,7 +12,7 @@ import { LogoProps } from './types';
 const Logo: React.FC<LogoProps> = ({ defaultWhite = false }: LogoProps) => {
   const { isScrolledY } = useScrollY();
   const imagePath =
-    !isScrolledY && defaultWĥite
+    !isScrolledY && defaultWhite
       ? '/images/logos/heco_logo_white.png'
       : '/images/logos/heco_logo_color.png';
 

--- a/frontend/containers/layouts/logo/component.tsx
+++ b/frontend/containers/layouts/logo/component.tsx
@@ -9,7 +9,7 @@ import { Paths } from 'enums';
 
 import { LogoProps } from './types';
 
-const Logo: React.FC<LogoProps> = ({ defaultWĥite = false }: LogoProps) => {
+const Logo: React.FC<LogoProps> = ({ defaultWhite = false }: LogoProps) => {
   const { isScrolledY } = useScrollY();
   const imagePath =
     !isScrolledY && defaultWĥite

--- a/frontend/containers/layouts/logo/component.tsx
+++ b/frontend/containers/layouts/logo/component.tsx
@@ -2,20 +2,17 @@ import cx from 'classnames';
 
 import Image from 'next/image';
 import Link from 'next/link';
-import { useRouter } from 'next/router';
 
 import { useScrollY } from 'hooks/use-scroll-y';
 
 import { Paths } from 'enums';
 
-const whiteLogoPaths: string[] = [Paths.Dashboard, Paths.Discover, Paths.Settings];
+import { LogoProps } from './types';
 
-const Logo = () => {
+const Logo: React.FC<LogoProps> = ({ defaultWĥite = false }: LogoProps) => {
   const { isScrolledY } = useScrollY();
-  const { pathname } = useRouter();
   const imagePath =
-    !isScrolledY &&
-    (pathname === Paths.Home || whiteLogoPaths.some((path) => pathname.startsWith(path)))
+    !isScrolledY && defaultWĥite
       ? '/images/logos/heco_logo_white.png'
       : '/images/logos/heco_logo_color.png';
 

--- a/frontend/containers/layouts/logo/types.ts
+++ b/frontend/containers/layouts/logo/types.ts
@@ -1,1 +1,4 @@
-export type LogoProps = {};
+export type LogoProps = {
+  /** Use the white version of the logo until the user has scrolled. Default to `false`. */
+  defaultWĥite?: boolean;
+};

--- a/frontend/containers/layouts/logo/types.ts
+++ b/frontend/containers/layouts/logo/types.ts
@@ -1,4 +1,4 @@
 export type LogoProps = {
   /** Use the white version of the logo until the user has scrolled. Default to `false`. */
-  defaultWĥite?: boolean;
+  defaultWhite?: boolean;
 };

--- a/frontend/layouts/dashboard/header/component.tsx
+++ b/frontend/layouts/dashboard/header/component.tsx
@@ -31,7 +31,7 @@ export const Header: FC<HeaderProps> = ({}: HeaderProps) => {
         <LayoutContainer>
           <div className="flex items-center justify-between h-18">
             <span className="justify-start">
-              <Logo defaultWĥite />
+              <Logo defaultWhite />
             </span>
             <span className="flex items-center justify-end flex-grow gap-2">
               <Navigation className="hidden lg:flex-1 lg:flex lg:items-center lg:justify-end lg:mr-4" />

--- a/frontend/layouts/dashboard/header/component.tsx
+++ b/frontend/layouts/dashboard/header/component.tsx
@@ -31,7 +31,7 @@ export const Header: FC<HeaderProps> = ({}: HeaderProps) => {
         <LayoutContainer>
           <div className="flex items-center justify-between h-18">
             <span className="justify-start">
-              <Logo />
+              <Logo defaultWĥite />
             </span>
             <span className="flex items-center justify-end flex-grow gap-2">
               <Navigation className="hidden lg:flex-1 lg:flex lg:items-center lg:justify-end lg:mr-4" />

--- a/frontend/layouts/discover-page/header/component.tsx
+++ b/frontend/layouts/discover-page/header/component.tsx
@@ -18,7 +18,7 @@ export const Header: FC<HeaderProps> = () => {
         <LayoutContainer>
           <div className="flex items-center justify-between h-14 sm:h-18">
             <span className="justify-start flex-1">
-              <Logo />
+              <Logo defaultWĥite />
             </span>
             <div className="flex items-center justify-end flex-1 gap-2">
               <LanguageSelector />

--- a/frontend/layouts/discover-page/header/component.tsx
+++ b/frontend/layouts/discover-page/header/component.tsx
@@ -18,7 +18,7 @@ export const Header: FC<HeaderProps> = () => {
         <LayoutContainer>
           <div className="flex items-center justify-between h-14 sm:h-18">
             <span className="justify-start flex-1">
-              <Logo defaultWĥite />
+              <Logo defaultWhite />
             </span>
             <div className="flex items-center justify-end flex-1 gap-2">
               <LanguageSelector />

--- a/frontend/layouts/static-page/header/component.tsx
+++ b/frontend/layouts/static-page/header/component.tsx
@@ -16,7 +16,7 @@ import LayoutContainer from 'components/layout-container';
 import { HeaderProps } from './types';
 
 export const Header: React.FC<HeaderProps> = ({
-  props: { transparent, className } = {},
+  props: { transparent, whiteLogo = false, className } = {},
 }: HeaderProps) => {
   const { isScrolledY } = useScrollY();
 
@@ -41,7 +41,7 @@ export const Header: React.FC<HeaderProps> = ({
         >
           <LayoutContainer>
             <div className="flex items-center justify-between pt-3 pb-3 md:pt-6 md:pb-4 lg:space-x-10">
-              <Logo />
+              <Logo defaultWĥite={whiteLogo} />
               <div className="flex">
                 <Navigation className="hidden lg:flex-1 lg:flex lg:items-center lg:justify-end lg:mr-4" />
                 <div className="flex items-center gap-2 lg:gap-4">

--- a/frontend/layouts/static-page/header/component.tsx
+++ b/frontend/layouts/static-page/header/component.tsx
@@ -41,7 +41,7 @@ export const Header: React.FC<HeaderProps> = ({
         >
           <LayoutContainer>
             <div className="flex items-center justify-between pt-3 pb-3 md:pt-6 md:pb-4 lg:space-x-10">
-              <Logo defaultWĥite={whiteLogo} />
+              <Logo defaultWhite={whiteLogo} />
               <div className="flex">
                 <Navigation className="hidden lg:flex-1 lg:flex lg:items-center lg:justify-end lg:mr-4" />
                 <div className="flex items-center gap-2 lg:gap-4">

--- a/frontend/layouts/static-page/header/types.ts
+++ b/frontend/layouts/static-page/header/types.ts
@@ -3,5 +3,7 @@ export interface HeaderProps {
   props?: React.ComponentProps<'header'> & {
     /** Whether the header should be transparent (when the page isn't scrolled) */
     transparent?: boolean;
+    /** Use the white version of the logo. Default to `false`. */
+    whiteLogo?: boolean;
   };
 }

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -43,6 +43,7 @@ Home.layout = {
   props: {
     headerProps: {
       transparent: true,
+      whiteLogo: true,
     },
   },
 };


### PR DESCRIPTION
This PR fixes an issue where the HeCo Invest logo is not visible on the crash error page (`/pages/_error.tsx`). The fix updates the logic that determines the default colour of the logo before the user starts scrolling.

## Testing instructions

Make sure the logo is visible on the following pages:
- `/`
- `/discover`
- `/dashboard` (login required)
- `/settings` (login required)

Finally, you can test that the logo is visible on the error page by following these steps:

1. Add this to the `pages/index.tsx` file
```ts
const router = useRouter();
if (router.query?.crash) throw new Error();
```
  2. Run the application in production mode: `yarn build && yarn start`
  3. Go to `/?crash=hello`


## Tracking

[LET-1362](https://vizzuality.atlassian.net/browse/LET-1362)


[LET-1362]: https://vizzuality.atlassian.net/browse/LET-1362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ