### PR TITLE
[LET-1432][FE] Add 'Gobierno de Espana' partner card description text placeholder

### DIFF
--- a/frontend/containers/about/our-partners/data.ts
+++ b/frontend/containers/about/our-partners/data.ts
@@ -145,7 +145,10 @@ export const usePartners = () => {
             id: 'AS8i3c',
           }),
         },
-        text: '',
+        text: formatMessage({
+          defaultMessage: 'Gobierno de España partner card description text',
+          id: 'IlZRZq',
+        }),
       },
     ],
     [formatMessage]


### PR DESCRIPTION
This PR adds a placeholder text for the "Gobierno de España" card in the partners section of the About page, so that it can be updated via Transifex later on. 

## Tracking

[LET-1432](https://vizzuality.atlassian.net/browse/LET-1432)


[LET-1432]: https://vizzuality.atlassian.net/browse/LET-1432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ