### PR TITLE
fix: admin mailer view format + update tests

### DIFF
--- a/backend/app/views/admin_mailer/investor_created.html.erb
+++ b/backend/app/views/admin_mailer/investor_created.html.erb
@@ -1,3 +1,3 @@
 <h3><%= t "admin_mailer.greetings", full_name: @admin.full_name %></h3>
-<p><%= t "admin_mailer.investor_created.content_html", new_investor_url: link_to(backoffice_investor_url(@investor)) %></p>
+<p><%= t "admin_mailer.investor_created.content_html", new_investor_url: link_to('New Investor', backoffice_investor_url(@investor)) %></p>
 <p><%= t "admin_mailer.farewell_html" %></p>

--- a/backend/app/views/admin_mailer/project_developer_created.htm.erb
+++ b/backend/app/views/admin_mailer/project_developer_created.htm.erb
@@ -1,3 +1,0 @@
-<h3><%= t "admin_mailer.greetings", full_name: @admin.full_name %></h3>
-<p><%= t "admin_mailer.project_developer_created.content_html", new_pd_url: link_to(backoffice_project_developer_url(@project_developer)) %></p>
-<p><%= t "admin_mailer.farewell_html" %></p>

--- a/backend/app/views/admin_mailer/project_developer_created.html.erb
+++ b/backend/app/views/admin_mailer/project_developer_created.html.erb
@@ -1,0 +1,3 @@
+<h3><%= t "admin_mailer.greetings", full_name: @admin.full_name %></h3>
+<p><%= t "admin_mailer.project_developer_created.content_html", new_pd_url: link_to('New Project Developer', backoffice_project_developer_url(@project_developer)) %></p>
+<p><%= t "admin_mailer.farewell_html" %></p>

--- a/backend/config/locales/zu.yml
+++ b/backend/config/locales/zu.yml
@@ -363,10 +363,10 @@ zu:
       reset_password_link: setup your new password
     investor_created:
       subject: New Investor account created!
-      content_html: "A new Investor account has been created and needs your inspection for approval. Please, review the account: %{new_investor_url} "
+      content_html: "A new Investor account has been created and needs your inspection for approval. Please, review the account: %{new_investor_url}"
     project_developer_created:
       subject: New Project developer account created!
-      content_html: "A new Project developer account has been created and needs your inspection for approval. Please, review the account: %{new_pd_url} "
+      content_html: "A new Project developer account has been created and needs your inspection for approval. Please, review the account: %{new_pd_url}"
   project_developer_mailer:
     greetings: Dear %{full_name},
     farewell_html: Best Regards,<br />Your HeCo Invest Team

--- a/backend/spec/mailers/admin_mailer_spec.rb
+++ b/backend/spec/mailers/admin_mailer_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe AdminMailer, type: :mailer do
   include ActionView::Helpers::UrlHelper
 
   let(:admin) { create :admin }
+  let(:project_developer) { create :project_developer }
+  let(:investor) { create :investor }
 
   describe ".first_time_login_instructions" do
     let(:mail) { AdminMailer.first_time_login_instructions admin }
@@ -17,6 +19,36 @@ RSpec.describe AdminMailer, type: :mailer do
       expect(mail.body.encoded).to match(I18n.t("admin_mailer.greetings", full_name: admin.full_name))
       expect(mail.body.encoded).to match(I18n.t("admin_mailer.first_time_login_instructions.content_html", reset_password_link: ""))
       expect(mail.body.encoded).to match(I18n.t("admin_mailer.first_time_login_instructions.reset_password_link"))
+      expect(mail.body.encoded).to match(I18n.t("admin_mailer.farewell_html"))
+    end
+  end
+
+  describe ".project_developer_created" do
+    let(:mail) { AdminMailer.project_developer_created admin, project_developer }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq(I18n.t("admin_mailer.project_developer_created.subject"))
+      expect(mail.to).to eq([admin.email])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match(I18n.t("admin_mailer.greetings", full_name: admin.full_name))
+      expect(mail.body.encoded).to match(I18n.t("admin_mailer.project_developer_created.content_html", new_pd_url: ""))
+      expect(mail.body.encoded).to match(I18n.t("admin_mailer.farewell_html"))
+    end
+  end
+
+  describe ".investor_created" do
+    let(:mail) { AdminMailer.investor_created admin, investor }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq(I18n.t("admin_mailer.investor_created.subject"))
+      expect(mail.to).to eq([admin.email])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match(I18n.t("admin_mailer.greetings", full_name: admin.full_name))
+      expect(mail.body.encoded).to match(I18n.t("admin_mailer.investor_created.content_html", new_investor_url: ""))
       expect(mail.body.encoded).to match(I18n.t("admin_mailer.farewell_html"))
     end
   end

--- a/backend/spec/mailers/admin_mailer_spec.rb
+++ b/backend/spec/mailers/admin_mailer_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe AdminMailer, type: :mailer do
 
     it "renders the body" do
       expect(mail.body.encoded).to match(I18n.t("admin_mailer.greetings", full_name: admin.full_name))
-      expect(mail.body.encoded).to match(I18n.t("admin_mailer.project_developer_created.content_html", new_pd_url: ""))
+      expect(mail.body.encoded).to match(I18n.t("admin_mailer.project_developer_created.content_html", new_pd_url: link_to("New Project Developer", backoffice_project_developer_url(project_developer))))
       expect(mail.body.encoded).to match(I18n.t("admin_mailer.farewell_html"))
     end
   end
@@ -48,7 +48,7 @@ RSpec.describe AdminMailer, type: :mailer do
 
     it "renders the body" do
       expect(mail.body.encoded).to match(I18n.t("admin_mailer.greetings", full_name: admin.full_name))
-      expect(mail.body.encoded).to match(I18n.t("admin_mailer.investor_created.content_html", new_investor_url: ""))
+      expect(mail.body.encoded).to match(I18n.t("admin_mailer.investor_created.content_html", new_investor_url: link_to("New Investor", backoffice_investor_url(investor))))
       expect(mail.body.encoded).to match(I18n.t("admin_mailer.farewell_html"))
     end
   end


### PR DESCRIPTION
Fix for previous admin notifications for new accounts creation:
- Mailer view for new project developer notification renamed to have correct format
- admin_mailer_spec.rb extended to cover project_developer_created and investor_created mailer views

## Testing instructions

admin_mailer_spec.rb extended to cover project_developer_created and investor_created mailer views

## Tracking

Link to the task(s), if any
