### PR TITLE
[LET-1426][FE] Cookies banner now links to the specific ToS section where the cookie…

### DIFF
--- a/frontend/components/privacy-notice/notice-content/component.tsx
+++ b/frontend/components/privacy-notice/notice-content/component.tsx
@@ -54,7 +54,7 @@ const NoticeContent: FC<NoticeContentProps> = ({}: NoticeContentProps) => {
                   id="RrcFtD"
                   values={{
                     a: (chunks) => (
-                      <Link href={Paths.TermsConditions}>
+                      <Link href={`${Paths.TermsConditions}#hyperlinks_and_cookies`}>
                         <a
                           className="underline focus-visible:outline focus-visible:outline-green-dark focus-visible:outline-2 focus-visible:outline-offset-2"
                           target="_blank"


### PR DESCRIPTION
Description of the PR

Cookies banner now links to the correct section of the ToS where the cookies policy is described. 

## Tracking

[LET-1426](https://vizzuality.atlassian.net/browse/LET-1426)


[LET-1426]: https://vizzuality.atlassian.net/browse/LET-1426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ