### PR TITLE
Fix icon  bug

### DIFF
--- a/frontend/components/forms/tag/component.tsx
+++ b/frontend/components/forms/tag/component.tsx
@@ -64,10 +64,7 @@ export const Tag = <FormValues extends FieldValues>({
       >
         {children}
         {showDeleteIcon && (
-          <Icon
-            className="w-3 h-3 ml-2 text-gray-900 sm:w-4 sm:h-4 min-w-min min-h-min"
-            icon={CloseIcon}
-          />
+          <Icon className="w-3 h-3 ml-2 text-gray-900 sm:w-4 sm:h-4" icon={CloseIcon} />
         )}
       </label>
     </div>


### PR DESCRIPTION
This PR fixes the bug with the icon size of selected filter tags on Safari

![Captura de pantalla 2023-01-03 a las 10 24 10](https://user-images.githubusercontent.com/48164343/214022940-997bb190-2aa1-4950-a129-237a2da46da4.png)

## Testing instructions

- Open http://localhost:3000/en/discover/projects?filter%5Bcategory%5D=forestry-and-agroforestry&filter%5Binstrument_type%5D=equity on Safari. 

The icon size should be correct

## Tracking

[LET-1348](https://vizzuality.atlassian.net/browse/LET-1348)

