### PR TITLE
[LET-1426][FE] Offset native anchor scrolling on the ToS page

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -111,6 +111,7 @@
     "react-stately": "^3.12.2",
     "react-table": "^7.8.0",
     "rooks": "^5.10.0",
+    "sass": "^1.70.0",
     "sharp": "^0.30.1",
     "slugify": "^1.6.5",
     "supercluster": "^7.1.5",

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -22,7 +22,7 @@ import localesConfig from 'locales.config.json';
 import store from 'store';
 import { LayoutStaticProp } from 'types';
 
-import 'styles/globals.css';
+import 'styles/globals.scss';
 
 // Enable dayjs to display translated dates in all the application's locales
 localesConfig.locales.forEach(({ locale }) => require(`dayjs/locale/${locale}.js`));

--- a/frontend/pages/terms-conditions.tsx
+++ b/frontend/pages/terms-conditions.tsx
@@ -75,7 +75,7 @@ const TermsConditions: PageComponent<TermsConditionsProps, StaticPageLayoutProps
               }
             )}
           </div>
-          <ol className="my-8 space-y-12">
+          <ol className="my-8 space-y-12 offset-target-anchor">
             <li className="list-decimal">
               <a href="#definitions">
                 <h2 id="definitions" className="font-semibold underline">

--- a/frontend/styles/globals.scss
+++ b/frontend/styles/globals.scss
@@ -205,3 +205,27 @@
     @apply cursor-default opacity-40;
   }
 }
+
+/**
+ * Because of the fixed/sticky header and the possible "BETA" version banner, target links in places such as
+ * the ToS will be hidden behind the fixed/sticky bars. These classes, when applied to a parent container, will
+ * make it so that the native scrolling to an anchor can still be used, but is offset thanks to
+ * https: //developer.mozilla.org/en-US/docs/Web/CSS/:target
+ *
+ *   Header:      sm:64px | md:80px
+ *   Beta banner: sm: 0px | md:44px
+ *   Offset:      sm: 4px | md:4px
+ */
+.offset-target-anchor {
+  *:target:before {
+    content: "";
+    display: block;
+    height: 70px;
+    margin: -70px 0 0;
+
+    @screen md {
+      height: 130px;
+      margin: -130px 0 0;
+    }
+  }
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -11618,6 +11618,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chokidar@npm:>=3.0.0 <4.0.0, chokidar@npm:^3.4.1, chokidar@npm:^3.4.2, chokidar@npm:^3.5.3":
+  version: 3.5.3
+  resolution: "chokidar@npm:3.5.3"
+  dependencies:
+    anymatch: ~3.1.2
+    braces: ~3.0.2
+    fsevents: ~2.3.2
+    glob-parent: ~5.1.2
+    is-binary-path: ~2.1.0
+    is-glob: ~4.0.1
+    normalize-path: ~3.0.0
+    readdirp: ~3.6.0
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  checksum: b49fcde40176ba007ff361b198a2d35df60d9bb2a5aab228279eb810feae9294a6b4649ab15981304447afe1e6ffbf4788ad5db77235dc770ab777c6e771980c
+  languageName: node
+  linkType: hard
+
 "chokidar@npm:^2.1.8":
   version: 2.1.8
   resolution: "chokidar@npm:2.1.8"
@@ -11638,25 +11657,6 @@ __metadata:
     fsevents:
       optional: true
   checksum: 0c43e89cbf0268ef1e1f41ce8ec5233c7ba022c6f3282c2ef6530e351d42396d389a1148c5a040f291cf1f4083a4c6b2f51dad3f31c726442ea9a337de316bcf
-  languageName: node
-  linkType: hard
-
-"chokidar@npm:^3.4.1, chokidar@npm:^3.4.2, chokidar@npm:^3.5.3":
-  version: 3.5.3
-  resolution: "chokidar@npm:3.5.3"
-  dependencies:
-    anymatch: ~3.1.2
-    braces: ~3.0.2
-    fsevents: ~2.3.2
-    glob-parent: ~5.1.2
-    is-binary-path: ~2.1.0
-    is-glob: ~4.0.1
-    normalize-path: ~3.0.0
-    readdirp: ~3.6.0
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  checksum: b49fcde40176ba007ff361b198a2d35df60d9bb2a5aab228279eb810feae9294a6b4649ab15981304447afe1e6ffbf4788ad5db77235dc770ab777c6e771980c
   languageName: node
   linkType: hard
 
@@ -15356,6 +15356,7 @@ __metadata:
     react-stately: ^3.12.2
     react-table: ^7.8.0
     rooks: ^5.10.0
+    sass: ^1.70.0
     sharp: ^0.30.1
     slugify: ^1.6.5
     storybook-addon-mock: ^2.4.1
@@ -15713,6 +15714,13 @@ __metadata:
   version: 9.0.12
   resolution: "immer@npm:9.0.12"
   checksum: bcbec6d76dac65e49068eb67ece4d407116e62b8cde3126aa89c801e408f5047763ba0aeb62f1938c1aa704bb6612f1d8302bb2a86fa1fc60fcc12d8b25dc895
+  languageName: node
+  linkType: hard
+
+"immutable@npm:^4.0.0":
+  version: 4.3.4
+  resolution: "immutable@npm:4.3.4"
+  checksum: de3edd964c394bab83432429d3fb0b4816b42f56050f2ca913ba520bd3068ec3e504230d0800332d3abc478616e8f55d3787424a90d0952e6aba864524f1afc3
   languageName: node
   linkType: hard
 
@@ -21694,6 +21702,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sass@npm:^1.70.0":
+  version: 1.70.0
+  resolution: "sass@npm:1.70.0"
+  dependencies:
+    chokidar: ">=3.0.0 <4.0.0"
+    immutable: ^4.0.0
+    source-map-js: ">=0.6.2 <2.0.0"
+  bin:
+    sass: sass.js
+  checksum: fd1b622cf9b7fa699a03ec634611997552ece45eb98ac365fef22f42bdcb8ed63b326b64173379c966830c8551ae801e44e4a00d2de16fdadda2dc8f35400bbb
+  languageName: node
+  linkType: hard
+
 "saxes@npm:^5.0.1":
   version: 5.0.1
   resolution: "saxes@npm:5.0.1"
@@ -22146,7 +22167,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-js@npm:^1.0.2":
+"source-map-js@npm:>=0.6.2 <2.0.0, source-map-js@npm:^1.0.2":
   version: 1.0.2
   resolution: "source-map-js@npm:1.0.2"
   checksum: c049a7fc4deb9a7e9b481ae3d424cc793cb4845daa690bc5a05d428bf41bf231ced49b4cf0c9e77f9d42fdb3d20d6187619fc586605f5eabe995a316da8d377c


### PR DESCRIPTION
This PR leverages the browsers' native `:target` in order to offset native anchor scrolling when a user is linked to a section. 

## Tracking

[LET-1426](https://vizzuality.atlassian.net/browse/LET-1426)


[LET-1426]: https://vizzuality.atlassian.net/browse/LET-1426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ