### PR TITLE
Infrastracture/fix jobs instance build

### DIFF
--- a/infrastructure/base/modules/env/main.tf
+++ b/infrastructure/base/modules/env/main.tf
@@ -167,6 +167,15 @@ module "backend_build" {
         "--region", var.gcp_region, "--max-instances", var.backend_max_scale
       ]
     },
+    {
+      name       = "gcr.io/google.com/cloudsdktool/cloud-sdk"
+      entrypoint = "gcloud"
+      args       = [
+        "run", "services", "update-traffic", "${var.project_name}-jobs",
+        "--region", var.gcp_region,
+        "--to-latest"
+      ]
+    }
   ]
 }
 


### PR DESCRIPTION
Looks like the latest jobs instance relese remains with 0% traffic, so trying to add a build step to reroute 100% traffic.
![Screenshot from 2023-11-27 13-44-50](https://github.com/Vizzuality/heco-invest/assets/134055/e009616a-459a-4627-bec2-6e702dcd26cd)

https://vizzuality.atlassian.net/browse/LET-1397?atlOrigin=eyJpIjoiZTg0OTY5MGFiNjM4NGQ0YThkZjI0NmRjNDIzZjM3YjkiLCJwIjoiaiJ9