### PR TITLE
Add an explanation of why HeCo Invest uses the US dollar

### DIFF
--- a/frontend/containers/faq-page/answers/projects/project-info/component.tsx
+++ b/frontend/containers/faq-page/answers/projects/project-info/component.tsx
@@ -328,6 +328,11 @@ export const ProjectInfo: FC = () => {
             defaultMessage: 'How much money did the project received or raised? (US$)',
             id: '1eETJy',
           })}
+          description={formatMessage({
+            defaultMessage:
+              'The HeCo Invest platform uses the US dollar as the reference currency, taking into account that the platform is primarily aimed at international investors.  These investors usually use the US dollar as a reference currency which facilitates their understanding of the proposals presented on the platform.',
+            id: 'KdWzZW',
+          })}
         />
         <ListItem
           title={formatMessage({

--- a/frontend/containers/faq-page/answers/shared-lists/funding-types/component.tsx
+++ b/frontend/containers/faq-page/answers/shared-lists/funding-types/component.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 
-import { useIntl } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import FaqList, { ListItem } from 'containers/faq-page/faq-list';
 
@@ -8,31 +8,39 @@ export const FundingTypesList: FC = () => {
   const { formatMessage } = useIntl();
 
   return (
-    <FaqList level="two">
-      <ListItem
-        // Less than sign must be escaped with an apostrophe
-        // https://github.com/formatjs/formatjs/issues/1845
-        title={formatMessage({ defaultMessage: "'<US$25,000 (Small grants)", id: 'Uomdkb' })}
-      />
-      <ListItem
-        title={formatMessage({
-          defaultMessage: 'US$25,000 – 150,000 (Prototyping)',
-          id: 'MZTu88',
-        })}
-      />
-      <ListItem
-        title={formatMessage({
-          defaultMessage: 'US$150,000 – 750,000 (Market validation)',
-          id: 'NLk0cp',
-        })}
-      />
-      <ListItem
-        title={formatMessage({
-          defaultMessage: '> US$750,000 (Scaling)',
-          id: 'E010/S',
-        })}
-      />
-    </FaqList>
+    <>
+      <FaqList level="two">
+        <ListItem
+          // Less than sign must be escaped with an apostrophe
+          // https://github.com/formatjs/formatjs/issues/1845
+          title={formatMessage({ defaultMessage: "'<US$25,000 (Small grants)", id: 'Uomdkb' })}
+        />
+        <ListItem
+          title={formatMessage({
+            defaultMessage: 'US$25,000 – 150,000 (Prototyping)',
+            id: 'MZTu88',
+          })}
+        />
+        <ListItem
+          title={formatMessage({
+            defaultMessage: 'US$150,000 – 750,000 (Market validation)',
+            id: 'NLk0cp',
+          })}
+        />
+        <ListItem
+          title={formatMessage({
+            defaultMessage: '> US$750,000 (Scaling)',
+            id: 'E010/S',
+          })}
+        />
+      </FaqList>
+      <p className="font-normal text-gray-700">
+        <FormattedMessage
+          defaultMessage="The HeCo Invest platform uses the US dollar as the reference currency, taking into account that the platform is primarily aimed at international investors.  These investors usually use the US dollar as a reference currency which facilitates their understanding of the proposals presented on the platform."
+          id="KdWzZW"
+        />
+      </p>
+    </>
   );
 };
 

--- a/frontend/containers/open-call-page/header/component.tsx
+++ b/frontend/containers/open-call-page/header/component.tsx
@@ -16,6 +16,7 @@ import OpenCallApplicationModal from 'containers/open-call-application-modal';
 import ShareIcons from 'containers/share-icons';
 
 import Button from 'components/button';
+import FieldInfo from 'components/forms/field-info';
 import Icon from 'components/icon';
 import LayoutContainer from 'components/layout-container';
 import { Languages, OpenCallStatus, UserRoles } from 'enums';
@@ -140,9 +141,18 @@ export const OpenCallHeader: FC<OpenCallHeaderProps> = ({ openCall, instrumentTy
                     >
                       ${maximum_funding_per_project.toLocaleString(locale)}
                     </span>
-                    <span id="open-call-value" className="leading-4 text-gray-400">
+                    <div id="open-call-value" className="leading-4 text-gray-400">
                       <FormattedMessage defaultMessage="Value" id="GufXy5" />
-                    </span>
+                      <div className="inline-block ml-2">
+                        <FieldInfo
+                          content={intl.formatMessage({
+                            defaultMessage:
+                              'The HeCo Invest platform uses the US dollar as the reference currency, taking into account that the platform is primarily aimed at international investors.  These investors usually use the US dollar as a reference currency which facilitates their understanding of the proposals presented on the platform.',
+                            id: 'KdWzZW',
+                          })}
+                        />
+                      </div>
+                    </div>
                   </div>
                   <div className="flex flex-col justify-end gap-2 md:items-start">
                     <div className="max-w-full">

--- a/frontend/containers/project-page/header/component.tsx
+++ b/frontend/containers/project-page/header/component.tsx
@@ -1,6 +1,6 @@
 import { FC, useMemo, useState } from 'react';
 
-import { Heart as HeartIcon, CheckCircle as CheckCircleIcon } from 'react-feather';
+import { Heart as HeartIcon } from 'react-feather';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import cx from 'classnames';
@@ -16,6 +16,7 @@ import ShareIcons from 'containers/share-icons';
 import ContactInformationModal from 'containers/social-contact/contact-information-modal';
 
 import Button from 'components/button';
+import FieldInfo from 'components/forms/field-info';
 import Icon from 'components/icon';
 import LayoutContainer from 'components/layout-container';
 import { logEvent } from 'lib/analytics/ga';
@@ -166,9 +167,18 @@ export const Header: FC<HeaderProps> = ({ className, project }: HeaderProps) => 
                 <span id="ticket-size" className="text-xl font-semibold leading-6">
                   {ticketSizeStr}
                 </span>
-                <span aria-labelledby="ticket-size" className="leading-4 text-gray-400">
+                <div aria-labelledby="ticket-size" className="leading-4 text-gray-400">
                   <FormattedMessage defaultMessage="Ticket size" id="lfx6Nc" />
-                </span>
+                  <div className="inline-block ml-2">
+                    <FieldInfo
+                      content={intl.formatMessage({
+                        defaultMessage:
+                          'The HeCo Invest platform uses the US dollar as the reference currency, taking into account that the platform is primarily aimed at international investors.  These investors usually use the US dollar as a reference currency which facilitates their understanding of the proposals presented on the platform.',
+                        id: 'KdWzZW',
+                      })}
+                    />
+                  </div>
+                </div>
               </div>
               <div className="flex flex-col justify-end gap-2 md:items-start">
                 <span id="instrument-types" className="text-xl font-semibold leading-6">

--- a/frontend/lang/transifex/zu.json
+++ b/frontend/lang/transifex/zu.json
@@ -1227,6 +1227,9 @@
   "KYymTZ": {
     "string": "{quantity, plural, one {project} other {projects}}"
   },
+  "KdWzZW": {
+    "string": "The HeCo Invest platform uses the US dollar as the reference currency, taking into account that the platform is primarily aimed at international investors. These investors usually use the US dollar as a reference currency which facilitates their understanding of the proposals presented on the platform."
+  },
   "KjV4yK": {
     "string": "The max development duration is 36 months"
   },


### PR DESCRIPTION
This PR adds an explanation of why HeCo Invest uses the US dollar in a few different places:

- FAQ
	- What information do I need to create a project?
	- What information do I need to create an investor account?
- Public project page (tooltip in the card)
- Public open call page (tooltip in the card)

## Testing instructions

1. Go to the FAQ, Projects tab, “What information do I need to create a project?” question

Look at point 16 and 20. Both must display the same text explaining the use of the US dollar.

2. Go to the Account tab, “What information do I need to create an investor account?” question

Look at point 10. Make sure the text is also there.

3. Go to a project that needs funding (such as `/en/project/agnieszka-figiel-pd-translation-test`)

In the header card, when you hover or focus info button next to the “Ticket size”, you must read the same explanation.

4. Go to an open call (such as `/en/open-call/clement-test-vizzuality-test-open-call-clement-2710221`)

In the header card, next to “Value”, hover or focus the info button. There will be the same tooltip as the previous step.

## Tracking

[LET-1327](https://vizzuality.atlassian.net/browse/LET-1327)

[LET-1327]: https://vizzuality.atlassian.net/browse/LET-1327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ