### PR TITLE
fix: Klab returns sustainability instead of demand

### DIFF
--- a/backend/app/jobs/klab/poll_impact_demands_job.rb
+++ b/backend/app/jobs/klab/poll_impact_demands_job.rb
@@ -27,7 +27,7 @@ module Klab
       Array.wrap(response.artifacts_ids).each.with_index do |artifact_id, idx|
         artifact_response = Klab::ExportArtifact.new(client).call artifact_id
         artifact_code = Klab::SubmitContext::Request::INDICATORS.keys[idx]
-        project.public_send "#{impact_level}_#{artifact_code}_demand=", artifact_response.summary["mean"]
+        project.public_send "#{impact_level}_#{artifact_code}_demand=", artifact_response.demand
       end
       project.assign_attributes "#{impact_level}_demands_calculated": true
       project.save!

--- a/backend/app/services/klab/calculate_project_impact_score.rb
+++ b/backend/app/services/klab/calculate_project_impact_score.rb
@@ -27,7 +27,7 @@ module Klab
         Rails.logger.debug "Exporting observable #{artifact_id}"
         export_resp = ExportArtifact.new(@client).call(artifact_id)
         artifact_code = Klab::SubmitContext::Request::INDICATORS.keys[idx]
-        result.send("#{artifact_code}=", export_resp.summary["mean"]) if artifact_code.present?
+        result.send("#{artifact_code}=", export_resp.demand) if artifact_code.present?
       end
       result
     rescue Faraday::ServerError => e

--- a/backend/app/services/klab/export_artifact.rb
+++ b/backend/app/services/klab/export_artifact.rb
@@ -31,6 +31,10 @@ module Klab
         @observable = body["observable"]
         @summary = body["dataSummary"]
       end
+
+      def demand
+        1 - summary["mean"].to_f
+      end
     end
 
     def initialize(client)

--- a/backend/spec/jobs/klab/poll_impact_demands_job_spec.rb
+++ b/backend/spec/jobs/klab/poll_impact_demands_job_spec.rb
@@ -23,10 +23,10 @@ RSpec.describe Klab::PollImpactDemandsJob, type: :job do
 
             project.reload
             expect(project.project_demands_calculated).to be_truthy
-            expect(project.project_biodiversity_demand).to eq(0.5545623521804952e0)
-            expect(project.project_climate_demand).to eq(0.7727616029821257)
-            expect(project.project_water_demand).to eq(0.8304636946009439)
-            expect(project.project_community_demand).to eq(0.5095993956721737)
+            expect(project.project_biodiversity_demand).to eq(0.4454376478195048)
+            expect(project.project_climate_demand).to eq(0.2272383970178743)
+            expect(project.project_water_demand).to eq(0.1695363053990561e0)
+            expect(project.project_community_demand).to eq(0.4904006043278263)
           end
         end
       end

--- a/backend/spec/services/klab/calculate_project_impact_score_spec.rb
+++ b/backend/spec/services/klab/calculate_project_impact_score_spec.rb
@@ -15,10 +15,10 @@ RSpec.describe Klab::CalculateProjectImpactScore do
 
     it "returns biodiversity score for precalculated geometry" do
       VCR.use_cassette("klab/calculate_project_impact_score") do
-        expect(subject.biodiversity).to eq(0.5545237701289529)
-        expect(subject.climate).to eq(0.7728172553609381)
-        expect(subject.community).to eq(0.5096142276290361)
-        expect(subject.water).to eq(0.830439023752767)
+        expect(subject.biodiversity).to eq(0.44547622987104707)
+        expect(subject.climate).to eq(0.22718274463906185)
+        expect(subject.community).to eq(0.4903857723709639)
+        expect(subject.water).to eq(0.169560976247233)
       end
     end
   end


### PR DESCRIPTION
I have run couple tests at Stage server and discovered that impacts and demands are just too different when compared with old implementation. Discussed this with @ikerey and it seems that `summary["mean"]` attribute which we get from BC3 corresponds to sustainability and not to demand. Demand can be computed from this value by `1 - summary["mean"]`.

## Testing instructions

This is quite difficult to test manually. Only way which comes to my mind is to verify that demand saved at project corresponds to `1 - VALUE_OBTAINED_FROM_BC3`. Individual steps could be like this:
 - pick some project
 - compute its demand by performing SubmitContext & PollImpactDemands jobs
 - run curl commands with same context string which was used by submit context job from previous step
 - verify that  demand value at project corresponds to `1 - summary["mean"]` value which you get from curl

## Tracking

BUG 🐛 
