### PR TITLE
Removed production http auth

### DIFF
--- a/infrastructure/base/main.tf
+++ b/infrastructure/base/main.tf
@@ -73,8 +73,8 @@ module "production" {
   from_email_address     = var.from_email_address
   instance_role          = "production"
   tag                    = "production"
-  http_auth_username     = var.production_http_auth_username
-  http_auth_password     = var.production_http_auth_password
+  http_auth_username     = ""
+  http_auth_password     = ""
   klab_api_host           = var.klab_api_host
   klab_api_username       = var.klab_api_username
   klab_api_password       = var.klab_api_password


### PR DESCRIPTION
## Testing instructions

No http auth should be in place on production site / backoffice

## Tracking

https://vizzuality.atlassian.net/browse/LET-1429?atlOrigin=eyJpIjoiMWZhZTc3OTg1ZWRmNDU5ZWFkZDlkZjIxZTVjNWNiMDAiLCJwIjoiaiJ9
