### PR TITLE
Add new GA event to track visits to the entities (projects, PDs, open calls and investors)

### DIFF
--- a/frontend/pages/investor/[id]/index.tsx
+++ b/frontend/pages/investor/[id]/index.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { useRouter } from 'next/router';
@@ -152,6 +154,12 @@ const InvestorPage: PageComponent<InvestorPageProps, StaticPageLayoutProps> = ({
     // is false.
     favoriteInvestor.mutate({ id: investor.id, isFavourite: investor.favourite });
   };
+
+  useEffect(() => {
+    logEvent('profile_visit', {
+      page_location: router.asPath,
+    });
+  }, [router.asPath]);
 
   return (
     <>

--- a/frontend/pages/open-call/[id]/index.tsx
+++ b/frontend/pages/open-call/[id]/index.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import { useRouter } from 'next/router';
 
 import { withLocalizedRequests } from 'hoc/locale';
@@ -18,6 +20,7 @@ import Head from 'components/head';
 import Loading from 'components/loading';
 import { Paths } from 'enums';
 import { StaticPageLayoutProps } from 'layouts/static-page';
+import { logEvent } from 'lib/analytics/ga';
 import { PageComponent } from 'types';
 import { GroupedEnums } from 'types/enums';
 import { OpenCall } from 'types/open-calls';
@@ -76,6 +79,12 @@ const OpenCallPage: PageComponent<OpenCallPageProps, StaticPageLayoutProps> = ({
     OPEN_CALL_QUERY_PARAMS,
     openCallProp
   );
+
+  useEffect(() => {
+    logEvent('profile_visit', {
+      page_location: router.asPath,
+    });
+  }, [router.asPath]);
 
   if (!openCall) {
     if (!isFetchingOpenCall) router.push(Paths.Dashboard);

--- a/frontend/pages/project-developer/[id]/index.tsx
+++ b/frontend/pages/project-developer/[id]/index.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { useRouter } from 'next/router';
@@ -161,6 +163,12 @@ const ProjectDeveloperPage: PageComponent<ProjectDeveloperPageProps, StaticPageL
       isFavourite: projectDeveloper.favourite,
     });
   };
+
+  useEffect(() => {
+    logEvent('profile_visit', {
+      page_location: router.asPath,
+    });
+  }, [router.asPath]);
 
   return (
     <>

--- a/frontend/pages/project/[id]/index.tsx
+++ b/frontend/pages/project/[id]/index.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import { useRouter } from 'next/router';
 
 import { withLocalizedRequests } from 'hoc/locale';
@@ -19,6 +21,7 @@ import LayoutContainer from 'components/layout-container';
 import Loading from 'components/loading';
 import { Paths } from 'enums';
 import { StaticPageLayoutProps } from 'layouts/static-page';
+import { logEvent } from 'lib/analytics/ga';
 import { PageComponent } from 'types';
 import { GroupedEnums as GroupedEnumsType } from 'types/enums';
 import { Project as ProjectType } from 'types/project';
@@ -90,6 +93,12 @@ const ProjectPage: PageComponent<ProjectPageProps, StaticPageLayoutProps> = ({
     data: { data: project },
     isFetching: isFetchingProject,
   } = useProject(router.query.id as string, PROJECT_QUERY_PARAMS, projectProp);
+
+  useEffect(() => {
+    logEvent('profile_visit', {
+      page_location: router.asPath,
+    });
+  }, [router.asPath]);
 
   if (!project) {
     if (!isFetchingProject) router.push(Paths.Dashboard);


### PR DESCRIPTION
This PR adds a new Google Analytics event that is triggered when the user visits a project, project developer, open call or investor. The event sends the relative URL of the page.

## Testing instructions

1. Install Google Analytics Debugger on Chrome
2. Load the website locally
3. Accept the use of cookies (if you denied them in the past, clean your local storage first)
4. Enable the extension by clicking on its icon
5. Open the developer tools, specifically the console
6. Go to a project, PD, open call or investor

Make sure you can see that the event `profile_visit` logged in the console and that it contains a `page_location` parameter.

7. Repeat with the other types of entity

## Tracking

[LET-1363](https://vizzuality.atlassian.net/browse/LET-1363)


[LET-1363]: https://vizzuality.atlassian.net/browse/LET-1363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ