### PR TITLE
fix: Klab context builder supports geojson data of Feature/FeatureCollection type

### DIFF
--- a/backend/app/services/geo_jsons/to_centroid.rb
+++ b/backend/app/services/geo_jsons/to_centroid.rb
@@ -13,17 +13,10 @@ module GeoJsons
     def call
       return if geo_json.blank?
 
-      compute_centroid_for unwrap_features_of(geo_json)
+      compute_centroid_for GeoJsons::ToGeometry.new(geo_json).call
     end
 
     private
-
-    def unwrap_features_of(geo_json)
-      return unwrap_features_of(geo_json.first) if geo_json.is_a? RGeo::GeoJSON::FeatureCollection # take first feature
-      return geo_json.geometry if geo_json.is_a? RGeo::GeoJSON::Feature
-
-      geo_json
-    end
 
     def compute_centroid_for(geometry)
       raise NoGeometry if geometry.blank?

--- a/backend/app/services/geo_jsons/to_geometry.rb
+++ b/backend/app/services/geo_jsons/to_geometry.rb
@@ -1,0 +1,22 @@
+module GeoJsons
+  class ToGeometry
+    attr_accessor :geo_json
+
+    def initialize(geo_json)
+      @geo_json = geo_json
+    end
+
+    def call
+      unwrap_features_of geo_json
+    end
+
+    private
+
+    def unwrap_features_of(geo_json)
+      return unwrap_features_of(geo_json.first) if geo_json.is_a? RGeo::GeoJSON::FeatureCollection # take first feature
+      return geo_json.geometry if geo_json.is_a? RGeo::GeoJSON::Feature
+
+      geo_json
+    end
+  end
+end

--- a/backend/app/services/klab/build_context_string.rb
+++ b/backend/app/services/klab/build_context_string.rb
@@ -46,7 +46,7 @@ module Klab
     def find_geometry
       case impact_level
       when "project"
-        RGeo::GeoJSON.decode project.geometry
+        GeoJsons::ToGeometry.new(RGeo::GeoJSON.decode(project.geometry)).call
       when "municipality"
         LocationGeometry.of_type(:municipality).intersection_with(project.centroid).first&.geometry
       when "hydrobasin"

--- a/backend/spec/services/geo_jsons/to_geometry_spec.rb
+++ b/backend/spec/services/geo_jsons/to_geometry_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe GeoJsons::ToGeometry do
+  subject { described_class.new(RGeo::GeoJSON.decode(geo_json.to_json)) }
+
+  describe "#call" do
+    context "when geo_json is nil" do
+      let(:geo_json) { nil }
+
+      it "return nil value" do
+        expect(subject.call).to be_nil
+      end
+    end
+
+    context "when geo_json is simple geometry" do
+      let(:geo_json) { {type: "Point", coordinates: [100.0, 0.0]} }
+
+      it "returns correct geometry" do
+        expect(subject.call).to eq(RGeo::GeoJSON.decode(geo_json.to_json))
+      end
+    end
+
+    context "when geo_json is feature" do
+      let(:geo_json) { {type: "Feature", geometry: {type: "Point", coordinates: [100.0, 0.0]}} }
+
+      it "returns correct geometry" do
+        expect(subject.call).to eq(RGeo::GeoJSON.decode(geo_json.to_json).geometry)
+      end
+    end
+
+    context "when geo_json is list of features" do
+      let(:geo_json) { {type: "FeatureCollection", features: [{type: "Feature", geometry: {type: "Point", coordinates: [100.0, 0.0]}}]} }
+
+      it "returns correct geometry" do
+        expect(subject.call).to eq(RGeo::GeoJSON.decode(geo_json.to_json).first.geometry)
+      end
+    end
+  end
+end


### PR DESCRIPTION
`Klab::BuildContextString` expected that geojson saved at project is simple geometry, but it can be also `FeatureCollection` or `Feature`. In such case, geometry data needs to be extracted from it so we can use it at other methods.

## Testing instructions

Tests give good idea how this fix can be tested. Pick any project and change geometry for example to `{type: "FeatureCollection", features: [{type: "Feature", geometry: {type: "Point", coordinates: [100.0, 0.0]}}]}`. It is important that type of geojson is either `FeatureCollection` or `Feature`. Build context string with help of `Klab::BuildContextString.new(project, "project").call` for such project and verify that proper response is returned (no error, etc.).

## Tracking

BUG 🐛 
