### PR TITLE
Set the same http auth password on staging and production

### DIFF
--- a/infrastructure/base/main.tf
+++ b/infrastructure/base/main.tf
@@ -77,8 +77,8 @@ module "production" {
   from_email_address     = var.from_email_address
   instance_role          = "production"
   tag                    = "production"
-  http_auth_username     = var.staging_http_auth_username
-  http_auth_password     = var.staging_http_auth_password
+  http_auth_username     = var.production_http_auth_username
+  http_auth_password     = var.production_http_auth_password
   klab_api_host           = var.klab_api_host
   klab_api_username       = var.klab_api_username
   klab_api_password       = var.klab_api_password

--- a/infrastructure/base/main.tf
+++ b/infrastructure/base/main.tf
@@ -77,8 +77,8 @@ module "production" {
   from_email_address     = var.from_email_address
   instance_role          = "production"
   tag                    = "production"
-  http_auth_username     = ""
-  http_auth_password     = ""
+  http_auth_username     = var.staging_http_auth_username
+  http_auth_password     = var.staging_http_auth_password
   klab_api_host           = var.klab_api_host
   klab_api_username       = var.klab_api_username
   klab_api_password       = var.klab_api_password

--- a/infrastructure/base/variables.tf
+++ b/infrastructure/base/variables.tf
@@ -98,6 +98,18 @@ variable "staging_http_auth_password" {
   default = ""
 }
 
+variable "production_http_auth_username" {
+  type = string
+  description = "Http auth username (for production)"
+  default = ""
+}
+
+variable "production_http_auth_password" {
+  type = string
+  description = "Http auth password (for production)"
+  default = ""
+}
+
 variable "klab_api_host" {
   type = string
   description = "Klab engine API host"


### PR DESCRIPTION
Setting http auth password in production to the same value as in staging

## Tracking

https://vizzuality.atlassian.net/jira/software/c/projects/LET/issues/LET-1370
