### PR TITLE
[LET-1430][FE] Terms of service page adjustments

### DIFF
--- a/frontend/pages/terms-conditions.tsx
+++ b/frontend/pages/terms-conditions.tsx
@@ -33,8 +33,8 @@ const TermsConditions: PageComponent<TermsConditionsProps, StaticPageLayoutProps
         <div className="h-auto">
           <h1 className="font-serif text-2xl text-center font-semibold md:text-3xl text-green-dark mb-10">
             <FormattedMessage
-              defaultMessage="TERMS AND CONDITIONS OF THE HeCo Invest PLATFORM"
-              id="6HVIBd"
+              defaultMessage='TERMS AND CONDITIONS OF THE "HeCo Invest" PLATFORM'
+              id="C5g7Dz"
             />
           </h1>
           <div className="my-4 mb-12 space-y-4">

--- a/frontend/pages/terms-conditions.tsx
+++ b/frontend/pages/terms-conditions.tsx
@@ -34,7 +34,7 @@ const TermsConditions: PageComponent<TermsConditionsProps, StaticPageLayoutProps
           <h1 className="font-serif text-2xl text-center font-semibold md:text-3xl text-green-dark mb-10">
             <FormattedMessage
               defaultMessage='TERMS AND CONDITIONS OF THE "HeCo Invest" PLATFORM'
-              id="C5g7Dz"
+              id="mDGfCm"
             />
           </h1>
           <div className="my-4 mb-12 space-y-4">
@@ -109,7 +109,7 @@ const TermsConditions: PageComponent<TermsConditionsProps, StaticPageLayoutProps
                     id: 'VADZzs',
                   },
                   {
-                    n: (...chunks) => <span className="font-semibold">{chunks}</span>,
+                    n: (...chunks) => <span className="font-semibold underline">{chunks}</span>,
                     p: (...chunks) => <p className="">{chunks}</p>,
                     li: (...chunks) => (
                       <li className="ml-14 [counter-increment:subsection] marker:[content:'1.'counters(subsection,'.')'.\00a0']">


### PR DESCRIPTION
This PR implements minor adjustments in the ToS page after QA:
- Quotes around _"HeCo Invest"_ in the page title  
- Second section, _"Definitions"_ to have an underline where the bolded entries are  

## Tracking

[LET-1430](https://vizzuality.atlassian.net/browse/LET-1430)


[LET-1430]: https://vizzuality.atlassian.net/browse/LET-1430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ