### PR TITLE
Update link url in new account mail notification

### DIFF
--- a/backend/app/views/admin_mailer/investor_created.html.erb
+++ b/backend/app/views/admin_mailer/investor_created.html.erb
@@ -1,3 +1,3 @@
 <h3><%= t "admin_mailer.greetings", full_name: @admin.full_name %></h3>
-<p><%= t "admin_mailer.investor_created.content_html", new_investor_url: link_to('New Investor', backoffice_investor_url(@investor)) %></p>
+<p><%= t "admin_mailer.investor_created.content_html", new_investor_url: link_to('New Investor', edit_backoffice_investor_url(@investor)) %></p>
 <p><%= t "admin_mailer.farewell_html" %></p>

--- a/backend/app/views/admin_mailer/project_developer_created.html.erb
+++ b/backend/app/views/admin_mailer/project_developer_created.html.erb
@@ -1,3 +1,3 @@
 <h3><%= t "admin_mailer.greetings", full_name: @admin.full_name %></h3>
-<p><%= t "admin_mailer.project_developer_created.content_html", new_pd_url: link_to('New Project Developer', backoffice_project_developer_url(@project_developer)) %></p>
+<p><%= t "admin_mailer.project_developer_created.content_html", new_pd_url: link_to('New Project Developer', edit_backoffice_project_developer_url(@project_developer)) %></p>
 <p><%= t "admin_mailer.farewell_html" %></p>

--- a/backend/spec/mailers/admin_mailer_spec.rb
+++ b/backend/spec/mailers/admin_mailer_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe AdminMailer, type: :mailer do
 
     it "renders the body" do
       expect(mail.body.encoded).to match(I18n.t("admin_mailer.greetings", full_name: admin.full_name))
-      expect(mail.body.encoded).to match(I18n.t("admin_mailer.project_developer_created.content_html", new_pd_url: link_to("New Project Developer", backoffice_project_developer_url(project_developer))))
+      expect(mail.body.encoded).to match(I18n.t("admin_mailer.project_developer_created.content_html", new_pd_url: link_to("New Project Developer", edit_backoffice_project_developer_url(project_developer))))
       expect(mail.body.encoded).to match(I18n.t("admin_mailer.farewell_html"))
     end
   end
@@ -48,7 +48,7 @@ RSpec.describe AdminMailer, type: :mailer do
 
     it "renders the body" do
       expect(mail.body.encoded).to match(I18n.t("admin_mailer.greetings", full_name: admin.full_name))
-      expect(mail.body.encoded).to match(I18n.t("admin_mailer.investor_created.content_html", new_investor_url: link_to("New Investor", backoffice_investor_url(investor))))
+      expect(mail.body.encoded).to match(I18n.t("admin_mailer.investor_created.content_html", new_investor_url: link_to("New Investor", edit_backoffice_investor_url(investor))))
       expect(mail.body.encoded).to match(I18n.t("admin_mailer.farewell_html"))
     end
   end


### PR DESCRIPTION
Currently the url to new accounts for approval sent in the mail notification is missing 'edit', PR is fixing it by using `edit_backoffice_project_developer_url` and `editt_backoffice_investor_url` helpers.

## Testing instructions
 Admin mailer test updated accordingly

## Tracking

Link to the task(s), if any
