### PR TITLE
fix: New tasks for fixing priority landscape geometries

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -46,6 +46,7 @@
 /db/seeds/files/basins.geojson
 /db/seeds/files/mosaics.geojson
 /db/seeds/files/municipalities.geojson
+/db/seeds/files/mosaics_corrected.geojson
 
 # Downloadable locales
 /config/locales/en.yml

--- a/backend/app/services/importers/geo_jsons/mosaics.rb
+++ b/backend/app/services/importers/geo_jsons/mosaics.rb
@@ -1,14 +1,36 @@
 module Importers
   module GeoJsons
     class Mosaics < Base
+      PRIORITY_LANDSCAPE_TRANSLATIONS = {
+        "Corazón Amazonía" => {name_en: "Amazon Heart", name_es: "Corazón Amazonía", name_pt: "Coração da Amazônia"},
+        "Piedemonte Amazónico - Macizo" => {name_en: "Amazonian Piedmont Massif", name_es: "Piedemonte Amazónico - Macizo", name_pt: "Maciço Piedemonte Amazônico"},
+        "Transición Orinoquía" => {name_en: "Orinoquía Transition", name_es: "Transición Orinoquía", name_pt: "Transição Orinoquía"},
+        "Orinoquía" => {name_en: "Orinoquía", name_es: "Orinoquía", name_pt: "Orinoquía"}
+      }
+      PRIORITY_LANDSCAPE_CODES = {
+        "Corazón Amazonía" => "priority-landscape-amazon-heart",
+        "Piedemonte Amazónico - Macizo" => "priority-landscape-amazonian-piedmont-massif",
+        "Transición Orinoquía" => "priority-landscape-orinoquia-transition",
+        "Orinoquía" => "priority-landscape-orinoquia",
+        "Cordillera Oriental" => "priority-landscape-cordillera-oriental",
+        "Cordillera Central" => "priority-landscape-cordillera-central",
+        "Pacífico - Marino Costero" => "priority-landscape-pacifico-marino-costero",
+        "Caribe" => "priority-landscape-caribe",
+        "Transición Pacífico - Caribe" => "priority-landscape-transicion-pacifico-caribe"
+      }
+
       private
 
       def attributes_of_record_for(feature)
         {
-          name_en: feature.properties["mosaico"],
+          name_en: PRIORITY_LANDSCAPE_TRANSLATIONS.dig(feature.properties["mosaico"], :name_en).presence || feature.properties["mosaico"],
+          name_es: feature.properties["mosaico"],
+          name_pt: PRIORITY_LANDSCAPE_TRANSLATIONS.dig(feature.properties["mosaico"], :name_pt),
           location_type: "priority_landscape",
           parent_id: country.id,
           geometry: feature.geometry,
+          visible: PRIORITY_LANDSCAPE_TRANSLATIONS.key?(feature.properties["mosaico"]),
+          code: PRIORITY_LANDSCAPE_CODES[feature.properties["mosaico"]],
           biodiversity: feature.properties["biodiversity"],
           biodiversity_demand: feature.properties["biodiversity_demand"],
           climate: feature.properties["climate"],

--- a/backend/spec/services/importers/geo_jsons/mosaics_spec.rb
+++ b/backend/spec/services/importers/geo_jsons/mosaics_spec.rb
@@ -24,13 +24,27 @@ RSpec.describe Importers::GeoJsons::Mosaics do
 
       it "creates correct priority_landscapes" do
         expect(priority_landscapes.count).to eq(2)
-        expect(priority_landscapes.pluck(:name_en)).to include("Cordillera Oriental")
-        expect(priority_landscapes.pluck(:name_en)).to include("Piedemonte Amazónico - Macizo")
+        expect(priority_landscapes.pluck(:name_es)).to include("Cordillera Oriental")
+        expect(priority_landscapes.pluck(:name_es)).to include("Piedemonte Amazónico - Macizo")
+      end
+
+      it "assigns correct attributes to first priority landscape" do
+        location = priority_landscapes.find_by name_es: "Cordillera Oriental"
+        expect(location.name_en).to eq("Cordillera Oriental")
+        expect(location.visible).to be_falsey
+        expect(location.code).to eq(Importers::GeoJsons::Mosaics::PRIORITY_LANDSCAPE_CODES["Cordillera Oriental"])
+      end
+
+      it "assigns correct attributes to second priority landscape" do
+        location = priority_landscapes.find_by name_es: "Piedemonte Amazónico - Macizo"
+        expect(location.name_en).to eq("Amazonian Piedmont Massif")
+        expect(location.visible).to be_truthy
+        expect(location.code).to eq(Importers::GeoJsons::Mosaics::PRIORITY_LANDSCAPE_CODES["Piedemonte Amazónico - Macizo"])
       end
 
       it "creates geometries records" do
         expect(LocationGeometry.count).to eq(priority_landscapes.count)
-        expect(priority_landscapes.find_by(name_en: "Piedemonte Amazónico - Macizo").location_geometry.geometry)
+        expect(priority_landscapes.find_by(name_es: "Piedemonte Amazónico - Macizo").location_geometry.geometry)
           .to eq(RGeo::GeoJSON.decode({type: "Polygon", coordinates: [[[105.0, 0.0], [106.0, 0.0], [106.0, 1.0], [105.0, 1.0], [105.0, 0.0]]]}.to_json))
       end
 


### PR DESCRIPTION
It seems there is some issue with our priority landscape geometries, because when send to BC3, error is returned. I have discussed this with Iker and he prepared simplified geometries which I have tested and which works.

This PR adds simple rake task which update geometries of priority landscapes at db. I will try to run it via console (tunnel) at Stage/Production. If I will encounter some issue, I will add migration which triggers this task.

I have also discovered that Mosaics importer does not have some attributes which were added later on. This was not relevant for data at Stage/Prod, because locations are already there, but it created damaged records when for example `rake db:seed` was run on local machine and location were imported from scratch.

## Testing instructions

I am not adding `mosaics_corrected.geojson` to this PR which is used by `rake priority_landscapes:fix_geometries`, but it should be possible to use for example  dummy data from test (https://github.com/Vizzuality/heco-invest/blob/develop/backend/spec/fixtures/files/dummy_mosaics.geojson). Just run this task with this dummy data and double check that geometry of existing locations gets updated to values from file.

## Tracking

BugFix related to BC3
