### PR TITLE
feat: Adding service for building k.LAB context string

### DIFF
--- a/backend/app/jobs/klab/submit_contexts_job.rb
+++ b/backend/app/jobs/klab/submit_contexts_job.rb
@@ -22,7 +22,7 @@ module Klab
         context_string = Klab::BuildContextString.new(project, impact_level).call
         next skip! impact_level if context_string.blank?
 
-        response = Klab::SubmitContext.new(client).call context_string
+        response = Klab::SubmitContext.new(client).call geometry: context_string
         result << {id: response.ticket_id, impact_level: impact_level}
       end
     end

--- a/backend/app/services/klab/README.md
+++ b/backend/app/services/klab/README.md
@@ -38,11 +38,24 @@ The response is rather long, what you need from it is the token which is under "
 }
 ```
 
+# K.LAB context string
+
+Geometry send to the k.LAB needs to be described by following string:
+```
+τ0(1){ttype=LOGICAL,period=[{TIME_PERIOD}],tscope=1.0,tunit=YEAR}S2({GRID_RESOLUTION_XY}){bbox=[{BOUNDING_BOX}],shape={WKB_SHAPE},proj=EPSG:4326}
+
+# example
+τ0(1){ttype=LOGICAL,period=[1640995200000 1672531200000],tscope=1.0,tunit=YEAR}S2(520,297){bbox=[-7.256596802202454 -4.408874148363334 38.39721372248553 40.02677860935444],shape=00000000030000000100000007C01D06C14FE6DEF24043B5F39D8BB550C0160A7B8B2DC6224044036D7B41B470C011A2AFE79D99FB4043B5C0443B5A7CC014D2EFCFADC624404355FA189A597CC0199C599EE6C5B8404332D7E635CC84C01C3D49F12A6BC440437995016B4E6CC01D06C14FE6DEF24043B5F39D8BB550,proj=EPSG:4326}
+```
+This string contains several interesting blocks:
+ - TIME_PERIOD: time period in milliseconds
+ - GRID_RESOLUTION_XY: resolution of grid inside bounding box which should respect its ratio
+ - BOUNDING_BOX: based on shape/geometry
+ - WKB_SHAPE: geometry at WKB format
+
 # Submitting a context and observations separately
 
-This example uses a predefined geometry of entire Colombia.
-
-TODO: figure out about passing geometries.
+There are two options when submitting a context. Either external resources (predefined geometry) can be used by setting up `urn` parameter or geometry can be defined by context string and passed to API by using `geometry` parameter. In second case, `contextType` parameter has to be set up as well.
 
 ```
 curl --location --request POST 'https://developers.integratedmodelling.org/modeler/api/v2/public/submit/context' \
@@ -50,6 +63,8 @@ curl --location --request POST 'https://developers.integratedmodelling.org/model
 --header 'Content-Type: application/json' \
 --data-raw '{
     "urn":"aries.heco.locations.colombia_continental",
+    "geometry": null,
+    "contextType": null,
     "estimate":"false"
 }'
 ```
@@ -357,14 +372,18 @@ curl --location --request POST 'https://developers.integratedmodelling.org/model
 --header 'Authorization: s7xvepxx8c6u' \
 --header 'Content-Type: application/json' \
 --data-raw '{
-    "urn":"aries.heco.locations.colombia_continental",
+    "geometry":"τ0(1){ttype=LOGICAL,period=[1640995200000 1672531200000],tscope=1.0,tunit=YEAR}S2(520,297){bbox=[-7.256596802202454 -4.408874148363334 38.39721372248553 40.02677860935444],shape=00000000030000000100000007C01D06C14FE6DEF24043B5F39D8BB550C0160A7B8B2DC6224044036D7B41B470C011A2AFE79D99FB4043B5C0443B5A7CC014D2EFCFADC624404355FA189A597CC0199C599EE6C5B8404332D7E635CC84C01C3D49F12A6BC440437995016B4E6CC01D06C14FE6DEF24043B5F39D8BB550,proj=EPSG:4326}",
+    "urn": null,
+    "contextType": "earth:Region",
     "observables": [
-      "im:Indicator value of ecology:Biodiversity",
-      "im:Indicator value of ecology:Ecosystem for es:ClimateRegulation",
-      "im:Indicator es.nca:Condition of demography:SocialStructure",
-      "im:Indicator es.nca:Condition of earth:Aquatic ecology:Ecosystem"
+      "im:Indicator (value of ecology:Biodiversity)",
+      "im:Indicator (value of ecology:Ecosystem for es:ClimateRegulation)",
+      "im:Indicator (es.nca:Condition of demography:Human demography:Community)",
+      "im:Indicator (es.nca:Condition of earth:Aquatic ecology:Ecosystem)"
     ],
-    "estimate":"false"
+    "estimate":"false",
+    "scenarios": [],
+    "estimatedCost": -1
 }'
 ```
 

--- a/backend/app/services/klab/build_context_string.rb
+++ b/backend/app/services/klab/build_context_string.rb
@@ -1,6 +1,10 @@
 module Klab
   class BuildContextString
+    class UnknownImpactLevel < StandardError; end
+
     attr_accessor :project, :impact_level
+
+    MAX_GRID_RESOLUTION = 256
 
     def initialize(project, impact_level)
       @project = project
@@ -8,9 +12,50 @@ module Klab
     end
 
     def call
-      # TODO: construct correct string based on project geometry and required impact level
-      # returns nil if there is no usable geometry which can be send to k.LAB (for example there is no intersection between project centroid and raster of appropriate location type)
-      "aries.heco.locations.colombia_continental"
+      geometry = find_geometry
+      return if geometry.blank?
+
+      box = bounding_box_for geometry
+      "τ0(1){ttype=LOGICAL,period=#{current_time_period},tscope=1.0,tunit=YEAR}S2(#{resolution_grid_for(box)})" \
+      "{bbox=[#{box.min_x} #{box.max_x} #{box.min_y} #{box.max_y}],shape=#{wkb_for(geometry)},proj=EPSG:4326}"
+    end
+
+    private
+
+    def wkb_for(geometry)
+      RGeo::WKRep::WKBGenerator.new(hex_format: true, type_format: :ewkb).generate(geometry).upcase
+    end
+
+    def bounding_box_for(geometry)
+      RGeo::Cartesian::BoundingBox.create_from_geometry geometry
+    end
+
+    def resolution_grid_for(box)
+      return "1,1" if (box.max_x - box.min_x).zero? || (box.max_y - box.min_y).zero?
+
+      ratio = (box.max_y - box.min_y) / (box.max_x - box.min_x)
+      "#{MAX_GRID_RESOLUTION},#{(MAX_GRID_RESOLUTION * ratio).round}"
+    end
+
+    def current_time_period
+      time_start = ((Time.now - 1.year).beginning_of_year + 1.hour).to_datetime.strftime "%Q"
+      time_end = (Time.now.beginning_of_year + 1.hour).to_datetime.strftime "%Q"
+      "[#{time_start} #{time_end}]"
+    end
+
+    def find_geometry
+      case impact_level
+      when "project"
+        RGeo::GeoJSON.decode project.geometry
+      when "municipality"
+        LocationGeometry.of_type(:municipality).intersection_with(project.centroid).first&.geometry
+      when "hydrobasin"
+        LocationGeometry.of_type(:basin).intersection_with(project.centroid).first&.geometry
+      when "priority_landscape"
+        LocationGeometry.of_type(:priority_landscape).intersection_with(project.centroid).first&.geometry
+      else
+        raise UnknownImpactLevel
+      end
     end
   end
 end

--- a/backend/app/services/klab/build_context_string.rb
+++ b/backend/app/services/klab/build_context_string.rb
@@ -38,8 +38,8 @@ module Klab
     end
 
     def current_time_period
-      time_start = ((Time.current.utc - 1.year).beginning_of_year + 1.hour).to_datetime.strftime "%Q"
-      time_end = (Time.current.utc.beginning_of_year + 1.hour).to_datetime.strftime "%Q"
+      time_start = (Time.now.utc - 1.year).beginning_of_year.to_datetime.strftime "%Q"
+      time_end = Time.now.utc.beginning_of_year.to_datetime.strftime "%Q"
       "[#{time_start} #{time_end}]"
     end
 

--- a/backend/app/services/klab/build_context_string.rb
+++ b/backend/app/services/klab/build_context_string.rb
@@ -38,8 +38,8 @@ module Klab
     end
 
     def current_time_period
-      time_start = ((Time.now - 1.year).beginning_of_year + 1.hour).to_datetime.strftime "%Q"
-      time_end = (Time.now.beginning_of_year + 1.hour).to_datetime.strftime "%Q"
+      time_start = ((Time.current.utc - 1.year).beginning_of_year + 1.hour).to_datetime.strftime "%Q"
+      time_end = (Time.current.utc.beginning_of_year + 1.hour).to_datetime.strftime "%Q"
       "[#{time_start} #{time_end}]"
     end
 

--- a/backend/app/services/klab/calculate_project_impact_score.rb
+++ b/backend/app/services/klab/calculate_project_impact_score.rb
@@ -3,8 +3,9 @@ module Klab
     ImpactScoreStruct = Struct.new(:biodiversity, :climate, :community, :water)
 
     # @param geometry [String] geometry in format recognised by ARIES
-    def initialize(geometry)
+    def initialize(geometry: nil, urn: nil)
       @geometry = geometry
+      @urn = urn
       @client = Klab::APIClient.new
     end
 
@@ -19,7 +20,7 @@ module Klab
     private
 
     def get_result_from_api
-      context_resp = Klab::SubmitContext.new(@client).call(@geometry)
+      context_resp = Klab::SubmitContext.new(@client).call(geometry: @geometry, urn: @urn)
       ticket_resp = Klab::PollTicket.new(@client).call(context_resp.ticket_id, async: false)
       result = ImpactScoreStruct.new
       ticket_resp.artifacts_ids.each.with_index do |artifact_id, idx|

--- a/backend/app/services/klab/run.rb
+++ b/backend/app/services/klab/run.rb
@@ -3,10 +3,11 @@ module Klab
   class Run
     def call
       started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      # TODO: transform project geometry to klab format, for now just a static example
-      # colombia = "aries.heco.locations.colombia_continental"
-      colombia_central = "τ0(1){ttype=LOGICAL,period=[1609459200000 1640995200000],tscope=1.0,tunit=YEAR}S2(934,631){bbox=[-75.2281407807369 -72.67107290964314 3.5641500380320963 5.302943221927137],shape=00000000030000000100000005C0522AF2DBCA0987400C8361185B1480C052CE99DBCA0987400C8361185B1480C052CE99DBCA098740153636BF7AE340C0522AF2DBCA098740153636BF7AE340C0522AF2DBCA0987400C8361185B1480,proj=EPSG:4326}"
-      pp CalculateProjectImpactScore.new(colombia_central).call
+      # Examples how context_string can look like and how it can be build
+      urn = nil # "aries.heco.locations.colombia_continental"
+      context_string = "τ0(1){ttype=LOGICAL,period=[1640995200000 1672531200000],tscope=1.0,tunit=YEAR}S2(520,297){bbox=[-7.256596802202454 -4.408874148363334 38.39721372248553 40.02677860935444],shape=00000000030000000100000007C01D06C14FE6DEF24043B5F39D8BB550C0160A7B8B2DC6224044036D7B41B470C011A2AFE79D99FB4043B5C0443B5A7CC014D2EFCFADC624404355FA189A597CC0199C599EE6C5B8404332D7E635CC84C01C3D49F12A6BC440437995016B4E6CC01D06C14FE6DEF24043B5F39D8BB550,proj=EPSG:4326}"
+      # context_string = Klab::BuildContextString.new(Project.last, "project").call
+      pp CalculateProjectImpactScore.new(geometry: context_string, urn: urn).call
       finished_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       Rails.logger.debug("Elapsed: #{finished_at - started_at}")
     rescue Faraday::ServerError => e

--- a/backend/app/services/klab/submit_context.rb
+++ b/backend/app/services/klab/submit_context.rb
@@ -13,13 +13,15 @@ module Klab
         @token = token
       end
 
-      def call(geometry)
+      def call(geometry: nil, urn: nil)
         @connection.post do |req|
           req.url url
           req.headers["Authorization"] = @token
           req.headers["Content-Type"] = "application/json"
           req.body = {
-            urn: geometry,
+            urn: urn,
+            geometry: geometry,
+            contextType: geometry.present? ? "earth:Region" : nil,
             observables: INDICATORS.values,
             scenarios: [],
             estimate: false,
@@ -48,10 +50,10 @@ module Klab
       @token = client.token
     end
 
-    def call(geometry)
+    def call(geometry: nil, urn: nil)
       Rails.logger.debug "Requesting context with observables"
       request = Request.new(@token)
-      response = Response.new(request.call(geometry))
+      response = Response.new(request.call(geometry: geometry, urn: urn))
       @ticket_id = response.ticket_id
       response
     end

--- a/backend/spec/factories/project.rb
+++ b/backend/spec/factories/project.rb
@@ -66,7 +66,7 @@ FactoryBot.define do
     end
 
     language { "en" }
-    geometry { {type: "Point", coordinates: [1, 2]} }
+    geometry { {type: "Polygon", coordinates: [[[-7.256596802202454, 39.42149705239956], [-5.510236906689473, 40.02677860935444], [-4.408874148363334, 39.419930008870296], [-5.205992932301829, 38.67169482742881], [-6.402685625872827, 38.39721372248553], [-7.059852379049463, 38.94985978831832], [-7.256596802202454, 39.42149705239956]]]} }
 
     trait :with_involved_project_developers do
       involved_project_developers { create_list(:project_developer, 2) }

--- a/backend/spec/fixtures/snapshots/api/v1/account/open-call-applications-create.json
+++ b/backend/spec/fixtures/snapshots/api/v1/account/open-call-applications-create.json
@@ -1,35 +1,35 @@
 {
   "data": {
-    "id": "08e3c6c9-44fd-4961-a280-14cff5e5d949",
+    "id": "af7ab4b5-2935-43b0-8d83-6de85287ed7f",
     "type": "open_call_application",
     "attributes": {
       "message": "This is message",
       "funded": false,
-      "created_at": "2022-08-25T09:02:38.099Z",
-      "updated_at": "2022-08-25T09:02:38.099Z"
+      "created_at": "2023-01-26T09:46:05.001Z",
+      "updated_at": "2023-01-26T09:46:05.001Z"
     },
     "relationships": {
       "open_call": {
         "data": {
-          "id": "650ab969-0395-4720-a7d3-c50b4dac14ad",
+          "id": "e28475dc-61dc-46a4-aad4-8825034f8fd0",
           "type": "open_call"
         }
       },
       "project": {
         "data": {
-          "id": "9ab432af-4f54-41f7-9220-7ffeadec0032",
+          "id": "3086734a-9d69-41c7-ab6b-c80c7eed176e",
           "type": "project"
         }
       },
       "project_developer": {
         "data": {
-          "id": "4332ef9d-ae51-4291-8319-690f16bb2ee4",
+          "id": "a61f959b-42ac-4b99-a1e0-5e4eda125af0",
           "type": "project_developer"
         }
       },
       "investor": {
         "data": {
-          "id": "2c8b1694-cf9a-4f70-b0da-67b17a283923",
+          "id": "74800101-3caa-4b38-b131-2ab473db0a46",
           "type": "investor"
         }
       }
@@ -37,7 +37,7 @@
   },
   "included": [
     {
-      "id": "9ab432af-4f54-41f7-9220-7ffeadec0032",
+      "id": "3086734a-9d69-41c7-ab6b-c80c7eed176e",
       "type": "project",
       "attributes": {
         "name": "Project 1",
@@ -81,13 +81,48 @@
         "language": "en",
         "account_language": "es",
         "geometry": {
-          "type": "Point",
+          "type": "Polygon",
           "coordinates": [
-            1.0,
-            2.0
+            [
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ],
+              [
+                -5.510236906689473,
+                40.02677860935444
+              ],
+              [
+                -4.408874148363334,
+                39.419930008870296
+              ],
+              [
+                -5.205992932301829,
+                38.67169482742881
+              ],
+              [
+                -6.402685625872827,
+                38.39721372248553
+              ],
+              [
+                -7.059852379049463,
+                38.94985978831832
+              ],
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ]
+            ]
           ]
         },
-        "created_at": "2022-08-25T09:02:37.915Z",
+        "verified": false,
+        "created_at": "2023-01-26T09:46:04.723Z",
+        "updated_at": "2023-01-26T09:46:04.723Z",
+        "project_biodiversity_impact": null,
+        "project_climate_impact": null,
+        "project_water_impact": null,
+        "project_community_impact": null,
+        "project_total_impact": null,
         "municipality_biodiversity_impact": null,
         "municipality_climate_impact": null,
         "municipality_water_impact": null,
@@ -104,40 +139,33 @@
         "priority_landscape_community_impact": null,
         "priority_landscape_total_impact": null,
         "impact_calculated": false,
-        "latitude": 2.0,
-        "longitude": 1.0,
+        "latitude": 39.21309022641362,
+        "longitude": -5.87810037515931,
         "favourite": false,
-        "verified": false,
-        "funded": null,
-        "updated_at": "2022-10-25T13:31:15.507Z",
-        "project_biodiversity_impact": null,
-        "project_climate_impact": null,
-        "project_water_impact": null,
-        "project_community_impact": null,
-        "project_total_impact": null
+        "funded": null
       },
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "4332ef9d-ae51-4291-8319-690f16bb2ee4",
+            "id": "a61f959b-42ac-4b99-a1e0-5e4eda125af0",
             "type": "project_developer"
           }
         },
         "country": {
           "data": {
-            "id": "890610fd-efb3-4024-b9a3-b8d863560f6e",
+            "id": "90d788bf-24f4-468b-94ac-cb176d742446",
             "type": "location"
           }
         },
         "municipality": {
           "data": {
-            "id": "eb951ebd-b76e-4115-b65e-90f094de3e27",
+            "id": "40287090-119d-4ed4-93ea-0d4141d9330d",
             "type": "location"
           }
         },
         "department": {
           "data": {
-            "id": "184c1f56-d55c-4232-a6c0-808d497c42e8",
+            "id": "a7c4ed47-2929-42e4-a344-dec9e6826a0e",
             "type": "location"
           }
         },
@@ -157,7 +185,7 @@
       }
     },
     {
-      "id": "4332ef9d-ae51-4291-8319-690f16bb2ee4",
+      "id": "a61f959b-42ac-4b99-a1e0-5e4eda125af0",
       "type": "project_developer",
       "attributes": {
         "name": "Kutch-Spencer",
@@ -182,28 +210,28 @@
         "account_language": "es",
         "entity_legal_registration_number": "564823570",
         "review_status": "approved",
-        "created_at": "2022-08-25T09:02:37.804Z",
+        "created_at": "2023-01-26T09:46:04.526Z",
         "contact_email": "contact@example.com",
         "contact_phone": "+57-1-xxx-xx-xx",
         "picture": {
+          "analyzed": false,
           "small": null,
           "medium": null,
-          "original": null,
-          "analyzed": false
+          "original": null
         },
         "favourite": false
       },
       "relationships": {
         "owner": {
           "data": {
-            "id": "0b54005d-4f64-4c05-8865-3e74ea777db7",
+            "id": "86058dca-8272-47ac-b1e6-7ae8366a0d93",
             "type": "user"
           }
         },
         "projects": {
           "data": [
             {
-              "id": "9ab432af-4f54-41f7-9220-7ffeadec0032",
+              "id": "3086734a-9d69-41c7-ab6b-c80c7eed176e",
               "type": "project"
             }
           ]
@@ -216,11 +244,11 @@
         "priority_landscapes": {
           "data": [
             {
-              "id": "ff37376e-180b-4e4f-9154-ddedc78be42a",
+              "id": "0b6d3ea6-ec57-45a7-b4e6-cc7a52ef3c92",
               "type": "location"
             },
             {
-              "id": "f4d83e35-e0fe-4a3c-bb9b-3fd89df24f6b",
+              "id": "f6b02f3e-6396-4bee-9369-5302a58adb96",
               "type": "location"
             }
           ]

--- a/backend/spec/fixtures/snapshots/api/v1/account/projects-favourites.json
+++ b/backend/spec/fixtures/snapshots/api/v1/account/projects-favourites.json
@@ -1,7 +1,7 @@
 {
   "data": [
     {
-      "id": "a15a8d1d-e1c3-4ea4-b3e8-48913678cbc8",
+      "id": "16dec361-38e0-4efa-a386-44de3817ea3c",
       "type": "project",
       "attributes": {
         "name": "Project 1",
@@ -45,13 +45,48 @@
         "language": "en",
         "account_language": "en",
         "geometry": {
-          "type": "Point",
+          "type": "Polygon",
           "coordinates": [
-            1.0,
-            2.0
+            [
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ],
+              [
+                -5.510236906689473,
+                40.02677860935444
+              ],
+              [
+                -4.408874148363334,
+                39.419930008870296
+              ],
+              [
+                -5.205992932301829,
+                38.67169482742881
+              ],
+              [
+                -6.402685625872827,
+                38.39721372248553
+              ],
+              [
+                -7.059852379049463,
+                38.94985978831832
+              ],
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ]
+            ]
           ]
         },
-        "created_at": "2022-07-27T07:56:04.885Z",
+        "verified": false,
+        "created_at": "2023-01-26T09:48:29.719Z",
+        "updated_at": "2023-01-26T09:48:29.719Z",
+        "project_biodiversity_impact": null,
+        "project_climate_impact": null,
+        "project_water_impact": null,
+        "project_community_impact": null,
+        "project_total_impact": null,
         "municipality_biodiversity_impact": null,
         "municipality_climate_impact": null,
         "municipality_water_impact": null,
@@ -67,41 +102,34 @@
         "priority_landscape_water_impact": null,
         "priority_landscape_community_impact": null,
         "priority_landscape_total_impact": null,
-        "latitude": 2.0,
-        "longitude": 1.0,
-        "favourite": true,
         "impact_calculated": false,
-        "verified": false,
-        "funded": null,
-        "updated_at": "2022-10-25T13:32:04.602Z",
-        "project_biodiversity_impact": null,
-        "project_climate_impact": null,
-        "project_water_impact": null,
-        "project_community_impact": null,
-        "project_total_impact": null
+        "latitude": 39.21309022641362,
+        "longitude": -5.87810037515931,
+        "favourite": true,
+        "funded": null
       },
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "d7d6216e-9f22-4442-ae95-900dad692018",
+            "id": "b78b6ca6-9d5e-4725-98e7-fe98b5e3ec03",
             "type": "project_developer"
           }
         },
         "country": {
           "data": {
-            "id": "68fc2f6b-6ba3-42a2-9f6c-905cd8ac69a0",
+            "id": "0a33aadb-9be0-4e0c-a49c-95d81878033b",
             "type": "location"
           }
         },
         "municipality": {
           "data": {
-            "id": "399e76c8-5008-4555-be6f-d76dfa74da75",
+            "id": "1b0d099a-d45c-4c70-8ac6-2e9441d4b230",
             "type": "location"
           }
         },
         "department": {
           "data": {
-            "id": "dac3fce5-eeaf-48da-a6ee-28df56e251cf",
+            "id": "05758676-9e87-4387-8ac6-a7b2f02e5dfa",
             "type": "location"
           }
         },

--- a/backend/spec/fixtures/snapshots/api/v1/account/projects.json
+++ b/backend/spec/fixtures/snapshots/api/v1/account/projects.json
@@ -1,10 +1,11 @@
 {
   "data": [
     {
-      "id": "df1a92db-c671-4cb0-b10c-61c69174b338",
+      "id": "02c96d27-a414-4a5a-9677-c095d1140734",
       "type": "project",
       "attributes": {
         "name": "Draft project",
+        "status": "draft",
         "slug": "kutch-spencer-draft-project",
         "description": "Dolores fugiat nesciunt. Ut laborum dolores. Sit neque eos. Expedita molestiae quia.",
         "development_stage": "scaling-up",
@@ -42,13 +43,50 @@
         "received_funding_investor": "Hilpert, Waters and Johnston",
         "relevant_links": null,
         "language": "en",
+        "account_language": "es",
         "geometry": {
-          "type": "Point",
+          "type": "Polygon",
           "coordinates": [
-            1.0,
-            2.0
+            [
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ],
+              [
+                -5.510236906689473,
+                40.02677860935444
+              ],
+              [
+                -4.408874148363334,
+                39.419930008870296
+              ],
+              [
+                -5.205992932301829,
+                38.67169482742881
+              ],
+              [
+                -6.402685625872827,
+                38.39721372248553
+              ],
+              [
+                -7.059852379049463,
+                38.94985978831832
+              ],
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ]
+            ]
           ]
         },
+        "verified": false,
+        "created_at": "2023-01-26T09:48:43.874Z",
+        "updated_at": "2023-01-26T09:48:43.874Z",
+        "project_biodiversity_impact": null,
+        "project_climate_impact": null,
+        "project_water_impact": null,
+        "project_community_impact": null,
+        "project_total_impact": null,
         "municipality_biodiversity_impact": null,
         "municipality_climate_impact": null,
         "municipality_water_impact": null,
@@ -64,44 +102,34 @@
         "priority_landscape_water_impact": null,
         "priority_landscape_community_impact": null,
         "priority_landscape_total_impact": null,
-        "latitude": 2.0,
-        "longitude": 1.0,
-        "favourite": false,
-        "created_at": "2022-06-27T09:04:33.005Z",
-        "status": "draft",
-        "account_language": "es",
         "impact_calculated": false,
-        "verified": false,
-        "funded": null,
-        "updated_at": "2022-10-25T13:31:59.625Z",
-        "project_biodiversity_impact": null,
-        "project_climate_impact": null,
-        "project_water_impact": null,
-        "project_community_impact": null,
-        "project_total_impact": null
+        "latitude": 39.21309022641362,
+        "longitude": -5.87810037515931,
+        "favourite": false,
+        "funded": null
       },
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "5257d4bf-7e77-40fd-abf0-5ca78cef1d5e",
+            "id": "06749b3f-d4cf-47d8-b06b-a12acef89e74",
             "type": "project_developer"
           }
         },
         "country": {
           "data": {
-            "id": "57ebc0b3-6188-4038-8f9d-1d16f9fe2795",
+            "id": "26af96bc-693e-435c-9087-32a33f4991df",
             "type": "location"
           }
         },
         "municipality": {
           "data": {
-            "id": "6d4c1423-8fd3-4de8-ba5d-5464ebce0dd2",
+            "id": "8c2607ea-0853-40c0-ae5b-aaf59b461b47",
             "type": "location"
           }
         },
         "department": {
           "data": {
-            "id": "6d2b6d95-9338-488a-bffe-dc66a93c1e66",
+            "id": "c4e5d9c8-e40f-4bc0-bea7-77bf6ddb006c",
             "type": "location"
           }
         },
@@ -121,10 +149,11 @@
       }
     },
     {
-      "id": "d2454295-5a2f-404e-a100-9e38bfc567b6",
+      "id": "6fc8f7db-489d-4531-8569-74626e5c227a",
       "type": "project",
       "attributes": {
         "name": "This PDs Project Amazing",
+        "status": "published",
         "slug": "kutch-spencer-this-pds-project-amazing",
         "description": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
         "development_stage": "scaling-up",
@@ -162,13 +191,50 @@
         "received_funding_investor": "Bartoletti and Sons",
         "relevant_links": null,
         "language": "en",
+        "account_language": "es",
         "geometry": {
-          "type": "Point",
+          "type": "Polygon",
           "coordinates": [
-            1.0,
-            2.0
+            [
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ],
+              [
+                -5.510236906689473,
+                40.02677860935444
+              ],
+              [
+                -4.408874148363334,
+                39.419930008870296
+              ],
+              [
+                -5.205992932301829,
+                38.67169482742881
+              ],
+              [
+                -6.402685625872827,
+                38.39721372248553
+              ],
+              [
+                -7.059852379049463,
+                38.94985978831832
+              ],
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ]
+            ]
           ]
         },
+        "verified": false,
+        "created_at": "2023-01-26T09:48:43.417Z",
+        "updated_at": "2023-01-26T09:48:43.417Z",
+        "project_biodiversity_impact": null,
+        "project_climate_impact": null,
+        "project_water_impact": null,
+        "project_community_impact": null,
+        "project_total_impact": null,
         "municipality_biodiversity_impact": null,
         "municipality_climate_impact": null,
         "municipality_water_impact": null,
@@ -184,44 +250,34 @@
         "priority_landscape_water_impact": null,
         "priority_landscape_community_impact": null,
         "priority_landscape_total_impact": null,
-        "latitude": 2.0,
-        "longitude": 1.0,
-        "favourite": false,
-        "created_at": "2022-06-27T09:04:32.944Z",
-        "status": "published",
-        "account_language": "es",
         "impact_calculated": false,
-        "verified": false,
-        "funded": null,
-        "updated_at": "2022-10-25T13:31:59.447Z",
-        "project_biodiversity_impact": null,
-        "project_climate_impact": null,
-        "project_water_impact": null,
-        "project_community_impact": null,
-        "project_total_impact": null
+        "latitude": 39.21309022641362,
+        "longitude": -5.87810037515931,
+        "favourite": false,
+        "funded": null
       },
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "5257d4bf-7e77-40fd-abf0-5ca78cef1d5e",
+            "id": "06749b3f-d4cf-47d8-b06b-a12acef89e74",
             "type": "project_developer"
           }
         },
         "country": {
           "data": {
-            "id": "236a7a1e-cfc0-4bb8-a3b6-5b9f14620c06",
+            "id": "10b146ae-9d1d-44d9-afdd-3a2e0c0df63b",
             "type": "location"
           }
         },
         "municipality": {
           "data": {
-            "id": "c49d2244-5efc-4be5-a029-9b70e6faaab7",
+            "id": "1e3d7b53-6ebf-41d0-a39f-218bc6ab4467",
             "type": "location"
           }
         },
         "department": {
           "data": {
-            "id": "1ea7eccc-18f7-45b8-b8a4-d53ebd23f02e",
+            "id": "c588c7a4-8ad1-4d5b-b003-6810b8078252",
             "type": "location"
           }
         },
@@ -241,7 +297,7 @@
       }
     },
     {
-      "id": "0be57ead-19e9-471a-b768-39b2f62aa48f",
+      "id": "a2dc2d24-b4c8-4f86-a710-4636a3c30ebd",
       "type": "project",
       "attributes": {
         "name": "This PDs Project Awesome",
@@ -283,14 +339,50 @@
         "received_funding_investor": "Kutch-Spencer",
         "relevant_links": null,
         "language": "en",
+        "account_language": "es",
         "geometry": {
-          "type": "Point",
+          "type": "Polygon",
           "coordinates": [
-            1.0,
-            2.0
+            [
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ],
+              [
+                -5.510236906689473,
+                40.02677860935444
+              ],
+              [
+                -4.408874148363334,
+                39.419930008870296
+              ],
+              [
+                -5.205992932301829,
+                38.67169482742881
+              ],
+              [
+                -6.402685625872827,
+                38.39721372248553
+              ],
+              [
+                -7.059852379049463,
+                38.94985978831832
+              ],
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ]
+            ]
           ]
         },
-        "created_at": "2022-07-05T08:47:28.745Z",
+        "verified": false,
+        "created_at": "2023-01-26T09:48:43.183Z",
+        "updated_at": "2023-01-26T09:48:43.183Z",
+        "project_biodiversity_impact": null,
+        "project_climate_impact": null,
+        "project_water_impact": null,
+        "project_community_impact": null,
+        "project_total_impact": null,
         "municipality_biodiversity_impact": null,
         "municipality_climate_impact": null,
         "municipality_water_impact": null,
@@ -306,42 +398,34 @@
         "priority_landscape_water_impact": null,
         "priority_landscape_community_impact": null,
         "priority_landscape_total_impact": null,
-        "latitude": 2.0,
-        "longitude": 1.0,
-        "favourite": false,
-        "account_language": "es",
         "impact_calculated": false,
-        "verified": false,
-        "funded": null,
-        "updated_at": "2022-10-25T13:31:59.403Z",
-        "project_biodiversity_impact": null,
-        "project_climate_impact": null,
-        "project_water_impact": null,
-        "project_community_impact": null,
-        "project_total_impact": null
+        "latitude": 39.21309022641362,
+        "longitude": -5.87810037515931,
+        "favourite": false,
+        "funded": null
       },
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "96792ae6-1d73-4197-af17-d7d7ea674bf8",
+            "id": "06749b3f-d4cf-47d8-b06b-a12acef89e74",
             "type": "project_developer"
           }
         },
         "country": {
           "data": {
-            "id": "c3c2cb10-68ce-4133-849d-aca56e8814ec",
+            "id": "f8bb4a85-e79c-4c9e-ae88-8d15df019586",
             "type": "location"
           }
         },
         "municipality": {
           "data": {
-            "id": "bb30f485-9389-4ce3-a0d4-7750301c538f",
+            "id": "d51941d3-62c0-486a-979d-62fa7ea372e3",
             "type": "location"
           }
         },
         "department": {
           "data": {
-            "id": "757482cd-1e59-4cc7-9009-826b5e761eaa",
+            "id": "8a3b7eea-b45a-4673-b209-a2bac589cf4f",
             "type": "location"
           }
         },

--- a/backend/spec/fixtures/snapshots/api/v1/get-project-developer-include-relationships.json
+++ b/backend/spec/fixtures/snapshots/api/v1/get-project-developer-include-relationships.json
@@ -1,6 +1,6 @@
 {
   "data": {
-    "id": "2b4be194-0707-4bae-947a-0ceffd2687de",
+    "id": "83446494-c1ac-4c1e-a287-c162fec0be70",
     "type": "project_developer",
     "attributes": {
       "name": "Kutch-Spencer"
@@ -9,11 +9,11 @@
       "involved_projects": {
         "data": [
           {
-            "id": "cc873ec3-bf64-4b87-815b-4199a4fd28df",
+            "id": "26ca4bd3-6e76-4e47-b696-09b85710688f",
             "type": "project"
           },
           {
-            "id": "ca86f3ba-e61f-4a7c-90eb-013287d12deb",
+            "id": "9e72aed1-a473-414e-ac8d-a05d97f87484",
             "type": "project"
           }
         ]
@@ -22,133 +22,11 @@
   },
   "included": [
     {
-      "id": "cc873ec3-bf64-4b87-815b-4199a4fd28df",
-      "type": "project",
-      "attributes": {
-        "name": "Project 2",
-        "slug": "hane-lehner-and-goyette-project-2",
-        "description": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
-        "development_stage": "scaling-up",
-        "estimated_duration_in_months": 13,
-        "target_groups": [
-          "urban-populations",
-          "indigenous-peoples"
-        ],
-        "impact_areas": [
-          "pollutants-reduction",
-          "carbon-emission-reduction"
-        ],
-        "sdgs": [
-          1,
-          4,
-          5
-        ],
-        "involved_project_developer_not_listed": false,
-        "problem": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
-        "solution": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
-        "expected_impact": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
-        "looking_for_funding": true,
-        "ticket_size": "scaling",
-        "instrument_types": [
-          "grant",
-          "loan"
-        ],
-        "sustainability": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
-        "replicability": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
-        "progress_impact_tracking": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
-        "received_funding": true,
-        "received_funding_amount_usd": "3000.0",
-        "received_funding_investor": "Bartoletti and Sons",
-        "relevant_links": null,
-        "language": "en",
-        "category": "forestry-and-agroforestry",
-        "favourite": null,
-        "geometry": {
-          "type": "Point",
-          "coordinates": [
-            1.0,
-            2.0
-          ]
-        },
-        "latitude": 2.0,
-        "longitude": 1.0,
-        "funding_plan": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
-        "municipality_biodiversity_impact": null,
-        "municipality_climate_impact": null,
-        "municipality_water_impact": null,
-        "municipality_community_impact": null,
-        "municipality_total_impact": null,
-        "hydrobasin_biodiversity_impact": null,
-        "hydrobasin_climate_impact": null,
-        "hydrobasin_water_impact": null,
-        "hydrobasin_community_impact": null,
-        "hydrobasin_total_impact": null,
-        "priority_landscape_biodiversity_impact": null,
-        "priority_landscape_climate_impact": null,
-        "priority_landscape_water_impact": null,
-        "priority_landscape_community_impact": null,
-        "priority_landscape_total_impact": null,
-        "created_at": "2022-06-24T09:06:30.522Z",
-        "status": "published",
-        "account_language": "en",
-        "impact_calculated": false,
-        "verified": false,
-        "funded": null,
-        "updated_at": "2022-10-25T13:21:51.149Z",
-        "project_biodiversity_impact": null,
-        "project_climate_impact": null,
-        "project_water_impact": null,
-        "project_community_impact": null,
-        "project_total_impact": null
-      },
-      "relationships": {
-        "project_developer": {
-          "data": {
-            "id": "681ab814-6afd-45c7-bd6c-06be7c98b6c3",
-            "type": "project_developer"
-          }
-        },
-        "involved_project_developers": {
-          "data": [
-            {
-              "id": "2b4be194-0707-4bae-947a-0ceffd2687de",
-              "type": "project_developer"
-            }
-          ]
-        },
-        "project_images": {
-          "data": [
-
-          ]
-        },
-        "country": {
-          "data": {
-            "id": "bd3fc33b-28e0-44ca-90c7-501b06796251",
-            "type": "location"
-          }
-        },
-        "municipality": {
-          "data": {
-            "id": "7312e65c-de64-41b1-ac1d-a59ade3f9bff",
-            "type": "location"
-          }
-        },
-        "department": {
-          "data": {
-            "id": "9bb163fb-33cf-466e-bd05-8eb70c775055",
-            "type": "location"
-          }
-        },
-        "priority_landscape": {
-          "data": null
-        }
-      }
-    },
-    {
-      "id": "ca86f3ba-e61f-4a7c-90eb-013287d12deb",
+      "id": "26ca4bd3-6e76-4e47-b696-09b85710688f",
       "type": "project",
       "attributes": {
         "name": "Project 1",
+        "status": "published",
         "slug": "bartoletti-and-sons-project-1",
         "description": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
         "development_stage": "scaling-up",
@@ -161,6 +39,7 @@
           "pollutants-reduction",
           "carbon-emission-reduction"
         ],
+        "category": "forestry-and-agroforestry",
         "sdgs": [
           1,
           4,
@@ -176,6 +55,7 @@
           "grant",
           "loan"
         ],
+        "funding_plan": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
         "sustainability": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
         "replicability": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
         "progress_impact_tracking": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
@@ -184,18 +64,50 @@
         "received_funding_investor": "Kutch-Spencer",
         "relevant_links": null,
         "language": "en",
-        "category": "forestry-and-agroforestry",
-        "favourite": null,
+        "account_language": "en",
         "geometry": {
-          "type": "Point",
+          "type": "Polygon",
           "coordinates": [
-            1.0,
-            2.0
+            [
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ],
+              [
+                -5.510236906689473,
+                40.02677860935444
+              ],
+              [
+                -4.408874148363334,
+                39.419930008870296
+              ],
+              [
+                -5.205992932301829,
+                38.67169482742881
+              ],
+              [
+                -6.402685625872827,
+                38.39721372248553
+              ],
+              [
+                -7.059852379049463,
+                38.94985978831832
+              ],
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ]
+            ]
           ]
         },
-        "latitude": 2.0,
-        "longitude": 1.0,
-        "funding_plan": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
+        "verified": false,
+        "created_at": "2023-01-26T09:50:37.265Z",
+        "updated_at": "2023-01-26T09:50:37.265Z",
+        "project_biodiversity_impact": null,
+        "project_climate_impact": null,
+        "project_water_impact": null,
+        "project_community_impact": null,
+        "project_total_impact": null,
         "municipality_biodiversity_impact": null,
         "municipality_climate_impact": null,
         "municipality_water_impact": null,
@@ -211,30 +123,44 @@
         "priority_landscape_water_impact": null,
         "priority_landscape_community_impact": null,
         "priority_landscape_total_impact": null,
-        "created_at": "2022-06-24T09:06:30.643Z",
-        "status": "published",
-        "account_language": "en",
         "impact_calculated": false,
-        "verified": false,
-        "funded": null,
-        "updated_at": "2022-10-25T13:21:51.306Z",
-        "project_biodiversity_impact": null,
-        "project_climate_impact": null,
-        "project_water_impact": null,
-        "project_community_impact": null,
-        "project_total_impact": null
+        "latitude": 39.21309022641362,
+        "longitude": -5.87810037515931,
+        "favourite": null,
+        "funded": null
       },
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "f3909f1b-47b4-4d58-bd59-b8129fd24a0a",
+            "id": "81b7bf4b-ceb9-4021-ac5e-72cf14089cc0",
             "type": "project_developer"
           }
+        },
+        "country": {
+          "data": {
+            "id": "0709c785-ea7b-44ed-82be-6a95061810b5",
+            "type": "location"
+          }
+        },
+        "municipality": {
+          "data": {
+            "id": "f3c3db1a-5e70-484d-b78b-86c339aa2cf0",
+            "type": "location"
+          }
+        },
+        "department": {
+          "data": {
+            "id": "8a2d9820-5d65-4aa0-a0af-d5c4d52400ae",
+            "type": "location"
+          }
+        },
+        "priority_landscape": {
+          "data": null
         },
         "involved_project_developers": {
           "data": [
             {
-              "id": "2b4be194-0707-4bae-947a-0ceffd2687de",
+              "id": "83446494-c1ac-4c1e-a287-c162fec0be70",
               "type": "project_developer"
             }
           ]
@@ -243,27 +169,157 @@
           "data": [
 
           ]
+        }
+      }
+    },
+    {
+      "id": "9e72aed1-a473-414e-ac8d-a05d97f87484",
+      "type": "project",
+      "attributes": {
+        "name": "Project 2",
+        "status": "published",
+        "slug": "hane-lehner-and-goyette-project-2",
+        "description": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
+        "development_stage": "scaling-up",
+        "estimated_duration_in_months": 13,
+        "target_groups": [
+          "urban-populations",
+          "indigenous-peoples"
+        ],
+        "impact_areas": [
+          "pollutants-reduction",
+          "carbon-emission-reduction"
+        ],
+        "category": "forestry-and-agroforestry",
+        "sdgs": [
+          1,
+          4,
+          5
+        ],
+        "involved_project_developer_not_listed": false,
+        "problem": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
+        "solution": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
+        "expected_impact": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
+        "looking_for_funding": true,
+        "ticket_size": "scaling",
+        "instrument_types": [
+          "grant",
+          "loan"
+        ],
+        "funding_plan": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
+        "sustainability": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
+        "replicability": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
+        "progress_impact_tracking": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
+        "received_funding": true,
+        "received_funding_amount_usd": "3000.0",
+        "received_funding_investor": "Bartoletti and Sons",
+        "relevant_links": null,
+        "language": "en",
+        "account_language": "en",
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ],
+              [
+                -5.510236906689473,
+                40.02677860935444
+              ],
+              [
+                -4.408874148363334,
+                39.419930008870296
+              ],
+              [
+                -5.205992932301829,
+                38.67169482742881
+              ],
+              [
+                -6.402685625872827,
+                38.39721372248553
+              ],
+              [
+                -7.059852379049463,
+                38.94985978831832
+              ],
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ]
+            ]
+          ]
+        },
+        "verified": false,
+        "created_at": "2023-01-26T09:50:37.555Z",
+        "updated_at": "2023-01-26T09:50:37.555Z",
+        "project_biodiversity_impact": null,
+        "project_climate_impact": null,
+        "project_water_impact": null,
+        "project_community_impact": null,
+        "project_total_impact": null,
+        "municipality_biodiversity_impact": null,
+        "municipality_climate_impact": null,
+        "municipality_water_impact": null,
+        "municipality_community_impact": null,
+        "municipality_total_impact": null,
+        "hydrobasin_biodiversity_impact": null,
+        "hydrobasin_climate_impact": null,
+        "hydrobasin_water_impact": null,
+        "hydrobasin_community_impact": null,
+        "hydrobasin_total_impact": null,
+        "priority_landscape_biodiversity_impact": null,
+        "priority_landscape_climate_impact": null,
+        "priority_landscape_water_impact": null,
+        "priority_landscape_community_impact": null,
+        "priority_landscape_total_impact": null,
+        "impact_calculated": false,
+        "latitude": 39.21309022641362,
+        "longitude": -5.87810037515931,
+        "favourite": null,
+        "funded": null
+      },
+      "relationships": {
+        "project_developer": {
+          "data": {
+            "id": "fd589048-589a-42de-9d37-ec30a33ea913",
+            "type": "project_developer"
+          }
         },
         "country": {
           "data": {
-            "id": "e20b6b1c-99d5-42d7-a024-15bff2c0c6f9",
+            "id": "8b0282d2-ddcc-478e-937d-6575140b0bd7",
             "type": "location"
           }
         },
         "municipality": {
           "data": {
-            "id": "42b10237-ddc0-4c95-9ad8-0d42a8fe2484",
+            "id": "a672430b-e687-4819-a1d8-36dbcd6f5316",
             "type": "location"
           }
         },
         "department": {
           "data": {
-            "id": "5d9e5da2-16a5-4365-944a-1b69b61c726e",
+            "id": "9bea5699-8d13-45ec-a9b5-ff1d681d17f0",
             "type": "location"
           }
         },
         "priority_landscape": {
           "data": null
+        },
+        "involved_project_developers": {
+          "data": [
+            {
+              "id": "83446494-c1ac-4c1e-a287-c162fec0be70",
+              "type": "project_developer"
+            }
+          ]
+        },
+        "project_images": {
+          "data": [
+
+          ]
         }
       }
     }

--- a/backend/spec/fixtures/snapshots/api/v1/project-developers-include-relationships.json
+++ b/backend/spec/fixtures/snapshots/api/v1/project-developers-include-relationships.json
@@ -1,7 +1,7 @@
 {
   "data": [
     {
-      "id": "0c2552a2-e1ac-4786-9f87-624411c7bbd1",
+      "id": "81b7bf4b-ceb9-4021-ac5e-72cf14089cc0",
       "type": "project_developer",
       "attributes": {
         "name": "Bartoletti and Sons"
@@ -15,7 +15,7 @@
       }
     },
     {
-      "id": "759984de-17f0-4396-9d6e-40676dd410dd",
+      "id": "f032fd5f-7df2-4ae7-8a97-a6332d06a035",
       "type": "project_developer",
       "attributes": {
         "name": "Becker LLC"
@@ -29,7 +29,7 @@
       }
     },
     {
-      "id": "b93e08e5-ad7b-4783-8e94-b2a45d4f6492",
+      "id": "fd589048-589a-42de-9d37-ec30a33ea913",
       "type": "project_developer",
       "attributes": {
         "name": "Hane, Lehner and Goyette"
@@ -43,7 +43,7 @@
       }
     },
     {
-      "id": "5d5665be-4c2a-403b-965d-cdd5f61be4cf",
+      "id": "e736a92e-d43c-48df-b87b-10ca31e6541c",
       "type": "project_developer",
       "attributes": {
         "name": "Hilpert, Waters and Johnston"
@@ -57,7 +57,7 @@
       }
     },
     {
-      "id": "5523d507-5a78-4e8a-a8fb-5474db1746d7",
+      "id": "87c85a57-47f8-4b6c-aac9-ef73e2389ca3",
       "type": "project_developer",
       "attributes": {
         "name": "Jacobson, Fritsch and Stanton"
@@ -71,7 +71,7 @@
       }
     },
     {
-      "id": "8b03b1cd-ff98-4ec8-9c5e-6ce24af78b11",
+      "id": "34391027-3b66-4d0e-870f-a9667581e855",
       "type": "project_developer",
       "attributes": {
         "name": "Keebler, Kub and Zemlak"
@@ -85,7 +85,7 @@
       }
     },
     {
-      "id": "40625360-65a5-45a7-8867-ee4ed47d244c",
+      "id": "83446494-c1ac-4c1e-a287-c162fec0be70",
       "type": "project_developer",
       "attributes": {
         "name": "Kutch-Spencer"
@@ -94,11 +94,11 @@
         "involved_projects": {
           "data": [
             {
-              "id": "05119ec0-7217-45f6-a26a-7f4debfdf3bf",
+              "id": "26ca4bd3-6e76-4e47-b696-09b85710688f",
               "type": "project"
             },
             {
-              "id": "e11e66a4-fa9c-4a65-9100-562cf8056265",
+              "id": "9e72aed1-a473-414e-ac8d-a05d97f87484",
               "type": "project"
             }
           ]
@@ -106,7 +106,7 @@
       }
     },
     {
-      "id": "656ab0e5-e118-4033-aaa6-73cccabfd5f3",
+      "id": "9eca5b32-eeba-4d3b-b207-cd94ffe04a27",
       "type": "project_developer",
       "attributes": {
         "name": "Lind, Langworth and Gottlieb"
@@ -120,7 +120,7 @@
       }
     },
     {
-      "id": "5994b3a8-4f98-4585-b02e-ade1859cb1e1",
+      "id": "44382460-07a6-4930-8873-83f7af209f2a",
       "type": "project_developer",
       "attributes": {
         "name": "Ritchie, Glover and Ward"
@@ -134,7 +134,7 @@
       }
     },
     {
-      "id": "b40abf91-e283-4000-a212-6feee6a1f10c",
+      "id": "c52ae360-39d4-4af2-acb1-699fb01c37c9",
       "type": "project_developer",
       "attributes": {
         "name": "Runolfsson and Sons"
@@ -150,10 +150,11 @@
   ],
   "included": [
     {
-      "id": "05119ec0-7217-45f6-a26a-7f4debfdf3bf",
+      "id": "26ca4bd3-6e76-4e47-b696-09b85710688f",
       "type": "project",
       "attributes": {
         "name": "Project 1",
+        "status": "published",
         "slug": "bartoletti-and-sons-project-1",
         "description": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
         "development_stage": "scaling-up",
@@ -191,13 +192,50 @@
         "received_funding_investor": "Kutch-Spencer",
         "relevant_links": null,
         "language": "en",
+        "account_language": "en",
         "geometry": {
-          "type": "Point",
+          "type": "Polygon",
           "coordinates": [
-            1.0,
-            2.0
+            [
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ],
+              [
+                -5.510236906689473,
+                40.02677860935444
+              ],
+              [
+                -4.408874148363334,
+                39.419930008870296
+              ],
+              [
+                -5.205992932301829,
+                38.67169482742881
+              ],
+              [
+                -6.402685625872827,
+                38.39721372248553
+              ],
+              [
+                -7.059852379049463,
+                38.94985978831832
+              ],
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ]
+            ]
           ]
         },
+        "verified": false,
+        "created_at": "2023-01-26T09:50:37.265Z",
+        "updated_at": "2023-01-26T09:50:37.265Z",
+        "project_biodiversity_impact": null,
+        "project_climate_impact": null,
+        "project_water_impact": null,
+        "project_community_impact": null,
+        "project_total_impact": null,
         "municipality_biodiversity_impact": null,
         "municipality_climate_impact": null,
         "municipality_water_impact": null,
@@ -213,44 +251,34 @@
         "priority_landscape_water_impact": null,
         "priority_landscape_community_impact": null,
         "priority_landscape_total_impact": null,
-        "latitude": 2.0,
-        "longitude": 1.0,
-        "favourite": null,
-        "created_at": "2022-06-24T09:06:30.522Z",
-        "status": "published",
-        "account_language": "en",
         "impact_calculated": false,
-        "verified": false,
-        "funded": null,
-        "updated_at": "2022-10-25T13:21:51.149Z",
-        "project_biodiversity_impact": null,
-        "project_climate_impact": null,
-        "project_water_impact": null,
-        "project_community_impact": null,
-        "project_total_impact": null
+        "latitude": 39.21309022641362,
+        "longitude": -5.87810037515931,
+        "favourite": null,
+        "funded": null
       },
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "0c2552a2-e1ac-4786-9f87-624411c7bbd1",
+            "id": "81b7bf4b-ceb9-4021-ac5e-72cf14089cc0",
             "type": "project_developer"
           }
         },
         "country": {
           "data": {
-            "id": "98ca0542-ce3c-47f6-baa9-1aaf1363d358",
+            "id": "0709c785-ea7b-44ed-82be-6a95061810b5",
             "type": "location"
           }
         },
         "municipality": {
           "data": {
-            "id": "3b18cc32-6dec-4635-b250-b3846aedc669",
+            "id": "f3c3db1a-5e70-484d-b78b-86c339aa2cf0",
             "type": "location"
           }
         },
         "department": {
           "data": {
-            "id": "0a3eff91-0ff5-4061-bb31-ab6f1ad98566",
+            "id": "8a2d9820-5d65-4aa0-a0af-d5c4d52400ae",
             "type": "location"
           }
         },
@@ -260,7 +288,7 @@
         "involved_project_developers": {
           "data": [
             {
-              "id": "40625360-65a5-45a7-8867-ee4ed47d244c",
+              "id": "83446494-c1ac-4c1e-a287-c162fec0be70",
               "type": "project_developer"
             }
           ]
@@ -273,10 +301,11 @@
       }
     },
     {
-      "id": "e11e66a4-fa9c-4a65-9100-562cf8056265",
+      "id": "9e72aed1-a473-414e-ac8d-a05d97f87484",
       "type": "project",
       "attributes": {
         "name": "Project 2",
+        "status": "published",
         "slug": "hane-lehner-and-goyette-project-2",
         "description": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
         "development_stage": "scaling-up",
@@ -314,13 +343,50 @@
         "received_funding_investor": "Bartoletti and Sons",
         "relevant_links": null,
         "language": "en",
+        "account_language": "en",
         "geometry": {
-          "type": "Point",
+          "type": "Polygon",
           "coordinates": [
-            1.0,
-            2.0
+            [
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ],
+              [
+                -5.510236906689473,
+                40.02677860935444
+              ],
+              [
+                -4.408874148363334,
+                39.419930008870296
+              ],
+              [
+                -5.205992932301829,
+                38.67169482742881
+              ],
+              [
+                -6.402685625872827,
+                38.39721372248553
+              ],
+              [
+                -7.059852379049463,
+                38.94985978831832
+              ],
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ]
+            ]
           ]
         },
+        "verified": false,
+        "created_at": "2023-01-26T09:50:37.555Z",
+        "updated_at": "2023-01-26T09:50:37.555Z",
+        "project_biodiversity_impact": null,
+        "project_climate_impact": null,
+        "project_water_impact": null,
+        "project_community_impact": null,
+        "project_total_impact": null,
         "municipality_biodiversity_impact": null,
         "municipality_climate_impact": null,
         "municipality_water_impact": null,
@@ -336,44 +402,34 @@
         "priority_landscape_water_impact": null,
         "priority_landscape_community_impact": null,
         "priority_landscape_total_impact": null,
-        "latitude": 2.0,
-        "longitude": 1.0,
-        "favourite": null,
-        "created_at": "2022-06-24T09:06:30.643Z",
-        "status": "published",
-        "account_language": "en",
         "impact_calculated": false,
-        "verified": false,
-        "funded": null,
-        "updated_at": "2022-10-25T13:21:51.306Z",
-        "project_biodiversity_impact": null,
-        "project_climate_impact": null,
-        "project_water_impact": null,
-        "project_community_impact": null,
-        "project_total_impact": null
+        "latitude": 39.21309022641362,
+        "longitude": -5.87810037515931,
+        "favourite": null,
+        "funded": null
       },
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "b93e08e5-ad7b-4783-8e94-b2a45d4f6492",
+            "id": "fd589048-589a-42de-9d37-ec30a33ea913",
             "type": "project_developer"
           }
         },
         "country": {
           "data": {
-            "id": "350c2288-23c7-43a6-9255-e6301404806d",
+            "id": "8b0282d2-ddcc-478e-937d-6575140b0bd7",
             "type": "location"
           }
         },
         "municipality": {
           "data": {
-            "id": "b4d8a255-eca1-405f-914e-5a5bcaea8b13",
+            "id": "a672430b-e687-4819-a1d8-36dbcd6f5316",
             "type": "location"
           }
         },
         "department": {
           "data": {
-            "id": "b1d4ced6-58c8-4377-bdd3-2119a4179f12",
+            "id": "9bea5699-8d13-45ec-a9b5-ff1d681d17f0",
             "type": "location"
           }
         },
@@ -383,7 +439,7 @@
         "involved_project_developers": {
           "data": [
             {
-              "id": "40625360-65a5-45a7-8867-ee4ed47d244c",
+              "id": "83446494-c1ac-4c1e-a287-c162fec0be70",
               "type": "project_developer"
             }
           ]

--- a/backend/spec/fixtures/snapshots/api/v1/project-maps.json
+++ b/backend/spec/fixtures/snapshots/api/v1/project-maps.json
@@ -4,8 +4,8 @@
       "id": "2882f74f-3f5c-4569-b1d2-77074f87360c",
       "type": "project_map",
       "attributes": {
-        "latitude": 2.0,
-        "longitude": 1.0,
+        "latitude": 39.21309022641362,
+        "longitude": -5.87810037515931,
         "category": "forestry-and-agroforestry",
         "verified": false
       }
@@ -14,8 +14,8 @@
       "id": "de68d9b0-fdb4-4f48-ad06-0932752f3c14",
       "type": "project_map",
       "attributes": {
-        "latitude": 2.0,
-        "longitude": 1.0,
+        "latitude": 39.21309022641362,
+        "longitude": -5.87810037515931,
         "category": "forestry-and-agroforestry",
         "verified": false
       }
@@ -24,8 +24,8 @@
       "id": "bf9f46b2-ab46-4e5d-ba44-b388117bd6ed",
       "type": "project_map",
       "attributes": {
-        "latitude": 2.0,
-        "longitude": 1.0,
+        "latitude": 39.21309022641362,
+        "longitude": -5.87810037515931,
         "category": "forestry-and-agroforestry",
         "verified": false
       }
@@ -34,8 +34,8 @@
       "id": "654cbc02-2e70-4c0f-9c4f-78200c476494",
       "type": "project_map",
       "attributes": {
-        "latitude": 2.0,
-        "longitude": 1.0,
+        "latitude": 39.21309022641362,
+        "longitude": -5.87810037515931,
         "category": "forestry-and-agroforestry",
         "verified": false
       }
@@ -44,8 +44,8 @@
       "id": "c431c8d6-2bc2-4500-a105-9a6b8bd34150",
       "type": "project_map",
       "attributes": {
-        "latitude": 2.0,
-        "longitude": 1.0,
+        "latitude": 39.21309022641362,
+        "longitude": -5.87810037515931,
         "category": "forestry-and-agroforestry",
         "verified": false
       }
@@ -54,8 +54,8 @@
       "id": "b521f30f-5d66-4158-bdc8-6b3bd2c7da3d",
       "type": "project_map",
       "attributes": {
-        "latitude": 2.0,
-        "longitude": 1.0,
+        "latitude": 39.21309022641362,
+        "longitude": -5.87810037515931,
         "category": "forestry-and-agroforestry",
         "verified": false
       }

--- a/backend/spec/fixtures/snapshots/api/v1/projects.json
+++ b/backend/spec/fixtures/snapshots/api/v1/projects.json
@@ -1,7 +1,7 @@
 {
   "data": [
     {
-      "id": "d04a46aa-dc51-4280-9e86-717b002b5ae6",
+      "id": "5a5ef24a-ae41-461b-bfe7-2c8545368a3d",
       "type": "project",
       "attributes": {
         "name": "Project 1",
@@ -45,13 +45,48 @@
         "language": "en",
         "account_language": "en",
         "geometry": {
-          "type": "Point",
+          "type": "Polygon",
           "coordinates": [
-            1.0,
-            2.0
+            [
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ],
+              [
+                -5.510236906689473,
+                40.02677860935444
+              ],
+              [
+                -4.408874148363334,
+                39.419930008870296
+              ],
+              [
+                -5.205992932301829,
+                38.67169482742881
+              ],
+              [
+                -6.402685625872827,
+                38.39721372248553
+              ],
+              [
+                -7.059852379049463,
+                38.94985978831832
+              ],
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ]
+            ]
           ]
         },
-        "created_at": "2022-08-19T13:20:43.214Z",
+        "verified": false,
+        "created_at": "2023-01-26T09:51:26.142Z",
+        "updated_at": "2023-01-26T09:51:26.142Z",
+        "project_biodiversity_impact": null,
+        "project_climate_impact": null,
+        "project_water_impact": null,
+        "project_community_impact": null,
+        "project_total_impact": null,
         "municipality_biodiversity_impact": null,
         "municipality_climate_impact": null,
         "municipality_water_impact": null,
@@ -68,40 +103,33 @@
         "priority_landscape_community_impact": null,
         "priority_landscape_total_impact": null,
         "impact_calculated": false,
-        "latitude": 2.0,
-        "longitude": 1.0,
+        "latitude": 39.21309022641362,
+        "longitude": -5.87810037515931,
         "favourite": null,
-        "verified": false,
-        "funded": null,
-        "updated_at": "2022-10-25T13:32:18.646Z",
-        "project_biodiversity_impact": null,
-        "project_climate_impact": null,
-        "project_water_impact": null,
-        "project_community_impact": null,
-        "project_total_impact": null
+        "funded": null
       },
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "a69a06fe-41e2-4bae-90d7-9600c11fa47e",
+            "id": "c790aa55-f9dc-47dc-8e4e-cc3fabf2b1de",
             "type": "project_developer"
           }
         },
         "country": {
           "data": {
-            "id": "6371d2b8-b3ba-4995-9938-4191fbabf488",
+            "id": "a79a5118-a010-46c3-b5ca-d2eda8acd218",
             "type": "location"
           }
         },
         "municipality": {
           "data": {
-            "id": "f4e0231f-fbaf-44fa-b10c-0775ceaf4010",
+            "id": "54ace988-a0da-4553-bf29-7129556275f7",
             "type": "location"
           }
         },
         "department": {
           "data": {
-            "id": "8d29714a-74ed-4edb-87ad-1256092421d6",
+            "id": "c7aa9771-ac93-4022-9c07-9f62982fcccf",
             "type": "location"
           }
         },
@@ -121,7 +149,7 @@
       }
     },
     {
-      "id": "c17acc35-a9eb-4862-9ef4-2bd5ba876517",
+      "id": "f54da724-ff9f-40af-9365-6afd03533f7d",
       "type": "project",
       "attributes": {
         "name": "Project 2",
@@ -165,13 +193,48 @@
         "language": "en",
         "account_language": "en",
         "geometry": {
-          "type": "Point",
+          "type": "Polygon",
           "coordinates": [
-            1.0,
-            2.0
+            [
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ],
+              [
+                -5.510236906689473,
+                40.02677860935444
+              ],
+              [
+                -4.408874148363334,
+                39.419930008870296
+              ],
+              [
+                -5.205992932301829,
+                38.67169482742881
+              ],
+              [
+                -6.402685625872827,
+                38.39721372248553
+              ],
+              [
+                -7.059852379049463,
+                38.94985978831832
+              ],
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ]
+            ]
           ]
         },
-        "created_at": "2022-08-19T13:20:43.647Z",
+        "verified": false,
+        "created_at": "2023-01-26T09:51:26.337Z",
+        "updated_at": "2023-01-26T09:51:26.337Z",
+        "project_biodiversity_impact": null,
+        "project_climate_impact": null,
+        "project_water_impact": null,
+        "project_community_impact": null,
+        "project_total_impact": null,
         "municipality_biodiversity_impact": null,
         "municipality_climate_impact": null,
         "municipality_water_impact": null,
@@ -188,40 +251,33 @@
         "priority_landscape_community_impact": null,
         "priority_landscape_total_impact": null,
         "impact_calculated": false,
-        "latitude": 2.0,
-        "longitude": 1.0,
+        "latitude": 39.21309022641362,
+        "longitude": -5.87810037515931,
         "favourite": null,
-        "verified": false,
-        "funded": null,
-        "updated_at": "2022-10-25T13:32:18.781Z",
-        "project_biodiversity_impact": null,
-        "project_climate_impact": null,
-        "project_water_impact": null,
-        "project_community_impact": null,
-        "project_total_impact": null
+        "funded": null
       },
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "20e94d75-bb10-4b4c-bb87-fabc3e95be4b",
+            "id": "969ea8da-b200-422f-b794-57def4220df2",
             "type": "project_developer"
           }
         },
         "country": {
           "data": {
-            "id": "3cc3a109-e584-4d9d-b4d4-1d3286a0fd27",
+            "id": "da19fb21-c676-47f6-b03f-478db14a3c36",
             "type": "location"
           }
         },
         "municipality": {
           "data": {
-            "id": "7e5843f6-bf94-4699-aeb8-c01a59452c47",
+            "id": "4d0fda8e-c47d-433f-9d6b-799ffc3f1cfa",
             "type": "location"
           }
         },
         "department": {
           "data": {
-            "id": "851ee01d-2755-4728-98f2-963ece6f1128",
+            "id": "10d4f2c2-1c3d-4a7d-91cc-65b96cd218bb",
             "type": "location"
           }
         },
@@ -241,7 +297,7 @@
       }
     },
     {
-      "id": "6eaae7a5-9b22-4111-9f1e-bdd18a1b7313",
+      "id": "6cd59ebe-9285-4f6f-93c5-57d0e5f9693a",
       "type": "project",
       "attributes": {
         "name": "Project 3",
@@ -285,13 +341,48 @@
         "language": "en",
         "account_language": "en",
         "geometry": {
-          "type": "Point",
+          "type": "Polygon",
           "coordinates": [
-            1.0,
-            2.0
+            [
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ],
+              [
+                -5.510236906689473,
+                40.02677860935444
+              ],
+              [
+                -4.408874148363334,
+                39.419930008870296
+              ],
+              [
+                -5.205992932301829,
+                38.67169482742881
+              ],
+              [
+                -6.402685625872827,
+                38.39721372248553
+              ],
+              [
+                -7.059852379049463,
+                38.94985978831832
+              ],
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ]
+            ]
           ]
         },
-        "created_at": "2022-08-19T13:20:43.865Z",
+        "verified": false,
+        "created_at": "2023-01-26T09:51:26.523Z",
+        "updated_at": "2023-01-26T09:51:26.523Z",
+        "project_biodiversity_impact": null,
+        "project_climate_impact": null,
+        "project_water_impact": null,
+        "project_community_impact": null,
+        "project_total_impact": null,
         "municipality_biodiversity_impact": null,
         "municipality_climate_impact": null,
         "municipality_water_impact": null,
@@ -308,40 +399,33 @@
         "priority_landscape_community_impact": null,
         "priority_landscape_total_impact": null,
         "impact_calculated": false,
-        "latitude": 2.0,
-        "longitude": 1.0,
+        "latitude": 39.21309022641362,
+        "longitude": -5.87810037515931,
         "favourite": null,
-        "verified": false,
-        "funded": null,
-        "updated_at": "2022-10-25T13:32:18.900Z",
-        "project_biodiversity_impact": null,
-        "project_climate_impact": null,
-        "project_water_impact": null,
-        "project_community_impact": null,
-        "project_total_impact": null
+        "funded": null
       },
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "aa472d62-0e66-4077-b8bd-f2312ec10401",
+            "id": "42791b66-4c69-4d48-a6be-6716d275a8e2",
             "type": "project_developer"
           }
         },
         "country": {
           "data": {
-            "id": "446cd6d7-b2e5-409a-b269-42a3d68a6e48",
+            "id": "dbd2bf73-b01f-4998-8c78-0cd95fc9858e",
             "type": "location"
           }
         },
         "municipality": {
           "data": {
-            "id": "75266e6d-f910-4931-9d69-74c1aa642804",
+            "id": "474186ee-1e4a-4d40-94f9-551661d5cbfc",
             "type": "location"
           }
         },
         "department": {
           "data": {
-            "id": "b89c8ac9-6acb-4d95-bf48-c4e99a398384",
+            "id": "097434e8-5b5e-473e-ba0c-266458fbafc8",
             "type": "location"
           }
         },
@@ -361,7 +445,7 @@
       }
     },
     {
-      "id": "e5a7e7de-2307-4e9d-a35a-98ad67d15e75",
+      "id": "3ce2173e-0aa9-4140-b330-99a226328c2d",
       "type": "project",
       "attributes": {
         "name": "Project 4",
@@ -405,13 +489,48 @@
         "language": "en",
         "account_language": "en",
         "geometry": {
-          "type": "Point",
+          "type": "Polygon",
           "coordinates": [
-            1.0,
-            2.0
+            [
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ],
+              [
+                -5.510236906689473,
+                40.02677860935444
+              ],
+              [
+                -4.408874148363334,
+                39.419930008870296
+              ],
+              [
+                -5.205992932301829,
+                38.67169482742881
+              ],
+              [
+                -6.402685625872827,
+                38.39721372248553
+              ],
+              [
+                -7.059852379049463,
+                38.94985978831832
+              ],
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ]
+            ]
           ]
         },
-        "created_at": "2022-08-19T13:20:44.073Z",
+        "verified": false,
+        "created_at": "2023-01-26T09:51:26.709Z",
+        "updated_at": "2023-01-26T09:51:26.709Z",
+        "project_biodiversity_impact": null,
+        "project_climate_impact": null,
+        "project_water_impact": null,
+        "project_community_impact": null,
+        "project_total_impact": null,
         "municipality_biodiversity_impact": null,
         "municipality_climate_impact": null,
         "municipality_water_impact": null,
@@ -428,40 +547,33 @@
         "priority_landscape_community_impact": null,
         "priority_landscape_total_impact": null,
         "impact_calculated": false,
-        "latitude": 2.0,
-        "longitude": 1.0,
+        "latitude": 39.21309022641362,
+        "longitude": -5.87810037515931,
         "favourite": null,
-        "verified": false,
-        "funded": null,
-        "updated_at": "2022-10-25T13:32:19.009Z",
-        "project_biodiversity_impact": null,
-        "project_climate_impact": null,
-        "project_water_impact": null,
-        "project_community_impact": null,
-        "project_total_impact": null
+        "funded": null
       },
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "b33c9488-06c5-49e5-994e-7dee11903f59",
+            "id": "8575de5c-385c-49d8-94da-431c5b38a32c",
             "type": "project_developer"
           }
         },
         "country": {
           "data": {
-            "id": "522f9ff3-cfed-4467-9c68-d51e4ec3005f",
+            "id": "f035d3a4-f536-45fe-b076-f2f49c926b16",
             "type": "location"
           }
         },
         "municipality": {
           "data": {
-            "id": "0d58a470-40c5-4b37-a999-7d27a2191d1e",
+            "id": "1e2cc9b9-6108-4a11-a4d9-4e00c99aa5c4",
             "type": "location"
           }
         },
         "department": {
           "data": {
-            "id": "5c2bed58-8f30-498a-a1a2-a7067fb52e89",
+            "id": "6397fce6-58fb-4b1d-b5a5-d277e78def7b",
             "type": "location"
           }
         },
@@ -481,7 +593,7 @@
       }
     },
     {
-      "id": "fc8e4f60-3ab3-46ea-8b91-f5ffe51a5c74",
+      "id": "19da8574-30d0-4f98-ae5c-07fd4b5d46f8",
       "type": "project",
       "attributes": {
         "name": "Project 5",
@@ -525,13 +637,48 @@
         "language": "en",
         "account_language": "en",
         "geometry": {
-          "type": "Point",
+          "type": "Polygon",
           "coordinates": [
-            1.0,
-            2.0
+            [
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ],
+              [
+                -5.510236906689473,
+                40.02677860935444
+              ],
+              [
+                -4.408874148363334,
+                39.419930008870296
+              ],
+              [
+                -5.205992932301829,
+                38.67169482742881
+              ],
+              [
+                -6.402685625872827,
+                38.39721372248553
+              ],
+              [
+                -7.059852379049463,
+                38.94985978831832
+              ],
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ]
+            ]
           ]
         },
-        "created_at": "2022-08-19T13:20:44.254Z",
+        "verified": false,
+        "created_at": "2023-01-26T09:51:26.897Z",
+        "updated_at": "2023-01-26T09:51:26.897Z",
+        "project_biodiversity_impact": null,
+        "project_climate_impact": null,
+        "project_water_impact": null,
+        "project_community_impact": null,
+        "project_total_impact": null,
         "municipality_biodiversity_impact": null,
         "municipality_climate_impact": null,
         "municipality_water_impact": null,
@@ -548,40 +695,33 @@
         "priority_landscape_community_impact": null,
         "priority_landscape_total_impact": null,
         "impact_calculated": false,
-        "latitude": 2.0,
-        "longitude": 1.0,
+        "latitude": 39.21309022641362,
+        "longitude": -5.87810037515931,
         "favourite": null,
-        "verified": false,
-        "funded": null,
-        "updated_at": "2022-10-25T13:32:19.111Z",
-        "project_biodiversity_impact": null,
-        "project_climate_impact": null,
-        "project_water_impact": null,
-        "project_community_impact": null,
-        "project_total_impact": null
+        "funded": null
       },
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "4b6d4197-9ecf-43c8-861f-aead0cffb079",
+            "id": "768a4e7e-d0b5-46c4-94bb-c80065e0945a",
             "type": "project_developer"
           }
         },
         "country": {
           "data": {
-            "id": "e63b2802-8fcc-4299-a60c-457d42aaedb0",
+            "id": "91f27a74-ca98-4ceb-bef4-6e07add375a0",
             "type": "location"
           }
         },
         "municipality": {
           "data": {
-            "id": "1b8387fc-d30c-469f-92d7-9cd943866d93",
+            "id": "8723166f-7671-4a2c-a3a0-258819d96458",
             "type": "location"
           }
         },
         "department": {
           "data": {
-            "id": "866848e0-437b-4409-8692-d7d0659c7881",
+            "id": "46a3d1fb-4699-43f3-98e0-da35df5f622e",
             "type": "location"
           }
         },
@@ -601,7 +741,7 @@
       }
     },
     {
-      "id": "2b2b3154-fe41-4f2f-a4f4-eaf9bc419342",
+      "id": "b99f0cda-d2c2-417a-b6f0-0c7cc9ca238c",
       "type": "project",
       "attributes": {
         "name": "Project 6",
@@ -645,13 +785,48 @@
         "language": "en",
         "account_language": "en",
         "geometry": {
-          "type": "Point",
+          "type": "Polygon",
           "coordinates": [
-            1.0,
-            2.0
+            [
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ],
+              [
+                -5.510236906689473,
+                40.02677860935444
+              ],
+              [
+                -4.408874148363334,
+                39.419930008870296
+              ],
+              [
+                -5.205992932301829,
+                38.67169482742881
+              ],
+              [
+                -6.402685625872827,
+                38.39721372248553
+              ],
+              [
+                -7.059852379049463,
+                38.94985978831832
+              ],
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ]
+            ]
           ]
         },
-        "created_at": "2022-08-19T13:20:44.445Z",
+        "verified": false,
+        "created_at": "2023-01-26T09:51:27.085Z",
+        "updated_at": "2023-01-26T09:51:27.085Z",
+        "project_biodiversity_impact": null,
+        "project_climate_impact": null,
+        "project_water_impact": null,
+        "project_community_impact": null,
+        "project_total_impact": null,
         "municipality_biodiversity_impact": null,
         "municipality_climate_impact": null,
         "municipality_water_impact": null,
@@ -668,40 +843,33 @@
         "priority_landscape_community_impact": null,
         "priority_landscape_total_impact": null,
         "impact_calculated": false,
-        "latitude": 2.0,
-        "longitude": 1.0,
+        "latitude": 39.21309022641362,
+        "longitude": -5.87810037515931,
         "favourite": null,
-        "verified": false,
-        "funded": null,
-        "updated_at": "2022-10-25T13:32:19.227Z",
-        "project_biodiversity_impact": null,
-        "project_climate_impact": null,
-        "project_water_impact": null,
-        "project_community_impact": null,
-        "project_total_impact": null
+        "funded": null
       },
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "7fa9af00-a643-42d9-a866-ad52e094f13c",
+            "id": "1e7b9f92-9215-4ccc-8d43-a4d24414e2f6",
             "type": "project_developer"
           }
         },
         "country": {
           "data": {
-            "id": "4df97a60-5408-4b9e-9022-782a4cea4c25",
+            "id": "a5d1624d-6bd6-4573-9767-a8f2cbcce18a",
             "type": "location"
           }
         },
         "municipality": {
           "data": {
-            "id": "b21dee2c-5c08-4881-960d-a55d74c8df0b",
+            "id": "33e4818b-c989-4c09-bdf2-b2c2ca6887f5",
             "type": "location"
           }
         },
         "department": {
           "data": {
-            "id": "4f8d08c4-dc69-430b-8a45-85747f54569b",
+            "id": "0d2fabbd-a749-4f72-8b4d-f81be5bb1c39",
             "type": "location"
           }
         },
@@ -721,7 +889,7 @@
       }
     },
     {
-      "id": "667c7d4f-e315-41b0-81a5-9a4144f6df7e",
+      "id": "2a7a36f2-7151-4e88-a0fb-0b7214673cec",
       "type": "project",
       "attributes": {
         "name": "Project 9",
@@ -765,13 +933,48 @@
         "language": "en",
         "account_language": "pt",
         "geometry": {
-          "type": "Point",
+          "type": "Polygon",
           "coordinates": [
-            1.0,
-            2.0
+            [
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ],
+              [
+                -5.510236906689473,
+                40.02677860935444
+              ],
+              [
+                -4.408874148363334,
+                39.419930008870296
+              ],
+              [
+                -5.205992932301829,
+                38.67169482742881
+              ],
+              [
+                -6.402685625872827,
+                38.39721372248553
+              ],
+              [
+                -7.059852379049463,
+                38.94985978831832
+              ],
+              [
+                -7.256596802202454,
+                39.42149705239956
+              ]
+            ]
           ]
         },
-        "created_at": "2022-08-19T13:20:45.218Z",
+        "verified": false,
+        "created_at": "2023-01-26T09:51:27.818Z",
+        "updated_at": "2023-01-26T09:51:27.818Z",
+        "project_biodiversity_impact": null,
+        "project_climate_impact": null,
+        "project_water_impact": null,
+        "project_community_impact": null,
+        "project_total_impact": null,
         "municipality_biodiversity_impact": null,
         "municipality_climate_impact": null,
         "municipality_water_impact": null,
@@ -788,40 +991,33 @@
         "priority_landscape_community_impact": null,
         "priority_landscape_total_impact": null,
         "impact_calculated": false,
-        "latitude": 2.0,
-        "longitude": 1.0,
+        "latitude": 39.21309022641362,
+        "longitude": -5.87810037515931,
         "favourite": null,
-        "verified": false,
-        "funded": null,
-        "updated_at": "2022-10-25T13:32:19.712Z",
-        "project_biodiversity_impact": null,
-        "project_climate_impact": null,
-        "project_water_impact": null,
-        "project_community_impact": null,
-        "project_total_impact": null
+        "funded": null
       },
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "41616af4-c10d-440e-94af-024a2bfe060a",
+            "id": "ac7b6275-ef3b-4e8a-b696-5d9901baad4a",
             "type": "project_developer"
           }
         },
         "country": {
           "data": {
-            "id": "c1eaebab-83c1-4dd1-87e2-f305711cc41b",
+            "id": "85ea2187-87f9-4039-8ae1-9f1245a22dfb",
             "type": "location"
           }
         },
         "municipality": {
           "data": {
-            "id": "218c28db-a993-4a9f-ac31-3dc72dd2e8c0",
+            "id": "8b267e36-b24f-4792-901e-06093464635d",
             "type": "location"
           }
         },
         "department": {
           "data": {
-            "id": "2b5790ca-ca6c-41bc-ac4e-072178017848",
+            "id": "e4c0367e-0590-4188-9a53-8df405d5156d",
             "type": "location"
           }
         },
@@ -841,7 +1037,7 @@
       }
     },
     {
-      "id": "f197bd99-aba1-40a8-a69d-05d5ba6516d2",
+      "id": "ef50b8b5-7b93-4cac-af17-c1fe7de9c299",
       "type": "project",
       "attributes": {
         "name": "Yellow Banana",
@@ -911,7 +1107,14 @@
             ]
           ]
         },
-        "created_at": "2022-08-19T13:20:42.795Z",
+        "verified": false,
+        "created_at": "2023-01-26T09:51:25.832Z",
+        "updated_at": "2023-01-26T09:51:25.832Z",
+        "project_biodiversity_impact": null,
+        "project_climate_impact": null,
+        "project_water_impact": null,
+        "project_community_impact": null,
+        "project_total_impact": null,
         "municipality_biodiversity_impact": null,
         "municipality_climate_impact": null,
         "municipality_water_impact": null,
@@ -931,54 +1134,47 @@
         "latitude": 0.5,
         "longitude": 0.5,
         "favourite": null,
-        "verified": false,
-        "funded": null,
-        "updated_at": "2022-10-25T13:32:18.480Z",
-        "project_biodiversity_impact": null,
-        "project_climate_impact": null,
-        "project_water_impact": null,
-        "project_community_impact": null,
-        "project_total_impact": null
+        "funded": null
       },
       "relationships": {
         "project_developer": {
           "data": {
-            "id": "38f98af0-e168-46fd-90dd-add9c7eab135",
+            "id": "068da73c-db94-4475-a120-34409c2367d4",
             "type": "project_developer"
           }
         },
         "country": {
           "data": {
-            "id": "402d724f-38c6-4252-906d-e3cb43d6585c",
+            "id": "5112c52b-7811-400e-a259-19eed65b40ce",
             "type": "location"
           }
         },
         "municipality": {
           "data": {
-            "id": "af7c186f-2dd8-40eb-a72b-1f070a26fdcf",
+            "id": "188286b9-873d-4a50-b3a6-054a05c1830b",
             "type": "location"
           }
         },
         "department": {
           "data": {
-            "id": "4677453d-8ca8-46a4-b316-e8f4b21cf796",
+            "id": "79d05aef-a328-427c-869f-32edeb15d790",
             "type": "location"
           }
         },
         "priority_landscape": {
           "data": {
-            "id": "19319f74-9fee-4a25-98e0-99e403532975",
+            "id": "e5f3c299-fed7-423b-b5ed-5f5abebc81a2",
             "type": "location"
           }
         },
         "involved_project_developers": {
           "data": [
             {
-              "id": "18d6b540-19a5-47f0-bde1-3c6f1b67ccbd",
+              "id": "cdbf6661-e9b3-4a37-a026-a383e952cbef",
               "type": "project_developer"
             },
             {
-              "id": "39de429a-beed-4815-9d7b-11e76c115cfb",
+              "id": "4fcdf2c1-61a7-4093-ad71-67baa127ad13",
               "type": "project_developer"
             }
           ]
@@ -986,11 +1182,11 @@
         "project_images": {
           "data": [
             {
-              "id": "e292a613-1f77-4631-a306-4f26e7cc3761",
+              "id": "14156618-09f2-40b0-9f6d-00aca5a0e581",
               "type": "project_image"
             },
             {
-              "id": "f3f6cb60-9a1b-46b8-90be-f8f28180dbb8",
+              "id": "4b74aa03-9264-4418-8a6e-89066f1a0656",
               "type": "project_image"
             }
           ]

--- a/backend/spec/jobs/klab/submit_contexts_job_spec.rb
+++ b/backend/spec/jobs/klab/submit_contexts_job_spec.rb
@@ -13,7 +13,13 @@ RSpec.describe Klab::SubmitContextsJob, type: :job do
 
   describe ".perform_now" do
     context "when context submitting is successful" do
-      before { VCR.turn_on! }
+      let(:build_context_string_service) { instance_double Klab::BuildContextString }
+
+      before do
+        allow(Klab::BuildContextString).to receive(:new).and_return(build_context_string_service)
+        allow(build_context_string_service).to receive(:call).and_return "aries.heco.locations.colombia_continental"
+        VCR.turn_on!
+      end
       after { VCR.turn_off! }
 
       it "enqueues klab poll demand jobs" do

--- a/backend/spec/services/klab/build_context_string_spec.rb
+++ b/backend/spec/services/klab/build_context_string_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+RSpec.describe Klab::BuildContextString do
+  subject { described_class.new project, impact_level }
+
+  let(:datetime) { DateTime.new 2023, 1, 25 }
+
+  describe "#call" do
+    context "when impact level is project" do
+      let(:project) { create :project, geometry: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1]]]} }
+      let(:impact_level) { "project" }
+
+      it "returns correct context string" do
+        travel_to datetime do
+          expect(subject.call)
+            .to eq("τ0(1){ttype=LOGICAL,period=[1640995200000 1672531200000],tscope=1.0,tunit=YEAR}S2(256,256){bbox=[0.0 1.0 0.0 1.0],shape=00000000030000000100000005000000000000000000000000000000003FF000000000000000000000000000003FF00000000000003FF000000000000000000000000000003FF000000000000000000000000000000000000000000000,proj=EPSG:4326}")
+        end
+      end
+    end
+
+    context "when impact level is municipality" do
+      let(:project) { create :project, geometry: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1]]]} }
+      let!(:location) do
+        create :municipality, :with_geometry,
+          geometry: RGeo::GeoJSON.decode({type: "Polygon", coordinates: [[[0.3, 0.3], [1.3, 0.3], [1.3, 1.3], [0.3, 1.3]]]}.to_json)
+      end
+      let(:impact_level) { "municipality" }
+
+      it "returns correct context string" do
+        travel_to datetime do
+          expect(subject.call)
+            .to eq("τ0(1){ttype=LOGICAL,period=[1640995200000 1672531200000],tscope=1.0,tunit=YEAR}S2(256,256){bbox=[0.3 1.3 0.3 1.3],shape=000000000300000001000000053FD33333333333333FD33333333333333FF4CCCCCCCCCCCD3FD33333333333333FF4CCCCCCCCCCCD3FF4CCCCCCCCCCCD3FD33333333333333FF4CCCCCCCCCCCD3FD33333333333333FD3333333333333,proj=EPSG:4326}")
+        end
+      end
+    end
+
+    context "when impact level is hydrobasin" do
+      let(:project) { create :project, geometry: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1]]]} }
+      let!(:location) do
+        create :location, :with_geometry, location_type: :basin,
+          geometry: RGeo::GeoJSON.decode({type: "Polygon", coordinates: [[[0.3, 0.3], [1.3, 0.3], [1.3, 3.3], [0.3, 3.3]]]}.to_json)
+      end
+      let(:impact_level) { "hydrobasin" }
+
+      it "returns correct context string" do
+        travel_to datetime do
+          expect(subject.call)
+            .to eq("τ0(1){ttype=LOGICAL,period=[1640995200000 1672531200000],tscope=1.0,tunit=YEAR}S2(256,768){bbox=[0.3 1.3 0.3 3.3],shape=000000000300000001000000053FD33333333333333FD33333333333333FF4CCCCCCCCCCCD3FD33333333333333FF4CCCCCCCCCCCD400A6666666666663FD3333333333333400A6666666666663FD33333333333333FD3333333333333,proj=EPSG:4326}")
+        end
+      end
+    end
+
+    context "when impact level is priority landscape" do
+      let(:project) { create :project, geometry: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1]]]} }
+      let!(:location) do
+        create :priority_landscape, :with_geometry,
+          geometry: RGeo::GeoJSON.decode({type: "Polygon", coordinates: [[[0.3, 0.3], [1.3, 0.3], [1.3, 1.3], [0.3, 1.3]]]}.to_json)
+      end
+      let(:impact_level) { "priority_landscape" }
+
+      it "returns correct context string" do
+        travel_to datetime do
+          expect(subject.call)
+            .to eq("τ0(1){ttype=LOGICAL,period=[1640995200000 1672531200000],tscope=1.0,tunit=YEAR}S2(256,256){bbox=[0.3 1.3 0.3 1.3],shape=000000000300000001000000053FD33333333333333FD33333333333333FF4CCCCCCCCCCCD3FD33333333333333FF4CCCCCCCCCCCD3FF4CCCCCCCCCCCD3FD33333333333333FF4CCCCCCCCCCCD3FD33333333333333FD3333333333333,proj=EPSG:4326}")
+        end
+      end
+    end
+
+    context "when impact level is unknown" do
+      let(:project) { create :project, geometry: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1]]]} }
+      let(:impact_level) { "UNKNOWN" }
+
+      it "raises exception" do
+        expect {
+          subject.call
+        }.to raise_error(described_class::UnknownImpactLevel)
+      end
+    end
+  end
+end

--- a/backend/spec/services/klab/build_context_string_spec.rb
+++ b/backend/spec/services/klab/build_context_string_spec.rb
@@ -32,6 +32,14 @@ RSpec.describe Klab::BuildContextString do
             .to eq("τ0(1){ttype=LOGICAL,period=[1640995200000 1672531200000],tscope=1.0,tunit=YEAR}S2(256,256){bbox=[0.3 1.3 0.3 1.3],shape=000000000300000001000000053FD33333333333333FD33333333333333FF4CCCCCCCCCCCD3FD33333333333333FF4CCCCCCCCCCCD3FF4CCCCCCCCCCCD3FD33333333333333FF4CCCCCCCCCCCD3FD33333333333333FD3333333333333,proj=EPSG:4326}")
         end
       end
+
+      context "when there is no intersection between project geometry and location" do
+        let(:project) { create :project, geometry: {type: "Polygon", coordinates: [[[100, 100], [101, 100], [101, 101], [100, 101]]]} }
+
+        it "returns nil" do
+          expect(subject.call).to be_nil
+        end
+      end
     end
 
     context "when impact level is hydrobasin" do

--- a/backend/spec/services/klab/calculate_project_impact_score_spec.rb
+++ b/backend/spec/services/klab/calculate_project_impact_score_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Klab::CalculateProjectImpactScore do
       allow(Klab::PollTicket).to receive(:sleep_interval).and_return(0)
     end
 
-    let(:service) { Klab::CalculateProjectImpactScore.new("aries.heco.locations.colombia_continental") }
+    let(:service) { Klab::CalculateProjectImpactScore.new(urn: "aries.heco.locations.colombia_continental") }
 
     subject { service.call }
 


### PR DESCRIPTION
Adding new service which helps to build context string send to k.LAB API via submit context API endpoint. I have tried to update Readme with new basic information how k.LAB string is constructed. Deeper implementation detail then can be found at `Klab::BuildContextString` service itself.

## Testing instructions

Find some project which have geometry (geojson) that you know how final k.LAB context string should look like. Build context string with `Klab::BuildContextString` and compare returned result with value that you have expected.

## Tracking

https://vizzuality.atlassian.net/browse/LET-1352
