### PR TITLE
feat: Adding simple rake task which recalculates impacts with k.LAB values

### DIFF
--- a/backend/lib/tasks/klab.rake
+++ b/backend/lib/tasks/klab.rake
@@ -1,8 +1,8 @@
 namespace :klab do
-  desc "Seeding database with geojson data for Colombia country"
+  desc "Recalculate impacts of all projects with demands obtained from k.LAB"
   task recalculate_impacts: :environment do
     Project.all.each_with_index do |project, i|
-      puts "Reset of demand values of #{project.name} project"
+      puts "Reset demand values of #{project.name} project"
       impact_columns = {}
       Project::IMPACT_LEVELS.each do |impact_level|
         impact_columns["#{impact_level}_demands_calculated"] = false

--- a/backend/lib/tasks/klab.rake
+++ b/backend/lib/tasks/klab.rake
@@ -1,0 +1,21 @@
+namespace :klab do
+  desc "Seeding database with geojson data for Colombia country"
+  task recalculate_impacts: :environment do
+    Project.all.each_with_index do |project, i|
+      puts "Reset of demand values of #{project.name} project"
+      impact_columns = {}
+      Project::IMPACT_LEVELS.each do |impact_level|
+        impact_columns["#{impact_level}_demands_calculated"] = false
+        (Project::IMPACT_DIMENSIONS - ["total"]).each do |impact_dimension|
+          impact_columns["#{impact_level}_#{impact_dimension}_demand"] = nil
+        end
+      end
+      project.update_columns impact_columns
+
+      puts "Enqueueing k.LAB jobs for #{project.name} project"
+      waiting_time = (10 * i).seconds # give k.LAB server some spare time so we don't overwhelm it :)
+      Klab::SubmitContextsJob.set(wait: waiting_time).perform_later project.id
+      Klab::CalculateImpactsJob.set(wait: waiting_time).perform_later project.id
+    end
+  end
+end


### PR DESCRIPTION
This PR adds new rake task which can be triggered by `rake klab: recalculate_impacts`. Its purpose is to:
 - reset demand attributes of all existing projects
 - enqueuing klab jobs for all projects (they should obtain new demands and recalculate existing impacts in background)

I have decided not to reset impact attributes for project itself when this job is run so they can still be used in case Klab jobs for whatever reason fails.

## Testing instructions

Run `rake klab: recalculate_impacts` and verify that demand attributes are reseted and Klab jobs are enqueued for all projects.

## Tracking

https://vizzuality.atlassian.net/browse/LET-1357
