### PR TITLE
LET-1375 [FE]: bold public and add private tags

### DIFF
--- a/frontend/containers/project-form/pages/other-information.tsx
+++ b/frontend/containers/project-form/pages/other-information.tsx
@@ -9,6 +9,7 @@ import ErrorMessage from 'components/forms/error-message';
 import Input from 'components/forms/input';
 import Label from 'components/forms/label';
 import Textarea from 'components/forms/textarea';
+import TextTag from 'components/tag';
 import { ProjectForm } from 'types/project';
 
 import { ProjectFormPagesProps } from '..';
@@ -46,8 +47,8 @@ const OtherInformation = ({
       </h1>
       <p className="mb-10 text-gray-900">
         <FormattedMessage
-          defaultMessage="This description should summarize your project in a few words. This might include relevant financial information that you want potential investors to know about. This information will be public except the one marked as <n>private</n> which will only be visible for admins."
-          id="l2Jd2p"
+          defaultMessage="This description should summarize your project in a few words. This might include relevant financial information that you want potential investors to know about. This information will be <n>public</n> except the one marked as <n>private</n> which will only be visible for admins."
+          id="q63Bcb"
           values={{
             n: (chunk: string) => <span className="font-semibold">{chunk}</span>,
           }}
@@ -98,6 +99,12 @@ const OtherInformation = ({
                 id="TnP0xP"
               />
             </span>
+            <TextTag
+              size="smallest"
+              className="ml-2 border-beige font-medium leading-[14px] text-sm text-gray-800 bg-beige"
+            >
+              <FormattedMessage defaultMessage="Private" id="viXE32" />
+            </TextTag>
           </Label>
           <Textarea
             placeholder={formatMessage({
@@ -122,6 +129,12 @@ const OtherInformation = ({
                 id="cmhwn3"
               />
             </span>
+            <TextTag
+              size="smallest"
+              className="ml-2 border-beige font-medium leading-[14px] text-sm text-gray-800 bg-beige"
+            >
+              <FormattedMessage defaultMessage="Private" id="viXE32" />
+            </TextTag>
           </Label>
           <Input
             placeholder={formatMessage({
@@ -197,6 +210,12 @@ const OtherInformation = ({
 
                 <FormattedMessage defaultMessage="No" id="oUWADl" />
               </Label>
+              <TextTag
+                size="smallest"
+                className="ml-4 border-beige font-medium leading-[14px] text-sm text-gray-800 bg-beige"
+              >
+                <FormattedMessage defaultMessage="Private" id="viXE32" />
+              </TextTag>
             </div>
           </fieldset>
         </div>


### PR DESCRIPTION
Fixes: bold "public" word and add private tags to new fields:

<img width="1017" alt="Screenshot 2023-11-30 at 00 12 09" src="https://github.com/Vizzuality/heco-invest/assets/51995866/355f9f60-128b-4421-8f63-32f70be04942">

## Tracking
See last comment on:
[LET-1375](https://vizzuality.atlassian.net/browse/LET-1375)


[LET-1375]: https://vizzuality.atlassian.net/browse/LET-1375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ