### PR TITLE
Update map search location

### DIFF
--- a/frontend/containers/discover-map/component.tsx
+++ b/frontend/containers/discover-map/component.tsx
@@ -18,7 +18,6 @@ import ClusterLayer from 'components/map/layers/cluster';
 import { Legend, LegendType } from 'components/map/legend/types';
 import ProjectMapPin from 'components/project-map-pin';
 import { logEvent } from 'lib/analytics/ga';
-import { ProjectMapParams } from 'types/project';
 
 import { useProjectsMap } from 'services/projects/projectService';
 
@@ -159,6 +158,11 @@ export const DiscoverMap: FC<DiscoverMapProps> = ({ onSelectProjectPin }) => {
           // interactable
           className="absolute flex items-start gap-2 inset-3.5 bottom-12 text-gray-800 text-sm pointer-events-none"
         >
+          <LocationSearcher
+            className="absolute pointer-events-auto"
+            onLocationSelected={handleLocationSelected}
+            isAlwaysOpen
+          />
           <MapLayersSelector
             className="pointer-events-auto"
             register={register}
@@ -193,10 +197,6 @@ export const DiscoverMap: FC<DiscoverMapProps> = ({ onSelectProjectPin }) => {
 
         <Controls className="w-full h-full">
           <div className="absolute flex flex-col items-end top-4 right-4 gap-y-2">
-            <LocationSearcher
-              className="absolute pointer-events-auto"
-              onLocationSelected={handleLocationSelected}
-            />
             <ZoomControl
               className="w-min "
               viewport={{ ...viewport }}

--- a/frontend/containers/discover-map/location-searcher/component.tsx
+++ b/frontend/containers/discover-map/location-searcher/component.tsx
@@ -42,6 +42,7 @@ export const LocationSearcher: FC<LocationSearcherProps> = ({
   };
 
   useOutsideClick(containerRef, () => {
+    setIsError(false);
     if (isAlwaysOpen || !isOpen || addressSetted) return;
     setIsOpen(false);
     handleClearSearch();
@@ -157,7 +158,7 @@ export const LocationSearcher: FC<LocationSearcherProps> = ({
                       'transition-all duration-500 ease-in-out outline-none placeholder-gray-800 text-sm overflow-ellipsis overflow-hidden whitespace-nowrap',
                       {
                         'w-0 opacity-0': !isOpen,
-                        'w-52 pr-6 opacity-100': isOpen || addressSetted,
+                        'w-40 pr-6 opacity-100': isOpen || addressSetted,
                       }
                     )}
                     aria-label={intl.formatMessage({
@@ -196,44 +197,40 @@ export const LocationSearcher: FC<LocationSearcherProps> = ({
                 </div>
 
                 <div
-                  className={cx(
-                    'absolute w-60 rounded h-0 opacity-0 px-3 py-0 mt-0 shadow-none bg-white transition-all',
-                    {
-                      'h-auto py-2 mt-1 shadow-2xl opacity-100': isOpen && !!suggestions.length,
-                    }
-                  )}
-                >
-                  {suggestions.map((suggestion) => {
-                    const className = cx({
-                      'bg-white cursor-pointer text-sm px-1.5 py-2 flex flex-col': true,
-                      'text-gray-800': suggestion.active,
-                      'text-gray-600': !suggestion.active,
-                    });
-                    return (
-                      <div
-                        key={suggestion.placeId}
-                        {...getSuggestionItemProps(suggestion, {
-                          className,
-                        })}
-                      >
-                        <p className="py-0 text-black">{suggestion.formattedSuggestion.mainText}</p>
-                        <p className="text-gray-800">
-                          {suggestion.formattedSuggestion.secondaryText}
-                        </p>
-                      </div>
-                    );
+                  className={cx('absolute w-48 rounded bg-white transition-all', {
+                    'h-auto py-2 mt-1 shadow-2xl opacity-100 px-3': isOpen,
+                    'h-0 py-0 mt-0 opacity-0 shadow-none':
+                      !isOpen || (!suggestions.length && !isError),
                   })}
-                </div>
-                <div
-                  className={cx(
-                    'absolute w-60 rounded h-0 opacity-0 shadow-none bg-white text-sm text-center text-gray-800 transition-all',
-                    {
-                      'h-auto p-4 mt-1 shadow-2xl opacity-100':
-                        isOpen && isError && !suggestions.length,
-                    }
-                  )}
                 >
-                  <FormattedMessage defaultMessage="No results found" id="hX5PAb" />
+                  {isError && !suggestions.length ? (
+                    <p className="py-2 text-center text-gray-800">
+                      <FormattedMessage defaultMessage="No results found" id="hX5PAb" />
+                    </p>
+                  ) : (
+                    suggestions.map((suggestion) => {
+                      const className = cx({
+                        'bg-white cursor-pointer text-sm px-1.5 py-2 flex flex-col': true,
+                        'text-gray-800': suggestion.active,
+                        'text-gray-600': !suggestion.active,
+                      });
+                      return (
+                        <div
+                          key={suggestion.placeId}
+                          {...getSuggestionItemProps(suggestion, {
+                            className,
+                          })}
+                        >
+                          <p className="py-0 text-black">
+                            {suggestion.formattedSuggestion.mainText}
+                          </p>
+                          <p className="text-gray-800">
+                            {suggestion.formattedSuggestion.secondaryText}
+                          </p>
+                        </div>
+                      );
+                    })
+                  )}
                 </div>
               </div>
             );


### PR DESCRIPTION
This PR updates the search location on discover/projects map 

![Screenshot 2023-01-21 at 13 04 05](https://user-images.githubusercontent.com/48164343/213866013-56ed3422-9fa3-459c-8fd9-9532b718e9cf.png)


## Testing instructions

Go to discover/projects:
- The search location input should be always open
- It should work properly
- [Design](https://www.figma.com/file/KC49uMR9t1YARmFR0Sr6aN/HeCo---Work-in-progress?node-id=6183%3A158332&t=Cpz8xaQs9sHurEGp-4)
- Make sure the search location in projects/new and projects/edit forms is still working

## Tracking

[LET-1340](https://vizzuality.atlassian.net/browse/LET-1340)


[LET-1340]: https://vizzuality.atlassian.net/browse/LET-1340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ