### PR TITLE
LET-1384 [BE] Add admin email notification when new account is created

### DIFF
--- a/backend/app/controllers/api/v1/accounts/investors_controller.rb
+++ b/backend/app/controllers/api/v1/accounts/investors_controller.rb
@@ -17,6 +17,7 @@ module API
             account = Account.create! account_params.merge(owner: current_user, users: [current_user])
             current_user.update! role: :investor
             investor = Investor.create! investor_params.merge(account: account)
+            Admin.all.each { |admin| AdminMailer.investor_created(admin, investor).deliver_later }
             render json: InvestorSerializer.new(
               investor,
               params: {current_user: current_user, current_ability: current_ability}

--- a/backend/app/controllers/api/v1/accounts/project_developers_controller.rb
+++ b/backend/app/controllers/api/v1/accounts/project_developers_controller.rb
@@ -17,6 +17,7 @@ module API
             account = Account.create! account_params.merge(owner: current_user, users: [current_user])
             current_user.update! role: :project_developer
             project_developer = ProjectDeveloper.create! project_developer_params.merge(account: account)
+            Admin.all.each { |admin| AdminMailer.project_developer_created(admin, project_developer).deliver_later }
             render json: ProjectDeveloperSerializer.new(
               project_developer,
               params: {current_user: current_user, current_ability: current_ability}

--- a/backend/app/mailers/admin_mailer.rb
+++ b/backend/app/mailers/admin_mailer.rb
@@ -8,6 +8,24 @@ class AdminMailer < ApplicationMailer
     end
   end
 
+  def project_developer_created(admin, project_developer)
+    @admin = admin
+    @project_developer = project_developer
+
+    I18n.with_locale admin.locale do
+      mail to: admin.email
+    end
+  end
+
+  def investor_created(admin, investor)
+    @admin = admin
+    @investor = investor
+
+    I18n.with_locale admin.locale do
+      mail to: admin.email
+    end
+  end
+
   private
 
   def set_reset_password_token(admin)

--- a/backend/app/views/admin_mailer/investor_created.html.erb
+++ b/backend/app/views/admin_mailer/investor_created.html.erb
@@ -1,0 +1,3 @@
+<h3><%= t "admin_mailer.greetings", full_name: @admin.full_name %></h3>
+<p><%= t "admin_mailer.investor_created.content_html", new_investor_url: link_to(backoffice_investor_url(@investor)) %></p>
+<p><%= t "admin_mailer.farewell_html" %></p>

--- a/backend/app/views/admin_mailer/project_developer_created.htm.erb
+++ b/backend/app/views/admin_mailer/project_developer_created.htm.erb
@@ -1,0 +1,3 @@
+<h3><%= t "admin_mailer.greetings", full_name: @admin.full_name %></h3>
+<p><%= t "admin_mailer.project_developer_created.content_html", new_pd_url: link_to(backoffice_project_developer_url(@project_developer)) %></p>
+<p><%= t "admin_mailer.farewell_html" %></p>

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -361,6 +361,12 @@ zu:
       subject: Your HeCo Invest Admin account was created!
       content_html: "To login for first time, please %{reset_password_link}."
       reset_password_link: setup your new password
+    investor_created:
+      subject: New Investor account created!
+      content_html: "A new Investor account has been created and needs your inspection for approval. Please, review the account: %{new_investor_url} "
+    project_developer_created:
+      subject: New Project developer account created!
+      content_html: "A new Project developer account has been created and needs your inspection for approval. Please, review the account: %{new_pd_url} "
   project_developer_mailer:
     greetings: Dear %{full_name},
     farewell_html: Best Regards,<br />Your HeCo Invest Team

--- a/backend/spec/requests/api/v1/accounts/investors_spec.rb
+++ b/backend/spec/requests/api/v1/accounts/investors_spec.rb
@@ -131,6 +131,13 @@ RSpec.describe "API V1 Account Investors", type: :request do
             expect(investor.public_send("#{attr}_#{investor_params[:language]}")).to eq(investor_params[attr])
           end
         end
+
+        it "queues email notification" do |example|
+          investor = Investor.find response_json["data"]["id"]
+          Admin.all.each do |admin|
+            expect(AdminMailer).to have_enqueued_mail(:investor_created).with(admin, investor)
+          end
+        end
       end
 
       response "422", "User already have account" do

--- a/backend/spec/requests/api/v1/accounts/project_developers_spec.rb
+++ b/backend/spec/requests/api/v1/accounts/project_developers_spec.rb
@@ -129,6 +129,14 @@ RSpec.describe "API V1 Account Project Developers", type: :request do
             submit_request example.metadata
           }.to have_enqueued_job(TranslateJob).at_least(:once)
         end
+
+        it "queues email notification" do |example|
+          submit_request example.metadata
+          project_developer = ProjectDeveloper.find response_json["data"]["id"]
+          Admin.all.each do |admin|
+            expect(AdminMailer).to have_enqueued_mail(:project_developer_created).with(admin, project_developer)
+          end
+        end
       end
 
       response "422", "User already have account" do


### PR DESCRIPTION
Adds new email notification for admin when new Investor or Project developer is created by User:

- update of Investor and ProjectDeveloper api controllers
- New methods added to AdminMailer
- News views for email notifications added

## Testing instructions

The api Investor and ProjectDeveloper controller tests updated with new checks for enqueued mail notifications for admins.

## Tracking

Link to the task(s), if any
[1384](https://vizzuality.atlassian.net/browse/LET-1384)
