### PR TITLE
[LET-1428][FE] Add hover effect to the 'About the partners' section in the About page

### DIFF
--- a/frontend/containers/about/our-allies/component.tsx
+++ b/frontend/containers/about/our-allies/component.tsx
@@ -5,6 +5,7 @@ import cx from 'classnames';
 import Image from 'next/image';
 
 import { useAlliesLogos, useSupportedByLogos } from './data';
+import Logo from './logo/component';
 
 export const OurAllies = () => {
   const alliesLogos = useAlliesLogos();
@@ -27,16 +28,7 @@ export const OurAllies = () => {
                 })}
               >
                 {row.map((logo) => {
-                  return (
-                    <span key={logo.src}>
-                      <Image
-                        src={logo.src}
-                        width={logo.width}
-                        height={logo.height}
-                        alt={logo.alt}
-                      />
-                    </span>
-                  );
+                  return <Logo key={logo.src} logo={logo} />;
                 })}
               </div>
             );
@@ -50,11 +42,7 @@ export const OurAllies = () => {
         <div className="flex flex-col mt-8">
           <div className="flex flex-wrap items-center justify-center gap-6">
             {supportedByLogos.map((logo) => {
-              return (
-                <span key={logo.src}>
-                  <Image src={logo.src} width={logo.width} height={logo.height} alt={logo.alt} />
-                </span>
-              );
+              return <Logo key={logo.src} logo={logo} />;
             })}
           </div>
         </div>

--- a/frontend/containers/about/our-allies/logo/component.tsx
+++ b/frontend/containers/about/our-allies/logo/component.tsx
@@ -1,0 +1,29 @@
+import { FC } from 'react';
+
+import Image from 'next/image';
+
+import Tooltip from 'components/tooltip';
+
+import { OurAlliesLogoType } from './';
+
+export const OurAlliesLogo: FC<OurAlliesLogoType> = ({ logo }) => {
+  return (
+    <span>
+      <Tooltip
+        arrow
+        arrowClassName="bg-black"
+        content={
+          <div className="max-w-xs p-2 font-sans text-sm font-normal text-white bg-black rounded-sm">
+            {logo.alt}
+          </div>
+        }
+      >
+        <span className="flex py-1 sm:py-0">
+          <Image src={logo.src} width={logo.width} height={logo.height} alt={logo.alt} />
+        </span>
+      </Tooltip>
+    </span>
+  );
+};
+
+export default OurAlliesLogo;

--- a/frontend/containers/about/our-allies/logo/index.ts
+++ b/frontend/containers/about/our-allies/logo/index.ts
@@ -1,0 +1,2 @@
+export type { OurAlliesLogoType } from './types';
+export { default } from './component';

--- a/frontend/containers/about/our-allies/logo/types.ts
+++ b/frontend/containers/about/our-allies/logo/types.ts
@@ -1,0 +1,8 @@
+export type OurAlliesLogoType = {
+  logo: {
+    src: string;
+    width: number;
+    height: number;
+    alt: string;
+  };
+};

--- a/frontend/containers/about/our-partners/card/component.tsx
+++ b/frontend/containers/about/our-partners/card/component.tsx
@@ -20,7 +20,7 @@ export const OurPartnersCard: FC<OurPartnersCardProps> = ({
   return (
     <button
       type="button"
-      className="py-6 px-4 bg-background-middle rounded-2xl focus-visible:outline focus-visible:outline-green-dark focus-visible:outline-2 focus-visible:outline-offset-2"
+      className="py-6 px-4 bg-background-middle rounded-2xl focus-visible:outline focus-visible:outline-green-dark focus-visible:outline-2 focus-visible:outline-offset-2 hover:shadow border border-transparent transition-all duration-500 hover:border-green-light"
       onClick={handleCardClick}
     >
       <div className="text-center">

--- a/frontend/containers/sdgs/component.tsx
+++ b/frontend/containers/sdgs/component.tsx
@@ -23,7 +23,7 @@ export const SDGs: FC<SDGsProps> = ({ className, size = 'small', sdgs = [] }: SD
             arrowClassName="bg-black"
             content={
               <div className="max-w-xs p-2 font-sans text-sm font-normal text-white bg-black rounded-sm">
-                {sdg.name}
+                haha
               </div>
             }
           >


### PR DESCRIPTION
This PR adds a hover effect (shadow + light green border) to the cards in the _About the partners_  section of the About page. A transition duration was added as well, for consistency with the other cards throughout the app. 

## Tracking

[LET-1428](https://vizzuality.atlassian.net/browse/LET-1428)


[LET-1428]: https://vizzuality.atlassian.net/browse/LET-1428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ