### PR TITLE
[LET-1437] Fix SDGs tooltips - test text incorrectly displayed; it should displa…

### DIFF
--- a/frontend/containers/sdgs/component.tsx
+++ b/frontend/containers/sdgs/component.tsx
@@ -23,7 +23,7 @@ export const SDGs: FC<SDGsProps> = ({ className, size = 'small', sdgs = [] }: SD
             arrowClassName="bg-black"
             content={
               <div className="max-w-xs p-2 font-sans text-sm font-normal text-white bg-black rounded-sm">
-                haha
+                {sdg.name}
               </div>
             }
           >


### PR DESCRIPTION
A test string was somehow left over when investigating/implementing https://github.com/Vizzuality/heco-invest/pull/829, this reverses this change:

when hovering and SDG image the SDG name should be shown. 

## Tracking

[LET-1437](https://vizzuality.atlassian.net/browse/LET-1437)


[LET-1437]: https://vizzuality.atlassian.net/browse/LET-1437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ